### PR TITLE
Potential fix for code scanning alert no. 8: Client-side cross-site scripting

### DIFF
--- a/pages/BlogPost.tsx
+++ b/pages/BlogPost.tsx
@@ -19,6 +19,16 @@ const BlogPost: React.FC = () => {
     const post = BLOG_POSTS.find(p => p.slug === slug);
     const contentRef = React.useRef<HTMLDivElement>(null);
 
+    // Validate slug to avoid propagating arbitrary user input into structured data
+    const isValidSlug = (value: unknown): value is string => {
+        if (typeof value !== 'string') return false;
+        // Allow only URL-safe slugs: letters, numbers, dashes and slashes
+        return /^[a-zA-Z0-9\-\/]+$/.test(value);
+    };
+
+    const canonicalBase = 'https://www.anhanga.tur.br/blog';
+    const canonicalUrl = isValidSlug(slug) ? `${canonicalBase}/${slug}` : canonicalBase;
+
     // Update WhatsApp links with tracking
     useEffect(() => {
         if (contentRef.current && post) {
@@ -70,7 +80,7 @@ const BlogPost: React.FC = () => {
                 description={post.excerpt}
                 image={post.image}
                 type="article"
-                canonical={`https://www.anhanga.tur.br/blog/${slug}`}
+                canonical={canonicalUrl}
             />
             <ArticleSchema
                 title={post.title}
@@ -78,12 +88,12 @@ const BlogPost: React.FC = () => {
                 image={post.image}
                 datePublished={post.date}
                 authorName={post.author}
-                url={`https://www.anhanga.tur.br/blog/${slug}`}
+                url={canonicalUrl}
             />
             <BreadcrumbSchema items={[
                 { name: 'Home', item: 'https://www.anhanga.tur.br/' },
                 { name: 'Blog', item: 'https://www.anhanga.tur.br/blog' },
-                { name: post.title, item: `https://www.anhanga.tur.br/blog/${slug}` }
+                { name: post.title, item: canonicalUrl }
             ]} />
 
             {/* Hero Header */}


### PR DESCRIPTION
Potential fix for [https://github.com/felipewilliam2/AV-SITE/security/code-scanning/8](https://github.com/felipewilliam2/AV-SITE/security/code-scanning/8)

General approach: ensure that the user-controlled `slug` cannot introduce unexpected or malformed content into the JSON-LD by validating or normalizing it before building the URL that is passed to `ArticleSchema`. That way, only slugs/URLs that match our expected pattern are used, and obviously malicious or malformed values are rejected or replaced.

Best, minimal-impact fix: in `pages/BlogPost.tsx`, derive a sanitized or validated URL that uses the `slug` only if it passes some simple checks (e.g., matches a conservative slug regex). Use this sanitized URL consistently for `SEO`, `ArticleSchema`, and `BreadcrumbSchema` instead of interpolating `slug` directly in JSX. This preserves functionality (legitimate slugs still work) while ensuring tainted input is constrained, and it fixes the dataflow path that CodeQL reports. We don’t need to change `ArticleSchema.tsx` itself; we can keep using `JSON.stringify` for the JSON-LD, but feed it a validated `url`.

Concretely:
- In `pages/BlogPost.tsx`, after computing `post` (and before the JSX return), introduce:
  - A helper to validate the slug against a safe pattern (letters, numbers, dashes).
  - A `const canonicalBase = 'https://www.anhanga.tur.br/blog';`
  - A `const canonicalUrl = isValidSlug(slug) ? \`\${canonicalBase}/\${slug}\` : canonicalBase;`
- Replace all occurrences of `` `https://www.anhanga.tur.br/blog/${slug}` `` in that file with `canonicalUrl`.
- This keeps URLs correct for valid slugs, and ensures that for unexpected values (including attempts at injection), the URL degrades to the base blog URL rather than embedding arbitrary user-controlled text.

No changes are required in `components/schemas/ArticleSchema.tsx` because it already constructs JSON via `JSON.stringify`; addressing the taint in `BlogPost.tsx` is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
