### PR TITLE
infra(seo): declare blog sitemap in robots.txt (#122)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -29,3 +29,4 @@ User-agent: YandexBot
 Crawl-delay: 2
 
 Sitemap: https://www.anhanga.tur.br/sitemap.xml
+Sitemap: https://blog.anhanga.tur.br/sitemap.xml


### PR DESCRIPTION
Fixes #122. Adds reference to https://blog.anhanga.tur.br/sitemap.xml in the main site robots.txt to improve cross-discovery by search engines.