### PR TITLE
feat(seo): block non-seo routes in robots.txt (#120)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,13 @@
 User-agent: *
 Allow: /
+Disallow: /api/
+Disallow: /admin/
+Disallow: /login/
+Disallow: /register/
+Disallow: /private/
+Disallow: /staging/
+Disallow: /cdn-cgi/
+Disallow: /_next/
 
 # AI Crawlers - Explicitly Allowed for GEO
 User-agent: GPTBot


### PR DESCRIPTION
Fixes #120. Adds Disallow rules for internal/backend paths (/api, /admin, /cdn-cgi, etc) to prevent crawler access.