### PR TITLE
chore(chatbot): refine system prompt for qualification flow

### DIFF
--- a/api/generate.ts
+++ b/api/generate.ts
@@ -610,9 +610,10 @@ export default async function handler(request: Request) {
                 responseText = buildRefinementMessage(validation.missing);
                 responseFunctionCall = undefined;
             } else {
+                const normalizedArgs: Record<string, unknown> = { ...validation.normalizedArgs };
                 responseFunctionCall = {
                     name: 'generate_budget_link',
-                    args: validation.normalizedArgs,
+                    args: normalizedArgs,
                 };
             }
         }


### PR DESCRIPTION
## Summary
- refine system prompt to allow one consolidated missing-fields message near handoff
- enforce city granularity for origin/destination fields
- align assumed_origin_br guidance with missing origin_region behavior
- instruct model to use "não informado" for missing qualification fields instead of inventing data

## Testing
- not run (text-only prompt update)