### PR TITLE
fix(chat): improve send button contrast in hero chat (#71)

### DIFF
--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -54,7 +54,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
                     disabled={disabled || !value.trim()}
                     aria-label="Enviar mensagem"
                     className={isHero
-                        ? 'absolute right-2 p-2 rounded-xl bg-brand-dark text-white hover:bg-brand-blue transition-all disabled:opacity-40 disabled:cursor-not-allowed'
+                        ? 'absolute right-2 p-2 rounded-xl bg-anhanga-blue text-white hover:bg-brand-blue transition-all disabled:opacity-40 disabled:cursor-not-allowed'
                         : 'absolute right-2 p-2 bg-brand-vibrant text-white rounded-xl hover:bg-brand-blue transition-all disabled:opacity-0 disabled:scale-75 focus:outline-none shadow-md'}
                 >
                     <Send className="w-4 h-4" />


### PR DESCRIPTION
## Problem
Send button in the hero chat input had low contrast/visibility.

## Fix
- Updated hero-mode send button styling to use a dark background with white icon for stronger contrast.

## How to test
1. Open the Home hero chat input.
2. Type any text and verify the send button is clearly visible.
3. Regression: `npm run test:regression`.

Fixes #71