### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/api/generate.ts
+++ b/api/generate.ts
@@ -720,7 +720,7 @@ export default async function handler(request: Request) {
             });
         }
 
-        console.log('SERVER: GEMINI_API_KEY found (length:', apiKey.length, ')');
+        console.log('SERVER: GEMINI_API_KEY is configured');
 
         const { contents } = await request.json();
 


### PR DESCRIPTION
Potential fix for [https://github.com/felipewilliam2/AV-SITE/security/code-scanning/3](https://github.com/felipewilliam2/AV-SITE/security/code-scanning/3)

In general, to fix clear-text logging of sensitive information, you should ensure logs never include secrets or values derived from them (tokens, API keys, passwords, or their lengths, prefixes, hashes, etc.), and instead log only non-sensitive metadata (e.g., “key configured: true/false”). Debugging checks should use booleans or generic status messages, and any deeper inspection must be done locally in a secure environment, not via production logs.

For this specific case in `api/generate.ts`, the best fix without changing functionality is to remove the `apiKey.length` from the log line, or replace the entire log with a generic message that does not depend on `apiKey`. We already log `!!apiKey` earlier (`'- GEMINI_API_KEY present:'`), so the additional log is redundant. I recommend changing line 723 from logging the length to logging a generic confirmation like `'SERVER: GEMINI_API_KEY is configured'`. This way, operational behavior is effectively unchanged (we still know a key is present) but no secret-derived data is logged.

Concretely:
- In `api/generate.ts`, locate the block around lines 703–724.
- Replace `console.log('SERVER: GEMINI_API_KEY found (length:', apiKey.length, ')');` with a log that doesn’t read `apiKey` at all, e.g. `console.log('SERVER: GEMINI_API_KEY is configured');`.
- No new imports, types, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
