### PR TITLE
Randomize Hero Background Video

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -15,3 +15,7 @@
 ## 2025-05-16 - Logic and Memoization Refactoring
 **Learning:** Pure utility functions and configuration arrays are frequently redefined inside component bodies in this codebase. Moving these outside, combined with `React.memo` for list items (like `FAQItem`), significantly stabilizes the component tree and reduces memory pressure. Always add `displayName` to memoized components for better DevTools visibility.
 **Action:** Systematically check for and move non-reactive logic and data outside the render loop.
+
+## 2025-05-22 - Randomization with Stable CWV
+**Learning:** Using a lazy initializer in `useState` is an efficient way to pick a random item on component mount without causing re-renders or breaking the stable state during the component's lifecycle. This satisfies requirements for variety while keeping the background stable for the user session.
+**Action:** Use `useState(() => pickRandom())` for initial random states that should not change until the next page load.

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -214,8 +214,11 @@ const getDaysInMonth = (date: Date) => {
 };
 
 const Hero: React.FC = () => {
-  // Keep hero media deterministic to improve cache hit and stable CWV.
-  const [backgroundVideo] = useState(() => HERO_VIDEOS[0]);
+  // Pick a random video on mount to provide a fresh experience on each visit.
+  const [backgroundVideo] = useState(() => {
+    const randomIndex = Math.floor(Math.random() * HERO_VIDEOS.length);
+    return HERO_VIDEOS[randomIndex];
+  });
   const [shouldRenderVideo, setShouldRenderVideo] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
   const optimizedPoster = useMemo(


### PR DESCRIPTION
This change modifies the `Hero` component to pick a random video from the `HERO_VIDEOS` array upon mounting. It uses a lazy initializer in `useState` to ensure the selection remains stable for the duration of the component's lifecycle while providing a varied experience across different page loads.

Verification:
- Build and regression tests passed.
- Playwright script confirmed unique video URLs across multiple reloads.

---
*PR created automatically by Jules for task [17272583748078071496](https://jules.google.com/task/17272583748078071496) started by @felipewilliam2*