### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main", "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/felipewilliam2/AV-SITE/security/code-scanning/2](https://github.com/felipewilliam2/AV-SITE/security/code-scanning/2)

In general, the fix is to explicitly configure `permissions` for the workflow or individual jobs so that the `GITHUB_TOKEN` has only the minimal rights required. For a straightforward CI workflow that checks out code, installs dependencies, runs lint/tests/build, and uploads artifacts, read-only access to repository contents is usually sufficient, and no special write scopes (like `pull-requests: write`) are needed.

The single best fix here, without changing existing functionality, is to add a `permissions` block at the top (workflow) level, right under `name: CI`. This will apply to all jobs (there is only `build-and-test`) and will override any broader org/repo defaults. Based on the shown steps, `contents: read` is enough: `actions/checkout` only needs read access to fetch the code; `actions/upload-artifact` uses the workflow’s storage and does not require repo write permissions. No other scopes are used. So we add:

```yaml
permissions:
  contents: read
```

on new line 2, and shift the rest down. No additional imports or dependencies are required; this is purely a YAML configuration change in `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
