### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete URL substring sanitization

### DIFF
--- a/data/mediaConfig.ts
+++ b/data/mediaConfig.ts
@@ -227,6 +227,19 @@ export const getDestinationImage = (city: string): string => {
 // IMAGE OPTIMIZATION HELPERS (for when using Cloudinary)
 // =============================================================================
 
+// Allowed Cloudinary hosts for URL optimization
+const ALLOWED_CLOUDINARY_HOSTS = ['res.cloudinary.com'];
+
+const isCloudinaryUrl = (url: string): boolean => {
+    try {
+        const parsed = new URL(url);
+        return ALLOWED_CLOUDINARY_HOSTS.includes(parsed.hostname);
+    } catch {
+        // If the URL is relative or invalid, do not treat it as Cloudinary
+        return false;
+    }
+};
+
 /**
  * Generate optimized Cloudinary URL
  * @param url Original Cloudinary URL
@@ -239,7 +252,7 @@ export const optimizeCloudinaryUrl = (
     format: 'auto' | 'webp' | 'avif' = 'auto'
 ): string => {
     // Only works with Cloudinary URLs
-    if (!url.includes('cloudinary.com')) {
+    if (!isCloudinaryUrl(url)) {
         return url;
     }
 
@@ -253,7 +266,7 @@ export const optimizeCloudinaryUrl = (
  * Only works with Cloudinary URLs
  */
 export const generateSrcSet = (url: string, sizes: number[] = [400, 800, 1200]): string => {
-    if (!url.includes('cloudinary.com')) {
+    if (!isCloudinaryUrl(url)) {
         return '';
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/felipewilliam2/AV-SITE/security/code-scanning/6](https://github.com/felipewilliam2/AV-SITE/security/code-scanning/6)

In general, the fix is to stop treating the URL as an opaque string when deciding whether it belongs to a trusted host. Instead, parse it with the standard `URL` API and validate its `hostname` (or `host`) against an explicit allowlist of domains that are truly controlled (e.g., `res.cloudinary.com`, `subdomain.res.cloudinary.com`). This ensures that `cloudinary.com` appearing in a path or in another domain (like `cloudinary.com.evil.com`) will not be incorrectly trusted.

Concretely for this file:

- In `optimizeCloudinaryUrl`, replace the current `if (!url.includes('cloudinary.com')) { return url; }` with logic that:
  - Tries to construct a `new URL(url)` (inside a try/catch to handle relative or invalid URLs).
  - Allows optimization if and only if the hostname is exactly `res.cloudinary.com` (the canonical Cloudinary asset host) or another explicitly whitelisted Cloudinary domain if needed.
  - Returns the original URL unchanged if parsing fails or the hostname is not in the allowlist.
- In `generateSrcSet`, do not independently use `includes`; instead:
  - Reuse the same hostname validation.
  - A simple way, without changing behavior, is to check `if (!isCloudinaryUrl(url)) return '';` where `isCloudinaryUrl` encapsulates the parsed-host allowlist logic.
- To avoid duplication and keep behavior consistent, introduce a small helper in this file, e.g.:
  - `const ALLOWED_CLOUDINARY_HOSTS = ['res.cloudinary.com'];`
  - `const isCloudinaryUrl = (url: string): boolean => { ... }`
- Use only built-in `URL` (no new external packages).

The edits are all within `data/mediaConfig.ts`, around the `optimizeCloudinaryUrl` and `generateSrcSet` functions, plus the insertion of the new helper constants/functions above them.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
