### PR TITLE
feat(seo): allow AI bots in robots.txt (#119)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,17 +3,9 @@ Allow: /
 
 # AI Crawlers - Explicitly Allowed for GEO
 User-agent: GPTBot
-Allow: /
-
 User-agent: ChatGPT-User
-Allow: /
-
 User-agent: PerplexityBot
-Allow: /
-
 User-agent: Claude-Web
-Allow: /
-
 User-agent: Google-Extended
 Allow: /
 


### PR DESCRIPTION
Fixes #119. Explicitly allows GPTBot, ChatGPT-User, PerplexityBot, Claude-Web, and Google-Extended in robots.txt for GEO strategy.