### PR TITLE
fix(chat): improve send button contrast in chat hero (#71)

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -418,7 +418,7 @@ const AIChat: React.FC = () => {
                 <button 
                   onClick={handleSend} 
                   disabled={isLoading || !input.trim()}
-                  className="absolute right-2 p-2 bg-brand-vibrant text-white rounded-xl hover:bg-brand-blue transition-all disabled:opacity-0 disabled:scale-75 focus:outline-none shadow-md"
+                  className="absolute right-2 p-2 bg-brand-dark text-white rounded-xl hover:bg-brand-blue transition-all disabled:opacity-0 disabled:scale-75 focus:outline-none shadow-md"
                   aria-label="Enviar mensagem"
                 >
                   <Send className="w-4 h-4" />


### PR DESCRIPTION
## Problem
Send button in the chat hero had low contrast (bg-brand-vibrant + white).

## Fix
- Switched send button background to `bg-brand-dark` to increase contrast while keeping the rest of the UI unchanged.

## How to test
1. Open Home page and use the chat hero input.
2. Verify the send button has higher contrast and still shows the Send icon.
3. Regression: `npm run test:regression`.

Fixes #71