### PR TITLE
Migrate SEO component from react-helmet-async to React 19 native head hoisting

### DIFF
--- a/components/SEO.tsx
+++ b/components/SEO.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Helmet } from 'react-helmet-async';
 
 interface SEOProps {
   title?: string;
@@ -57,30 +56,25 @@ export const SEO: React.FC<SEOProps> = ({
     canonicalUrl = normalizeCanonical(window.location.href);
   }
 
+  // React 19 natively hoists <title>, <meta>, and <link> elements to <head>,
+  // which is more reliable than react-helmet-async in concurrent rendering.
   return (
-    <Helmet defer={false}>
-      {/* Standard Metadata */}
+    <>
       <title>{fullTitle}</title>
       <meta name="description" content={description} />
       <meta name="keywords" content={keywords} />
       {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
-
-      {/* Open Graph */}
       <meta property="og:type" content={type} />
       <meta property="og:title" content={fullTitle} />
       <meta property="og:description" content={description} />
       {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
       <meta property="og:image" content={image} />
       <meta property="og:site_name" content={siteName} />
-
-      {/* Twitter */}
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={fullTitle} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:image" content={image} />
-
-      {/* Robots */}
       <meta name="robots" content={robots} />
-    </Helmet>
+    </>
   );
 };

--- a/pages/landings/BetoCarreroLanding.tsx
+++ b/pages/landings/BetoCarreroLanding.tsx
@@ -34,7 +34,7 @@ const BetoCarreroLanding: React.FC = () => {
       />
       <ServiceSchema
         name="Pacote Beto Carrero personalizado"
-        description="Planejamento de pacote para Beto Carrero with hotel, ingressos, transporte e suporte especializado."
+        description="Planejamento de pacote para Beto Carrero com hotel, ingressos, transporte e suporte especializado."
         serviceUrl="https://www.anhanga.tur.br/beto-carrero"
         serviceType="Pacote de viagem para parque temático"
         areaServed="São Paulo e Brasil"

--- a/pages/landings/LollapaloozaLanding.tsx
+++ b/pages/landings/LollapaloozaLanding.tsx
@@ -30,7 +30,7 @@ const LollapaloozaLanding: React.FC = () => {
     <>
       <SEO
         title="Pacotes Lollapalooza 2026: Viagem para o Festival em São Paulo"
-        description="Garanta seu pacote para Lollapalooza 2026 with hotel, transporte e suporte especializado em São Paulo. Planejamento completo para curtir o festival sem preocupações."
+        description="Garanta seu pacote para Lollapalooza 2026 com hotel, transporte e suporte especializado em São Paulo. Planejamento completo para curtir o festival sem preocupações."
         canonical="https://www.anhanga.tur.br/lollapalooza-2026"
         keywords="pacotes Lollapalooza 2026, viagem Lollapalooza São Paulo, hotel para Lollapalooza, pacote festival em São Paulo"
       />


### PR DESCRIPTION
## Summary
Migrated the SEO component to leverage React 19's native support for hoisting `<title>`, `<meta>`, and `<link>` elements to the document head, removing the dependency on `react-helmet-async`.

## Key Changes
- **Removed react-helmet-async dependency**: Replaced `<Helmet>` wrapper with a fragment (`<>`) in the SEO component
- **Simplified component structure**: Removed defer={false} prop and comment sections, relying on React 19's automatic head hoisting
- **Fixed typos**: Corrected "with" to "com" (Portuguese) in two landing page descriptions:
  - BetoCarreroLanding.tsx: Updated ServiceSchema description
  - LollapaloozaLanding.tsx: Updated SEO description

## Implementation Details
React 19 natively hoists `<title>`, `<meta>`, and `<link>` elements to the document head during rendering, which provides more reliable behavior in concurrent rendering scenarios compared to the previous react-helmet-async approach. The component now returns a fragment containing all metadata elements, and React automatically ensures they're placed in the correct location.

https://claude.ai/code/session_01QUm4ofaqJ81xhDaAdnkVM8