### PR TITLE
chore: adicionar templates de issue (docs, testes, performance)

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentacao.md
+++ b/.github/ISSUE_TEMPLATE/documentacao.md
@@ -1,0 +1,35 @@
+---
+name: 📚 Documentação
+about: Melhorias em docs (README, guias, exemplos, .env.example)
+title: "[DOCS] "
+labels: documentation
+assignees: ''
+---
+
+## 🎯 Objetivo
+<!-- O que você quer documentar/atualizar? -->
+
+## 📋 Contexto
+<!-- Por que isso é necessário agora? O que está confuso/faltando? -->
+
+## ✅ Critérios de Aceitação
+- [ ] 
+- [ ] 
+
+## 🏗️ Escopo
+**Arquivos/páginas afetadas:**
+- 
+
+**Conteúdo que deve ser incluído:**
+- 
+
+## 🧪 Como validar
+<!-- Como saber que a documentação ficou correta? -->
+- [ ] Links revisados e funcionando
+- [ ] Passos testados (copiar/colar) em ambiente limpo
+
+## 📎 Referências
+<!-- Links, issues relacionadas, prints, docs externas -->
+
+---
+> **Para o Codex:** Atualize apenas a documentação e exemplos necessários. Não mude comportamento de código sem necessidade.

--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -1,0 +1,38 @@
+---
+name: ⚡ Performance
+about: Melhorias de performance (bundle, LCP/CLS, render, caching)
+title: "[PERF] "
+labels: performance
+assignees: ''
+---
+
+## 🎯 Objetivo
+<!-- Qual métrica ou comportamento precisa melhorar? -->
+
+## 📋 Contexto
+<!-- Onde está lento e em qual fluxo/página? -->
+
+## 📈 Métrica/Benchmark
+<!-- Preencha com números antes/depois quando possível -->
+- **Antes:** 
+- **Depois (esperado):** 
+- **Ferramenta:** Lighthouse / Web Vitals / DevTools / logs
+
+## 🔁 Como reproduzir / medir
+1. 
+2. 
+3. 
+
+## ✅ Critérios de Aceitação
+- [ ] Melhoria mensurável (antes/depois)
+- [ ] Sem regressões funcionais
+- [ ] Sem aumentar risco de custo (ex.: chamadas desnecessárias)
+
+## 💡 Ideias / Hipóteses
+- 
+
+## 📎 Evidências
+<!-- Prints do Lighthouse, perf profile, links -->
+
+---
+> **Para o Codex:** Faça mudanças pequenas e mensuráveis. Inclua “como medir” e o ganho obtido.

--- a/.github/ISSUE_TEMPLATE/testes-qa.md
+++ b/.github/ISSUE_TEMPLATE/testes-qa.md
@@ -1,0 +1,38 @@
+---
+name: 🧪 Testes / QA
+about: Criar ou ajustar testes, casos de regressão e checks de CI
+title: "[TEST] "
+labels: tests
+assignees: ''
+---
+
+## 🎯 Objetivo
+<!-- Que cobertura de teste/validação está faltando? -->
+
+## 📋 Contexto
+<!-- Bug/feature que motivou isso. Linke issue/PR se existir. -->
+
+## ✅ Critérios de Aceitação
+- [ ] Teste(s) novo(s) cobrindo o cenário
+- [ ] Testes passam no CI/local
+- [ ] (Opcional) Caso de regressão documentado
+
+## 🧩 Cenários a cobrir
+- [ ] Caminho feliz (happy path)
+- [ ] Erros/edge cases
+- [ ] Regressão específica: ___
+
+## 🛠️ Onde adicionar
+- **Unit:** 
+- **Integration:** 
+- **E2E (se existir):** 
+
+## ▶️ Como rodar
+<!-- Preencha com comandos reais do repo -->
+- `npm test` / `npm run test` / `npm run test:regression`
+
+## 📎 Evidências
+<!-- Logs, prints do CI, links de runs -->
+
+---
+> **Para o Codex:** Priorize testes determinísticos (sem flakiness). Evite mocks excessivos e prefira validar comportamento.


### PR DESCRIPTION
Adiciona 3 templates novos em `.github/ISSUE_TEMPLATE/`:

- 📚 Documentação (`labels: documentation`)
- 🧪 Testes / QA (`labels: tests`)
- ⚡ Performance (`labels: performance`)

Também garanti os labels via API (criados: `tests`, `performance`; `documentation` já existia).

Como testar:
- Issues → New issue → verificar que os 3 templates aparecem e já aplicam label automaticamente.