### PR TITLE
feat(chatbot): integrar deal no HubSpot e endurecer handoff de tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@ GEMINI_API_KEY=sua_chave_api_aqui
 # REQUIRED - HubSpot CRM (para captura de leads via chatbot)
 # =============================================================================
 HUBSPOT_TOKEN=seu_token_do_app_privado
+HUBSPOT_DEAL_PIPELINE_ID=id_do_pipeline_deals
+HUBSPOT_DEAL_STAGE_ID=id_do_stage_deals
+
+# OPTIONAL - Property name for BANT summary on Deal (default: bant_summary)
+# HUBSPOT_DEAL_BANT_PROPERTY=bant_summary
+
+# OPTIONAL - Contact property to store unmapped tracking JSON
+# HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY=tracking_payload_json
 
 # =============================================================================
 # OPTIONAL - Deployment Configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,16 +15,19 @@ npm run dev       # Start dev server at http://localhost:3000
 npm run build     # Production build to /dist
 npm run preview   # Preview production build at http://localhost:4173
 npm run deploy    # Build + deploy to GitHub Pages
+npm run test:regression  # Run regression tests (Node built-in test runner, strip-types)
 ```
 
 ## Environment Variables
 
-Required for AI chatbot functionality:
-- `GEMINI_API_KEY` - Google Gemini API key (get at https://aistudio.google.com/apikey)
-- `GEMINI_MODEL` - Model version (default: `gemini-2.5-flash`)
-- `VITE_BASE_PATH` - Base path for deployment (default: `/`)
-- `VITE_MEDIA_CDN_URL` - Optional CDN base URL for media assets (videos/images)
-- `ALLOWED_ORIGIN` - CORS allowed origin for API (default: `*`)
+```bash
+GEMINI_API_KEY=       # Google Gemini API key (required for chatbot)
+GEMINI_MODEL=         # Model version (default: gemini-2.5-flash)
+HUBSPOT_TOKEN=        # HubSpot private app token (required for lead capture)
+VITE_BASE_PATH=       # Base path for deployment (default: /)
+VITE_MEDIA_CDN_URL=   # Optional CDN base URL for media assets
+ALLOWED_ORIGIN=       # CORS allowed origin for API (default: *)
+```
 
 Copy `.env.example` to `.env` for local development.
 
@@ -32,37 +35,65 @@ Copy `.env.example` to `.env` for local development.
 
 ### Directory Structure
 
-- `/components` - React components (Header, Footer, AIChat, SEO, etc.)
-  - `/ui` - Generic UI components (LazyImage)
-  - `/schemas` - JSON-LD schema components for SEO
-- `/pages` - Page-level route components (Home, BlogList, BlogPost, Terms, Privacy)
-- `/services` - API clients (geminiService.ts for AI chat)
-- `/api` - Vercel Edge Functions (generate.ts proxies Gemini API)
-- `/utils` - Helper functions (whatsapp.ts, share.ts)
-- `/data` - Static content data (blogData.ts, mediaConfig.ts)
-- `/public` - Static assets, sitemap.xml, robots.txt
+- `/api` - Vercel Edge Functions: `generate.ts` (AI chatbot proxy) and `submit-lead.ts` (HubSpot CRM)
+- `/components` - React components; `/ui` for generic UI, `/schemas` for JSON-LD SEO, `/landings` for event landing pages
+- `/pages` - Route-level components (Home, BlogList, BlogPost, BlogRedirect, Terms, Privacy, SiteMap)
+- `/services` - `geminiService.ts`: client-side Gemini API communication
+- `/hooks` - `useLeadCapture.ts`: lead submission hook
+- `/types` - TypeScript types (`leadCapture.ts`)
+- `/utils` - `whatsapp.ts` (UTM tracking + link generation), `share.ts`, `blog.ts`
+- `/data` - `mediaConfig.ts` (media URLs + optimization), `blogData.ts` (static blog content)
 
 ### Key Patterns
 
-**Import Alias:** Use `@/` for root-relative imports (e.g., `@/components/Header`)
+**Import Alias:** Use `@/` for root-relative imports (e.g., `@/components/Header`).
 
-**AI Integration:** The Gemini API is called via a serverless proxy at `/api/generate.ts` to protect the API key. The client-side service is in `/services/geminiService.ts`. The API includes rate limiting (10 requests/minute per IP) and CORS protection.
+**Routing:** BrowserRouter with two layout branches in `App.tsx`:
+- `/beto-carrero`, `/lollapalooza-2026`, `/orlando` → Dedicated landing pages (no Header/Footer/AIChat)
+- All other routes → MainSiteShell (Header + AIChat + Footer)
+- `/blog` and `/blog/:slug` redirect to an external blog domain via `BlogRedirect.tsx`
+- `*` → redirect to `/`
+- Pages are lazy-loaded with `React.lazy` + `Suspense`
 
-**Media Assets:** Centralized in `/data/mediaConfig.ts`. When ready to migrate to CDN, set `VITE_MEDIA_CDN_URL` and update the URLs in the config file.
+**AI Chatbot Flow:**
+1. `AIChat.tsx` collects conversation history and calls `geminiService.ts`
+2. `geminiService.ts` POSTs to `/api/generate` (proxy to Gemini) — uses localhost in dev, `/api/generate` in prod
+3. `/api/generate.ts` runs a BANT qualification dialog (Need, Authority, Budget, Timeline) via a state-machine system prompt, enforces single-question-per-response, and calls the `generate_budget_link` tool when qualification is complete
+4. The budget link response is displayed with a WhatsApp CTA; under-30-day bookings are handed off to a human agent
 
-**Routing:** React Router with hash-based smooth scrolling for same-page navigation. All unknown routes redirect to home.
+**Lead Capture Flow:**
+- On budget link generation, `useLeadCapture.ts` submits to `/api/submit-lead.ts`
+- `submit-lead.ts` creates/updates a HubSpot contact with BANT summary and UTM attribution
+- Error codes: 400 (validation), 401 (bad token), 409 (duplicate email), 500 (server)
 
-**Styling:** Tailwind CSS with custom theme colors (cyan, blue, yellow, dark, light) and fonts (Poppins, Merriweather) defined in `tailwind.config.js`.
+**UTM Tracking (`utils/whatsapp.ts`):**
+- Captures UTM params and click IDs (gclid, fbclid, ttclid, etc.) from URL on page load
+- Extracts GA4 client ID and session ID from cookies
+- Persists to `sessionStorage` + cookies (30-day expiry)
+- `useWhatsAppLink()` hook appends all tracking params to WhatsApp URLs
+- Pushes to GTM `dataLayer` on capture
 
-**SEO:** Dynamic meta tags via React Helmet Async. Schema components in `/components/schemas/` generate JSON-LD structured data.
+**Media Assets (`data/mediaConfig.ts`):**
+- Cloudinary for hero videos and destination images; Pexels as fallback
+- `optimizeRemoteImageUrl()` proxies through wsrv.nl for WebP conversion
+- `optimizeCloudinaryUrl()` applies width/format transforms
+- `generateSrcSet()` builds responsive srcsets
+- To migrate to CDN, set `VITE_MEDIA_CDN_URL`
 
-**Analytics:** Google Tag Manager (GTM-T2KGS86G) and HubSpot tracking are embedded in index.html.
+**API Security (`/api/generate.ts`):**
+- Rate limiting: 10 requests/minute per IP (in-memory)
+- Message history capped at 50 entries; message size limits enforced
+- Block list of 18+ countries/regions (war zones, sanctioned territories)
+- Prompt injection prevention in system instruction
+
+**Styling:** Tailwind CSS with brand colors (cyan, blue, yellow, dark, light) and Anhangá palette (`#0056D2`, `#003B8E`, `#FFD600`). Custom animations (`fade-in-up`, `pop-in`, `float`, `blob`) and shadows (`glow`, `hard`, `float`) defined in `tailwind.config.js`. Fonts: Poppins/Inter (sans), Merriweather (serif/blog), Fredoka/Outfit (heading).
+
+**SEO:** React Helmet Async for dynamic meta tags. Schema components in `/components/schemas/` emit JSON-LD (LocalBusiness, FAQ, Breadcrumb). GTM (GTM-T2KGS86G) and HubSpot tracking in `index.html`.
 
 ### Deployment
 
-Pre-configured for:
-- **Vercel** (primary) - `vercel.json` includes security headers and SPA rewrites
-- **Netlify** - `netlify.toml` configuration
-- **GitHub Pages** - via `npm run deploy` (requires `VITE_BASE_PATH` env var)
+- **Vercel** (primary) — `vercel.json` includes security headers, SPA rewrite, and domain redirects (`anhanga.tur.br` → `www.anhanga.tur.br`)
+- **Netlify** — `netlify.toml`
+- **GitHub Pages** — `npm run deploy` (requires `VITE_BASE_PATH`)
 
-Build output goes to `/dist` directory.
+Build chunks: `react-vendor` and `ai-vendor` (manual split in `vite.config.ts`).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ O site institucional da **Anhangá Viagens** é uma plataforma moderna e interat
 - Node.js 18+
 - Chave da API do Google Gemini
 - Token de app privado do HubSpot (para captura de leads do chatbot)
+- IDs de Pipeline e Stage de Deals no HubSpot
 
 ## 📦 Instalação
 
@@ -58,6 +59,12 @@ O site institucional da **Anhangá Viagens** é uma plataforma moderna e interat
    ```env
    GEMINI_API_KEY=sua_chave_api_aqui
    HUBSPOT_TOKEN=seu_token_do_app_privado
+   HUBSPOT_DEAL_PIPELINE_ID=id_do_pipeline_deals
+   HUBSPOT_DEAL_STAGE_ID=id_do_stage_deals
+   # Opcional (default: bant_summary)
+   HUBSPOT_DEAL_BANT_PROPERTY=bant_summary
+   # Opcional (fallback para tracking não mapeado)
+   HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY=tracking_payload_json
    ```
    > 💡 Obtenha sua chave em: [Google AI Studio](https://aistudio.google.com/apikey)
 
@@ -82,7 +89,7 @@ O projeto está pré-configurado para deploy simplificado em plataformas como Ve
 
 1. Faça o fork do repositório.
 2. Conecte sua conta do GitHub ao Vercel.
-3. Importe o repositório e configure as variáveis de ambiente `GEMINI_API_KEY` e `HUBSPOT_TOKEN` no painel do projeto.
+3. Importe o repositório e configure as variáveis de ambiente `GEMINI_API_KEY`, `HUBSPOT_TOKEN`, `HUBSPOT_DEAL_PIPELINE_ID` e `HUBSPOT_DEAL_STAGE_ID` no painel do projeto.
 4. O deploy será feito automaticamente a cada push para a branch principal.
 
 ### Netlify

--- a/api/generate.ts
+++ b/api/generate.ts
@@ -39,6 +39,7 @@ interface BudgetToolArgs {
     decision_role?: string;
     need_summary?: string;
     timeline_window?: string;
+    baggage_preference?: string;
     assumed_origin_br?: boolean;
 }
 
@@ -428,6 +429,7 @@ function validateBudgetToolArgs(rawArgs: unknown): BudgetValidationResult {
         decision_role: cleanString(raw.decision_role) || 'não informado',
         need_summary: cleanString(raw.need_summary) || 'não informado',
         timeline_window: cleanString(raw.timeline_window) || 'não informado',
+        baggage_preference: cleanString(raw.baggage_preference) || '',
         assumed_origin_br: assumedOriginBr,
     };
 
@@ -518,6 +520,7 @@ const budgetTool: FunctionDeclaration = {
             decision_role: { type: Type.STRING, description: "Papel de decisão do cliente (decisor principal, compartilha decisão, etc.)." },
             need_summary: { type: Type.STRING, description: "Resumo da necessidade principal (BANT - Need)." },
             timeline_window: { type: Type.STRING, description: "Janela de decisão/embarque (BANT - Timeline)." },
+            baggage_preference: { type: Type.STRING, description: "Preferência de tarifa de bagagem quando houver trecho aéreo (mala de mão ou bagagem despachada)." },
             assumed_origin_br: { type: Type.BOOLEAN, description: "Use true quando origem não for informada e Brasil for assumido." }
         },
         required: ["destination", "destination_city", "origin_city", "dates", "adults"]
@@ -607,6 +610,7 @@ TOOL_CALL_CONTRACT
 - Chame generate_budget_link apenas quando tiver:
   destination, destination_city (ou "a definir" após tentativa), origin_city (ou "a definir" após tentativa), dates (ou "a definir"), adults, e child_ages quando houver crianças.
 - Inclua sempre os campos: origin_city, origin_region, destination_city, destination_region, trip_scope, budget_range, decision_role, need_summary, timeline_window.
+- Quando o trajeto for provavelmente aéreo (ex.: internacional, América do Sul ou longa distância), pergunte preferência de bagagem e inclua baggage_preference quando houver.
 - Não invente qualificação. Se não tiver dado explícito, use "não informado" para decision_role, need_summary e timeline_window.
 - Evite perguntas de confirmação sobre escopo e taxonomia de orçamento; priorize a continuidade para gerar o link.
 - Quando chamar a ferramenta, escreva um texto curto de transição e sem repetir dados técnicos.

--- a/api/submit-lead.ts
+++ b/api/submit-lead.ts
@@ -1,14 +1,45 @@
-import type { LeadUtms, SubmitLeadRequest, SubmitLeadResponse } from '../types/leadCapture';
+import type { LeadTracking, LeadUtms, SubmitLeadRequest, SubmitLeadResponse } from '../types/leadCapture';
 
 export const config = {
     runtime: 'edge',
 };
 
-interface HubSpotContactResponse {
+interface HubSpotObjectResponse {
     id?: string;
 }
 
+interface HubSpotSearchResponse {
+    results?: Array<{ id?: string }>;
+}
+
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const TRACKING_PROPERTY_MAP: Record<string, string> = {
+    cid: 'ga_client_id',
+    sid: 'ga_session_id',
+    gclid: 'hs_google_click_id',
+    fbclid: 'hs_facebook_click_id',
+    msclkid: 'hs_linkedin_click_id',
+    ttclid: 'tiktok_id',
+    gbraid: 'gbraid',
+};
+
+const KNOWN_TRACKING_KEYS = new Set([
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+    'cid',
+    'sid',
+    'gclid',
+    'fbclid',
+    'msclkid',
+    'ttclid',
+    'wbraid',
+    'gbraid',
+    'fbc',
+]);
 
 function buildCorsHeaders(): Record<string, string> {
     return {
@@ -22,7 +53,7 @@ function cleanString(value: unknown): string {
     return typeof value === 'string' ? value.trim() : '';
 }
 
-function normalizeUtm(value: unknown): string | null {
+function normalizeNullable(value: unknown): string | null {
     if (typeof value !== 'string') return null;
     const trimmed = value.trim();
     return trimmed.length > 0 ? trimmed : null;
@@ -32,11 +63,53 @@ function normalizeUtms(value: unknown): LeadUtms {
     const source = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
 
     return {
-        utm_source: normalizeUtm(source.utm_source),
-        utm_medium: normalizeUtm(source.utm_medium),
-        utm_campaign: normalizeUtm(source.utm_campaign),
-        utm_term: normalizeUtm(source.utm_term),
-        utm_content: normalizeUtm(source.utm_content),
+        utm_source: normalizeNullable(source.utm_source),
+        utm_medium: normalizeNullable(source.utm_medium),
+        utm_campaign: normalizeNullable(source.utm_campaign),
+        utm_term: normalizeNullable(source.utm_term),
+        utm_content: normalizeNullable(source.utm_content),
+    };
+}
+
+function normalizeTracking(value: unknown, utms: LeadUtms): LeadTracking {
+    const source = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+    const extrasInput = source.extras && typeof source.extras === 'object'
+        ? (source.extras as Record<string, unknown>)
+        : {};
+
+    const extras: Record<string, string> = {};
+
+    for (const [key, raw] of Object.entries(extrasInput)) {
+        const normalized = normalizeNullable(raw);
+        if (normalized) {
+            extras[key] = normalized;
+        }
+    }
+
+    for (const [key, raw] of Object.entries(source)) {
+        if (key === 'extras' || KNOWN_TRACKING_KEYS.has(key)) continue;
+        const normalized = normalizeNullable(raw);
+        if (normalized) {
+            extras[key] = normalized;
+        }
+    }
+
+    return {
+        utm_source: normalizeNullable(source.utm_source) ?? utms.utm_source,
+        utm_medium: normalizeNullable(source.utm_medium) ?? utms.utm_medium,
+        utm_campaign: normalizeNullable(source.utm_campaign) ?? utms.utm_campaign,
+        utm_term: normalizeNullable(source.utm_term) ?? utms.utm_term,
+        utm_content: normalizeNullable(source.utm_content) ?? utms.utm_content,
+        cid: normalizeNullable(source.cid),
+        sid: normalizeNullable(source.sid),
+        gclid: normalizeNullable(source.gclid),
+        fbclid: normalizeNullable(source.fbclid),
+        msclkid: normalizeNullable(source.msclkid),
+        ttclid: normalizeNullable(source.ttclid),
+        wbraid: normalizeNullable(source.wbraid),
+        gbraid: normalizeNullable(source.gbraid),
+        fbc: normalizeNullable(source.fbc),
+        extras: Object.keys(extras).length > 0 ? extras : undefined,
     };
 }
 
@@ -70,6 +143,9 @@ function validatePayload(payload: unknown): { valid: true; data: SubmitLeadReque
         return { valid: false, error: 'Email inválido.' };
     }
 
+    const utms = normalizeUtms(raw.utms);
+    const tracking = normalizeTracking(raw.tracking, utms);
+
     return {
         valid: true,
         data: {
@@ -77,9 +153,244 @@ function validatePayload(payload: unknown): { valid: true; data: SubmitLeadReque
             lastName,
             email,
             bantSummary,
-            utms: normalizeUtms(raw.utms),
+            utms,
+            tracking,
         },
     };
+}
+
+function getTrackingEntries(tracking?: LeadTracking): Record<string, string> {
+    if (!tracking) return {};
+
+    const baseEntries: Record<string, string | null | undefined> = {
+        cid: tracking.cid,
+        sid: tracking.sid,
+        gclid: tracking.gclid,
+        fbclid: tracking.fbclid,
+        msclkid: tracking.msclkid,
+        ttclid: tracking.ttclid,
+        gbraid: tracking.gbraid,
+        wbraid: tracking.wbraid,
+        fbc: tracking.fbc,
+    };
+
+    const normalized: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(baseEntries)) {
+        if (!value) continue;
+        const trimmed = value.trim();
+        if (!trimmed) continue;
+        normalized[key] = trimmed;
+    }
+
+    if (tracking.extras) {
+        for (const [key, value] of Object.entries(tracking.extras)) {
+            const trimmed = value.trim();
+            if (!trimmed) continue;
+            normalized[key] = trimmed;
+        }
+    }
+
+    return normalized;
+}
+
+export function mapTrackingToContactProperties(tracking?: LeadTracking): {
+    properties: Record<string, string>;
+    unmapped: Record<string, string>;
+} {
+    const values = getTrackingEntries(tracking);
+    const properties: Record<string, string> = {};
+    const unmapped: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(values)) {
+        const mappedProperty = TRACKING_PROPERTY_MAP[key];
+        if (mappedProperty) {
+            properties[mappedProperty] = value;
+        } else {
+            unmapped[key] = value;
+        }
+    }
+
+    return { properties, unmapped };
+}
+
+function buildContactProperties(payload: SubmitLeadRequest): Record<string, string> {
+    const properties: Record<string, string> = {
+        firstname: payload.firstName,
+        lastname: payload.lastName,
+        email: payload.email,
+    };
+
+    if (payload.utms.utm_source) properties.ultimo_utm_source = payload.utms.utm_source;
+    if (payload.utms.utm_medium) properties.ultimo_utm_medium = payload.utms.utm_medium;
+    if (payload.utms.utm_campaign) properties.ultimo_utm_campaign = payload.utms.utm_campaign;
+    if (payload.utms.utm_term) properties.utm_term = payload.utms.utm_term;
+    if (payload.utms.utm_content) properties.ultimo_utm_content = payload.utms.utm_content;
+
+    const trackingMapping = mapTrackingToContactProperties(payload.tracking);
+    Object.assign(properties, trackingMapping.properties);
+
+    const fallbackProperty = cleanString(process.env.HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY);
+    if (fallbackProperty && Object.keys(trackingMapping.unmapped).length > 0) {
+        properties[fallbackProperty] = JSON.stringify(trackingMapping.unmapped);
+    }
+
+    return properties;
+}
+
+async function hubspotRequest(
+    token: string,
+    path: string,
+    init: RequestInit,
+): Promise<Response> {
+    const headers = new Headers(init.headers || {});
+    headers.set('Authorization', `Bearer ${token}`);
+    headers.set('Content-Type', 'application/json');
+
+    return fetch(`https://api.hubapi.com${path}`, {
+        ...init,
+        headers,
+    });
+}
+
+async function getContactIdByEmail(token: string, email: string): Promise<string | null> {
+    const response = await hubspotRequest(token, '/crm/v3/objects/contacts/search', {
+        method: 'POST',
+        body: JSON.stringify({
+            filterGroups: [
+                {
+                    filters: [
+                        {
+                            propertyName: 'email',
+                            operator: 'EQ',
+                            value: email,
+                        },
+                    ],
+                },
+            ],
+            properties: ['email'],
+            limit: 1,
+        }),
+    });
+
+    if (response.status === 401) {
+        throw new Error('UNAUTHORIZED');
+    }
+
+    if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        throw new Error(`CONTACT_SEARCH_FAILED:${response.status}:${detail}`);
+    }
+
+    const data = (await response.json().catch(() => ({}))) as HubSpotSearchResponse;
+    const contactId = cleanString(data.results?.[0]?.id);
+
+    return contactId || null;
+}
+
+async function updateContactProperties(token: string, contactId: string, properties: Record<string, string>): Promise<void> {
+    const response = await hubspotRequest(token, `/crm/v3/objects/contacts/${contactId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ properties }),
+    });
+
+    if (response.status === 401) {
+        throw new Error('UNAUTHORIZED');
+    }
+
+    if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        throw new Error(`CONTACT_UPDATE_FAILED:${response.status}:${detail}`);
+    }
+}
+
+async function createDeal(token: string, properties: Record<string, string>): Promise<string> {
+    const response = await hubspotRequest(token, '/crm/v3/objects/deals', {
+        method: 'POST',
+        body: JSON.stringify({ properties }),
+    });
+
+    if (response.status === 401) {
+        throw new Error('UNAUTHORIZED');
+    }
+
+    if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        throw new Error(`DEAL_CREATE_FAILED:${response.status}:${detail}`);
+    }
+
+    const data = (await response.json().catch(() => ({}))) as HubSpotObjectResponse;
+    const dealId = cleanString(data.id);
+    if (!dealId) {
+        throw new Error('DEAL_CREATE_FAILED:missing_id');
+    }
+
+    return dealId;
+}
+
+async function associateDealToContact(token: string, dealId: string, contactId: string): Promise<void> {
+    const response = await hubspotRequest(
+        token,
+        `/crm/v4/objects/deals/${dealId}/associations/default/contacts/${contactId}`,
+        {
+            method: 'PUT',
+            body: JSON.stringify({}),
+        },
+    );
+
+    if (response.status === 401) {
+        throw new Error('UNAUTHORIZED');
+    }
+
+    if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        throw new Error(`DEAL_ASSOCIATION_FAILED:${response.status}:${detail}`);
+    }
+}
+
+async function createFallbackNote(token: string, contactId: string, body: string): Promise<void> {
+    const noteResponse = await hubspotRequest(token, '/crm/v3/objects/notes', {
+        method: 'POST',
+        body: JSON.stringify({
+            properties: {
+                hs_timestamp: new Date().toISOString(),
+                hs_note_body: body,
+            },
+        }),
+    });
+
+    if (noteResponse.status === 401) {
+        throw new Error('UNAUTHORIZED');
+    }
+
+    if (!noteResponse.ok) {
+        const detail = await noteResponse.text().catch(() => '');
+        throw new Error(`NOTE_CREATE_FAILED:${noteResponse.status}:${detail}`);
+    }
+
+    const noteData = (await noteResponse.json().catch(() => ({}))) as HubSpotObjectResponse;
+    const noteId = cleanString(noteData.id);
+    if (!noteId) {
+        throw new Error('NOTE_CREATE_FAILED:missing_id');
+    }
+
+    const associationResponse = await hubspotRequest(
+        token,
+        `/crm/v4/objects/notes/${noteId}/associations/default/contacts/${contactId}`,
+        {
+            method: 'PUT',
+            body: JSON.stringify({}),
+        },
+    );
+
+    if (associationResponse.status === 401) {
+        throw new Error('UNAUTHORIZED');
+    }
+
+    if (!associationResponse.ok) {
+        const detail = await associationResponse.text().catch(() => '');
+        throw new Error(`NOTE_ASSOCIATION_FAILED:${associationResponse.status}:${detail}`);
+    }
 }
 
 export default async function handler(request: Request): Promise<Response> {
@@ -102,12 +413,28 @@ export default async function handler(request: Request): Promise<Response> {
     }
 
     const hubspotToken = process.env.HUBSPOT_TOKEN;
+    const dealPipelineId = cleanString(process.env.HUBSPOT_DEAL_PIPELINE_ID);
+    const dealStageId = cleanString(process.env.HUBSPOT_DEAL_STAGE_ID);
+    const dealBantProperty = cleanString(process.env.HUBSPOT_DEAL_BANT_PROPERTY) || 'bant_summary';
+
     if (!hubspotToken) {
         return buildErrorResponse(
             {
                 ok: false,
                 code: 'SERVER_CONFIG_ERROR',
                 error: 'Server configuration error: HUBSPOT_TOKEN missing',
+            },
+            500,
+            corsHeaders,
+        );
+    }
+
+    if (!dealPipelineId || !dealStageId) {
+        return buildErrorResponse(
+            {
+                ok: false,
+                code: 'SERVER_CONFIG_ERROR',
+                error: 'Server configuration error: HUBSPOT_DEAL_PIPELINE_ID or HUBSPOT_DEAL_STAGE_ID missing',
             },
             500,
             corsHeaders,
@@ -145,29 +472,16 @@ export default async function handler(request: Request): Promise<Response> {
         }
 
         const payload = validation.data;
-        const properties: Record<string, string> = {
-            firstname: payload.firstName,
-            lastname: payload.lastName,
-            email: payload.email,
-            bant_summary: payload.bantSummary,
-        };
+        const contactProperties = buildContactProperties(payload);
 
-        if (payload.utms.utm_source) properties.ultimo_utm_source = payload.utms.utm_source;
-        if (payload.utms.utm_medium) properties.ultimo_utm_medium = payload.utms.utm_medium;
-        if (payload.utms.utm_campaign) properties.ultimo_utm_campaign = payload.utms.utm_campaign;
-        if (payload.utms.utm_term) properties.utm_term = payload.utms.utm_term;
-        if (payload.utms.utm_content) properties.ultimo_utm_content = payload.utms.utm_content;
+        let contactId = '';
 
-        const hubspotResponse = await fetch('https://api.hubapi.com/crm/v3/objects/contacts', {
+        const createContactResponse = await hubspotRequest(hubspotToken, '/crm/v3/objects/contacts', {
             method: 'POST',
-            headers: {
-                Authorization: `Bearer ${hubspotToken}`,
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ properties }),
+            body: JSON.stringify({ properties: contactProperties }),
         });
 
-        if (hubspotResponse.status === 401) {
+        if (createContactResponse.status === 401) {
             return buildErrorResponse(
                 {
                     ok: false,
@@ -179,21 +493,51 @@ export default async function handler(request: Request): Promise<Response> {
             );
         }
 
-        if (hubspotResponse.status === 409) {
-            return buildErrorResponse(
-                {
-                    ok: false,
-                    code: 'HUBSPOT_DUPLICATE_CONTACT',
-                    error: 'Contato já existe no HubSpot.',
-                },
-                409,
-                corsHeaders,
-            );
-        }
+        if (createContactResponse.status === 409) {
+            try {
+                const existingContactId = await getContactIdByEmail(hubspotToken, payload.email);
+                if (!existingContactId) {
+                    return buildErrorResponse(
+                        {
+                            ok: false,
+                            code: 'HUBSPOT_API_ERROR',
+                            error: 'Contato duplicado, mas não foi possível localizar o registro existente.',
+                        },
+                        502,
+                        corsHeaders,
+                    );
+                }
 
-        if (!hubspotResponse.ok) {
-            const hubspotErrorText = await hubspotResponse.text().catch(() => '');
-            console.error('HUBSPOT: Error creating contact', hubspotResponse.status, hubspotErrorText);
+                contactId = existingContactId;
+                await updateContactProperties(hubspotToken, contactId, contactProperties);
+            } catch (error: unknown) {
+                const message = error instanceof Error ? error.message : 'Unknown duplicate-contact error';
+                if (message.includes('UNAUTHORIZED')) {
+                    return buildErrorResponse(
+                        {
+                            ok: false,
+                            code: 'HUBSPOT_UNAUTHORIZED',
+                            error: 'Token do HubSpot inválido ou sem permissão.',
+                        },
+                        401,
+                        corsHeaders,
+                    );
+                }
+
+                console.error('HUBSPOT: Duplicate contact recovery failed', message);
+                return buildErrorResponse(
+                    {
+                        ok: false,
+                        code: 'HUBSPOT_API_ERROR',
+                        error: 'Falha ao recuperar contato existente no HubSpot.',
+                    },
+                    502,
+                    corsHeaders,
+                );
+            }
+        } else if (!createContactResponse.ok) {
+            const hubspotErrorText = await createContactResponse.text().catch(() => '');
+            console.error('HUBSPOT: Error creating contact', createContactResponse.status, hubspotErrorText);
 
             return buildErrorResponse(
                 {
@@ -204,16 +548,68 @@ export default async function handler(request: Request): Promise<Response> {
                 502,
                 corsHeaders,
             );
+        } else {
+            const hubspotData = (await createContactResponse.json().catch(() => ({}))) as HubSpotObjectResponse;
+            contactId = cleanString(hubspotData.id) || 'unknown';
         }
 
-        const hubspotData = (await hubspotResponse.json().catch(() => ({}))) as HubSpotContactResponse;
-        const contactId = cleanString(hubspotData.id) || 'unknown';
+        const dealProperties: Record<string, string> = {
+            dealname: `Lead chatbot - ${payload.firstName} ${payload.lastName}`,
+            pipeline: dealPipelineId,
+            dealstage: dealStageId,
+            [dealBantProperty]: payload.bantSummary,
+        };
+
+        let dealId: string | undefined;
+        let warning: string | undefined;
+
+        try {
+            dealId = await createDeal(hubspotToken, dealProperties);
+            await associateDealToContact(hubspotToken, dealId, contactId);
+        } catch (dealError: unknown) {
+            const message = dealError instanceof Error ? dealError.message : 'Unknown deal error';
+
+            if (message.includes('UNAUTHORIZED')) {
+                return buildErrorResponse(
+                    {
+                        ok: false,
+                        code: 'HUBSPOT_UNAUTHORIZED',
+                        error: 'Token do HubSpot inválido ou sem permissão.',
+                    },
+                    401,
+                    corsHeaders,
+                );
+            }
+
+            console.error('HUBSPOT: Deal creation/association failed', message);
+
+            warning = 'Contato salvo, mas não foi possível criar ou associar o deal automaticamente.';
+
+            try {
+                const noteBody = [
+                    'Fallback automático do chatbot:',
+                    warning,
+                    `Lead: ${payload.firstName} ${payload.lastName} <${payload.email}>`,
+                    `BANT: ${payload.bantSummary}`,
+                ].join('\n');
+
+                await createFallbackNote(hubspotToken, contactId, noteBody);
+                warning = `${warning} Uma nota foi registrada no contato para acompanhamento manual.`;
+            } catch (noteError: unknown) {
+                const noteMessage = noteError instanceof Error ? noteError.message : 'Unknown note fallback error';
+                console.error('HUBSPOT: Note fallback failed', noteMessage);
+            }
+        }
 
         return new Response(
             JSON.stringify({
                 ok: true,
                 contactId,
-                message: 'Contato criado com sucesso no HubSpot.',
+                dealId,
+                warning,
+                message: dealId
+                    ? 'Contato e deal criados com sucesso no HubSpot.'
+                    : 'Contato criado com sucesso no HubSpot.',
             } satisfies SubmitLeadResponse),
             {
                 status: 201,

--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -225,7 +225,7 @@ const AIChat: React.FC = () => {
     });
 
     if (result.ok) {
-      return { ok: true, url: result.whatsappUrl };
+      return { ok: true, url: result.whatsappUrl, notice: result.warning };
     }
 
     if (result.code === 'HUBSPOT_DUPLICATE_CONTACT') {
@@ -261,7 +261,13 @@ const AIChat: React.FC = () => {
     }
 
     if (response.budgetLink) {
-        setLeadDraft({ bantSummary: response.budgetLink.bantSummary });
+        setLeadDraft({
+            bantSummary: response.budgetLink.bantSummary,
+            origin: response.budgetLink.origin,
+            destination: response.budgetLink.destination,
+            dates: response.budgetLink.dates,
+            baggagePreference: response.budgetLink.baggagePreference || '',
+        });
 
         setMessages(prev => [...prev, { 
             role: 'model', 

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -1,12 +1,16 @@
 import { useEffect, useState } from 'react';
-import { getWhatsAppLink } from '../utils/whatsapp';
-import type { LeadUtms, SubmitLeadRequest, SubmitLeadResponse } from '../types/leadCapture';
+import { getTrackingDataObject, getWhatsAppLink } from '../utils/whatsapp';
+import type { LeadTracking, LeadUtms, SubmitLeadRequest, SubmitLeadResponse } from '../types/leadCapture';
 
 interface LeadDraft {
     firstName: string;
     lastName: string;
     email: string;
     bantSummary: string;
+    origin: string;
+    destination: string;
+    dates: string;
+    baggagePreference: string;
 }
 
 type LeadDraftPartial = Partial<LeadDraft>;
@@ -16,6 +20,8 @@ type SubmitLeadHookResult =
         ok: true;
         whatsappUrl: string;
         contactId: string;
+        dealId?: string;
+        warning?: string;
     }
     | {
         ok: false;
@@ -37,65 +43,102 @@ const EMPTY_LEAD_DRAFT: LeadDraft = {
     lastName: '',
     email: '',
     bantSummary: '',
+    origin: '',
+    destination: '',
+    dates: '',
+    baggagePreference: '',
 };
 
 function cleanValue(value: string): string {
     return value.trim();
 }
 
-function getQueryFromLocation(): URLSearchParams {
-    if (typeof window === 'undefined') return new URLSearchParams();
-
-    let search = window.location.search;
-
-    if (!search && window.location.hash.includes('?')) {
-        const [, hashQuery = ''] = window.location.hash.split('?');
-        if (hashQuery) {
-            search = `?${hashQuery}`;
-        }
-    }
-
-    if (!search && window.location.href.includes('?')) {
-        try {
-            search = new URL(window.location.href).search;
-        } catch {
-            search = '';
-        }
-    }
-
-    return new URLSearchParams(search);
+function toNullable(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
 }
 
-function getNullableParam(params: URLSearchParams, key: keyof LeadUtms): string | null {
-    const value = params.get(key);
-    if (!value) return null;
-
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : null;
+function extractUtms(tracking: LeadTracking): LeadUtms {
+    return {
+        utm_source: tracking.utm_source ?? null,
+        utm_medium: tracking.utm_medium ?? null,
+        utm_campaign: tracking.utm_campaign ?? null,
+        utm_term: tracking.utm_term ?? null,
+        utm_content: tracking.utm_content ?? null,
+    };
 }
 
-function captureInitialUtms(): LeadUtms {
-    const params = getQueryFromLocation();
+function captureInitialTracking(): LeadTracking {
+    const source = getTrackingDataObject() || {};
+
+    const knownKeys = new Set([
+        'utm_source',
+        'utm_medium',
+        'utm_campaign',
+        'utm_term',
+        'utm_content',
+        'cid',
+        'sid',
+        'gclid',
+        'fbclid',
+        'msclkid',
+        'ttclid',
+        'wbraid',
+        'gbraid',
+        'fbc',
+    ]);
+
+    const extras: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(source)) {
+        if (knownKeys.has(key)) continue;
+        if (typeof value !== 'string') continue;
+
+        const normalized = value.trim();
+        if (!normalized) continue;
+
+        extras[key] = normalized;
+    }
 
     return {
-        utm_source: getNullableParam(params, 'utm_source'),
-        utm_medium: getNullableParam(params, 'utm_medium'),
-        utm_campaign: getNullableParam(params, 'utm_campaign'),
-        utm_term: getNullableParam(params, 'utm_term'),
-        utm_content: getNullableParam(params, 'utm_content'),
+        utm_source: toNullable(source.utm_source),
+        utm_medium: toNullable(source.utm_medium),
+        utm_campaign: toNullable(source.utm_campaign),
+        utm_term: toNullable(source.utm_term),
+        utm_content: toNullable(source.utm_content),
+        cid: toNullable(source.cid),
+        sid: toNullable(source.sid),
+        gclid: toNullable(source.gclid),
+        fbclid: toNullable(source.fbclid),
+        msclkid: toNullable(source.msclkid),
+        ttclid: toNullable(source.ttclid),
+        wbraid: toNullable(source.wbraid),
+        gbraid: toNullable(source.gbraid),
+        fbc: toNullable(source.fbc),
+        extras: Object.keys(extras).length > 0 ? extras : undefined,
     };
 }
 
 function buildWhatsAppMessage(lead: LeadDraft): string {
-    return [
-        'Olá! Finalizei minha qualificação pelo chatbot da Anhangá.',
+    const origin = cleanValue(lead.origin) || 'A definir';
+    const destination = cleanValue(lead.destination) || 'A definir';
+    const dates = cleanValue(lead.dates) || 'A definir';
+    const baggagePreference = cleanValue(lead.baggagePreference);
+
+    const lines = [
+        'Olá! Vim pelo chatbot da Anhangá e gostaria de continuar meu atendimento.',
         '',
-        `👤 Nome: ${lead.firstName} ${lead.lastName}`.trim(),
-        `📧 E-mail: ${lead.email}`,
-        `🎯 Resumo BANT: ${lead.bantSummary}`,
-        '',
-        'Gostaria de continuar meu atendimento com a equipe.',
-    ].join('\n');
+        `🛫 Origem: ${origin}`,
+        `📍 Destino: ${destination}`,
+        `📅 Datas: ${dates}`,
+    ];
+
+    if (baggagePreference) {
+        lines.push(`🧳 Bagagem: ${baggagePreference}`);
+    }
+
+    return lines.join('\n');
 }
 
 function resolveSubmitLeadEndpoint(): string {
@@ -107,13 +150,16 @@ function resolveSubmitLeadEndpoint(): string {
 }
 
 export function useLeadCapture() {
-    const [utms, setUtms] = useState<LeadUtms>(() => captureInitialUtms());
+    const [tracking, setTracking] = useState<LeadTracking>(() => captureInitialTracking());
+    const [utms, setUtms] = useState<LeadUtms>(() => extractUtms(captureInitialTracking()));
     const [leadDraft, setLeadDraftState] = useState<LeadDraft>(EMPTY_LEAD_DRAFT);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
-        setUtms(captureInitialUtms());
+        const captured = captureInitialTracking();
+        setTracking(captured);
+        setUtms(extractUtms(captured));
     }, []);
 
     const setLeadDraft = (partial: LeadDraftPartial): void => {
@@ -132,6 +178,11 @@ export function useLeadCapture() {
         setError(null);
         setIsSubmitting(true);
 
+        const latestTracking = captureInitialTracking();
+        const latestUtms = extractUtms(latestTracking);
+        setTracking(latestTracking);
+        setUtms(latestUtms);
+
         const merged: LeadDraft = {
             ...leadDraft,
             ...overrides,
@@ -142,7 +193,11 @@ export function useLeadCapture() {
             lastName: cleanValue(merged.lastName),
             email: cleanValue(merged.email).toLowerCase(),
             bantSummary: cleanValue(merged.bantSummary),
-            utms: { ...utms } || EMPTY_UTMS,
+            utms: { ...latestUtms } || EMPTY_UTMS,
+            tracking: {
+                ...latestTracking,
+                ...latestUtms,
+            },
         };
 
         if (!payload.firstName || !payload.lastName || !payload.email || !payload.bantSummary) {
@@ -188,13 +243,17 @@ export function useLeadCapture() {
             }
 
             const contactId = typeof responseData.contactId === 'string' ? responseData.contactId : 'unknown';
-            const whatsappUrl = getWhatsAppLink(buildWhatsAppMessage(payload));
+            const dealId = typeof responseData.dealId === 'string' ? responseData.dealId : undefined;
+            const warning = typeof responseData.warning === 'string' ? responseData.warning : undefined;
+            const whatsappUrl = getWhatsAppLink(buildWhatsAppMessage(merged), { appendTrackingRef: false });
 
             setIsSubmitting(false);
 
             return {
                 ok: true,
                 contactId,
+                dealId,
+                warning,
                 whatsappUrl,
             };
         } catch (requestError: unknown) {
@@ -215,6 +274,7 @@ export function useLeadCapture() {
 
     return {
         utms,
+        tracking,
         leadDraft,
         isSubmitting,
         error,

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,4 +1,4 @@
-import { getWhatsAppLink } from "../utils/whatsapp";
+import { getWhatsAppLink } from "../utils/whatsapp.ts";
 
 interface BudgetFunctionArgs {
   destination?: string;
@@ -15,15 +15,16 @@ interface BudgetFunctionArgs {
   decision_role?: string;
   need_summary?: string;
   timeline_window?: string;
+  baggage_preference?: string;
 }
 
 interface ChatResponse {
   text?: string;
   budgetLink?: {
+    origin: string;
     destination: string;
     dates: string;
-    travelers: string;
-    interests: string;
+    baggagePreference?: string;
     url: string;
     bantSummary: string;
   };
@@ -40,25 +41,21 @@ const formatLocation = (city?: string, region?: string, fallback = 'A definir'):
   return `${cityText}, ${regionText}`;
 };
 
-const mapTripScopeLabel = (scope?: string): string => {
-  if (scope === 'national') return 'Nacional';
-  if (scope === 'south_america') return 'América do Sul';
-  if (scope === 'international') return 'Internacional';
-  return 'A definir';
+const cleanOptional = (value?: string): string => {
+  if (typeof value !== 'string') return '';
+  return value.trim();
 };
 
 export const getTravelAdvice = async (history: { role: 'user' | 'model', text: string }[]): Promise<ChatResponse> => {
   try {
-    // Converter histórico simples para o formato da API
     const contents = history.map(msg => ({
       role: msg.role,
       parts: [{ text: msg.text }]
     }));
 
-    // Detectar ambiente e configurar endpoint
     const isDev = typeof window !== 'undefined' && window.location.hostname === 'localhost';
-    const apiEndpoint = isDev 
-      ? 'http://localhost:3000/api/generate' 
+    const apiEndpoint = isDev
+      ? 'http://localhost:3000/api/generate'
       : '/api/generate';
 
     console.log('[GeminiService] Using endpoint:', apiEndpoint);
@@ -74,7 +71,6 @@ export const getTravelAdvice = async (history: { role: 'user' | 'model', text: s
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
 
-      // Handle rate limiting specifically
       if (response.status === 429) {
         const retryAfter = errorData.retryAfter || 60;
         return {
@@ -82,7 +78,6 @@ export const getTravelAdvice = async (history: { role: 'user' | 'model', text: s
         };
       }
 
-      // Handle specific error types
       if (response.status === 500) {
         console.error('[GeminiService] Server error:', errorData);
         throw new Error('Erro interno do servidor');
@@ -102,25 +97,12 @@ export const getTravelAdvice = async (history: { role: 'user' | 'model', text: s
     const data = await response.json();
     const result: ChatResponse = {};
 
-    // 1. Texto da resposta
     if (data.text) {
       result.text = data.text;
     }
 
-    // 2. Function Call (Orçamento)
     if (data.functionCall && data.functionCall.name === 'generate_budget_link') {
       const args: BudgetFunctionArgs = data.functionCall.args || {};
-
-      // Formatar texto de viajantes
-      const adultsCount = Number.isInteger(args.adults) && (args.adults as number) > 0 ? (args.adults as number) : 2;
-      const childAges = Array.isArray(args.child_ages) ? args.child_ages : [];
-
-      let travelersText = `${adultsCount} Adulto${adultsCount !== 1 ? 's' : ''}`;
-
-      if (childAges.length > 0) {
-        const agesString = childAges.map((age: number) => `${age} anos`).join(', ');
-        travelersText += `, ${childAges.length} Criança${childAges.length !== 1 ? 's' : ''} (${agesString})`;
-      }
 
       const originText = formatLocation(args.origin_city, args.origin_region, 'Origem a definir');
       const destinationText = formatLocation(
@@ -128,26 +110,36 @@ export const getTravelAdvice = async (history: { role: 'user' | 'model', text: s
         args.destination_region,
         args.destination || 'Destino a definir'
       );
-      const scopeText = mapTripScopeLabel(args.trip_scope);
+
       const budgetText = args.budget_range?.trim() || 'A definir';
       const needText = args.need_summary?.trim() || 'Não informado';
       const decisionRoleText = args.decision_role?.trim() || 'Não informado';
       const timelineText = args.timeline_window?.trim() || 'Não informado';
       const bantSummary = `Need: ${needText} | Authority: ${decisionRoleText} | Budget: ${budgetText} | Timeline: ${timelineText}`;
 
-      // Construir link do WhatsApp
-      const text = `Olá! Vim pelo Chatbot da Anhangá. Gostaria de um orçamento:\n\n🛫 Origem: ${originText}\n📍 Destino: ${destinationText}\n🌎 Escopo: ${scopeText}\n📅 Data: ${args.dates || 'A definir'}\n👥 Viajantes: ${travelersText}\n💰 Faixa de investimento: ${budgetText}\n✨ Interesses: ${args.interests || 'Geral'}\n🎯 Necessidade principal: ${needText}\n👤 Decisor(a): ${decisionRoleText}\n⏱️ Janela de decisão: ${timelineText}`;
+      const baggagePreference = cleanOptional(args.baggage_preference);
+
+      const messageLines = [
+        'Olá! Vim pelo Chatbot da Anhangá. Gostaria de continuar meu atendimento:',
+        '',
+        `🛫 Origem: ${originText}`,
+        `📍 Destino: ${destinationText}`,
+        `📅 Datas: ${args.dates || 'A definir'}`,
+      ];
+
+      if (baggagePreference) {
+        messageLines.push(`🧳 Bagagem: ${baggagePreference}`);
+      }
 
       result.budgetLink = {
+        origin: originText,
         destination: destinationText,
         dates: args.dates || 'A definir',
-        travelers: travelersText,
-        interests: args.interests || '',
-        url: getWhatsAppLink(text),
-        bantSummary
+        baggagePreference: baggagePreference || undefined,
+        url: getWhatsAppLink(messageLines.join('\n'), { appendTrackingRef: false }),
+        bantSummary,
       };
 
-      // Fallback: se não veio texto, adicionar um padrão
       if (!result.text) {
         result.text = "Prontinho! ✨ Preparei seu link direto para falar com nossos especialistas. É só clicar abaixo 👇";
       }
@@ -158,14 +150,13 @@ export const getTravelAdvice = async (history: { role: 'user' | 'model', text: s
   } catch (error: any) {
     console.error("[GeminiService] Erro ao consultar Gemini:", error);
 
-    // Mensagens de erro amigáveis baseadas no tipo de erro
     if (error?.message?.includes('API key missing') || error?.message?.includes('invalid')) {
       return { text: "⚠️ Erro de configuração no servidor. A chave da API não foi encontrada ou é inválida." };
     }
 
     if (error?.message?.includes('Failed to fetch') || error?.name === 'TypeError') {
-      return { 
-        text: "🔌 Não foi possível conectar ao servidor. Verifique sua conexão com a internet ou tente novamente em alguns instantes." 
+      return {
+        text: "🔌 Não foi possível conectar ao servidor. Verifique sua conexão com a internet ou tente novamente em alguns instantes."
       };
     }
 

--- a/tests/chatbot-regressions.test.ts
+++ b/tests/chatbot-regressions.test.ts
@@ -57,3 +57,10 @@ test('system prompt should include friendly under-30-days handoff message', () =
         /consultor no WhatsApp para verificar pacotes para outras datas\?/,
     );
 });
+
+test('system prompt should mention baggage preference for likely air routes', () => {
+    assert.match(
+        SYSTEM_INSTRUCTION,
+        /baggage_preference/,
+    );
+});

--- a/tests/gemini-whatsapp.test.ts
+++ b/tests/gemini-whatsapp.test.ts
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getTravelAdvice } from '../services/geminiService.ts';
+
+const originalFetch = global.fetch;
+
+test('chatbot whatsapp message should omit BANT and tracking suffix', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+    });
+
+    global.fetch = async () => new Response(
+        JSON.stringify({
+            functionCall: {
+                name: 'generate_budget_link',
+                args: {
+                    origin_city: 'Porto Alegre',
+                    origin_region: 'RS',
+                    destination_city: 'Rio de Janeiro',
+                    destination_region: 'RJ',
+                    dates: 'próximo mês',
+                    baggage_preference: 'Mala de mão',
+                    need_summary: 'Viagem de lazer',
+                    decision_role: 'não informado',
+                    budget_range: 'até R$ 10 mil',
+                    timeline_window: 'próximo mês',
+                },
+            },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+
+    const response = await getTravelAdvice([{ role: 'user', text: 'teste' }]);
+
+    assert.ok(response.budgetLink, 'budgetLink should be present');
+
+    const link = new URL(response.budgetLink!.url);
+    const text = decodeURIComponent(link.searchParams.get('text') || '');
+
+    assert.match(text, /Origem: Porto Alegre, RS/);
+    assert.match(text, /Destino: Rio de Janeiro, RJ/);
+    assert.match(text, /Datas: próximo mês/);
+    assert.match(text, /Bagagem: Mala de mão/);
+
+    assert.doesNotMatch(text, /Need:/);
+    assert.doesNotMatch(text, /\|\| Dados:/);
+});
+
+test('chatbot whatsapp message should omit baggage line when unavailable', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+    });
+
+    global.fetch = async () => new Response(
+        JSON.stringify({
+            functionCall: {
+                name: 'generate_budget_link',
+                args: {
+                    origin_city: 'São Paulo',
+                    origin_region: 'SP',
+                    destination_city: 'Salvador',
+                    destination_region: 'BA',
+                    dates: 'setembro',
+                    need_summary: 'Viagem de lazer',
+                    decision_role: 'não informado',
+                    budget_range: 'R$ 10-20 mil',
+                    timeline_window: 'setembro',
+                },
+            },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+
+    const response = await getTravelAdvice([{ role: 'user', text: 'teste' }]);
+
+    assert.ok(response.budgetLink, 'budgetLink should be present');
+
+    const link = new URL(response.budgetLink!.url);
+    const text = decodeURIComponent(link.searchParams.get('text') || '');
+
+    assert.match(text, /Origem: São Paulo, SP/);
+    assert.match(text, /Destino: Salvador, BA/);
+    assert.match(text, /Datas: setembro/);
+    assert.doesNotMatch(text, /Bagagem:/);
+    assert.doesNotMatch(text, /\|\| Dados:/);
+});

--- a/tests/submit-lead.test.ts
+++ b/tests/submit-lead.test.ts
@@ -1,0 +1,244 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler, { mapTrackingToContactProperties } from '../api/submit-lead.ts';
+
+const originalFetch = global.fetch;
+const originalEnv = {
+    HUBSPOT_TOKEN: process.env.HUBSPOT_TOKEN,
+    HUBSPOT_DEAL_PIPELINE_ID: process.env.HUBSPOT_DEAL_PIPELINE_ID,
+    HUBSPOT_DEAL_STAGE_ID: process.env.HUBSPOT_DEAL_STAGE_ID,
+    HUBSPOT_DEAL_BANT_PROPERTY: process.env.HUBSPOT_DEAL_BANT_PROPERTY,
+    HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY: process.env.HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY,
+};
+
+function restoreEnv() {
+    process.env.HUBSPOT_TOKEN = originalEnv.HUBSPOT_TOKEN;
+    process.env.HUBSPOT_DEAL_PIPELINE_ID = originalEnv.HUBSPOT_DEAL_PIPELINE_ID;
+    process.env.HUBSPOT_DEAL_STAGE_ID = originalEnv.HUBSPOT_DEAL_STAGE_ID;
+    process.env.HUBSPOT_DEAL_BANT_PROPERTY = originalEnv.HUBSPOT_DEAL_BANT_PROPERTY;
+    process.env.HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY = originalEnv.HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY;
+}
+
+function buildRequest(body: Record<string, unknown>): Request {
+    return new Request('http://localhost/api/submit-lead', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+function getUrl(input: RequestInfo | URL): string {
+    if (typeof input === 'string') return input;
+    if (input instanceof URL) return input.toString();
+    return input.url;
+}
+
+test('mapTrackingToContactProperties should map msclkid to hs_linkedin_click_id', () => {
+    const mapped = mapTrackingToContactProperties({
+        utm_source: null,
+        utm_medium: null,
+        utm_campaign: null,
+        utm_term: null,
+        utm_content: null,
+        cid: 'ga.123',
+        msclkid: 'ms-abc',
+        gclid: 'g-xyz',
+    });
+
+    assert.equal(mapped.properties.ga_client_id, 'ga.123');
+    assert.equal(mapped.properties.hs_linkedin_click_id, 'ms-abc');
+    assert.equal(mapped.properties.hs_google_click_id, 'g-xyz');
+});
+
+test('submit-lead should create contact and deal on first attempt', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    process.env.HUBSPOT_TOKEN = 'test-token';
+    process.env.HUBSPOT_DEAL_PIPELINE_ID = 'pipeline-1';
+    process.env.HUBSPOT_DEAL_STAGE_ID = 'stage-1';
+    process.env.HUBSPOT_DEAL_BANT_PROPERTY = 'bant_summary';
+
+    const calls: Array<{ url: string; method: string; body: any }> = [];
+
+    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = getUrl(input);
+        const method = init?.method || 'GET';
+        const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+        calls.push({ url, method, body });
+
+        if (url.endsWith('/crm/v3/objects/contacts') && method === 'POST') {
+            return new Response(JSON.stringify({ id: 'contact-1' }), { status: 201 });
+        }
+
+        if (url.endsWith('/crm/v3/objects/deals') && method === 'POST') {
+            return new Response(JSON.stringify({ id: 'deal-1' }), { status: 201 });
+        }
+
+        if (url.endsWith('/crm/v4/objects/deals/deal-1/associations/default/contacts/contact-1') && method === 'PUT') {
+            return new Response(null, { status: 204 });
+        }
+
+        throw new Error(`Unexpected request: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const response = await handler(buildRequest({
+        firstName: 'Felipe',
+        lastName: 'William',
+        email: 'felipe@example.com',
+        bantSummary: 'Need: Praia | Authority: casal | Budget: 20k | Timeline: setembro',
+        utms: {
+            utm_source: 'google',
+            utm_medium: 'cpc',
+            utm_campaign: 'rio',
+            utm_term: 'rio viagem',
+            utm_content: 'ad-1',
+        },
+        tracking: {
+            cid: 'cid-1',
+            sid: 'sid-1',
+            gclid: 'gclid-1',
+            fbclid: 'fbclid-1',
+            msclkid: 'msclkid-1',
+            ttclid: 'ttclid-1',
+            gbraid: 'gbraid-1',
+        },
+    }));
+
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.contactId, 'contact-1');
+    assert.equal(payload.dealId, 'deal-1');
+
+    const contactRequest = calls.find((call) => call.url.endsWith('/crm/v3/objects/contacts'));
+    assert.ok(contactRequest, 'contact creation request should exist');
+
+    const contactProps = contactRequest!.body?.properties || {};
+    assert.equal(contactProps.ga_client_id, 'cid-1');
+    assert.equal(contactProps.ga_session_id, 'sid-1');
+    assert.equal(contactProps.hs_google_click_id, 'gclid-1');
+    assert.equal(contactProps.hs_facebook_click_id, 'fbclid-1');
+    assert.equal(contactProps.hs_linkedin_click_id, 'msclkid-1');
+});
+
+test('submit-lead should recover on duplicate contact and still create deal', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    process.env.HUBSPOT_TOKEN = 'test-token';
+    process.env.HUBSPOT_DEAL_PIPELINE_ID = 'pipeline-1';
+    process.env.HUBSPOT_DEAL_STAGE_ID = 'stage-1';
+
+    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = getUrl(input);
+        const method = init?.method || 'GET';
+
+        if (url.endsWith('/crm/v3/objects/contacts') && method === 'POST') {
+            return new Response(JSON.stringify({ status: 'error' }), { status: 409 });
+        }
+
+        if (url.endsWith('/crm/v3/objects/contacts/search') && method === 'POST') {
+            return new Response(JSON.stringify({ results: [{ id: 'contact-existing' }] }), { status: 200 });
+        }
+
+        if (url.endsWith('/crm/v3/objects/contacts/contact-existing') && method === 'PATCH') {
+            return new Response(JSON.stringify({ id: 'contact-existing' }), { status: 200 });
+        }
+
+        if (url.endsWith('/crm/v3/objects/deals') && method === 'POST') {
+            return new Response(JSON.stringify({ id: 'deal-2' }), { status: 201 });
+        }
+
+        if (url.endsWith('/crm/v4/objects/deals/deal-2/associations/default/contacts/contact-existing') && method === 'PUT') {
+            return new Response(null, { status: 204 });
+        }
+
+        throw new Error(`Unexpected request: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const response = await handler(buildRequest({
+        firstName: 'Felipe',
+        lastName: 'William',
+        email: 'felipe@example.com',
+        bantSummary: 'Need: Praia | Authority: casal | Budget: 20k | Timeline: setembro',
+        utms: {},
+        tracking: {
+            cid: 'cid-2',
+            utm_source: null,
+            utm_medium: null,
+            utm_campaign: null,
+            utm_term: null,
+            utm_content: null,
+        },
+    }));
+
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.contactId, 'contact-existing');
+    assert.equal(payload.dealId, 'deal-2');
+});
+
+test('submit-lead should create fallback note and return warning when deal fails', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    process.env.HUBSPOT_TOKEN = 'test-token';
+    process.env.HUBSPOT_DEAL_PIPELINE_ID = 'pipeline-1';
+    process.env.HUBSPOT_DEAL_STAGE_ID = 'stage-1';
+
+    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = getUrl(input);
+        const method = init?.method || 'GET';
+
+        if (url.endsWith('/crm/v3/objects/contacts') && method === 'POST') {
+            return new Response(JSON.stringify({ id: 'contact-3' }), { status: 201 });
+        }
+
+        if (url.endsWith('/crm/v3/objects/deals') && method === 'POST') {
+            return new Response(JSON.stringify({ status: 'error' }), { status: 500 });
+        }
+
+        if (url.endsWith('/crm/v3/objects/notes') && method === 'POST') {
+            return new Response(JSON.stringify({ id: 'note-1' }), { status: 201 });
+        }
+
+        if (url.endsWith('/crm/v4/objects/notes/note-1/associations/default/contacts/contact-3') && method === 'PUT') {
+            return new Response(null, { status: 204 });
+        }
+
+        throw new Error(`Unexpected request: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const response = await handler(buildRequest({
+        firstName: 'Felipe',
+        lastName: 'William',
+        email: 'felipe@example.com',
+        bantSummary: 'Need: Praia | Authority: casal | Budget: 20k | Timeline: setembro',
+        utms: {},
+        tracking: {
+            utm_source: null,
+            utm_medium: null,
+            utm_campaign: null,
+            utm_term: null,
+            utm_content: null,
+        },
+    }));
+
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.contactId, 'contact-3');
+    assert.equal(payload.dealId, undefined);
+    assert.match(payload.warning, /nota foi registrada/i);
+});

--- a/types/leadCapture.ts
+++ b/types/leadCapture.ts
@@ -6,17 +6,38 @@ export interface LeadUtms {
     utm_content: string | null;
 }
 
+export interface LeadTracking {
+    utm_source: string | null;
+    utm_medium: string | null;
+    utm_campaign: string | null;
+    utm_term: string | null;
+    utm_content: string | null;
+    cid?: string | null;
+    sid?: string | null;
+    gclid?: string | null;
+    fbclid?: string | null;
+    msclkid?: string | null;
+    ttclid?: string | null;
+    wbraid?: string | null;
+    gbraid?: string | null;
+    fbc?: string | null;
+    extras?: Record<string, string>;
+}
+
 export interface SubmitLeadRequest {
     firstName: string;
     lastName: string;
     email: string;
     utms: LeadUtms;
+    tracking?: LeadTracking;
     bantSummary: string;
 }
 
 export interface SubmitLeadSuccess {
     ok: true;
     contactId: string;
+    dealId?: string;
+    warning?: string;
     message: string;
 }
 

--- a/utils/whatsapp.ts
+++ b/utils/whatsapp.ts
@@ -1,10 +1,10 @@
 /**
  * WhatsApp Tracking Utility - React Version
- * Captures UTMs, Click IDs (gclid, fbclid, ttclid, wbraid, gbraid), 
+ * Captures UTMs, Click IDs (gclid, fbclid, ttclid, wbraid, gbraid),
  * Microsoft Ads (hsa_*) params, GA4 Client ID and Session ID
- * 
- * IMPORTANT: This module captures UTM params immediately on load and stores them
- * in memory + cookie to ensure they are available even after URL changes.
+ *
+ * IMPORTANT: This module captures tracking params immediately on load and stores them
+ * in memory + sessionStorage + cookie to ensure data is available after URL changes.
  */
 
 import { useState, useEffect } from 'react';
@@ -13,7 +13,7 @@ const TRACKING_PARAMS = [
     'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term',
     'gclid', 'fbclid', 'ttclid', 'wbraid', 'gbraid', 'msclkid'
 ];
-// Microsoft Ads (hsa_) parameters are captured dynamically - no need to list all
+// Microsoft Ads (hsa_*) parameters are captured dynamically
 const HSA_PREFIX = 'hsa_';
 const COOKIE_NAME = 'tracking_data';
 const STORAGE_KEY = 'anhanga_tracking_data';
@@ -21,61 +21,54 @@ const WHATSAPP_NUMBER = '551152833309';
 // Cookie name for GA4 session (dynamic based on measurement ID suffix)
 const GA4_SESSION_COOKIE = '_ga_QDBT5PM4KP';
 
-// In-memory cache for captured tracking data (persists across renders)
+export interface WhatsAppLinkOptions {
+    appendTrackingRef?: boolean;
+}
+
+export type TrackingData = Record<string, string>;
+
 let cachedTrackingData: string | null = null;
+let cachedTrackingObject: TrackingData | null = null;
 let hasInitialized = false;
 
-// Helper to set cookie
 const setCookie = (name: string, value: string, days: number) => {
     if (typeof document === 'undefined') return;
     const date = new Date();
     date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-    const expires = "expires=" + date.toUTCString();
-    document.cookie = name + "=" + encodeURIComponent(value) + ";" + expires + ";path=/";
+    const expires = `expires=${date.toUTCString()}`;
+    document.cookie = `${name}=${encodeURIComponent(value)};${expires};path=/`;
 };
 
-// Helper to get cookie
 const getCookie = (name: string): string | null => {
     if (typeof document === 'undefined') return null;
-    const nameEQ = name + "=";
-    const ca = document.cookie.split(';');
-    for (let i = 0; i < ca.length; i++) {
-        let c = ca[i];
-        while (c.charAt(0) === ' ') c = c.substring(1, c.length);
-        if (c.indexOf(nameEQ) === 0) return decodeURIComponent(c.substring(nameEQ.length, c.length));
+    const nameEQ = `${name}=`;
+    const chunks = document.cookie.split(';');
+
+    for (const chunk of chunks) {
+        const trimmed = chunk.trim();
+        if (trimmed.startsWith(nameEQ)) {
+            return decodeURIComponent(trimmed.slice(nameEQ.length));
+        }
     }
+
     return null;
 };
 
-/**
- * Gets the GA4 Client ID from the _ga cookie
- */
 const getGA4ClientId = (): string | null => {
     if (typeof document === 'undefined') return null;
     const match = document.cookie.match(/_ga=GA1\.\d+\.(\d+\.\d+)/);
     return match ? match[1] : null;
 };
 
-/**
- * Gets the GA4 Session ID from the _ga_QDBT5PM4KP cookie
- * Cookie format: "GS1.1.SESSION_ID.COUNT.ENGAGEMENT.TIMESTAMP.0.0.0"
- * The session_id is the third segment (index 2) after splitting by "."
- */
 const getGA4SessionId = (): string | null => {
     if (typeof document === 'undefined') return null;
 
     const cookieValue = getCookie(GA4_SESSION_COOKIE);
     if (!cookieValue) return null;
 
-    // Split the cookie value by "."
-    // Format: GS1.1.1700000000.1.1.1700000000.0.0.0
     const parts = cookieValue.split('.');
-
-    // The session ID is typically at index 2 (third segment)
-    // Validate that it looks like a timestamp (10+ digits)
     if (parts.length >= 3) {
         const sessionId = parts[2];
-        // Verify it's a valid timestamp-like number (10 digits for Unix timestamp)
         if (/^\d{10,}$/.test(sessionId)) {
             return sessionId;
         }
@@ -84,225 +77,227 @@ const getGA4SessionId = (): string | null => {
     return null;
 };
 
-/**
- * Captures tracking data from URL and stores in memory/cookie.
- * This function runs immediately and stores the result for later use.
- */
-const captureTrackingData = (): string | null => {
-    if (typeof window === 'undefined') return null;
+function parseTrackingDataString(dataString: string): TrackingData {
+    const parsed: TrackingData = {};
 
-    const trackingData: Record<string, string> = {};
-    let foundInUrl = false;
+    dataString
+        .split(',')
+        .map((segment) => segment.trim())
+        .filter(Boolean)
+        .forEach((entry) => {
+            const separatorIndex = entry.indexOf('=');
+            if (separatorIndex <= 0) return;
 
-    // Get the full URL including hash for HashRouter support
+            const key = entry.slice(0, separatorIndex).trim();
+            const value = entry.slice(separatorIndex + 1).trim();
+            if (!key || !value) return;
+
+            parsed[key] = value;
+        });
+
+    return parsed;
+}
+
+function serializeTrackingData(data: TrackingData): string {
+    return Object.entries(data)
+        .filter(([key, value]) => Boolean(key) && Boolean(value))
+        .map(([key, value]) => `${key}=${value}`)
+        .join(', ');
+}
+
+function getSearchStringFromLocation(): string {
+    if (typeof window === 'undefined') return '';
+
     let searchString = window.location.search;
 
-    // If using HashRouter, params might be after the hash
-    // Example: /#/?utm_source=... or /?utm_source=...#/
     if (!searchString && window.location.hash.includes('?')) {
         const hashParts = window.location.hash.split('?');
         if (hashParts[1]) {
-            searchString = '?' + hashParts[1];
+            searchString = `?${hashParts[1]}`;
         }
     }
 
-    // Also check if params are before the hash (normal case)
     if (!searchString && window.location.href.includes('?')) {
-        const url = new URL(window.location.href);
-        searchString = url.search;
+        try {
+            searchString = new URL(window.location.href).search;
+        } catch {
+            searchString = '';
+        }
     }
 
+    return searchString;
+}
+
+const captureTrackingDataObject = (): TrackingData | null => {
+    if (typeof window === 'undefined') return null;
+
+    const trackingData: TrackingData = {};
+    let foundInUrl = false;
+
+    const searchString = getSearchStringFromLocation();
     const urlParams = new URLSearchParams(searchString);
 
-    // 0. Try to load from SessionStorage first for internal consistency
     try {
         const stored = sessionStorage.getItem(STORAGE_KEY);
         if (stored) {
-            const parsed = JSON.parse(stored);
+            const parsed = JSON.parse(stored) as TrackingData;
             Object.assign(trackingData, parsed);
         }
-    } catch (e) {
-        // Fallback silently if sessionStorage is blocked
+    } catch {
+        // Ignore storage failures
     }
 
-    // 1. Try URL parameters first
-    const msclkid = urlParams.get("msclkid"); if (msclkid) { trackingData["msclkid"] = msclkid; foundInUrl = true; }
-    TRACKING_PARAMS.forEach(param => {
+    TRACKING_PARAMS.forEach((param) => {
         const value = urlParams.get(param);
-        if (value) {
-            // Decode URI component to handle %20 and other encoded chars
-            try {
-                trackingData[param] = decodeURIComponent(value);
-            } catch {
-                trackingData[param] = value;
-            }
-            foundInUrl = true;
+        if (!value) return;
+
+        try {
+            trackingData[param] = decodeURIComponent(value);
+        } catch {
+            trackingData[param] = value;
         }
+        foundInUrl = true;
     });
 
-    // 2. Capture all Microsoft Ads (hsa_) parameters dynamically
     urlParams.forEach((value, key) => {
-        if (key.startsWith(HSA_PREFIX)) {
-            try {
-                trackingData[key] = decodeURIComponent(value);
-            } catch {
-                trackingData[key] = value;
-            }
-            foundInUrl = true;
+        if (!key.startsWith(HSA_PREFIX)) return;
+
+        try {
+            trackingData[key] = decodeURIComponent(value);
+        } catch {
+            trackingData[key] = value;
         }
+        foundInUrl = true;
     });
 
-    // 3. Add GA4 Client ID
     const cid = getGA4ClientId();
-    if (cid) {
-        trackingData['cid'] = cid;
-    }
+    if (cid) trackingData.cid = cid;
 
-    // 4. Add GA4 Session ID
     const sid = getGA4SessionId();
-    if (sid) {
-        trackingData['sid'] = sid;
-    }
+    if (sid) trackingData.sid = sid;
 
     if (trackingData.fbclid && !trackingData.fbc) {
         trackingData.fbc = `fb.1.${Date.now()}.${trackingData.fbclid}`;
     }
 
-    if (foundInUrl || cid || sid) {
-        // Save to SessionStorage if found in URL or new IDs captured
+    if (foundInUrl || cid || sid || Object.keys(trackingData).length > 0) {
         try {
             sessionStorage.setItem(STORAGE_KEY, JSON.stringify(trackingData));
-        } catch (e) {}
-
-        // Construct string with comma separator for readability
-        const dataString = Object.keys(trackingData)
-            .map(key => `${key}=${trackingData[key]}`)
-            .join(', ');
-
-        // Save to cookie for future persistence (30 days)
-        setCookie(COOKIE_NAME, dataString, 30);
-
-        // Cache in memory
-        cachedTrackingData = dataString;
-
-        console.log('[WhatsApp Tracking] Captured data:', dataString);
-
-        // Push tracking data to dataLayer for GTM to capture
-        if (typeof window !== 'undefined' && (window as any).dataLayer) {
-            (window as any).dataLayer.push({
-                event: 'tracking_data_captured',
-                ...trackingData // Spread the trackingData object into the dataLayer event
-            });
-            console.log('[WhatsApp Tracking] Pushed to dataLayer:', trackingData);
+        } catch {
+            // Ignore storage failures
         }
 
-        return dataString;
+        const dataString = serializeTrackingData(trackingData);
+        if (dataString) {
+            setCookie(COOKIE_NAME, dataString, 30);
+            cachedTrackingData = dataString;
+            cachedTrackingObject = { ...trackingData };
+
+            if (typeof window !== 'undefined' && (window as any).dataLayer) {
+                (window as any).dataLayer.push({
+                    event: 'tracking_data_captured',
+                    ...trackingData,
+                });
+            }
+        }
+
+        return Object.keys(trackingData).length > 0 ? { ...trackingData } : null;
     }
 
-    // 5. Fallback to Cookie
     const cookieData = getCookie(COOKIE_NAME);
     if (cookieData) {
         cachedTrackingData = cookieData;
+        cachedTrackingObject = parseTrackingDataString(cookieData);
+        return { ...cachedTrackingObject };
     }
 
-    return cookieData;
+    return null;
 };
 
-/**
- * Initialize tracking capture immediately when module loads
- */
+const captureTrackingData = (): string | null => {
+    const objectData = captureTrackingDataObject();
+    if (!objectData) return null;
+
+    const serialized = serializeTrackingData(objectData);
+    cachedTrackingData = serialized || null;
+    return cachedTrackingData;
+};
+
 const initializeTracking = () => {
     if (hasInitialized) return;
     hasInitialized = true;
 
     if (typeof window !== 'undefined') {
-        // Capture immediately
-        captureTrackingData();
+        captureTrackingDataObject();
 
-        // Also capture on DOMContentLoaded to catch any late URL processing
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', () => {
-                captureTrackingData();
+                captureTrackingDataObject();
             });
         }
 
-        // And on window load as a final fallback
         window.addEventListener('load', () => {
-            captureTrackingData();
+            captureTrackingDataObject();
         });
     }
 };
 
-// Run initialization immediately
 initializeTracking();
 
-/**
- * Retrieves tracking reference string with all parameters
- * Uses cached data if available, otherwise captures fresh
- * Format: "utm_source=google, gclid=123, cid=456.789, sid=1700000000"
- */
-export const getTrackingRef = (): string | null => {
-    // Always try to capture fresh data to pick up URL changes in SPA
-    return captureTrackingData();
+export const getTrackingDataObject = (): TrackingData | null => {
+    const latest = captureTrackingDataObject();
+    if (latest) return latest;
+
+    if (cachedTrackingObject && Object.keys(cachedTrackingObject).length > 0) {
+        return { ...cachedTrackingObject };
+    }
+
+    return null;
 };
 
-/**
- * Generates a WhatsApp URL with the tracking reference appended to the message.
- * Uses " || Dados: " separator for better readability.
- * @param message The message to be sent.
- * @returns The full WhatsApp URL.
- */
-export const getWhatsAppLink = (message: string): string => {
-    const ref = getTrackingRef();
-    let finalMessage = message;
+export const getTrackingRef = (): string | null => {
+    const tracking = getTrackingDataObject();
+    if (!tracking) return null;
 
-    // Remove any old tracking suffixes to avoid duplication
+    const serialized = serializeTrackingData(tracking);
+    return serialized.length > 0 ? serialized : null;
+};
+
+export const getWhatsAppLink = (message: string, options: WhatsAppLinkOptions = {}): string => {
+    const { appendTrackingRef = true } = options;
+    const ref = appendTrackingRef ? getTrackingRef() : null;
+
+    let finalMessage = message;
     finalMessage = finalMessage.split(' || Dados:')[0].split(' [ref:')[0].trim();
 
-    if (ref) {
+    if (appendTrackingRef && ref) {
         finalMessage += ` || Dados: ${ref}`;
     }
 
     return `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(finalMessage)}`;
 };
 
-/**
- * React Hook for WhatsApp link that updates after component mounts.
- * This ensures the tracking data is captured even if the initial render
- * happens before window.location is fully processed.
- * 
- * @param message The message to be sent via WhatsApp
- * @returns The WhatsApp URL, which updates after mount if needed
- */
-export const useWhatsAppLink = (message: string): string => {
-    const [whatsappUrl, setWhatsappUrl] = useState(() => getWhatsAppLink(message));
+export const useWhatsAppLink = (message: string, options: WhatsAppLinkOptions = {}): string => {
+    const [whatsappUrl, setWhatsappUrl] = useState(() => getWhatsAppLink(message, options));
 
     useEffect(() => {
-        // Re-capture tracking data after mount
-        const newUrl = getWhatsAppLink(message);
-        if (newUrl !== whatsappUrl) {
-            setWhatsappUrl(newUrl);
-        }
+        const newUrl = getWhatsAppLink(message, options);
+        setWhatsappUrl((prev) => (prev === newUrl ? prev : newUrl));
 
-        // Also update after a short delay to catch any late-loading GA data
         const timer = setTimeout(() => {
-            captureTrackingData();
-            const updatedUrl = getWhatsAppLink(message);
-            setWhatsappUrl(updatedUrl);
+            captureTrackingDataObject();
+            const updatedUrl = getWhatsAppLink(message, options);
+            setWhatsappUrl((prev) => (prev === updatedUrl ? prev : updatedUrl));
         }, 1000);
 
         return () => clearTimeout(timer);
-    }, [message]);
+    }, [message, options.appendTrackingRef]);
 
     return whatsappUrl;
 };
 
-/**
- * Force re-capture of tracking data.
- * Call this if you need to refresh the tracking info.
- */
 export const refreshTrackingData = (): string | null => {
     cachedTrackingData = null;
+    cachedTrackingObject = null;
     return captureTrackingData();
 };
-


### PR DESCRIPTION
## Resumo
- integra fluxo de CRM completo no chatbot: contato + deal + associação no HubSpot
- move BANT para o Deal (com fallback de nota no contato quando deal/associação falha)
- envia tracking sensível no contato com mapeamento fixo (incluindo msclkid -> hs_linkedin_click_id)
- simplifica mensagem de WhatsApp para origem/destino/datas e bagagem (quando houver), sem BANT e sem sufixo de tracking
- adiciona suporte a baggage_preference no contrato do generate_budget_link
- atualiza docs/envs para setup de deal e fallback de tracking

## Mudanças principais
- api/submit-lead.ts
  - criação/recuperação de contato (409 -> search por email + patch)
  - criação de deal e associação deal->contato
  - fallback operacional com nota no contato
  - resposta de sucesso enriquecida com dealId e warning
- hooks/useLeadCapture.ts
  - captura de tracking completo
  - payload com tracking estruturado
  - mensagem de WhatsApp enxuta
- services/geminiService.ts
  - link de WhatsApp sem append de tracking
  - remoção de BANT da mensagem
  - suporte a baggage_preference
- utils/whatsapp.ts
  - novo getTrackingDataObject()
  - getWhatsAppLink(message, { appendTrackingRef })
- types/leadCapture.ts
  - novos tipos de tracking
  - SubmitLeadSuccess com dealId/warning
- api/generate.ts
  - baggage_preference em args/tool contract e instrução de coleta
- documentação
  - .env.example, README.md

## Testes
- npm run test:regression ✅
- npm run build ✅
- novas suítes:
  - tests/submit-lead.test.ts
  - tests/gemini-whatsapp.test.ts

## Observações
- inclui também alteração em CLAUDE.md (confirmada por você).
