### PR TITLE
Elevate Claude workflow permissions to write access

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow permissions for the Claude bot to enable write access to repository contents, pull requests, and issues.

## Changes
- Changed `contents` permission from `read` to `write`
- Changed `pull-requests` permission from `read` to `write`
- Changed `issues` permission from `read` to `write`
- Retained `id-token: write` and `actions: read` permissions

## Details
These permission escalations enable the Claude bot to perform write operations such as creating/updating pull requests, modifying issues, and writing to repository contents. This is necessary for the bot to take automated actions beyond just reading and analyzing repository state.

https://claude.ai/code/session_01EtNjnF8RJTST9XJTmB1uBE