### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/data/mediaConfig.ts
+++ b/data/mediaConfig.ts
@@ -69,15 +69,20 @@ export const optimizeRemoteImageUrl = (
         return rawUrl;
     }
 
-    if (rawUrl.includes('res.cloudinary.com') && rawUrl.includes('/image/upload/')) {
-        // Inject Cloudinary delivery transformations only if not already present.
-        if (rawUrl.includes('/image/upload/f_') || rawUrl.includes('/image/upload/q_') || rawUrl.includes('/image/upload/w_')) {
-            return rawUrl;
+    try {
+        const url = new URL(rawUrl);
+        if (url.hostname === 'res.cloudinary.com' && rawUrl.includes('/image/upload/')) {
+            // Inject Cloudinary delivery transformations only if not already present.
+            if (rawUrl.includes('/image/upload/f_') || rawUrl.includes('/image/upload/q_') || rawUrl.includes('/image/upload/w_')) {
+                return rawUrl;
+            }
+            const transforms = height
+                ? `f_auto,q_auto,w_${width},h_${height},c_fill`
+                : `f_auto,q_auto,w_${width}`;
+            return rawUrl.replace('/image/upload/', `/image/upload/${transforms}/`);
         }
-        const transforms = height
-            ? `f_auto,q_auto,w_${width},h_${height},c_fill`
-            : `f_auto,q_auto,w_${width}`;
-        return rawUrl.replace('/image/upload/', `/image/upload/${transforms}/`);
+    } catch {
+        // If URL parsing fails, fall through to wsrv.nl proxy handling below.
     }
 
     const withoutProtocol = rawUrl.replace(/^https?:\/\//, '');


### PR DESCRIPTION
Potential fix for [https://github.com/felipewilliam2/AV-SITE/security/code-scanning/5](https://github.com/felipewilliam2/AV-SITE/security/code-scanning/5)

In general, to fix incomplete URL substring sanitization, you should parse the URL and examine `hostname` (or `host`) instead of using `String.prototype.includes` on the raw string. For “is this a Cloudinary URL?” you should check that `new URL(rawUrl).hostname` exactly matches (or appropriately ends with) the expected host, rather than checking for `res.cloudinary.com` anywhere in the string.

For this specific code, the best fix with minimal behavior change is:

- Replace the `rawUrl.includes('res.cloudinary.com')` condition with a check that parses `rawUrl` using `new URL(rawUrl)` and compares `url.hostname` to `'res.cloudinary.com'`.
- Keep the existing `rawUrl.includes('/image/upload/')` part untouched, because that’s a path-based check and not a host validation.
- Wrap the new `URL` parsing in a `try/catch` block so that malformed URLs don’t throw and instead fall through to the existing wsrv.nl logic, preserving behavior in error cases.

Concretely:

- In `data/mediaConfig.ts`, in the `optimizeRemoteImageUrl` function, lines 72–81 need to be updated.
- Introduce a `try { const url = new URL(rawUrl); ... } catch { /* fall through */ }` around the Cloudinary condition.
- Inside the `try`, test `if (url.hostname === 'res.cloudinary.com' && rawUrl.includes('/image/upload/')) { ... }`.
- If the hostname matches and the path segment condition passes, keep the existing logic that checks for existing Cloudinary transforms and injects new ones via `rawUrl.replace('/image/upload/', ...)`.
- If parsing fails (invalid URL) or host doesn’t match, just fall through to the existing wsrv.nl proxy code.

No new external libraries are needed; `URL` is already used earlier in this function and is standard.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
