### PR TITLE
[SEO] Redirect /blog/* to blog.anhanga.tur.br (Issue #118)

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
         "https://instagram.com/anhangaviagens",
         "https://facebook.com/profile.php?id=61585422494271"
       ],
+      "blog": "https://blog.anhanga.tur.br",
       "aggregateRating": {
         "@type": "AggregateRating",
         "ratingValue": "4.94",


### PR DESCRIPTION
Closes #118\n\n- Confirms /blog and /blog/:slug routes redirect to https://blog.anhanga.tur.br\n- Adds  field to TravelAgency JSON-LD in index.html\n\nNotes:\n- vercel.json already contains 301 redirects for /blog and /blog/:slug*; BlogRedirect provides client-side fallback + noindex.