### PR TITLE
feat(seo): throttle aggressive bots with Crawl-delay (#121)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -17,4 +17,15 @@ User-agent: Claude-Web
 User-agent: Google-Extended
 Allow: /
 
+# Aggressive SEO Bots - Throttled
+User-agent: AhrefsBot
+User-agent: SemrushBot
+User-agent: DotBot
+User-agent: MJ12bot
+User-agent: BLEXBot
+User-agent: PetalBot
+User-agent: Baiduspider
+User-agent: YandexBot
+Crawl-delay: 2
+
 Sitemap: https://www.anhanga.tur.br/sitemap.xml


### PR DESCRIPTION
Fixes #121. Adds Crawl-delay: 2 for bots like Ahrefs, Semrush, MJ12, etc. to reduce server load without blocking access.