### PR TITLE
chore: ajustar issue templates (remover link de Discussions)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,3 @@
 blank_issues_enabled: false
-contact_links:
-  - name: 💬 Discussão geral
-    url: https://github.com/orgs/community/discussions
-    about: Para dúvidas que não se encaixam nos templates acima, use as discussões.
+# Repo privado: Discussions não usado no momento.
+# Se habilitar Discussions no futuro, podemos adicionar um contact_link aqui.


### PR DESCRIPTION
Remove o contact_link de Discussions do `.github/ISSUE_TEMPLATE/config.yml` (repo privado, Discussions não é usado).

Também criei labels ausentes no repo via API: `infra`, `refactor` (para casar com os templates).

Como testar:
- Ir em Issues → New issue e verificar que só aparecem os templates, sem link de Discussions.