### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Python CI
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/felipewilliam2/AV-SITE/security/code-scanning/1](https://github.com/felipewilliam2/AV-SITE/security/code-scanning/1)

In general, the fix is to explicitly declare `permissions` for the workflow or for each job, granting only the scopes required. This job only checks out code, sets up Python, caches dependencies, and runs lint/tests; it does not need write access to the repository or to issues/PRs. Therefore, `contents: read` is sufficient as a minimal, least-privilege configuration.

The best non-breaking fix is to add a `permissions` block at the top (root) level of the workflow, right below `name: Python CI` (or just below `on:`) so that it applies to all jobs in this workflow. We will set `contents: read`, which is compatible with `actions/checkout@v4` and other steps that only read the repository. No other scopes appear to be required by the shown steps.

Concretely, in `.github/workflows/playwright.yml`, between line 1 (`name: Python CI`) and line 2 (`on:`), insert:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are required, and this does not change any behavior of the existing steps; it only constrains the default token permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
