### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/data/mediaConfig.ts
+++ b/data/mediaConfig.ts
@@ -233,13 +233,23 @@ export const getDestinationImage = (city: string): string => {
  * @param width Desired width
  * @param format Output format (auto recommended)
  */
+const isCloudinaryUrl = (url: string): boolean => {
+    try {
+        const parsed = new URL(url);
+        const host = parsed.hostname.toLowerCase();
+        return host === 'cloudinary.com' || host.endsWith('.cloudinary.com');
+    } catch {
+        return false;
+    }
+};
+
 export const optimizeCloudinaryUrl = (
     url: string,
     width: number = 800,
     format: 'auto' | 'webp' | 'avif' = 'auto'
 ): string => {
     // Only works with Cloudinary URLs
-    if (!url.includes('cloudinary.com')) {
+    if (!isCloudinaryUrl(url)) {
         return url;
     }
 
@@ -253,7 +263,7 @@ export const optimizeCloudinaryUrl = (
  * Only works with Cloudinary URLs
  */
 export const generateSrcSet = (url: string, sizes: number[] = [400, 800, 1200]): string => {
-    if (!url.includes('cloudinary.com')) {
+    if (!isCloudinaryUrl(url)) {
         return '';
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/felipewilliam2/AV-SITE/security/code-scanning/7](https://github.com/felipewilliam2/AV-SITE/security/code-scanning/7)

In general, to fix incomplete URL substring sanitization, the URL must be parsed and its host compared against an explicit set of allowed hostnames, rather than using `includes` on the full URL string. The comparison should tolerate common Cloudinary host variants (such as `res.cloudinary.com`, possibly regional suffixes) while still disallowing hosts like `cloudinary.com.evil.com` or `evilcloudinary.com`.

For this file, the best fix is to introduce a small helper that safely determines whether a given URL is a Cloudinary URL by parsing it with the standard `URL` class and then validating `hostname`. We then replace the two `url.includes('cloudinary.com')` checks in `optimizeCloudinaryUrl` and `generateSrcSet` with calls to this helper. A robust hostname check can require that the hostname is either exactly `cloudinary.com` or ends with `.cloudinary.com`, which covers `res.cloudinary.com`, `sub.res.cloudinary.com`, etc., but not `cloudinary.com.evil.com`.

Concretely:
- Add a new internal helper function in `data/mediaConfig.ts`, near the other helpers:

  ```ts
  const isCloudinaryUrl = (url: string): boolean => {
      try {
          const parsed = new URL(url);
          const host = parsed.hostname.toLowerCase();
          return host === 'cloudinary.com' || host.endsWith('.cloudinary.com');
      } catch {
          return false;
      }
  };
  ```

- Change in `optimizeCloudinaryUrl`:

  ```ts
  if (!url.includes('cloudinary.com')) {
      return url;
  }
  ```

  to:

  ```ts
  if (!isCloudinaryUrl(url)) {
      return url;
  }
  ```

- Change in `generateSrcSet`:

  ```ts
  if (!url.includes('cloudinary.com')) {
      return '';
  }
  ```

  to:

  ```ts
  if (!isCloudinaryUrl(url)) {
      return '';
  }
  ```

The global `URL` class is standard in modern browsers and Node 18+ / many bundlers; no new imports are required. This keeps existing behavior (only process Cloudinary URLs) but makes the check resilient against malicious or malformed URLs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
