### PR TITLE
[codex] migrate lead capture flows to n8n webhooks

### DIFF
--- a/api/submit-lead.ts
+++ b/api/submit-lead.ts
@@ -32,7 +32,7 @@ function createRequestId(): string {
 }
 
 function truncateDetail(detail: string): string | undefined {
-    const normalized = detail.trim();
+    const normalized = detail.replace(/[\r\n]+/g, ' ').trim();
     return normalized ? normalized.substring(0, 600) : undefined;
 }
 
@@ -101,6 +101,7 @@ export function classifySubmitLeadError(error: unknown): {
     code: SubmitLeadInternalErrorCode;
     status: number;
     error: string;
+    detail?: string;
 } {
     const message = error instanceof Error ? error.message : String(error);
     const match = message.match(/^N8N_WEBHOOK_ERROR:(\d+):(.*)$/s);
@@ -112,10 +113,13 @@ export function classifySubmitLeadError(error: unknown): {
         };
     }
 
+    const detail = truncateDetail(match[2] || '');
+
     return {
         code: 'N8N_WEBHOOK_ERROR',
         status: 502,
         error: 'Erro ao enviar lead.',
+        detail,
     };
 }
 
@@ -328,6 +332,7 @@ export default async function handler(request: Request): Promise<Response> {
             code: classified.code,
             status: classified.status,
             errorType: error instanceof Error ? error.name : typeof error,
+            detail: classified.detail,
         });
 
         return buildJsonResponse(

--- a/api/submit-lead.ts
+++ b/api/submit-lead.ts
@@ -2,19 +2,10 @@ import type { SubmitLeadRequest, SubmitLeadResponse } from '../types/leadCapture
 import { buildCorsHeaders, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import { cleanString, validatePayload } from '../lib/lead-logic';
-import {
-    associateDealToContact,
-    buildAdditionalContactProperties,
-    buildCoreContactProperties,
-    createDeal,
-    createFallbackNote,
-    getContactIdByEmail,
-    hubspotRequest,
-    updateContactProperties,
-    type HubSpotObjectResponse,
-} from '../services/hubspot';
+import { buildN8nLeadPayload } from '../lib/n8n-payloads';
 import { sendGoogleConversion } from '../lib/conversions/google';
 import { sendMetaConversion } from '../lib/conversions/meta';
+import { sendLeadToN8n } from '../services/n8n';
 
 export const config = {
     runtime: 'edge',
@@ -24,30 +15,11 @@ const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
 
 interface SubmitLeadConfig {
-    hubspotToken: string;
-    dealPipelineId: string;
-    dealStageId: string;
-    dealBantProperty: string;
+    webhookUrl: string;
+    webhookSecret: string;
 }
 
-interface DealCreationResult {
-    dealId?: string;
-    warning?: string;
-}
-
-interface ParsedHubSpotError {
-    status?: number;
-    detail?: string;
-    isUnauthorized: boolean;
-    isPropertyError: boolean;
-}
-
-interface FailedContactPropertyBatch {
-    properties: Record<string, string>;
-    status?: number;
-    code: 'HUBSPOT_UNAUTHORIZED' | 'HUBSPOT_PROPERTY_ERROR' | 'HUBSPOT_API_ERROR';
-    detail?: string;
-}
+type SubmitLeadInternalErrorCode = 'N8N_WEBHOOK_ERROR' | 'INTERNAL_ERROR';
 
 type LeadLogLevel = 'info' | 'warn' | 'error';
 
@@ -92,7 +64,7 @@ function emitLeadLog(level: LeadLogLevel, requestId: string, stage: string, deta
     console.log('SUBMIT_LEAD', payload);
 }
 
-function buildErrorResponse(
+function buildJsonResponse(
     body: SubmitLeadResponse,
     status: number,
     corsHeaders: Record<string, string>,
@@ -103,65 +75,48 @@ function buildErrorResponse(
 
     return new Response(JSON.stringify(body), {
         status,
-        headers: { 'Content-Type': 'application/json', ...(requestId ? { 'X-Request-Id': requestId } : {}), ...corsHeaders },
+        headers: {
+            'Content-Type': 'application/json',
+            ...(requestId ? { 'X-Request-Id': requestId } : {}),
+            ...corsHeaders,
+        },
     });
 }
 
-function buildSuccessResponse(
-    body: SubmitLeadResponse,
-    status: number,
-    corsHeaders: Record<string, string>,
-): Response {
-    const requestId = typeof body === 'object' && body && 'requestId' in body && typeof body.requestId === 'string'
-        ? body.requestId
-        : undefined;
+function getSubmitLeadConfig(): SubmitLeadConfig | null {
+    const webhookUrl = cleanString(process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL);
+    const webhookSecret = cleanString(process.env.N8N_WEBHOOK_SECRET);
 
-    return new Response(JSON.stringify(body), {
-        status,
-        headers: { 'Content-Type': 'application/json', ...(requestId ? { 'X-Request-Id': requestId } : {}), ...corsHeaders },
-    });
-}
-
-function isHubSpotPropertyStatus(status: number): boolean {
-    return status === 400 || status === 422;
-}
-
-function parseHubSpotErrorMessage(message: string): ParsedHubSpotError {
-    if (message.includes('UNAUTHORIZED')) {
-        return {
-            isUnauthorized: true,
-            isPropertyError: false,
-        };
+    if (!webhookUrl || !webhookSecret) {
+        return null;
     }
-
-    const match = message.match(/^[A-Z_]+:(\d+):(.*)$/s);
-    if (!match) {
-        return {
-            detail: truncateDetail(message),
-            isUnauthorized: false,
-            isPropertyError: false,
-        };
-    }
-
-    const status = Number(match[1]);
-    const detail = truncateDetail(match[2] || '');
 
     return {
-        status: Number.isFinite(status) ? status : undefined,
-        detail,
-        isUnauthorized: false,
-        isPropertyError: Number.isFinite(status) ? isHubSpotPropertyStatus(status) : false,
+        webhookUrl,
+        webhookSecret,
     };
 }
 
-function appendWarning(existing: string | undefined, next: string | undefined): string | undefined {
-    if (!existing) return next;
-    if (!next) return existing;
-    return `${existing} ${next}`;
-}
+export function classifySubmitLeadError(error: unknown): {
+    code: SubmitLeadInternalErrorCode;
+    status: number;
+    error: string;
+} {
+    const message = error instanceof Error ? error.message : String(error);
+    const match = message.match(/^N8N_WEBHOOK_ERROR:(\d+):(.*)$/s);
+    if (!match) {
+        return {
+            code: 'INTERNAL_ERROR',
+            status: 500,
+            error: 'Erro interno ao processar envio do lead.',
+        };
+    }
 
-function shouldAttemptFallbackNote(parsedError: ParsedHubSpotError): boolean {
-    return !parsedError.isUnauthorized && parsedError.status !== 504;
+    return {
+        code: 'N8N_WEBHOOK_ERROR',
+        status: 502,
+        error: 'Erro ao enviar lead.',
+    };
 }
 
 async function getRateLimitResponse(
@@ -184,7 +139,7 @@ async function getRateLimitResponse(
         retryAfterSeconds: Math.ceil(rateLimit.resetIn / 1000),
     });
 
-    return buildErrorResponse(
+    return buildJsonResponse(
         {
             ok: false,
             requestId,
@@ -201,23 +156,6 @@ async function getRateLimitResponse(
     );
 }
 
-function getSubmitLeadConfig(): SubmitLeadConfig | null {
-    const hubspotToken = process.env.HUBSPOT_TOKEN;
-    const dealPipelineId = cleanString(process.env.HUBSPOT_DEAL_PIPELINE_ID);
-    const dealStageId = cleanString(process.env.HUBSPOT_DEAL_STAGE_ID);
-
-    if (!hubspotToken || !dealPipelineId || !dealStageId) {
-        return null;
-    }
-
-    return {
-        hubspotToken,
-        dealPipelineId,
-        dealStageId,
-        dealBantProperty: cleanString(process.env.HUBSPOT_DEAL_BANT_PROPERTY) || 'bant_summary',
-    };
-}
-
 async function parseRequestBody(
     request: Request,
     corsHeaders: Record<string, string>,
@@ -226,7 +164,7 @@ async function parseRequestBody(
     try {
         return await request.json();
     } catch {
-        return buildErrorResponse(
+        return buildJsonResponse(
             {
                 ok: false,
                 requestId,
@@ -246,7 +184,7 @@ function validateRequestPayload(
 ): SubmitLeadRequest | Response {
     const validation = validatePayload(rawBody);
     if (validation.valid === false) {
-        return buildErrorResponse(
+        return buildJsonResponse(
             {
                 ok: false,
                 requestId,
@@ -259,392 +197,6 @@ function validateRequestPayload(
     }
 
     return validation.data;
-}
-
-async function recoverDuplicateContact(
-    hubspotToken: string,
-    email: string,
-    coreContactProperties: Record<string, string>,
-): Promise<string> {
-    const existingContactId = await getContactIdByEmail(hubspotToken, email);
-    if (!existingContactId) {
-        throw new Error('CONTACT_SEARCH_FAILED:404:Contact ID not found for existing email');
-    }
-
-    await updateContactProperties(hubspotToken, existingContactId, coreContactProperties);
-    return existingContactId;
-}
-
-async function createOrUpdateContact(
-    hubspotToken: string,
-    payload: { email: string },
-    coreContactProperties: Record<string, string>,
-    corsHeaders: Record<string, string>,
-    requestId: string,
-): Promise<string | Response> {
-    emitLeadLog('info', requestId, 'contact_create_or_update', {
-        email: maskEmail(payload.email),
-        propertyCount: Object.keys(coreContactProperties).length,
-    });
-
-    const createContactResponse = await hubspotRequest(hubspotToken, '/crm/v3/objects/contacts', {
-        method: 'POST',
-        body: JSON.stringify({ properties: coreContactProperties }),
-    });
-
-    if (createContactResponse.status === 401 || createContactResponse.status === 403) {
-        emitLeadLog('error', requestId, 'contact_create_or_update_failed', {
-            code: 'HUBSPOT_UNAUTHORIZED',
-            status: createContactResponse.status,
-        });
-
-        return buildErrorResponse(
-            {
-                ok: false,
-                requestId,
-                code: 'HUBSPOT_UNAUTHORIZED',
-                error: 'Erro de integração com o CRM',
-            },
-            createContactResponse.status,
-            corsHeaders,
-        );
-    }
-
-    if (createContactResponse.status === 409) {
-        emitLeadLog('warn', requestId, 'contact_duplicate_detected', {
-            email: maskEmail(payload.email),
-        });
-
-        try {
-            const existingContactId = await recoverDuplicateContact(hubspotToken, payload.email, coreContactProperties);
-
-            emitLeadLog('info', requestId, 'contact_create_or_update_success', {
-                mode: 'updated_existing',
-                contactId: existingContactId,
-            });
-
-            return existingContactId;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : 'Unknown recovery error';
-            const parsedError = parseHubSpotErrorMessage(message);
-            const errorCode = parsedError.isUnauthorized
-                ? 'HUBSPOT_UNAUTHORIZED'
-                : parsedError.isPropertyError
-                    ? 'HUBSPOT_PROPERTY_ERROR'
-                    : 'HUBSPOT_API_ERROR';
-
-            emitLeadLog('error', requestId, 'contact_create_or_update_failed', {
-                phase: 'duplicate_recovery',
-                code: errorCode,
-                status: parsedError.status,
-                detail: parsedError.detail,
-            });
-
-            if (parsedError.isUnauthorized) {
-                return buildErrorResponse(
-                    {
-                        ok: false,
-                        requestId,
-                        code: 'HUBSPOT_UNAUTHORIZED',
-                        error: 'Erro de integração com o CRM',
-                    },
-                    401,
-                    corsHeaders,
-                );
-            }
-
-            if (parsedError.isPropertyError) {
-                return buildErrorResponse(
-                    {
-                        ok: false,
-                        requestId,
-                        code: 'HUBSPOT_PROPERTY_ERROR',
-                        error: 'Erro de integração com o CRM: propriedades do contato inválidas ou não configuradas.',
-                    },
-                    502,
-                    corsHeaders,
-                );
-            }
-
-            return buildErrorResponse(
-                {
-                    ok: false,
-                    requestId,
-                    code: 'HUBSPOT_API_ERROR',
-                    error: 'Erro ao processar contato',
-                },
-                502,
-                corsHeaders,
-            );
-        }
-    }
-
-    if (!createContactResponse.ok) {
-        const hubspotErrorText = await createContactResponse.text().catch(() => '');
-        const errorCode = isHubSpotPropertyStatus(createContactResponse.status)
-            ? 'HUBSPOT_PROPERTY_ERROR'
-            : 'HUBSPOT_API_ERROR';
-
-        emitLeadLog('error', requestId, 'contact_create_or_update_failed', {
-            code: errorCode,
-            status: createContactResponse.status,
-            detail: truncateDetail(hubspotErrorText),
-        });
-
-        return buildErrorResponse(
-            {
-                ok: false,
-                requestId,
-                code: errorCode,
-                error: errorCode === 'HUBSPOT_PROPERTY_ERROR'
-                    ? 'Erro de integração com o CRM: propriedades do contato inválidas ou não configuradas.'
-                    : 'Erro de integração com o CRM',
-            },
-            502,
-            corsHeaders,
-        );
-    }
-
-    const hubspotData = (await createContactResponse.json().catch(() => ({}))) as HubSpotObjectResponse;
-    const contactId = cleanString(hubspotData.id);
-    if (!contactId) {
-        emitLeadLog('error', requestId, 'contact_create_or_update_failed', {
-            code: 'HUBSPOT_API_ERROR',
-            detail: 'missing_contact_id',
-        });
-
-        return buildErrorResponse(
-            {
-                ok: false,
-                requestId,
-                code: 'HUBSPOT_API_ERROR',
-                error: 'Erro de integração com o CRM',
-            },
-            502,
-            corsHeaders,
-        );
-    }
-
-    emitLeadLog('info', requestId, 'contact_create_or_update_success', {
-        mode: 'created',
-        contactId,
-    });
-
-    return contactId;
-}
-
-async function syncAdditionalContactProperties(
-    hubspotToken: string,
-    contactId: string,
-    additionalProperties: Record<string, string>,
-    payload: {
-        firstName: string;
-        lastName: string;
-        email: string;
-        bantSummary: string;
-    },
-    requestId: string,
-): Promise<string | undefined> {
-    const propertyEntries = Object.entries(additionalProperties);
-    if (propertyEntries.length === 0) {
-        return undefined;
-    }
-
-    emitLeadLog('info', requestId, 'contact_enrichment_start', {
-        contactId,
-        propertyCount: propertyEntries.length,
-    });
-
-    try {
-        await updateContactProperties(hubspotToken, contactId, additionalProperties);
-        emitLeadLog('info', requestId, 'contact_enrichment_success', {
-            contactId,
-            propertyCount: propertyEntries.length,
-        });
-        return undefined;
-    } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : 'Unknown property sync error';
-        const parsedError = parseHubSpotErrorMessage(message);
-        const failedBatch: FailedContactPropertyBatch = {
-            properties: additionalProperties,
-            status: parsedError.status,
-            code: parsedError.isUnauthorized
-                ? 'HUBSPOT_UNAUTHORIZED'
-                : parsedError.isPropertyError
-                    ? 'HUBSPOT_PROPERTY_ERROR'
-                    : 'HUBSPOT_API_ERROR',
-            detail: parsedError.detail,
-        };
-
-        emitLeadLog(parsedError.isPropertyError ? 'warn' : 'error', requestId, 'contact_enrichment_failed', {
-            contactId,
-            propertyCount: propertyEntries.length,
-            code: failedBatch.code,
-            status: parsedError.status,
-            detail: parsedError.detail,
-        });
-
-        const warningBase = 'Contato salvo, mas alguns dados de rastreamento/UTM não puderam ser gravados automaticamente no HubSpot.';
-        const warningContext = [
-            `Contato HubSpot: ${contactId}`,
-            `Falha do enrichment: batch [${failedBatch.code}${failedBatch.status ? ` ${failedBatch.status}` : ''}]`,
-            `Payload não persistido: ${JSON.stringify(failedBatch.properties)}`,
-        ];
-
-        if (!shouldAttemptFallbackNote(parsedError)) {
-            emitLeadLog('warn', requestId, 'fallback_note_skipped', {
-                contactId,
-                phase: 'contact_enrichment',
-                code: failedBatch.code,
-                status: failedBatch.status,
-            });
-            return warningBase;
-        }
-
-        return await createFallbackNoteForLead(
-            hubspotToken,
-            contactId,
-            payload,
-            warningBase,
-            requestId,
-            warningContext,
-        );
-    }
-}
-
-function buildDealProperties(
-    payload: {
-        firstName: string;
-        lastName: string;
-        destination: string;
-        bantSummary: string;
-    },
-    config: SubmitLeadConfig,
-): Record<string, string> {
-    const rawDealName = `Lead chatbot - ${payload.firstName} ${payload.lastName} - ${payload.destination}`;
-
-    return {
-        dealname: rawDealName.length > 255 ? `${rawDealName.substring(0, 252)}...` : rawDealName,
-        pipeline: config.dealPipelineId,
-        dealstage: config.dealStageId,
-        [config.dealBantProperty]: payload.bantSummary,
-    };
-}
-
-async function createFallbackNoteForLead(
-    hubspotToken: string,
-    contactId: string,
-    payload: {
-        firstName: string;
-        lastName: string;
-        email: string;
-        bantSummary: string;
-    },
-    baseWarning: string,
-    requestId: string,
-    extraContext: string[] = [],
-): Promise<string> {
-    try {
-        const noteBody = [
-            'Fallback automático do chatbot:',
-            baseWarning,
-            `Lead: ${payload.firstName} ${payload.lastName} <${payload.email}>`,
-            `BANT: ${payload.bantSummary}`,
-            ...extraContext,
-        ].join('\n');
-
-        await createFallbackNote(hubspotToken, contactId, noteBody);
-        return `${baseWarning} Uma nota foi registrada no contato para acompanhamento manual.`;
-    } catch (noteError: unknown) {
-        emitLeadLog('error', requestId, 'fallback_note_failed', {
-            contactId,
-            detail: truncateDetail(noteError instanceof Error ? noteError.message : String(noteError)),
-        });
-
-        return baseWarning;
-    }
-}
-
-async function createDealForLead(
-    hubspotToken: string,
-    contactId: string,
-    payload: {
-        firstName: string;
-        lastName: string;
-        email: string;
-        destination: string;
-        bantSummary: string;
-    },
-    config: SubmitLeadConfig,
-    corsHeaders: Record<string, string>,
-    requestId: string,
-): Promise<DealCreationResult | Response> {
-    emitLeadLog('info', requestId, 'deal_create', {
-        contactId,
-        destination: payload.destination,
-    });
-
-    try {
-        const dealId = await createDeal(hubspotToken, buildDealProperties(payload, config));
-        await associateDealToContact(hubspotToken, dealId, contactId);
-
-        emitLeadLog('info', requestId, 'deal_associate', {
-            contactId,
-            dealId,
-        });
-
-        return { dealId };
-    } catch (dealError: unknown) {
-        const message = dealError instanceof Error ? dealError.message : 'Unknown deal error';
-        const parsedError = parseHubSpotErrorMessage(message);
-
-        emitLeadLog(parsedError.isPropertyError ? 'warn' : 'error', requestId, 'deal_create_failed', {
-            contactId,
-            code: parsedError.isUnauthorized
-                ? 'HUBSPOT_UNAUTHORIZED'
-                : parsedError.isPropertyError
-                    ? 'HUBSPOT_PROPERTY_ERROR'
-                    : 'HUBSPOT_API_ERROR',
-            status: parsedError.status,
-            detail: parsedError.detail,
-        });
-
-        if (parsedError.isUnauthorized) {
-            return buildErrorResponse(
-                {
-                    ok: false,
-                    requestId,
-                    code: 'HUBSPOT_UNAUTHORIZED',
-                    error: 'Erro de integração com o CRM',
-                },
-                401,
-                corsHeaders,
-            );
-        }
-
-        const warningBase = parsedError.isPropertyError
-            ? 'Contato salvo, mas o deal não foi criado automaticamente por erro de propriedade no HubSpot.'
-            : 'Contato salvo, mas não foi possível criar ou associar o deal automaticamente.';
-        if (!shouldAttemptFallbackNote(parsedError)) {
-            emitLeadLog('warn', requestId, 'fallback_note_skipped', {
-                contactId,
-                phase: 'deal_create',
-                status: parsedError.status,
-                detail: parsedError.detail,
-            });
-            return { warning: warningBase };
-        }
-
-        const warning = await createFallbackNoteForLead(
-            hubspotToken,
-            contactId,
-            payload,
-            warningBase,
-            requestId,
-        );
-
-        return { warning };
-    }
 }
 
 async function trackLeadConversions(payload: SubmitLeadRequest, requestId: string): Promise<void> {
@@ -688,11 +240,8 @@ export default async function handler(request: Request): Promise<Response> {
             return new Response(null, { status: 204, headers: corsHeaders });
         }
 
-        const rateLimitResponse = await getRateLimitResponse(request, corsHeaders, requestId);
-        if (rateLimitResponse) return rateLimitResponse;
-
         if (request.method !== 'POST') {
-            return buildErrorResponse(
+            return buildJsonResponse(
                 {
                     ok: false,
                     requestId,
@@ -708,17 +257,16 @@ export default async function handler(request: Request): Promise<Response> {
         if (!config) {
             emitLeadLog('error', requestId, 'config', {
                 code: 'SERVER_CONFIG_ERROR',
-                hasHubSpotToken: Boolean(process.env.HUBSPOT_TOKEN),
-                hasPipelineId: Boolean(cleanString(process.env.HUBSPOT_DEAL_PIPELINE_ID)),
-                hasDealStageId: Boolean(cleanString(process.env.HUBSPOT_DEAL_STAGE_ID)),
+                hasWebhookUrl: Boolean(cleanString(process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL)),
+                hasWebhookSecret: Boolean(cleanString(process.env.N8N_WEBHOOK_SECRET)),
             });
 
-            return buildErrorResponse(
+            return buildJsonResponse(
                 {
                     ok: false,
                     requestId,
                     code: 'SERVER_CONFIG_ERROR',
-                    error: 'Erro de configuração do servidor',
+                    error: 'Integração de lead indisponível no momento.',
                 },
                 500,
                 corsHeaders,
@@ -746,47 +294,22 @@ export default async function handler(request: Request): Promise<Response> {
             ),
         });
 
-        const coreContactProperties = buildCoreContactProperties(payload);
-        const contactId = await createOrUpdateContact(
-            config.hubspotToken,
-            payload,
-            coreContactProperties,
-            corsHeaders,
+        const rateLimitResponse = await getRateLimitResponse(request, corsHeaders, requestId);
+        if (rateLimitResponse) return rateLimitResponse;
+
+        await sendLeadToN8n(
+            config.webhookUrl,
+            config.webhookSecret,
             requestId,
+            buildN8nLeadPayload(payload, requestId),
         );
-        if (contactId instanceof Response) return contactId;
 
-        const additionalContactProperties = buildAdditionalContactProperties(payload);
-        const [contactWarning, dealResult] = await Promise.all([
-            syncAdditionalContactProperties(
-                config.hubspotToken,
-                contactId,
-                additionalContactProperties,
-                payload,
-                requestId,
-            ),
-            createDealForLead(
-                config.hubspotToken,
-                contactId,
-                payload,
-                config,
-                corsHeaders,
-                requestId,
-            ),
-        ]);
-        if (dealResult instanceof Response) return dealResult;
-
-        const response = buildSuccessResponse(
+        const response = buildJsonResponse(
             {
                 ok: true,
                 requestId,
-                contactId,
-                dealId: dealResult.dealId,
-                warning: appendWarning(contactWarning, dealResult.warning),
-                message: dealResult.dealId
-                    ? 'Contato e deal criados com sucesso no HubSpot.'
-                    : 'Contato criado com sucesso no HubSpot.',
-            } satisfies SubmitLeadResponse,
+                message: 'Enviado com sucesso',
+            },
             201,
             corsHeaders,
         );
@@ -799,21 +322,22 @@ export default async function handler(request: Request): Promise<Response> {
 
         return response;
     } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
+        const classified = classifySubmitLeadError(error);
 
-        emitLeadLog('error', requestId, 'unexpected', {
-            code: 'HUBSPOT_API_ERROR',
-            detail: truncateDetail(message),
+        emitLeadLog('error', requestId, classified.code === 'N8N_WEBHOOK_ERROR' ? 'n8n_webhook_failed' : 'unexpected', {
+            code: classified.code,
+            status: classified.status,
+            errorType: error instanceof Error ? error.name : typeof error,
         });
 
-        return buildErrorResponse(
+        return buildJsonResponse(
             {
                 ok: false,
                 requestId,
-                code: 'HUBSPOT_API_ERROR',
-                error: 'Erro interno ao processar envio do lead.',
+                code: classified.code,
+                error: classified.error,
             },
-            500,
+            classified.status,
             corsHeaders,
         );
     }

--- a/api/submit-waitlist.ts
+++ b/api/submit-waitlist.ts
@@ -1,19 +1,10 @@
-import type { SubmitLeadRequest } from '../types/leadCapture';
 import type { SubmitWaitlistRequest, SubmitWaitlistResponse } from '../types/waitlist';
 import { buildCorsHeaders, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import { cleanString } from '../lib/lead-logic';
-import { buildWaitlistNoteBody, splitWaitlistName, validateWaitlistPayload } from '../lib/waitlist-logic';
-import {
-    addContactToList,
-    buildAdditionalContactProperties,
-    buildCoreContactProperties,
-    createContactNote,
-    getContactIdByEmail,
-    hubspotRequest,
-    type HubSpotObjectResponse,
-    updateContactProperties,
-} from '../services/hubspot';
+import { buildN8nWaitlistPayload } from '../lib/n8n-payloads';
+import { validateWaitlistPayload } from '../lib/waitlist-logic';
+import { sendWaitlistToN8n } from '../services/n8n';
 
 export const config = {
     runtime: 'edge',
@@ -21,6 +12,11 @@ export const config = {
 
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
+
+interface SubmitWaitlistConfig {
+    webhookUrl: string;
+    webhookSecret: string;
+}
 
 function createRequestId(): string {
     if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -41,109 +37,90 @@ function buildJsonResponse(body: SubmitWaitlistResponse, status: number, corsHea
     });
 }
 
-function parseHubSpotError(error: unknown): { code: 'HUBSPOT_UNAUTHORIZED' | 'HUBSPOT_PROPERTY_ERROR' | 'HUBSPOT_API_ERROR'; status: number } {
+function getSubmitWaitlistConfig(): SubmitWaitlistConfig | null {
+    const webhookUrl = cleanString(process.env.N8N_SUBMIT_WAITLIST_WEBHOOK_URL);
+    const webhookSecret = cleanString(process.env.N8N_WEBHOOK_SECRET);
+
+    if (!webhookUrl || !webhookSecret) {
+        return null;
+    }
+
+    return {
+        webhookUrl,
+        webhookSecret,
+    };
+}
+
+export function classifySubmitWaitlistError(error: unknown): {
+    code: 'N8N_WEBHOOK_ERROR' | 'INTERNAL_ERROR';
+    status: number;
+    error: string;
+} {
     const message = error instanceof Error ? error.message : String(error);
-
-    if (message.includes('UNAUTHORIZED')) {
-        return { code: 'HUBSPOT_UNAUTHORIZED', status: 401 };
+    const match = message.match(/^N8N_WEBHOOK_ERROR:(\d+):(.*)$/s);
+    if (!match) {
+        return {
+            code: 'INTERNAL_ERROR',
+            status: 500,
+            error: 'Erro interno ao processar envio da lista de espera.',
+        };
     }
 
-    const match = message.match(/^[A-Z_]+:(\d+):(.*)$/s);
-    const status = match ? Number(match[1]) : 502;
-
-    if (status === 400 || status === 422) {
-        return { code: 'HUBSPOT_PROPERTY_ERROR', status: 502 };
-    }
-
-    return { code: 'HUBSPOT_API_ERROR', status: 502 };
+    return {
+        code: 'N8N_WEBHOOK_ERROR',
+        status: 502,
+        error: 'Erro ao enviar inscrição na lista de espera.',
+    };
 }
 
-async function createOrUpdateContact(
-    token: string,
-    coreProperties: Record<string, string>,
-    email: string,
-): Promise<string> {
-    const createContactResponse = await hubspotRequest(token, '/crm/v3/objects/contacts', {
-        method: 'POST',
-        body: JSON.stringify({ properties: coreProperties }),
-    });
-
-    if (createContactResponse.status === 401 || createContactResponse.status === 403) {
-        throw new Error('UNAUTHORIZED');
-    }
-
-    if (createContactResponse.status === 409) {
-        const existingContactId = await getContactIdByEmail(token, email);
-        if (!existingContactId) {
-            throw new Error('CONTACT_SEARCH_FAILED:404:Contact ID not found for existing email');
-        }
-
-        await updateContactProperties(token, existingContactId, coreProperties);
-        return existingContactId;
-    }
-
-    if (!createContactResponse.ok) {
-        const detail = await createContactResponse.text().catch(() => '');
-        throw new Error(`CONTACT_CREATE_FAILED:${createContactResponse.status}:${detail}`);
-    }
-
-    const data = (await createContactResponse.json().catch(() => ({}))) as HubSpotObjectResponse;
-    if (!data.id) {
-        throw new Error('CONTACT_CREATE_FAILED:502:missing_contact_id');
-    }
-
-    return data.id;
-}
-
-async function processWaitlistSync(
-    hubspotToken: string,
-    payload: SubmitWaitlistRequest,
-    enrichmentPayload: SubmitLeadRequest
-): Promise<{ contactId: string; warning?: string }> {
-    const coreContactProperties = buildCoreContactProperties(enrichmentPayload);
-    const additionalContactProperties = buildAdditionalContactProperties(enrichmentPayload);
-
-    const contactId = await createOrUpdateContact(hubspotToken, coreContactProperties, payload.email);
-    let warning: string | undefined;
-
-    if (Object.keys(additionalContactProperties).length > 0) {
-        try {
-            await updateContactProperties(hubspotToken, contactId, additionalContactProperties);
-        } catch (trackingError: unknown) {
-            console.error('submit-waitlist: failed to update additional contact properties', trackingError);
-            warning = 'Contato salvo, mas alguns dados de rastreamento não puderam ser gravados.';
-        }
-    }
-
-    const lollapaloozaListId = cleanString(process.env.HUBSPOT_LOLLAPALOOZA_LIST_ID);
-    if (lollapaloozaListId) {
-        try {
-            await addContactToList(hubspotToken, lollapaloozaListId, contactId);
-        } catch (listError: unknown) {
-            console.error('submit-waitlist: failed to add contact to lollapalooza list', listError);
-        }
-    } else {
-        console.info('submit-waitlist: lollapalooza waitlist list id is not configured');
-    }
-
+async function parseRequestBody(
+    request: Request,
+    corsHeaders: Record<string, string>,
+    requestId: string,
+): Promise<unknown | Response> {
     try {
-        await createContactNote(hubspotToken, contactId, buildWaitlistNoteBody(payload));
-    } catch (noteError: unknown) {
-        console.error('submit-waitlist: failed to create waitlist note', noteError);
-        warning = warning || 'Contato salvo, mas a anotação de waitlist não pôde ser registrada automaticamente.';
+        return await request.json();
+    } catch {
+        return buildJsonResponse(
+            {
+                ok: false,
+                requestId,
+                code: 'VALIDATION_ERROR',
+                error: 'JSON inválido no corpo da requisição.',
+            },
+            400,
+            corsHeaders,
+        );
     }
-
-    return { contactId, warning };
 }
 
-export default async function handler(request: Request): Promise<Response> {
-    const corsHeaders = buildCorsHeaders();
-    const requestId = createRequestId();
-
-    if (request.method === 'OPTIONS') {
-        return new Response(null, { status: 204, headers: corsHeaders });
+function validateRequestPayload(
+    rawBody: unknown,
+    corsHeaders: Record<string, string>,
+    requestId: string,
+): SubmitWaitlistRequest | Response {
+    const validation = validateWaitlistPayload(rawBody);
+    if (validation.valid === false) {
+        return buildJsonResponse(
+            {
+                ok: false,
+                requestId,
+                code: 'VALIDATION_ERROR',
+                error: validation.error,
+            },
+            400,
+            corsHeaders,
+        );
     }
 
+    return validation.data;
+}
+
+async function getRateLimitResponse(
+    request: Request,
+    corsHeaders: Record<string, string>,
+    requestId: string,
+): Promise<Response | null> {
     const clientIP = getClientIP(request);
     const rateLimit = await checkRateLimit(clientIP, {
         limit: RATE_LIMIT_MAX_REQUESTS,
@@ -151,70 +128,96 @@ export default async function handler(request: Request): Promise<Response> {
         prefix: 'ratelimit:submit-waitlist',
     });
 
-    if (!rateLimit.allowed) {
-        return buildJsonResponse(
-            { ok: false, requestId, code: 'RATE_LIMIT_EXCEEDED', error: 'Muitas tentativas. Tente novamente em breve.' },
-            429,
-            {
-                ...corsHeaders,
-                'Retry-After': String(Math.ceil(rateLimit.resetIn / 1000)),
-                'X-RateLimit-Remaining': String(rateLimit.remaining),
-                'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimit.resetIn) / 1000)),
-            },
+    if (rateLimit.allowed) return null;
+
+    return buildJsonResponse(
+        {
+            ok: false,
+            requestId,
+            code: 'RATE_LIMIT_EXCEEDED',
+            error: 'Muitas tentativas. Tente novamente em breve.',
+        },
+        429,
+        {
+            ...corsHeaders,
+            'Retry-After': String(Math.ceil(rateLimit.resetIn / 1000)),
+            'X-RateLimit-Remaining': String(rateLimit.remaining),
+            'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimit.resetIn) / 1000)),
+        },
+    );
+}
+
+export default async function handler(request: Request): Promise<Response> {
+    const corsHeaders = buildCorsHeaders();
+    const requestId = createRequestId();
+
+    try {
+        if (request.method === 'OPTIONS') {
+            return new Response(null, { status: 204, headers: corsHeaders });
+        }
+
+        if (request.method !== 'POST') {
+            return buildJsonResponse(
+                {
+                    ok: false,
+                    requestId,
+                    code: 'METHOD_NOT_ALLOWED',
+                    error: 'Método não permitido.',
+                },
+                405,
+                corsHeaders,
+            );
+        }
+
+        const config = getSubmitWaitlistConfig();
+        if (!config) {
+            return buildJsonResponse(
+                {
+                    ok: false,
+                    requestId,
+                    code: 'SERVER_CONFIG_ERROR',
+                    error: 'Integração de waitlist indisponível no momento.',
+                },
+                500,
+                corsHeaders,
+            );
+        }
+
+        const rawBody = await parseRequestBody(request, corsHeaders, requestId);
+        if (rawBody instanceof Response) return rawBody;
+
+        const payload = validateRequestPayload(rawBody, corsHeaders, requestId);
+        if (payload instanceof Response) return payload;
+
+        const rateLimitResponse = await getRateLimitResponse(request, corsHeaders, requestId);
+        if (rateLimitResponse) return rateLimitResponse;
+
+        await sendWaitlistToN8n(
+            config.webhookUrl,
+            config.webhookSecret,
+            requestId,
+            buildN8nWaitlistPayload(payload, requestId),
         );
-    }
-
-    if (request.method !== 'POST') {
-        return buildJsonResponse({ ok: false, requestId, code: 'METHOD_NOT_ALLOWED', error: 'Método não permitido.' }, 405, corsHeaders);
-    }
-
-    let rawPayload: unknown;
-    try {
-        rawPayload = await request.json();
-    } catch {
-        return buildJsonResponse({ ok: false, requestId, code: 'VALIDATION_ERROR', error: 'Payload inválido.' }, 400, corsHeaders);
-    }
-
-    const validation = validateWaitlistPayload(rawPayload);
-    if (validation.valid === false) {
-        return buildJsonResponse({ ok: false, requestId, code: 'VALIDATION_ERROR', error: validation.error }, 400, corsHeaders);
-    }
-
-    const hubspotToken = process.env.HUBSPOT_TOKEN;
-    if (!hubspotToken) {
-        return buildJsonResponse({ ok: false, requestId, code: 'SERVER_CONFIG_ERROR', error: 'Integração de waitlist indisponível no momento.' }, 500, corsHeaders);
-    }
-
-    const payload = validation.data;
-    const { firstName, lastName } = splitWaitlistName(payload.name);
-    const enrichmentPayload: SubmitLeadRequest = {
-        firstName,
-        lastName,
-        email: payload.email,
-        bantSummary: 'Lista de Espera Lollapalooza 2027',
-        destination: 'Lollapalooza Brasil',
-        utms: payload.utms,
-        tracking: payload.tracking,
-    };
-
-    try {
-        const { contactId, warning } = await processWaitlistSync(hubspotToken, payload, enrichmentPayload);
 
         return buildJsonResponse(
-            { ok: true, requestId, contactId, warning, message: 'Cadastro realizado com sucesso na lista de espera.' },
+            {
+                ok: true,
+                requestId,
+                message: 'Enviado com sucesso',
+            },
             201,
             corsHeaders,
         );
     } catch (error: unknown) {
-        const parsed = parseHubSpotError(error);
+        const classified = classifySubmitWaitlistError(error);
         return buildJsonResponse(
             {
                 ok: false,
                 requestId,
-                code: parsed.code,
-                error: parsed.code === 'HUBSPOT_UNAUTHORIZED' ? 'Erro de integração com o CRM.' : 'Erro ao salvar sua inscrição na lista de espera.',
+                code: classified.code,
+                error: classified.error,
             },
-            parsed.status,
+            classified.status,
             corsHeaders,
         );
     }

--- a/api/submit-waitlist.ts
+++ b/api/submit-waitlist.ts
@@ -18,6 +18,13 @@ interface SubmitWaitlistConfig {
     webhookSecret: string;
 }
 
+function truncateDetail(detail: string): string | undefined {
+    const trimmed = detail.replace(/[\r\n]+/g, ' ').trim();
+    if (!trimmed) return undefined;
+
+    return trimmed.slice(0, 200);
+}
+
 function createRequestId(): string {
     if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
         return crypto.randomUUID();
@@ -55,6 +62,7 @@ export function classifySubmitWaitlistError(error: unknown): {
     code: 'N8N_WEBHOOK_ERROR' | 'INTERNAL_ERROR';
     status: number;
     error: string;
+    detail?: string;
 } {
     const message = error instanceof Error ? error.message : String(error);
     const match = message.match(/^N8N_WEBHOOK_ERROR:(\d+):(.*)$/s);
@@ -66,10 +74,13 @@ export function classifySubmitWaitlistError(error: unknown): {
         };
     }
 
+    const detail = truncateDetail(match[2] || '');
+
     return {
         code: 'N8N_WEBHOOK_ERROR',
         status: 502,
         error: 'Erro ao enviar inscrição na lista de espera.',
+        detail,
     };
 }
 

--- a/components/CallToAction.tsx
+++ b/components/CallToAction.tsx
@@ -104,7 +104,7 @@ const CallToAction: React.FC = () => {
                                 <ChatCentered className="w-5 h-5" weight="fill" />
                             </button>
 
-                            {/* Botão secundário — captura nome + email → HubSpot */}
+                            {/* Botão secundário — captura nome + email para o fluxo de lead */}
                             {formState === 'closed' && (
                                 <button
                                     onClick={() => setFormState('open')}

--- a/docs/superpowers/plans/2026-04-03-n8n-webhook-lead-implementation.md
+++ b/docs/superpowers/plans/2026-04-03-n8n-webhook-lead-implementation.md
@@ -1,0 +1,627 @@
+# N8N Webhook Lead Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace direct HubSpot writes in the rich lead and waitlist API handlers with validated server-to-server n8n webhook delivery while preserving existing public route contracts and user-facing flow guarantees.
+
+**Architecture:** Keep `api/submit-lead.ts` and `api/submit-waitlist.ts` as the trust boundary for parsing, validation, sanitization, and rate limiting. Introduce a focused `services/n8n.ts` transport plus optional payload builders so both routes emit stable webhook contracts and return neutral success responses. Frontend callers stay on the same route URLs, with only response-shape expectations updated away from HubSpot-specific fields.
+
+**Tech Stack:** React 19, TypeScript, Vite edge-style API handlers, `node:test`, Playwright, shared helpers in `lib/` and `services/`
+
+---
+
+## File Structure
+
+### New Files
+
+- Create: `services/n8n.ts`
+  Centralize webhook transport, timeout handling, auth headers, sanitized error mapping, and typed helper functions for lead and waitlist delivery.
+
+- Create: `lib/n8n-payloads.ts`
+  Build clean outbound payloads for the two workflows so route files stay focused on orchestration.
+
+### Modified Files
+
+- Modify: `api/submit-lead.ts`
+  Remove HubSpot orchestration, keep validation/rate limiting, call `services/n8n.ts`, preserve async conversion tracking unless implementation uncovers a blocking dependency.
+
+- Modify: `api/submit-waitlist.ts`
+  Remove HubSpot orchestration, keep validation/rate limiting, call `services/n8n.ts`.
+
+- Modify: `types/leadCapture.ts`
+  Remove HubSpot-specific success response fields and add the new `N8N_WEBHOOK_ERROR` code.
+
+- Modify: `types/waitlist.ts`
+  Remove HubSpot-specific success response fields and add the new `N8N_WEBHOOK_ERROR` code.
+
+- Modify: `hooks/useLeadCapture.ts`
+  Update success parsing to stop expecting `contactId` and `dealId`, and update the fallback error copy away from HubSpot-specific wording.
+
+- Modify: `tests/submit-lead.test.ts`
+  Replace HubSpot API mocking with n8n webhook mocking and assert the normalized outbound contract.
+
+- Modify: `tests/submit-waitlist.test.ts`
+  Replace HubSpot API mocking with n8n webhook mocking and assert the normalized outbound contract.
+
+- Modify: `tests/e2e/chatbot-lead-submit.spec.ts`
+  Keep the WhatsApp handoff guarantees, but remove HubSpot-specific assertions from mocked responses and expectations.
+
+- Modify: `tests/e2e/lollapalooza-waitlist.spec.ts`
+  Adjust any response expectations if they still assume `contactId` or HubSpot-specific messaging.
+
+- Modify: `README.md`
+  Update environment variable documentation and integration description from HubSpot direct writes to n8n webhooks if the README still documents the old flow.
+
+## Chunk 1: Shared N8N Transport and Payload Builders
+
+### Task 1: Add typed webhook payload builders
+
+**Files:**
+- Create: `lib/n8n-payloads.ts`
+- Modify: `types/leadCapture.ts`
+- Modify: `types/waitlist.ts`
+- Test: `tests/submit-lead.test.ts`
+- Test: `tests/submit-waitlist.test.ts`
+
+- [ ] **Step 1: Write failing route-level assertions for the new outbound payload shapes**
+
+Add or update route tests to assert that:
+
+- `submit-lead` sends `requestId`, `source`, `lead`, `utms`, `tracking`, and `meta.receivedAt`
+- `submit-waitlist` sends `requestId`, `source`, `waitlist`, `utms`, `tracking`, and `meta.receivedAt`
+- response success shape no longer depends on `contactId` or `dealId`
+
+Run:
+
+```bash
+pnpm test:regression -- --test-name-pattern="submit-lead|submit-waitlist"
+```
+
+Expected:
+
+- FAIL because the handlers still call HubSpot and still return legacy response fields
+
+- [ ] **Step 2: Add the response-type changes first**
+
+Update `types/leadCapture.ts`:
+
+- remove `contactId` and `dealId` from `SubmitLeadSuccess`
+- keep `warning?`
+- keep `message`
+- add `'N8N_WEBHOOK_ERROR'` to `SubmitLeadErrorCode`
+
+Update `types/waitlist.ts`:
+
+- remove `contactId` from `SubmitWaitlistSuccess`
+- keep `warning?`
+- keep `message`
+- add `'N8N_WEBHOOK_ERROR'` to `SubmitWaitlistErrorCode`
+
+- [ ] **Step 3: Implement payload builder helpers**
+
+In `lib/n8n-payloads.ts`, add small focused builders:
+
+- `buildN8nLeadPayload(payload: SubmitLeadRequest, requestId: string)`
+- `buildN8nWaitlistPayload(payload: SubmitWaitlistRequest, requestId: string)`
+
+Required shape:
+
+```ts
+{
+  requestId,
+  source: 'submit-lead' | 'submit-waitlist',
+  lead? / waitlist?,
+  utms,
+  tracking,
+  meta: { receivedAt: new Date().toISOString() }
+}
+```
+
+Implementation rules:
+
+- do not re-sanitize here; trust validated route input
+- keep the shape explicit and stable
+- preserve `null` values where the normalized types already produce them
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+pnpm test:regression -- --test-name-pattern="submit-lead|submit-waitlist"
+```
+
+Expected:
+
+- route tests still fail overall because transport is still HubSpot-based
+- type-level and shape-related expectations compile cleanly
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add types/leadCapture.ts types/waitlist.ts lib/n8n-payloads.ts tests/submit-lead.test.ts tests/submit-waitlist.test.ts
+git commit -m "refactor: define n8n lead and waitlist contracts"
+```
+
+### Task 2: Add the shared n8n transport
+
+**Files:**
+- Create: `services/n8n.ts`
+- Test: `tests/submit-lead.test.ts`
+- Test: `tests/submit-waitlist.test.ts`
+
+- [ ] **Step 1: Write failing tests for webhook transport behavior through the route seam**
+
+Extend the route tests so they assert:
+
+- request hits the configured n8n URL
+- `X-Webhook-Secret` and `X-Request-Id` headers are sent
+- timeout or non-2xx response produces `N8N_WEBHOOK_ERROR`
+
+Run:
+
+```bash
+pnpm test:regression -- --test-name-pattern="submit-lead|submit-waitlist"
+```
+
+Expected:
+
+- FAIL because no n8n transport exists yet
+
+- [ ] **Step 2: Implement `services/n8n.ts`**
+
+Add:
+
+- `getN8nTimeoutMs()`
+- `n8nRequest(url: string, secret: string, requestId: string, payload: unknown): Promise<Response>`
+- `sendLeadToN8n(...)`
+- `sendWaitlistToN8n(...)`
+
+Behavior requirements:
+
+- `Content-Type: application/json`
+- `X-Webhook-Secret`
+- `X-Request-Id`
+- explicit timeout using `AbortController`
+- throw sanitized errors on timeout and non-2xx response
+
+Suggested internal error format:
+
+```ts
+new Error(`N8N_WEBHOOK_ERROR:${status}:${detail}`)
+```
+
+and for timeout:
+
+```ts
+new Error(`N8N_WEBHOOK_ERROR:504:Webhook request timed out after ${timeoutMs}ms`)
+```
+
+- [ ] **Step 3: Keep the service free of route-specific logic**
+
+Do not:
+
+- read request bodies directly
+- perform validation already handled in `lib/`
+- shape client responses inside `services/n8n.ts`
+
+Do:
+
+- keep env handling at the route/config boundary
+- keep transport only in `services/n8n.ts`
+
+- [ ] **Step 4: Run focused regression tests**
+
+Run:
+
+```bash
+pnpm test:regression -- --test-name-pattern="submit-lead|submit-waitlist"
+```
+
+Expected:
+
+- some route tests may still fail because handlers are not using the service yet
+- transport-related assertions should now have an implementation target
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/n8n.ts tests/submit-lead.test.ts tests/submit-waitlist.test.ts
+git commit -m "feat: add n8n webhook transport service"
+```
+
+## Chunk 2: Migrate Public API Handlers
+
+### Task 3: Migrate `submit-lead` to n8n delivery
+
+**Files:**
+- Modify: `api/submit-lead.ts`
+- Modify: `tests/submit-lead.test.ts`
+
+- [ ] **Step 1: Write or update failing tests for the new route behavior**
+
+Cover:
+
+- success returns `201` with `message: "Enviado com sucesso"`
+- success does not require `contactId` or `dealId`
+- invalid webhook config returns `SERVER_CONFIG_ERROR`
+- non-2xx webhook response returns `N8N_WEBHOOK_ERROR`
+- outbound request body uses the normalized contract from `lib/n8n-payloads.ts`
+
+Run:
+
+```bash
+pnpm test:regression -- --test-name-pattern="submit-lead"
+```
+
+Expected:
+
+- FAIL with the legacy HubSpot behavior
+
+- [ ] **Step 2: Replace the HubSpot config boundary**
+
+In `api/submit-lead.ts`:
+
+- remove `HUBSPOT_*` config requirements from the route
+- add a route-local config function for:
+  - `N8N_SUBMIT_LEAD_WEBHOOK_URL`
+  - `N8N_WEBHOOK_SECRET`
+- keep request ID generation
+- keep CORS, method gate, parse, validation, and rate limiting order
+
+- [ ] **Step 3: Remove HubSpot orchestration from the route**
+
+Delete route-local responsibilities that are now obsolete:
+
+- create/update contact flow
+- additional property enrichment flow
+- deal creation flow
+- fallback HubSpot note flow
+- HubSpot-specific warning/error parsing
+
+Replace with:
+
+- `buildN8nLeadPayload(validatedPayload, requestId)`
+- `sendLeadToN8n(webhookUrl, secret, requestId, outboundPayload)`
+
+- [ ] **Step 4: Return the new success and error contracts**
+
+Success:
+
+```json
+{
+  "ok": true,
+  "requestId": "req_123",
+  "message": "Enviado com sucesso"
+}
+```
+
+Failure on n8n transport:
+
+```json
+{
+  "ok": false,
+  "requestId": "req_123",
+  "code": "N8N_WEBHOOK_ERROR",
+  "error": "Erro ao enviar lead."
+}
+```
+
+Keep error copy sanitized and product-neutral.
+
+- [ ] **Step 5: Preserve async conversion tracking unless blocked**
+
+Keep `trackLeadConversions(payload, requestId)` after a successful webhook delivery unless implementation proves that:
+
+- conversions depend on HubSpot IDs
+- or the spec must be amended
+
+If blocked, stop and amend the spec rather than making an implicit product decision.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+pnpm test:regression -- --test-name-pattern="submit-lead"
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/submit-lead.ts tests/submit-lead.test.ts
+git commit -m "refactor: route submit-lead through n8n webhook"
+```
+
+### Task 4: Migrate `submit-waitlist` to n8n delivery
+
+**Files:**
+- Modify: `api/submit-waitlist.ts`
+- Modify: `tests/submit-waitlist.test.ts`
+
+- [ ] **Step 1: Write or update failing tests for the waitlist route**
+
+Cover:
+
+- success returns `201` with `message: "Enviado com sucesso"` or the approved waitlist-specific success text if product chooses to keep it separate during implementation
+- route sends waitlist-specific outbound payload
+- missing config returns `SERVER_CONFIG_ERROR`
+- n8n failure returns `N8N_WEBHOOK_ERROR`
+
+Run:
+
+```bash
+pnpm test:regression -- --test-name-pattern="submit-waitlist"
+```
+
+Expected:
+
+- FAIL with the current HubSpot behavior
+
+- [ ] **Step 2: Replace the HubSpot-specific flow**
+
+In `api/submit-waitlist.ts`:
+
+- keep method handling
+- keep rate limiting
+- keep `validateWaitlistPayload`
+- remove contact creation, list membership, and note creation logic
+- replace with:
+  - route-local config lookup for `N8N_SUBMIT_WAITLIST_WEBHOOK_URL` and `N8N_WEBHOOK_SECRET`
+  - `buildN8nWaitlistPayload(validatedPayload, requestId)`
+  - `sendWaitlistToN8n(...)`
+
+- [ ] **Step 3: Return the new neutral response contract**
+
+Success:
+
+```json
+{
+  "ok": true,
+  "requestId": "req_456",
+  "message": "Enviado com sucesso"
+}
+```
+
+No HubSpot-specific response data should remain.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+pnpm test:regression -- --test-name-pattern="submit-waitlist"
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/submit-waitlist.ts tests/submit-waitlist.test.ts
+git commit -m "refactor: route waitlist submissions through n8n webhook"
+```
+
+## Chunk 3: Frontend and E2E Compatibility
+
+### Task 5: Update frontend response parsing for the neutral contract
+
+**Files:**
+- Modify: `hooks/useLeadCapture.ts`
+- Modify: `components/AIChat.tsx`
+- Modify: `components/CallToAction.tsx`
+- Test: `tests/e2e/chatbot-lead-submit.spec.ts`
+
+- [ ] **Step 1: Write or update the failing browser and hook expectations**
+
+Focus on observable behavior:
+
+- chatbot still opens WhatsApp immediately
+- lead submit still happens in the background
+- success no longer depends on `contactId` or `dealId`
+- any fallback client copy no longer mentions HubSpot
+
+Run:
+
+```bash
+pnpm test:e2e -- chatbot-lead-submit
+```
+
+Expected:
+
+- FAIL if the browser test still expects HubSpot-specific success payloads or copy
+
+- [ ] **Step 2: Update `hooks/useLeadCapture.ts`**
+
+Adjust:
+
+- `SubmitLeadSuccessResult` to require only `requestId`, `warning?`, and a successful `ok`
+- `buildSubmitLeadSuccessResult()` to stop extracting `contactId` and `dealId`
+- default error text in `buildSubmitLeadErrorResult()` to change from HubSpot wording to neutral wording such as `Falha ao enviar lead.`
+
+Do not change:
+
+- event ID generation
+- tracking capture
+- dataLayer behavior
+
+- [ ] **Step 3: Update any UI assumptions if needed**
+
+Review `components/AIChat.tsx` and `components/CallToAction.tsx` for any logic that depends on `contactId`, `dealId`, or HubSpot-specific wording. Keep behavior unchanged if no dependency exists.
+
+- [ ] **Step 4: Run focused verification**
+
+Run:
+
+```bash
+pnpm test:e2e -- chatbot-lead-submit
+pnpm test:regression -- --test-name-pattern="useLeadCapture|submit-lead"
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hooks/useLeadCapture.ts components/AIChat.tsx components/CallToAction.tsx tests/e2e/chatbot-lead-submit.spec.ts
+git commit -m "refactor: align lead capture UI with n8n response contract"
+```
+
+### Task 6: Update waitlist browser coverage if needed
+
+**Files:**
+- Modify: `tests/e2e/lollapalooza-waitlist.spec.ts`
+
+- [ ] **Step 1: Inspect the test for HubSpot-specific assumptions**
+
+Check for:
+
+- mocked response requiring `contactId`
+- success copy requiring old CRM-oriented text
+
+- [ ] **Step 2: Update test expectations minimally**
+
+Keep:
+
+- user-visible success behavior
+- route URL
+- form submission guarantees
+
+Remove:
+
+- provider-specific response assumptions
+
+- [ ] **Step 3: Run focused E2E verification**
+
+Run:
+
+```bash
+pnpm test:e2e -- lollapalooza-waitlist
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/lollapalooza-waitlist.spec.ts
+git commit -m "test: align waitlist e2e coverage with n8n flow"
+```
+
+## Chunk 4: Docs and Final Verification
+
+### Task 7: Update environment and integration docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: any example env docs that still describe HubSpot as the direct lead destination
+
+- [ ] **Step 1: Write doc changes**
+
+Update:
+
+- required environment variables
+- architecture description for lead capture
+- any setup wording that still says direct HubSpot submission from the app
+
+Keep docs scoped to touched areas only.
+
+- [ ] **Step 2: Verify docs for accuracy against implementation**
+
+Check that docs reference:
+
+- `N8N_SUBMIT_LEAD_WEBHOOK_URL`
+- `N8N_SUBMIT_WAITLIST_WEBHOOK_URL`
+- `N8N_WEBHOOK_SECRET`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md docs
+git commit -m "docs: update lead capture setup for n8n webhooks"
+```
+
+### Task 8: Run full verification before completion
+
+**Files:**
+- Modify: none unless failures require targeted fixes
+
+- [ ] **Step 1: Run regression coverage**
+
+```bash
+pnpm test:regression
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 2: Run type checks**
+
+```bash
+pnpm typecheck
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 3: Run targeted browser coverage**
+
+```bash
+pnpm test:e2e -- chatbot-lead-submit
+pnpm test:e2e -- lollapalooza-waitlist
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 4: Review git diff for scope control**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- api/submit-lead.ts api/submit-waitlist.ts services/n8n.ts lib/n8n-payloads.ts hooks/useLeadCapture.ts tests/submit-lead.test.ts tests/submit-waitlist.test.ts tests/e2e/chatbot-lead-submit.spec.ts tests/e2e/lollapalooza-waitlist.spec.ts README.md
+```
+
+Expected:
+
+- only route, service, payload, type, test, and doc files relevant to the n8n migration are changed
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add api/submit-lead.ts api/submit-waitlist.ts services/n8n.ts lib/n8n-payloads.ts hooks/useLeadCapture.ts types/leadCapture.ts types/waitlist.ts tests/submit-lead.test.ts tests/submit-waitlist.test.ts tests/e2e/chatbot-lead-submit.spec.ts tests/e2e/lollapalooza-waitlist.spec.ts README.md
+git commit -m "feat: migrate lead capture flows to n8n webhooks"
+```
+
+## Standards Checklist
+
+- [x] `docs/standards/code-style.md`
+- [x] `docs/standards/testing.md`
+- [x] `docs/standards/api-conventions.md`
+- [x] `docs/standards/security.md`
+
+## Notes for the Implementer
+
+- Keep the current route URLs to avoid unnecessary browser churn.
+- Reuse the existing validation helpers. Do not move validation responsibility into n8n.
+- Keep logs structured and avoid logging secrets, full webhook URLs with secrets, or raw PII.
+- If the implementation reveals that conversion tracking should move to n8n, stop and amend the approved spec instead of making that product decision implicitly.
+- There is an unrelated existing modification in `index.html` in the working tree. Do not overwrite or revert it.
+
+## Review Constraint
+
+This environment has subagent tooling, but delegation is not permitted unless the user explicitly asks for subagents. Because of that, the plan-document reviewer loop from the skill is intentionally not executed here. If subagent use becomes explicitly authorized later, run a plan review pass before execution.

--- a/docs/superpowers/specs/2026-04-03-n8n-webhook-lead-design.md
+++ b/docs/superpowers/specs/2026-04-03-n8n-webhook-lead-design.md
@@ -1,0 +1,391 @@
+# N8N Webhook Lead Flow Design
+
+## Summary
+
+This design replaces direct HubSpot writes in the public lead-capture API handlers with server-to-server webhook delivery to n8n.
+
+The site remains the trust boundary for:
+
+- request parsing
+- validation and normalization
+- rate limiting
+- request ID generation
+- sanitized error responses
+
+Two public flows remain separate because they carry different business meaning and payload complexity:
+
+- `submit-lead` for richer chatbot and homepage lead captures
+- `submit-waitlist` for the Lollapalooza waitlist capture flow
+
+The frontend should continue calling the same public API routes. The route handlers will change destination only.
+
+## Goals
+
+- Keep payload validation and normalization in the AV-SITE backend
+- Send clean, predictable webhook payloads to n8n
+- Preserve separate contracts for rich leads and waitlist submissions
+- Remove direct frontend coupling to HubSpot-specific response fields
+- Minimize frontend changes and preserve existing user-facing behavior
+
+## Non-Goals
+
+- Rebuild or redesign the chatbot handoff UX
+- Change the browser-visible rate limiting behavior
+- Move validation responsibility into n8n
+- Redesign the waitlist capture product flow
+- Remove existing conversion tracking in this change unless implementation needs a scoped follow-up decision
+
+## Current State
+
+### Public Lead Flow
+
+`/api/submit-lead` currently:
+
+1. handles CORS and method gates
+2. applies rate limiting
+3. parses JSON
+4. validates and normalizes with `lib/lead-logic.ts`
+5. reads HubSpot configuration from environment variables
+6. creates or updates a HubSpot contact
+7. enriches contact properties with tracking and UTM fields
+8. creates and associates a HubSpot deal
+9. returns HubSpot-specific response data
+10. triggers conversion tracking asynchronously
+
+### Waitlist Flow
+
+`/api/submit-waitlist` currently:
+
+1. handles CORS and method gates
+2. applies rate limiting
+3. parses JSON
+4. validates and normalizes with `lib/waitlist-logic.ts`
+5. reads HubSpot configuration from environment variables
+6. creates or updates a HubSpot contact
+7. optionally enriches tracking fields
+8. optionally adds the contact to the configured HubSpot list
+9. adds a note for waitlist context
+10. returns HubSpot-specific response data
+
+## Decision
+
+Keep the public API routes and validation behavior, but replace HubSpot orchestration with dedicated n8n webhook delivery.
+
+Recommended structure:
+
+- keep `api/submit-lead.ts` as the public rich lead endpoint
+- keep `api/submit-waitlist.ts` as the public waitlist endpoint
+- add a focused `services/n8n.ts` transport layer for outbound webhook delivery
+- optionally add `lib/n8n-payloads.ts` to build stable webhook payload shapes
+
+## Why This Design
+
+This approach preserves the strongest part of the current implementation: the site already acts as a safe boundary that validates and sanitizes untrusted browser input before any external side effect.
+
+It also avoids pushing CRM-specific assumptions into the frontend or into n8n workflow logic. n8n should receive trusted, predictable payloads and focus on automation, routing, CRM writes, or downstream notifications.
+
+## Contracts
+
+### Public Request Contracts
+
+The browser-facing request contracts remain unchanged for this design.
+
+`submit-lead` continues to accept the existing `SubmitLeadRequest` contract.
+
+`submit-waitlist` continues to accept the existing `SubmitWaitlistRequest` contract.
+
+### Outbound Webhook Contract: Rich Lead
+
+Proposed n8n payload for `submit-lead`:
+
+```json
+{
+  "requestId": "req_123",
+  "source": "submit-lead",
+  "lead": {
+    "firstName": "Felipe",
+    "lastName": "Williams",
+    "email": "felipe@example.com",
+    "destination": "Orlando, Flórida",
+    "bantSummary": "Need: ...",
+    "eventId": "lead_abc"
+  },
+  "utms": {
+    "utm_source": "google",
+    "utm_medium": "cpc",
+    "utm_campaign": "orlando",
+    "utm_term": null,
+    "utm_content": null
+  },
+  "tracking": {
+    "utm_source": "google",
+    "utm_medium": "cpc",
+    "utm_campaign": "orlando",
+    "utm_term": null,
+    "utm_content": null,
+    "cid": null,
+    "sid": null,
+    "gclid": "test-gclid",
+    "fbclid": null,
+    "msclkid": null,
+    "ttclid": null,
+    "wbraid": null,
+    "gbraid": null,
+    "fbc": null,
+    "fbp": null,
+    "extras": {}
+  },
+  "meta": {
+    "receivedAt": "2026-04-03T00:00:00.000Z"
+  }
+}
+```
+
+Notes:
+
+- Payload is already sanitized and normalized
+- Optional values may be `null`
+- `extras` should only contain already-sanitized additional tracking keys
+- `source` is explicit so workflows can route safely inside n8n
+
+### Outbound Webhook Contract: Waitlist
+
+Proposed n8n payload for `submit-waitlist`:
+
+```json
+{
+  "requestId": "req_456",
+  "source": "submit-waitlist",
+  "waitlist": {
+    "name": "Felipe Williams",
+    "email": "felipe@example.com",
+    "sourcePage": "/lollapalooza"
+  },
+  "utms": {
+    "utm_source": "instagram",
+    "utm_medium": null,
+    "utm_campaign": null,
+    "utm_term": null,
+    "utm_content": null
+  },
+  "tracking": {
+    "utm_source": "instagram",
+    "utm_medium": null,
+    "utm_campaign": null,
+    "utm_term": null,
+    "utm_content": null,
+    "cid": null,
+    "sid": null,
+    "gclid": null,
+    "fbclid": "fbclid-123",
+    "msclkid": null,
+    "ttclid": null,
+    "wbraid": null,
+    "gbraid": null,
+    "fbc": null,
+    "fbp": null,
+    "extras": {}
+  },
+  "meta": {
+    "receivedAt": "2026-04-03T00:00:00.000Z"
+  }
+}
+```
+
+## Public Response Contract
+
+Move away from HubSpot-specific response fields such as `contactId` and `dealId`.
+
+Recommended successful response shape for both endpoints:
+
+```json
+{
+  "ok": true,
+  "requestId": "req_123",
+  "message": "Enviado com sucesso"
+}
+```
+
+Optional warning shape:
+
+```json
+{
+  "ok": true,
+  "requestId": "req_123",
+  "message": "Enviado com sucesso",
+  "warning": "Mensagem adicional opcional"
+}
+```
+
+Error shape remains structured:
+
+```json
+{
+  "ok": false,
+  "requestId": "req_123",
+  "code": "VALIDATION_ERROR",
+  "error": "Mensagem segura para o cliente"
+}
+```
+
+## Security and Trust Boundary
+
+Validation and normalization must remain server-side before any webhook delivery.
+
+Existing logic to preserve:
+
+- `cleanString`
+- `normalizeNullable`
+- `normalizeUtms`
+- `normalizeTracking`
+- `validatePayload`
+- `validateWaitlistPayload`
+- existing rate limiting via `lib/rate-limit.ts`
+- existing CORS and IP extraction via `lib/network.ts`
+
+Recommended webhook authentication:
+
+- site sends `X-Webhook-Secret` using an environment variable
+- site sends `X-Request-Id` for traceability
+- n8n validates the secret before processing
+
+Optional future hardening:
+
+- add `X-Webhook-Timestamp`
+- add request signing if needed later
+
+## Error Handling
+
+The new n8n transport should use explicit timeout behavior and sanitized failures.
+
+Recommended client-visible codes:
+
+- `VALIDATION_ERROR`
+- `METHOD_NOT_ALLOWED`
+- `RATE_LIMIT_EXCEEDED`
+- `SERVER_CONFIG_ERROR`
+- `N8N_WEBHOOK_ERROR`
+
+Suggested mapping:
+
+- missing webhook config -> `500 SERVER_CONFIG_ERROR`
+- webhook timeout or non-2xx response -> `502 N8N_WEBHOOK_ERROR`
+- malformed request body -> `400 VALIDATION_ERROR`
+- invalid method -> `405 METHOD_NOT_ALLOWED`
+- rate limit exceeded -> `429 RATE_LIMIT_EXCEEDED`
+
+Client-facing success and failure text must avoid leaking upstream response bodies or secrets.
+
+## Proposed File Changes
+
+### Add
+
+- `services/n8n.ts`
+  Centralizes webhook fetch behavior, headers, timeout, and error mapping
+
+### Optional Add
+
+- `lib/n8n-payloads.ts`
+  Builds outbound webhook payloads for lead and waitlist flows
+
+### Update
+
+- `api/submit-lead.ts`
+  Replace HubSpot orchestration with n8n webhook delivery while preserving request validation and rate limiting
+
+- `api/submit-waitlist.ts`
+  Replace HubSpot orchestration with the waitlist webhook delivery while preserving request validation and rate limiting
+
+- `types/leadCapture.ts`
+  Remove or revise HubSpot-specific success fields in response types
+
+- `types/waitlist.ts`
+  Remove or revise HubSpot-specific success fields in response types
+
+- `hooks/useLeadCapture.ts`
+  Update success parsing expectations if response fields change
+
+- any tests that assert `contactId`, `dealId`, or HubSpot-specific success text
+
+## Environment Variables
+
+Required:
+
+- `N8N_SUBMIT_LEAD_WEBHOOK_URL`
+- `N8N_SUBMIT_WAITLIST_WEBHOOK_URL`
+- `N8N_WEBHOOK_SECRET`
+
+Recommended:
+
+- `N8N_WEBHOOK_TIMEOUT_MS`
+
+## Testing Plan
+
+Behavior changes require automated test updates.
+
+### Unit and Route Tests
+
+Update:
+
+- `tests/submit-lead.test.ts`
+- `tests/submit-waitlist.test.ts`
+
+Expected changes:
+
+- mock one outbound webhook request instead of multiple HubSpot API calls
+- assert normalized payload shape sent to n8n
+- assert response contract uses `Enviado com sucesso`
+- assert timeout and non-2xx webhook failures map to `N8N_WEBHOOK_ERROR`
+
+Keep and extend validation tests around:
+
+- `validatePayload`
+- `validateWaitlistPayload`
+- tracking normalization
+- event ID preservation
+
+### Browser Tests
+
+Review and update:
+
+- `tests/e2e/chatbot-lead-submit.spec.ts`
+
+Expected changes:
+
+- preserve the guarantee that WhatsApp opens immediately
+- preserve `/api/submit-lead` request behavior
+- remove assumptions about `contactId`, `dealId`, and HubSpot-specific success messaging if present
+
+Waitlist E2E coverage should also be updated if it currently asserts HubSpot-specific response fields.
+
+### Verification Commands
+
+Relevant verification after implementation:
+
+- `pnpm test:regression`
+- `pnpm typecheck`
+- `pnpm test:e2e` if browser behavior or response-dependent UI changes are touched
+
+## Risks
+
+- Hidden frontend assumptions about `contactId` or `dealId`
+- Existing tests tightly coupled to HubSpot mock behavior
+- n8n webhook timeout causing degraded perceived reliability if timeout is too long
+- workflow-side failures becoming harder to inspect without request ID propagation
+
+## Mitigations
+
+- keep the frontend route URLs unchanged
+- keep request validation logic unchanged
+- return stable neutral success text
+- include `requestId` in responses and outbound webhook headers
+- use short explicit timeout in the n8n service wrapper
+
+## Open Implementation Notes
+
+- This design intentionally keeps conversion tracking unchanged for now. During implementation, confirm whether conversions should still fire when webhook delivery succeeds, or whether that logic should move into n8n.
+- This design intentionally keeps public route names unchanged to minimize browser-side changes.
+
+## Exceptions
+
+None currently proposed. If implementation reveals a reason to preserve legacy response fields temporarily for compatibility, document that as a temporary exception in implementation notes or PR notes.

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -19,8 +19,6 @@ export type LeadDraftPartial = Partial<LeadDraft>;
 type SubmitLeadResponseData = {
     error?: string;
     code?: string;
-    contactId?: string;
-    dealId?: string;
     requestId?: string;
     warning?: string;
 };
@@ -29,8 +27,6 @@ export type SubmitLeadHookResult =
     | {
         ok: true;
         requestId: string;
-        contactId: string;
-        dealId?: string;
         warning?: string;
     }
     | {
@@ -305,10 +301,10 @@ function buildSubmitLeadErrorResult(
         ? parsed.rawData.error
         : parsed.responseText && !isHtmlPayload(parsed.responseText)
             ? truncateResponseText(parsed.responseText)
-            : `Falha ao enviar lead para o HubSpot (status ${status}).`;
+            : `Falha ao enviar lead (status ${status}).`;
     const apiCode = typeof parsed.rawData.code === 'string'
         ? parsed.rawData.code
-        : 'HUBSPOT_API_ERROR';
+        : 'API_ERROR';
 
     return {
         ok: false,
@@ -325,8 +321,6 @@ function buildSubmitLeadSuccessResult(parsed: ParsedSubmitLeadResponse): SubmitL
         requestId: typeof parsed.rawData.requestId === 'string'
             ? parsed.rawData.requestId
             : (parsed.responseRequestId || 'unknown'),
-        contactId: typeof parsed.rawData.contactId === 'string' ? parsed.rawData.contactId : 'unknown',
-        dealId: typeof parsed.rawData.dealId === 'string' ? parsed.rawData.dealId : undefined,
         warning: typeof parsed.rawData.warning === 'string' ? parsed.rawData.warning : undefined,
     };
 }

--- a/hooks/useWaitlistCapture.ts
+++ b/hooks/useWaitlistCapture.ts
@@ -7,7 +7,6 @@ type SubmitWaitlistResult =
     | {
         ok: true;
         requestId: string;
-        contactId: string;
         warning?: string;
         message: string;
     }
@@ -89,8 +88,8 @@ function buildSubmitWaitlistError(
     return {
         ok: false,
         requestId: typeof payload.requestId === 'string' ? payload.requestId : response.headers.get('X-Request-Id') || undefined,
-        error: typeof payload.error === 'string' ? payload.error : `Falha ao enviar waitlist (status ${response.status}).`,
-        code: typeof payload.code === 'string' ? payload.code : 'HUBSPOT_API_ERROR',
+        error: typeof payload.error === 'string' ? payload.error : `Falha ao enviar cadastro (status ${response.status}).`,
+        code: typeof payload.code === 'string' ? payload.code : 'API_ERROR',
         status: response.status,
     };
 }
@@ -177,14 +176,13 @@ export function useWaitlistCapture() {
             return {
                 ok: true,
                 requestId: String(responsePayload.requestId || response.headers.get('X-Request-Id') || 'unknown'),
-                contactId: typeof responsePayload.contactId === 'string' ? responsePayload.contactId : 'unknown',
                 warning: typeof responsePayload.warning === 'string' ? responsePayload.warning : undefined,
                 message: typeof responsePayload.message === 'string'
                     ? responsePayload.message
-                    : 'Cadastro realizado com sucesso na lista de espera.',
+                    : 'Cadastro recebido com sucesso.',
             };
         } catch (requestError: unknown) {
-            const message = requestError instanceof Error ? requestError.message : 'Falha de rede ao enviar waitlist.';
+            const message = requestError instanceof Error ? requestError.message : 'Falha de rede ao enviar cadastro.';
             setError(message);
             setIsSubmitting(false);
 

--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
         (function(w,d,t,u,n,a,m){w['MauticTrackingObject']=n;
             w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),
             m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://mkt.anhanga.tur.br/mtc.js','mt');
+        })(window,document,'script','https://mkt.anhanga.tur.br/mtc.js','mt');
         mt('send', 'pageview');
     </script>
 </body>

--- a/lib/n8n-payloads.ts
+++ b/lib/n8n-payloads.ts
@@ -1,0 +1,115 @@
+import type { SubmitLeadRequest } from '../types/leadCapture';
+import type { SubmitWaitlistRequest } from '../types/waitlist';
+
+export interface N8nLeadTracking {
+    utm_source: string | null;
+    utm_medium: string | null;
+    utm_campaign: string | null;
+    utm_term: string | null;
+    utm_content: string | null;
+    cid?: string | null;
+    sid?: string | null;
+    gclid?: string | null;
+    fbclid?: string | null;
+    msclkid?: string | null;
+    ttclid?: string | null;
+    wbraid?: string | null;
+    gbraid?: string | null;
+    fbc?: string | null;
+    fbp?: string | null;
+    extras: Record<string, string>;
+}
+
+export interface N8nLeadPayload {
+    requestId: string;
+    source: 'submit-lead';
+    lead: {
+        firstName: string;
+        lastName: string;
+        email: string;
+        eventId: string | null;
+        bantSummary: string;
+        destination: string;
+    };
+    utms: SubmitLeadRequest['utms'];
+    tracking: N8nLeadTracking;
+    meta: {
+        receivedAt: string;
+    };
+}
+
+export interface N8nWaitlistPayload {
+    requestId: string;
+    source: 'submit-waitlist';
+    waitlist: {
+        name: string;
+        email: string;
+        sourcePage: string;
+    };
+    utms: SubmitWaitlistRequest['utms'];
+    tracking: SubmitWaitlistRequest['tracking'];
+    meta: {
+        receivedAt: string;
+    };
+}
+
+function buildLeadTracking(payload: SubmitLeadRequest): N8nLeadTracking {
+    const tracking = payload.tracking;
+    const leadTracking: N8nLeadTracking = {
+        utm_source: tracking?.utm_source ?? payload.utms.utm_source,
+        utm_medium: tracking?.utm_medium ?? payload.utms.utm_medium,
+        utm_campaign: tracking?.utm_campaign ?? payload.utms.utm_campaign,
+        utm_term: tracking?.utm_term ?? payload.utms.utm_term,
+        utm_content: tracking?.utm_content ?? payload.utms.utm_content,
+        cid: tracking?.cid ?? null,
+        sid: tracking?.sid ?? null,
+        gclid: tracking?.gclid ?? null,
+        fbclid: tracking?.fbclid ?? null,
+        msclkid: tracking?.msclkid ?? null,
+        ttclid: tracking?.ttclid ?? null,
+        wbraid: tracking?.wbraid ?? null,
+        gbraid: tracking?.gbraid ?? null,
+        fbc: tracking?.fbc ?? null,
+        fbp: tracking?.fbp ?? null,
+        extras: tracking?.extras ?? {},
+    };
+
+    return leadTracking;
+}
+
+export function buildN8nLeadPayload(payload: SubmitLeadRequest, requestId: string): N8nLeadPayload {
+    return {
+        requestId,
+        source: 'submit-lead',
+        lead: {
+            firstName: payload.firstName,
+            lastName: payload.lastName,
+            email: payload.email,
+            eventId: payload.event_id ?? null,
+            bantSummary: payload.bantSummary,
+            destination: payload.destination,
+        },
+        utms: payload.utms,
+        tracking: buildLeadTracking(payload),
+        meta: {
+            receivedAt: new Date().toISOString(),
+        },
+    };
+}
+
+export function buildN8nWaitlistPayload(payload: SubmitWaitlistRequest, requestId: string): N8nWaitlistPayload {
+    return {
+        requestId,
+        source: 'submit-waitlist',
+        waitlist: {
+            name: payload.name,
+            email: payload.email,
+            sourcePage: payload.sourcePage,
+        },
+        utms: payload.utms,
+        tracking: payload.tracking,
+        meta: {
+            receivedAt: new Date().toISOString(),
+        },
+    };
+}

--- a/lib/n8n-payloads.ts
+++ b/lib/n8n-payloads.ts
@@ -53,28 +53,45 @@ export interface N8nWaitlistPayload {
     };
 }
 
-function buildLeadTracking(payload: SubmitLeadRequest): N8nLeadTracking {
+function toNullableTrackingValue(value: string | null | undefined): string | null {
+    return value ?? null;
+}
+
+function buildLeadTrackingUtms(payload: SubmitLeadRequest) {
     const tracking = payload.tracking;
-    const leadTracking: N8nLeadTracking = {
+
+    return {
         utm_source: tracking?.utm_source ?? payload.utms.utm_source,
         utm_medium: tracking?.utm_medium ?? payload.utms.utm_medium,
         utm_campaign: tracking?.utm_campaign ?? payload.utms.utm_campaign,
         utm_term: tracking?.utm_term ?? payload.utms.utm_term,
         utm_content: tracking?.utm_content ?? payload.utms.utm_content,
-        cid: tracking?.cid ?? null,
-        sid: tracking?.sid ?? null,
-        gclid: tracking?.gclid ?? null,
-        fbclid: tracking?.fbclid ?? null,
-        msclkid: tracking?.msclkid ?? null,
-        ttclid: tracking?.ttclid ?? null,
-        wbraid: tracking?.wbraid ?? null,
-        gbraid: tracking?.gbraid ?? null,
-        fbc: tracking?.fbc ?? null,
-        fbp: tracking?.fbp ?? null,
-        extras: tracking?.extras ?? {},
     };
+}
 
-    return leadTracking;
+function buildLeadTrackingIds(payload: SubmitLeadRequest) {
+    const tracking = payload.tracking;
+
+    return {
+        cid: toNullableTrackingValue(tracking?.cid),
+        sid: toNullableTrackingValue(tracking?.sid),
+        gclid: toNullableTrackingValue(tracking?.gclid),
+        fbclid: toNullableTrackingValue(tracking?.fbclid),
+        msclkid: toNullableTrackingValue(tracking?.msclkid),
+        ttclid: toNullableTrackingValue(tracking?.ttclid),
+        wbraid: toNullableTrackingValue(tracking?.wbraid),
+        gbraid: toNullableTrackingValue(tracking?.gbraid),
+        fbc: toNullableTrackingValue(tracking?.fbc),
+        fbp: toNullableTrackingValue(tracking?.fbp),
+    };
+}
+
+function buildLeadTracking(payload: SubmitLeadRequest): N8nLeadTracking {
+    return {
+        ...buildLeadTrackingUtms(payload),
+        ...buildLeadTrackingIds(payload),
+        extras: payload.tracking?.extras ?? {},
+    };
 }
 
 export function buildN8nLeadPayload(payload: SubmitLeadRequest, requestId: string): N8nLeadPayload {

--- a/services/n8n.ts
+++ b/services/n8n.ts
@@ -1,0 +1,103 @@
+import type { N8nLeadPayload, N8nWaitlistPayload } from '../lib/n8n-payloads';
+
+const DEFAULT_N8N_REQUEST_TIMEOUT_MS = 1500;
+
+export function getN8nTimeoutMs(): number {
+    const configured = Number.parseInt(String(process.env.N8N_WEBHOOK_TIMEOUT_MS ?? ''), 10);
+    if (!Number.isFinite(configured) || configured < 50) {
+        return DEFAULT_N8N_REQUEST_TIMEOUT_MS;
+    }
+
+    return configured;
+}
+
+function sanitizeErrorDetail(value: string): string {
+    return value
+        .replace(/[\r\n]+/g, ' ')
+        .trim()
+        .slice(0, 200);
+}
+
+function createTimeoutError(timeoutMs: number): Error {
+    return new Error(`N8N_WEBHOOK_ERROR:504:Webhook request timed out after ${timeoutMs}ms`);
+}
+
+async function assertN8nResponseOk(response: Response): Promise<void> {
+    if (response.ok) return;
+
+    await response.text().catch(() => '');
+    throw new Error(`N8N_WEBHOOK_ERROR:${response.status}:Webhook request failed`);
+}
+
+function normalizeNetworkError(): Error {
+    return new Error('N8N_WEBHOOK_ERROR:502:Webhook request failed');
+}
+
+export async function n8nRequest(
+    url: string,
+    secret: string,
+    requestId: string,
+    payload: unknown,
+): Promise<Response> {
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+    headers.set('X-Webhook-Secret', secret);
+    headers.set('X-Request-Id', requestId);
+
+    const timeoutMs = getN8nTimeoutMs();
+    const controller = new AbortController();
+    const timeoutError = createTimeoutError(timeoutMs);
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+        const response = await Promise.race([
+            fetch(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify(payload),
+                signal: controller.signal,
+            }),
+            new Promise<Response>((_, reject) => {
+                timeoutHandle = setTimeout(() => {
+                    controller.abort();
+                    reject(timeoutError);
+                }, timeoutMs);
+            }),
+        ]);
+
+        await assertN8nResponseOk(response);
+        return response;
+    } catch (error: unknown) {
+        if (error instanceof Error && error.name === 'AbortError') {
+            throw timeoutError;
+        }
+
+        if (error instanceof Error && error.message.startsWith('N8N_WEBHOOK_ERROR:')) {
+            throw error;
+        }
+
+        throw normalizeNetworkError();
+    } finally {
+        if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+        }
+    }
+}
+
+export function sendLeadToN8n(
+    url: string,
+    secret: string,
+    requestId: string,
+    payload: N8nLeadPayload,
+): Promise<Response> {
+    return n8nRequest(url, secret, requestId, payload);
+}
+
+export function sendWaitlistToN8n(
+    url: string,
+    secret: string,
+    requestId: string,
+    payload: N8nWaitlistPayload,
+): Promise<Response> {
+    return n8nRequest(url, secret, requestId, payload);
+}

--- a/services/n8n.ts
+++ b/services/n8n.ts
@@ -25,8 +25,9 @@ function createTimeoutError(timeoutMs: number): Error {
 async function assertN8nResponseOk(response: Response): Promise<void> {
     if (response.ok) return;
 
-    await response.text().catch(() => '');
-    throw new Error(`N8N_WEBHOOK_ERROR:${response.status}:Webhook request failed`);
+    const detail = sanitizeErrorDetail(await response.text().catch(() => ''));
+    const message = detail || 'Webhook request failed';
+    throw new Error(`N8N_WEBHOOK_ERROR:${response.status}:${message}`);
 }
 
 function normalizeNetworkError(): Error {

--- a/tests/e2e/chatbot-lead-submit.spec.ts
+++ b/tests/e2e/chatbot-lead-submit.spec.ts
@@ -64,9 +64,7 @@ test.describe('Chatbot lead handoff', () => {
         body: JSON.stringify({
           ok: true,
           requestId: 'req-e2e-1',
-          contactId: 'contact-e2e-1',
-          dealId: 'deal-e2e-1',
-          message: 'Contato e deal criados com sucesso no HubSpot.',
+          warning: 'Acompanhamento será realizado por um canal alternativo.',
         }),
       });
     });
@@ -149,7 +147,7 @@ test.describe('Chatbot lead handoff', () => {
     });
   });
 
-  test('should open WhatsApp immediately even when HubSpot submit fails in the background', async ({ page }) => {
+  test('should open WhatsApp immediately even when lead submit fails in the background', async ({ page }) => {
     let submitRequestCount = 0;
     let submitPayload: Record<string, unknown> | null = null;
 
@@ -193,8 +191,8 @@ test.describe('Chatbot lead handoff', () => {
         body: JSON.stringify({
           ok: false,
           requestId: 'req-e2e-fail',
-          code: 'HUBSPOT_PROPERTY_ERROR',
-          error: 'Propriedade inválida no HubSpot.',
+          code: 'UPSTREAM_VALIDATION_ERROR',
+          error: 'Falha ao processar o envio.',
         }),
       });
     });
@@ -213,16 +211,16 @@ test.describe('Chatbot lead handoff', () => {
 
     await page.getByRole('button', { name: 'Salvar e abrir WhatsApp' }).click();
 
-    // WhatsApp must open immediately (before HubSpot submission completes) —
+    // WhatsApp must open immediately (before lead submission completes) —
     // this is the core guarantee of the fire-and-forget design.
     await expect.poll(() => page.evaluate(() => window.__openedUrls?.length ?? 0)).toBe(1);
     const openedUrl = await page.evaluate(() => window.__openedUrls?.[0] ?? '');
     expect(decodeURIComponent(openedUrl)).toContain('wa.me/');
 
-    // HubSpot submission happened in the background
+    // Lead submission happened in the background
     await expect.poll(() => submitRequestCount).toBe(1);
 
-    // No UI error alert — HubSpot errors are silently logged to console
+    // No UI error alert — upstream errors are silently logged to console
     await expect(page.getByRole('alert')).not.toBeVisible();
 
     // The lead form ("Link Gerado") is still rendered (popup opened in a new tab,

--- a/tests/e2e/lollapalooza-waitlist.spec.ts
+++ b/tests/e2e/lollapalooza-waitlist.spec.ts
@@ -27,8 +27,7 @@ test.describe('Lollapalooza evergreen landing waitlist', () => {
         body: JSON.stringify({
           ok: true,
           requestId: 'req-waitlist-e2e',
-          contactId: 'contact-waitlist-e2e',
-          message: 'Cadastro realizado com sucesso na lista de espera.',
+          message: 'Cadastro recebido com sucesso.',
         }),
       });
     });

--- a/tests/submit-lead.test.ts
+++ b/tests/submit-lead.test.ts
@@ -1,21 +1,21 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import handler from '../api/submit-lead.ts';
-import { mapTrackingToContactProperties } from '../services/hubspot.ts';
+import handler, { classifySubmitLeadError } from '../api/submit-lead.ts';
+import { buildN8nLeadPayload } from '../lib/n8n-payloads.ts';
+import { sendLeadToN8n } from '../services/n8n.ts';
 import { validatePayload } from '../lib/lead-logic.ts';
 
 const originalFetch = global.fetch;
 const originalEnv = {
-    HUBSPOT_TOKEN: process.env.HUBSPOT_TOKEN,
-    HUBSPOT_DEAL_PIPELINE_ID: process.env.HUBSPOT_DEAL_PIPELINE_ID,
-    HUBSPOT_DEAL_STAGE_ID: process.env.HUBSPOT_DEAL_STAGE_ID,
-    HUBSPOT_DEAL_BANT_PROPERTY: process.env.HUBSPOT_DEAL_BANT_PROPERTY,
-    HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY: process.env.HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY,
-    HUBSPOT_REQUEST_TIMEOUT_MS: process.env.HUBSPOT_REQUEST_TIMEOUT_MS,
     SUBMIT_LEAD_RATE_LIMIT_TIMEOUT_MS: process.env.SUBMIT_LEAD_RATE_LIMIT_TIMEOUT_MS,
     META_PIXEL_ID: process.env.META_PIXEL_ID,
     META_ACCESS_TOKEN: process.env.META_ACCESS_TOKEN,
+    GA4_MEASUREMENT_ID: process.env.GA4_MEASUREMENT_ID,
+    GA4_API_SECRET: process.env.GA4_API_SECRET,
+    N8N_SUBMIT_LEAD_WEBHOOK_URL: process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL,
+    N8N_WEBHOOK_SECRET: process.env.N8N_WEBHOOK_SECRET,
+    N8N_WEBHOOK_TIMEOUT_MS: process.env.N8N_WEBHOOK_TIMEOUT_MS,
 };
 
 function restoreEnvValue(key: string, value: string | undefined) {
@@ -28,27 +28,28 @@ function restoreEnvValue(key: string, value: string | undefined) {
 }
 
 function restoreEnv() {
-    restoreEnvValue('HUBSPOT_TOKEN', originalEnv.HUBSPOT_TOKEN);
-    restoreEnvValue('HUBSPOT_DEAL_PIPELINE_ID', originalEnv.HUBSPOT_DEAL_PIPELINE_ID);
-    restoreEnvValue('HUBSPOT_DEAL_STAGE_ID', originalEnv.HUBSPOT_DEAL_STAGE_ID);
-    restoreEnvValue('HUBSPOT_DEAL_BANT_PROPERTY', originalEnv.HUBSPOT_DEAL_BANT_PROPERTY);
-    restoreEnvValue('HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY', originalEnv.HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY);
-    restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
     restoreEnvValue('SUBMIT_LEAD_RATE_LIMIT_TIMEOUT_MS', originalEnv.SUBMIT_LEAD_RATE_LIMIT_TIMEOUT_MS);
     restoreEnvValue('META_PIXEL_ID', originalEnv.META_PIXEL_ID);
     restoreEnvValue('META_ACCESS_TOKEN', originalEnv.META_ACCESS_TOKEN);
+    restoreEnvValue('GA4_MEASUREMENT_ID', originalEnv.GA4_MEASUREMENT_ID);
+    restoreEnvValue('GA4_API_SECRET', originalEnv.GA4_API_SECRET);
+    restoreEnvValue('N8N_SUBMIT_LEAD_WEBHOOK_URL', originalEnv.N8N_SUBMIT_LEAD_WEBHOOK_URL);
+    restoreEnvValue('N8N_WEBHOOK_SECRET', originalEnv.N8N_WEBHOOK_SECRET);
+    restoreEnvValue('N8N_WEBHOOK_TIMEOUT_MS', originalEnv.N8N_WEBHOOK_TIMEOUT_MS);
 }
 
-function buildRequest(body: Record<string, unknown>): Request {
+function buildRequest(body: Record<string, unknown>, init?: { headers?: Record<string, string>; method?: string }): Request {
     const ipSuffix = Math.floor(Math.random() * 200) + 1;
+    const method = init?.method || 'POST';
 
     return new Request('http://localhost/api/submit-lead', {
-        method: 'POST',
+        method,
         headers: {
             'Content-Type': 'application/json',
             'x-real-ip': `127.0.0.${ipSuffix}`,
+            ...init?.headers,
         },
-        body: JSON.stringify(body),
+        body: method === 'OPTIONS' ? undefined : JSON.stringify(body),
     });
 }
 
@@ -58,116 +59,78 @@ function getUrl(input: RequestInfo | URL): string {
     return input.url;
 }
 
-interface MockHubSpotRequestBody {
-    data?: Array<Record<string, unknown>>;
-    properties?: Record<string, unknown>;
-    test_event_code?: string;
-}
-
-interface MockHubSpotRequest {
-    url: string;
-    method: string;
-    body?: MockHubSpotRequestBody;
-}
-
-interface MockHubSpotRoute {
-    matches: (request: MockHubSpotRequest) => boolean;
-    respond: (request: MockHubSpotRequest) => Response | Promise<Response>;
-}
-
-function buildMockHubSpotRequest(input: RequestInfo | URL, init?: RequestInit): MockHubSpotRequest {
-    return {
-        url: getUrl(input),
-        method: init?.method || 'GET',
-        body: init?.body ? JSON.parse(String(init.body)) as MockHubSpotRequestBody : undefined,
-    };
-}
-
-function createMockHubSpotFetch(calls: MockHubSpotRequest[], routes: MockHubSpotRoute[]): typeof fetch {
-    return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const request = buildMockHubSpotRequest(input, init);
-        calls.push(request);
-
-        for (const route of routes) {
-            if (route.matches(request)) {
-                return await route.respond(request);
-            }
-        }
-
-        throw new Error(`Unexpected request: ${request.method} ${request.url}`);
-    }) as typeof fetch;
-}
-
-function collectContactPatchProperties(calls: MockHubSpotRequest[], contactId: string): Record<string, unknown> {
-    const patches = calls.filter((call) => call.url.endsWith(`/crm/v3/objects/contacts/${contactId}`) && call.method === 'PATCH');
-    return Object.assign({}, ...patches.map((call) => call.body?.properties || {}));
-}
-
 function hashNormalized(value: string): string {
     return createHash('sha256').update(value.trim().toLowerCase()).digest('hex');
 }
 
-async function waitForCall(
-    predicate: (call: MockHubSpotRequest) => boolean,
-    calls: MockHubSpotRequest[],
-    timeoutMs = 50,
-): Promise<MockHubSpotRequest | undefined> {
-    const start = Date.now();
-
-    while (Date.now() - start < timeoutMs) {
-        const match = calls.find(predicate);
-        if (match) return match;
-        await new Promise((resolve) => setTimeout(resolve, 1));
-    }
-
-    return calls.find(predicate);
+function buildLeadPayloadFixture() {
+    return {
+        firstName: 'Felipe',
+        lastName: 'William',
+        email: 'felipe@example.com',
+        event_id: 'lead_test_123abc',
+        bantSummary: 'Need: Praia | Authority: casal | Budget: 20k | Timeline: setembro',
+        destination: 'Rio de Janeiro',
+        utms: {
+            utm_source: 'google',
+            utm_medium: 'cpc',
+            utm_campaign: 'rio',
+            utm_term: 'rio viagem',
+            utm_content: 'ad-1',
+        },
+        tracking: {
+            utm_source: 'google',
+            utm_medium: 'cpc',
+            utm_campaign: 'rio',
+            utm_term: 'rio viagem',
+            utm_content: 'ad-1',
+            cid: 'cid-1',
+            sid: 'sid-1',
+            gclid: 'gclid-1',
+            fbclid: 'fbclid-1',
+            fbc: 'fb.1.1736366050.fbclid-1',
+            msclkid: 'msclkid-1',
+            ttclid: 'ttclid-1',
+            wbraid: null,
+            gbraid: 'gbraid-1',
+            fbp: 'fb.1.1736366050.1234567890',
+        },
+    };
 }
 
-test('mapTrackingToContactProperties should map msclkid to hs_linkedin_click_id', () => {
-    const mapped = mapTrackingToContactProperties({
-        utm_source: null,
-        utm_medium: null,
-        utm_campaign: null,
-        utm_term: null,
-        utm_content: null,
-        cid: 'ga.123',
-        fbc: 'fb.1.1736366050.fbclid-123',
-        fbp: 'fb.1.1736366050.1234567890',
-        msclkid: 'ms-abc',
-        gclid: 'g-xyz',
-        wbraid: 'w-123',
-    });
+interface MockN8nRequest {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body?: Record<string, unknown>;
+}
 
-    assert.equal(mapped.properties.ga_client_id, 'ga.123');
-    assert.equal(mapped.properties.hs_facebook_click_id, 'fb.1.1736366050.fbclid-123');
-    assert.equal(mapped.properties.av_fbp, 'fb.1.1736366050.1234567890');
-    assert.equal(mapped.properties.hs_linkedin_click_id, 'ms-abc');
-    assert.equal(mapped.properties.hs_google_click_id, 'g-xyz');
-    assert.equal(mapped.properties.wbraid, 'w-123');
-});
+function buildMockN8nRequest(input: RequestInfo | URL, init?: RequestInit): MockN8nRequest {
+    const headers = new Headers(init?.headers);
 
-test('mapTrackingToContactProperties should map HubSpot tracking fields used by FEL-45', () => {
-    const mapped = mapTrackingToContactProperties({
-        utm_source: null,
-        utm_medium: null,
-        utm_campaign: null,
-        utm_term: null,
-        utm_content: null,
-        cid: 'ga.321',
-        sid: 'sid-456',
-        fbclid: 'fbclid-123',
-        fbc: 'fb.1.1736366050123.fbclid-123',
-        fbp: 'fb.1.1736366050.1234567890',
-    });
+    return {
+        url: getUrl(input),
+        method: init?.method || 'GET',
+        headers: Object.fromEntries(headers.entries()),
+        body: init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : undefined,
+    };
+}
 
-    assert.deepEqual(mapped.properties, {
-        ga_client_id: 'ga.321',
-        ga_session_id: 'sid-456',
-        hs_facebook_click_id: 'fb.1.1736366050123.fbclid-123',
-        av_fbp: 'fb.1.1736366050.1234567890',
-    });
-    assert.deepEqual(mapped.unmapped, {});
-});
+function createMockN8nFetch(
+    calls: MockN8nRequest[],
+    response: Response | ((request: MockN8nRequest) => Response | Promise<Response>),
+): typeof fetch {
+    return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const request = buildMockN8nRequest(input, init);
+        calls.push(request);
+
+        if (typeof response === 'function') {
+            return await response(request);
+        }
+
+        return response;
+    }) as typeof fetch;
+}
 
 test('validatePayload should preserve fbp as a top-level tracking field', () => {
     const result = validatePayload({
@@ -216,55 +179,11 @@ test('validatePayload should preserve sanitized event_id when provided', () => {
     assert.equal(result.data.event_id, 'lead_&lt;meta&gt;&capi');
 });
 
-test('submit-lead should create contact and deal on first attempt', async (t) => {
-    t.after(() => {
-        global.fetch = originalFetch;
-        restoreEnv();
-    });
-
-    process.env.HUBSPOT_TOKEN = 'test-token';
-    process.env.HUBSPOT_DEAL_PIPELINE_ID = 'pipeline-1';
-    process.env.HUBSPOT_DEAL_STAGE_ID = 'stage-1';
-    process.env.HUBSPOT_DEAL_BANT_PROPERTY = 'bant_summary';
-    process.env.META_PIXEL_ID = 'pixel-1';
-    process.env.META_ACCESS_TOKEN = 'token-1';
-
-    const calls: MockHubSpotRequest[] = [];
-
-    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const url = getUrl(input);
-        const method = init?.method || 'GET';
-        const body = init?.body ? JSON.parse(String(init.body)) as MockHubSpotRequestBody : undefined;
-        calls.push({ url, method, body });
-
-        if (url.endsWith('/crm/v3/objects/contacts') && method === 'POST') {
-            return new Response(JSON.stringify({ id: 'contact-1' }), { status: 201 });
-        }
-
-        if (url.endsWith('/crm/v3/objects/contacts/contact-1') && method === 'PATCH') {
-            return new Response(JSON.stringify({ id: 'contact-1' }), { status: 200 });
-        }
-
-        if (url.endsWith('/crm/v3/objects/deals') && method === 'POST') {
-            return new Response(JSON.stringify({ id: 'deal-1' }), { status: 201 });
-        }
-
-        if (url.endsWith('/crm/v4/objects/deals/deal-1/associations/default/contacts/contact-1') && method === 'PUT') {
-            return new Response(null, { status: 204 });
-        }
-
-        if (url.startsWith('https://graph.facebook.com/v19.0/pixel-1/events') && method === 'POST') {
-            return new Response(JSON.stringify({ events_received: 1 }), { status: 200 });
-        }
-
-        throw new Error(`Unexpected request: ${method} ${url}`);
-    }) as typeof fetch;
-
-    const response = await handler(buildRequest({
+test('buildN8nLeadPayload should build the outbound webhook contract', () => {
+    const payload = buildN8nLeadPayload({
         firstName: 'Felipe',
         lastName: 'William',
         email: 'felipe@example.com',
-        event_id: 'lead_test_123abc',
         bantSummary: 'Need: Praia | Authority: casal | Budget: 20k | Timeline: setembro',
         destination: 'Rio de Janeiro',
         utms: {
@@ -275,6 +194,11 @@ test('submit-lead should create contact and deal on first attempt', async (t) =>
             utm_content: 'ad-1',
         },
         tracking: {
+            utm_source: 'google',
+            utm_medium: 'cpc',
+            utm_campaign: 'rio',
+            utm_term: 'rio viagem',
+            utm_content: 'ad-1',
             cid: 'cid-1',
             sid: 'sid-1',
             gclid: 'gclid-1',
@@ -282,489 +206,484 @@ test('submit-lead should create contact and deal on first attempt', async (t) =>
             fbc: 'fb.1.1736366050.fbclid-1',
             msclkid: 'msclkid-1',
             ttclid: 'ttclid-1',
+            wbraid: null,
             gbraid: 'gbraid-1',
             fbp: 'fb.1.1736366050.1234567890',
         },
-    }));
+    }, 'req-lead-123');
 
-    assert.equal(response.status, 201);
-    const payload = await response.json();
+    assert.deepEqual(payload, {
+        requestId: 'req-lead-123',
+        source: 'submit-lead',
+        lead: {
+            firstName: 'Felipe',
+            lastName: 'William',
+            email: 'felipe@example.com',
+            eventId: null,
+            bantSummary: 'Need: Praia | Authority: casal | Budget: 20k | Timeline: setembro',
+            destination: 'Rio de Janeiro',
+        },
+        utms: {
+            utm_source: 'google',
+            utm_medium: 'cpc',
+            utm_campaign: 'rio',
+            utm_term: 'rio viagem',
+            utm_content: 'ad-1',
+        },
+        tracking: {
+            utm_source: 'google',
+            utm_medium: 'cpc',
+            utm_campaign: 'rio',
+            utm_term: 'rio viagem',
+            utm_content: 'ad-1',
+            cid: 'cid-1',
+            sid: 'sid-1',
+            gclid: 'gclid-1',
+            fbclid: 'fbclid-1',
+            fbc: 'fb.1.1736366050.fbclid-1',
+            msclkid: 'msclkid-1',
+            ttclid: 'ttclid-1',
+            wbraid: null,
+            gbraid: 'gbraid-1',
+            fbp: 'fb.1.1736366050.1234567890',
+            extras: {},
+        },
+        meta: {
+            receivedAt: payload.meta.receivedAt,
+        },
+    });
 
-    assert.equal(payload.ok, true);
-    assert.equal(typeof payload.requestId, 'string');
-    assert.ok(payload.requestId.length > 0);
-    assert.equal(payload.contactId, 'contact-1');
-    assert.equal(payload.dealId, 'deal-1');
-
-    const contactRequest = calls.find((call) => call.url.endsWith('/crm/v3/objects/contacts'));
-    assert.ok(contactRequest, 'contact creation request should exist');
-
-    const contactProps = contactRequest!.body?.properties || {};
-    assert.equal(contactProps.firstname, 'Felipe');
-    assert.equal(contactProps.lastname, 'William');
-    assert.equal(contactProps.email, 'felipe@example.com');
-
-    const enrichedContactProps = collectContactPatchProperties(calls, 'contact-1');
-    assert.equal(enrichedContactProps.av_event_id, 'lead_test_123abc');
-    assert.equal(enrichedContactProps.ga_client_id, 'cid-1');
-    assert.equal(enrichedContactProps.ga_session_id, 'sid-1');
-    assert.equal(enrichedContactProps.hs_google_click_id, 'gclid-1');
-    assert.equal(enrichedContactProps.hs_facebook_click_id, 'fb.1.1736366050.fbclid-1');
-    assert.equal(enrichedContactProps.av_fbp, 'fb.1.1736366050.1234567890');
-    assert.equal(enrichedContactProps.hs_linkedin_click_id, 'msclkid-1');
-    assert.equal(
-        calls.filter((call) => call.url.endsWith('/crm/v3/objects/contacts/contact-1') && call.method === 'PATCH').length,
-        1,
-    );
-
-    const metaRequest = await waitForCall(
-        (call) => call.url.startsWith('https://graph.facebook.com/v19.0/pixel-1/events'),
-        calls,
-    );
-    assert.ok(metaRequest, 'meta request should exist');
-    assert.match(metaRequest!.url, /access_token=token-1$/);
-
-    const metaEvent = metaRequest!.body?.data?.[0];
-    assert.ok(metaEvent, 'meta event payload should exist');
-    assert.equal(metaEvent?.event_id, 'lead_test_123abc');
-    assert.equal(metaEvent?.event_name, 'Lead');
-    assert.equal(
-        (metaEvent?.custom_data as Record<string, unknown>)?.content_name,
-        'Rio de Janeiro',
-    );
-    assert.equal(
-        (metaEvent?.user_data as Record<string, unknown>)?.fbp,
-        'fb.1.1736366050.1234567890',
-    );
-    assert.deepEqual(
-        (metaEvent?.user_data as Record<string, unknown>)?.em,
-        [hashNormalized('felipe@example.com')],
-    );
-
-    const dealRequest = calls.find((call) => call.url.endsWith('/crm/v3/objects/deals'));
-    assert.ok(dealRequest, 'deal creation request should exist');
-    assert.equal(dealRequest!.body?.properties?.dealname, 'Lead chatbot - Felipe William - Rio de Janeiro');
+    assert.match(payload.meta.receivedAt, /^\d{4}-\d{2}-\d{2}T/);
 });
 
-test('submit-lead should sanitize XSS payloads in inputs', async (t) => {
+test('sendLeadToN8n should send request metadata and webhook auth headers', async (t) => {
+    const originalTimeout = process.env.N8N_WEBHOOK_TIMEOUT_MS;
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        if (originalTimeout === undefined) {
+            delete process.env.N8N_WEBHOOK_TIMEOUT_MS;
+        } else {
+            process.env.N8N_WEBHOOK_TIMEOUT_MS = originalTimeout;
+        }
+    });
+
+    process.env.N8N_WEBHOOK_TIMEOUT_MS = '200';
+
+    const calls: MockN8nRequest[] = [];
+    global.fetch = createMockN8nFetch(calls, new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const body = buildLeadPayloadFixture();
+    await sendLeadToN8n(
+        'https://n8n.example/webhook/submit-lead',
+        'secret-123',
+        'req-lead-456',
+        buildN8nLeadPayload(body, 'req-lead-456'),
+    );
+
+    assert.equal(calls.length, 1);
+    const request = calls[0]!;
+    assert.equal(request.url, 'https://n8n.example/webhook/submit-lead');
+    assert.equal(request.method, 'POST');
+    assert.equal(request.headers['content-type'], 'application/json');
+    assert.equal(request.headers['x-webhook-secret'], 'secret-123');
+    assert.equal(request.headers['x-request-id'], 'req-lead-456');
+
+    assert.equal(request.body?.requestId, 'req-lead-456');
+    assert.equal(request.body?.source, 'submit-lead');
+    assert.deepEqual(request.body?.lead, {
+        firstName: body.firstName,
+        lastName: body.lastName,
+        email: body.email,
+        eventId: body.event_id,
+        bantSummary: body.bantSummary,
+        destination: body.destination,
+    });
+    assert.deepEqual(request.body?.utms, body.utms);
+    assert.deepEqual(request.body?.tracking, {
+        utm_source: body.tracking.utm_source,
+        utm_medium: body.tracking.utm_medium,
+        utm_campaign: body.tracking.utm_campaign,
+        utm_term: body.tracking.utm_term,
+        utm_content: body.tracking.utm_content,
+        cid: body.tracking.cid,
+        sid: body.tracking.sid,
+        gclid: body.tracking.gclid,
+        fbclid: body.tracking.fbclid,
+        msclkid: body.tracking.msclkid,
+        ttclid: body.tracking.ttclid,
+        wbraid: body.tracking.wbraid,
+        gbraid: body.tracking.gbraid,
+        fbc: body.tracking.fbc,
+        fbp: body.tracking.fbp,
+        extras: {},
+    });
+    assert.match(String((request.body?.meta as Record<string, unknown> | undefined)?.receivedAt), /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test('submit-lead should send sanitized validated values to n8n', async (t) => {
     t.after(() => {
         global.fetch = originalFetch;
         restoreEnv();
     });
 
-    process.env.HUBSPOT_TOKEN = 'test-token';
-    process.env.HUBSPOT_DEAL_PIPELINE_ID = 'pipeline-1';
-    process.env.HUBSPOT_DEAL_STAGE_ID = 'stage-1';
-    process.env.HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY = 'contact_tracking_fallback';
+    process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL = 'https://n8n.example/webhook/submit-lead';
+    process.env.N8N_WEBHOOK_SECRET = 'secret-123';
+    process.env.N8N_WEBHOOK_TIMEOUT_MS = '200';
+    delete process.env.META_PIXEL_ID;
+    delete process.env.META_ACCESS_TOKEN;
+    delete process.env.GA4_MEASUREMENT_ID;
+    delete process.env.GA4_API_SECRET;
 
-    const calls: MockHubSpotRequest[] = [];
-
-    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const url = getUrl(input);
-        const method = init?.method || 'GET';
-        const body = init?.body ? JSON.parse(String(init.body)) as MockHubSpotRequestBody : undefined;
-        calls.push({ url, method, body });
-
-        if (url.endsWith('/crm/v3/objects/contacts') && method === 'POST') {
-            return new Response(JSON.stringify({ id: 'contact-1' }), { status: 201 });
-        }
-        if (url.endsWith('/crm/v3/objects/contacts/contact-1') && method === 'PATCH') {
-            return new Response(JSON.stringify({ id: 'contact-1' }), { status: 200 });
-        }
-        if (url.endsWith('/crm/v3/objects/deals') && method === 'POST') {
-            return new Response(JSON.stringify({ id: 'deal-1' }), { status: 201 });
-        }
-        if (url.includes('/associations/')) {
-            return new Response(null, { status: 204 });
-        }
-
-        return new Response(JSON.stringify({}), { status: 200 });
-    }) as typeof fetch;
+    const calls: MockN8nRequest[] = [];
+    global.fetch = createMockN8nFetch(calls, new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
     const response = await handler(buildRequest({
         firstName: "<script>alert('xss')</script>John",
         lastName: "Doe >",
-        email: "john@example.com",
-        bantSummary: "Need: <img src=x onerror=alert(1)>",
-        destination: "Mars <script>",
+        email: 'john@example.com',
+        event_id: ' lead_<meta>&capi ',
+        bantSummary: 'Need: <img src=x onerror=alert(1)>',
+        destination: 'Mars <script>',
         utms: {
-            utm_source: "<svg onload=alert(1)>",
+            utm_source: '<svg onload=alert(1)>',
+            utm_medium: null,
+            utm_campaign: null,
+            utm_term: null,
+            utm_content: null,
         },
         tracking: {
+            utm_source: '<svg onload=alert(1)>',
+            utm_medium: null,
+            utm_campaign: null,
+            utm_term: null,
+            utm_content: null,
             extras: {
-                "<p>custom</p>": "<b>value</b>"
-            }
-        }
-    }));
-
-    assert.equal(response.status, 201);
-
-    const contactRequest = calls.find((call) => call.url.endsWith('/crm/v3/objects/contacts'));
-    const contactProps = contactRequest!.body.properties;
-
-    assert.equal(contactProps.firstname, "&lt;script&gt;alert('xss')&lt;/script&gt;John");
-    assert.equal(contactProps.lastname, "Doe &gt;");
-
-    const enrichedContactProps = collectContactPatchProperties(calls, 'contact-1');
-    assert.equal(enrichedContactProps.ultimo_utm_source, "&lt;svg onload=alert(1)&gt;");
-
-    const dealRequest = calls.find((call) => call.url.endsWith('/crm/v3/objects/deals'));
-    const dealProps = dealRequest!.body.properties;
-    const dealName = typeof dealProps.dealname === 'string' ? dealProps.dealname : '';
-    assert.ok(dealName.includes("&lt;script&gt;"));
-    const bantProperty = process.env.HUBSPOT_DEAL_BANT_PROPERTY || 'bant_summary';
-    assert.equal(dealProps[bantProperty], "Need: &lt;img src=x onerror=alert(1)&gt;");
-
-    // Check extras sanitization
-    const trackingFallback = typeof enrichedContactProps.contact_tracking_fallback === 'string'
-        ? enrichedContactProps.contact_tracking_fallback
-        : '{}';
-    const extras = JSON.parse(trackingFallback) as Record<string, string>;
-    assert.ok(extras["&lt;p&gt;custom&lt;/p&gt;"], "Key should be sanitized");
-    assert.equal(extras["&lt;p&gt;custom&lt;/p&gt;"], "&lt;b&gt;value&lt;/b&gt;");
-});
-
-test('submit-lead should recover on duplicate contact and still create deal', async (t) => {
-    t.after(() => {
-        global.fetch = originalFetch;
-        restoreEnv();
-    });
-
-    process.env.HUBSPOT_TOKEN = 'test-token';
-    process.env.HUBSPOT_DEAL_PIPELINE_ID = 'pipeline-1';
-    process.env.HUBSPOT_DEAL_STAGE_ID = 'stage-1';
-    process.env.HUBSPOT_DEAL_BANT_PROPERTY = 'bant_summary';
-
-    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const url = getUrl(input);
-        const method = init?.method || 'GET';
-
-        if (url.endsWith('/crm/v3/objects/contacts') && method === 'POST') {
-            return new Response(JSON.stringify({ status: 'error' }), { status: 409 });
-        }
-
-        if (url.endsWith('/crm/v3/objects/contacts/search') && method === 'POST') {
-            return new Response(JSON.stringify({ results: [{ id: 'contact-existing' }] }), { status: 200 });
-        }
-
-        if (url.endsWith('/crm/v3/objects/contacts/contact-existing') && method === 'PATCH') {
-            return new Response(JSON.stringify({ id: 'contact-existing' }), { status: 200 });
-        }
-
-        if (url.endsWith('/crm/v3/objects/deals') && method === 'POST') {
-            return new Response(JSON.stringify({ id: 'deal-2' }), { status: 201 });
-        }
-
-        if (url.endsWith('/crm/v4/objects/deals/deal-2/associations/default/contacts/contact-existing') && method === 'PUT') {
-            return new Response(null, { status: 204 });
-        }
-
-        throw new Error(`Unexpected request: ${method} ${url}`);
-    }) as typeof fetch;
-
-    const response = await handler(buildRequest({
-        firstName: 'Felipe',
-        lastName: 'William',
-        email: 'felipe@example.com',
-        bantSummary: 'Need: Praia | Authority: casal | Budget: 20k | Timeline: setembro',
-        destination: 'Paris',
-        utms: {},
-        tracking: {
-            cid: 'cid-2',
-            utm_source: null,
-            utm_medium: null,
-            utm_campaign: null,
-            utm_term: null,
-            utm_content: null,
-        },
-    }));
-
-    assert.equal(response.status, 201);
-    const payload = await response.json();
-
-    assert.equal(payload.ok, true);
-    assert.equal(typeof payload.requestId, 'string');
-    assert.ok(payload.requestId.length > 0);
-    assert.equal(payload.contactId, 'contact-existing');
-    assert.equal(payload.dealId, 'deal-2');
-});
-
-test('submit-lead should create fallback note and return warning when deal fails', async (t) => {
-    t.after(() => {
-        global.fetch = originalFetch;
-        restoreEnv();
-    });
-
-    process.env.HUBSPOT_TOKEN = 'test-token';
-    process.env.HUBSPOT_DEAL_PIPELINE_ID = 'pipeline-1';
-    process.env.HUBSPOT_DEAL_STAGE_ID = 'stage-1';
-
-    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const url = getUrl(input);
-        const method = init?.method || 'GET';
-
-        if (url.endsWith('/crm/v3/objects/contacts') && method === 'POST') {
-            return new Response(JSON.stringify({ id: 'contact-3' }), { status: 201 });
-        }
-
-        if (url.endsWith('/crm/v3/objects/contacts/contact-3') && method === 'PATCH') {
-            return new Response(JSON.stringify({ id: 'contact-3' }), { status: 200 });
-        }
-
-        if (url.endsWith('/crm/v3/objects/deals') && method === 'POST') {
-            return new Response(JSON.stringify({ status: 'error' }), { status: 500 });
-        }
-
-        if (url.endsWith('/crm/v3/objects/notes') && method === 'POST') {
-            return new Response(JSON.stringify({ id: 'note-1' }), { status: 201 });
-        }
-
-        if (url.endsWith('/crm/v4/objects/notes/note-1/associations/default/contacts/contact-3') && method === 'PUT') {
-            return new Response(null, { status: 204 });
-        }
-
-        throw new Error(`Unexpected request: ${method} ${url}`);
-    }) as typeof fetch;
-
-    const response = await handler(buildRequest({
-        firstName: 'Felipe',
-        lastName: 'William',
-        email: 'felipe@example.com',
-        bantSummary: 'Need: Praia | Authority: casal | Budget: 20k | Timeline: setembro',
-        destination: 'Orlando',
-        utms: {},
-        tracking: {
-            utm_source: null,
-            utm_medium: null,
-            utm_campaign: null,
-            utm_term: null,
-            utm_content: null,
-        },
-    }));
-
-    assert.equal(response.status, 201);
-    const payload = await response.json();
-
-    assert.equal(payload.ok, true);
-    assert.equal(typeof payload.requestId, 'string');
-    assert.ok(payload.requestId.length > 0);
-    assert.equal(payload.contactId, 'contact-3');
-    assert.equal(payload.dealId, undefined);
-    assert.match(payload.warning, /nota foi registrada/i);
-});
-
-test('submit-lead should keep the contact when optional HubSpot properties fail', async (t) => {
-    t.after(() => {
-        global.fetch = originalFetch;
-        restoreEnv();
-    });
-
-    process.env.HUBSPOT_TOKEN = 'test-token';
-    process.env.HUBSPOT_DEAL_PIPELINE_ID = 'pipeline-1';
-    process.env.HUBSPOT_DEAL_STAGE_ID = 'stage-1';
-
-    const calls: MockHubSpotRequest[] = [];
-
-    global.fetch = createMockHubSpotFetch(calls, [
-        {
-            matches: ({ url, method }) => url.endsWith('/crm/v3/objects/contacts') && method === 'POST',
-            respond: () => new Response(JSON.stringify({ id: 'contact-4' }), { status: 201 }),
-        },
-        {
-            matches: ({ url, method }) => url.endsWith('/crm/v3/objects/contacts/contact-4') && method === 'PATCH',
-            respond: ({ body }) => {
-                const propertyName = Object.keys(body?.properties || {})[0];
-                if (propertyName === 'ultimo_utm_source') {
-                    return new Response(JSON.stringify({
-                        status: 'error',
-                        message: 'Property values were not valid',
-                    }), { status: 400 });
-                }
-
-                return new Response(JSON.stringify({ id: 'contact-4' }), { status: 200 });
+                '<p>custom</p>': '<b>value</b>',
             },
         },
-        {
-            matches: ({ url, method }) => url.endsWith('/crm/v3/objects/deals') && method === 'POST',
-            respond: () => new Response(JSON.stringify({ id: 'deal-4' }), { status: 201 }),
-        },
-        {
-            matches: ({ url, method }) => url.endsWith('/crm/v4/objects/deals/deal-4/associations/default/contacts/contact-4') && method === 'PUT',
-            respond: () => new Response(null, { status: 204 }),
-        },
-        {
-            matches: ({ url, method }) => url.endsWith('/crm/v3/objects/notes') && method === 'POST',
-            respond: () => new Response(JSON.stringify({ id: 'note-contact-warning' }), { status: 201 }),
-        },
-        {
-            matches: ({ url, method }) => url.endsWith('/crm/v4/objects/notes/note-contact-warning/associations/default/contacts/contact-4') && method === 'PUT',
-            respond: () => new Response(null, { status: 204 }),
-        },
-    ]);
-
-    const response = await handler(buildRequest({
-        firstName: 'Felipe',
-        lastName: 'William',
-        email: 'felipe@example.com',
-        bantSummary: 'Need: Disney | Authority: casal | Budget: 20k | Timeline: junho',
-        destination: 'Orlando',
-        utms: {
-            utm_source: 'google',
-            utm_medium: null,
-            utm_campaign: null,
-            utm_term: null,
-            utm_content: null,
-        },
-        tracking: {
-            utm_source: 'google',
-            utm_medium: null,
-            utm_campaign: null,
-            utm_term: null,
-            utm_content: null,
-            cid: 'cid-4',
-        },
     }));
 
     assert.equal(response.status, 201);
-    const payload = await response.json();
 
-    assert.equal(payload.ok, true);
-    assert.equal(payload.contactId, 'contact-4');
-    assert.equal(payload.dealId, 'deal-4');
-    assert.match(payload.warning, /dados de rastreamento\/UTM/i);
-    assert.match(payload.warning, /nota foi registrada/i);
-
-    const contactCreateRequest = calls.find((call) => call.url.endsWith('/crm/v3/objects/contacts') && call.method === 'POST');
-    assert.deepEqual(contactCreateRequest?.body?.properties, {
-        firstname: 'Felipe',
-        lastname: 'William',
-        email: 'felipe@example.com',
+    const request = calls[0]!;
+    assert.deepEqual(request.body?.lead, {
+        firstName: '&lt;script&gt;alert(\'xss\')&lt;/script&gt;John',
+        lastName: 'Doe &gt;',
+        email: 'john@example.com',
+        eventId: 'lead_&lt;meta&gt;&capi',
+        bantSummary: 'Need: &lt;img src=x onerror=alert(1)&gt;',
+        destination: 'Mars &lt;script&gt;',
     });
-
-    const enrichedContactProps = collectContactPatchProperties(calls, 'contact-4');
-    assert.equal(enrichedContactProps.ga_client_id, 'cid-4');
-    assert.equal(enrichedContactProps.ultimo_utm_source, 'google');
-    assert.equal(
-        calls.filter((call) => call.url.endsWith('/crm/v3/objects/contacts/contact-4') && call.method === 'PATCH').length,
-        1,
-    );
-
-    const noteRequest = calls.find((call) => call.url.endsWith('/crm/v3/objects/notes') && call.method === 'POST');
-    assert.ok(noteRequest, 'fallback note should be created for rejected optional properties');
-    assert.match(String(noteRequest?.body?.properties?.hs_note_body || ''), /ultimo_utm_source/);
+    assert.deepEqual(request.body?.tracking, {
+        utm_source: '&lt;svg onload=alert(1)&gt;',
+        utm_medium: null,
+        utm_campaign: null,
+        utm_term: null,
+        utm_content: null,
+        cid: null,
+        sid: null,
+        gclid: null,
+        fbclid: null,
+        msclkid: null,
+        ttclid: null,
+        wbraid: null,
+        gbraid: null,
+        fbc: null,
+        fbp: null,
+        extras: {
+            '&lt;p&gt;custom&lt;/p&gt;': '&lt;b&gt;value&lt;/b&gt;',
+        },
+    });
 });
 
-test('submit-lead should return requestId and property-specific code when HubSpot rejects contact properties', async (t) => {
+test('sendLeadToN8n should reject timed out webhook deliveries with a sanitized error', async (t) => {
+    const originalTimeout = process.env.N8N_WEBHOOK_TIMEOUT_MS;
+
     t.after(() => {
         global.fetch = originalFetch;
-        restoreEnv();
+        if (originalTimeout === undefined) {
+            delete process.env.N8N_WEBHOOK_TIMEOUT_MS;
+        } else {
+            process.env.N8N_WEBHOOK_TIMEOUT_MS = originalTimeout;
+        }
     });
 
-    process.env.HUBSPOT_TOKEN = 'test-token';
-    process.env.HUBSPOT_DEAL_PIPELINE_ID = 'pipeline-1';
-    process.env.HUBSPOT_DEAL_STAGE_ID = 'stage-1';
+    process.env.N8N_WEBHOOK_TIMEOUT_MS = '20';
+    global.fetch = (async () => new Promise<Response>(() => {})) as typeof fetch;
 
-    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const url = getUrl(input);
-        const method = init?.method || 'GET';
+    await assert.rejects(
+        () => sendLeadToN8n(
+            'https://n8n.example/webhook/submit-lead',
+            'secret-123',
+            'req-timeout',
+            buildN8nLeadPayload(buildLeadPayloadFixture(), 'req-timeout'),
+        ),
+        (error: unknown) => error instanceof Error && error.message.startsWith('N8N_WEBHOOK_ERROR:504:'),
+    );
+});
 
-        if (url.endsWith('/crm/v3/objects/contacts') && method === 'POST') {
-            return new Response(JSON.stringify({
-                status: 'error',
-                message: 'Property values were not valid',
-            }), { status: 400 });
+test('sendLeadToN8n should normalize raw network failures into N8N_WEBHOOK_ERROR', async (t) => {
+    const originalTimeout = process.env.N8N_WEBHOOK_TIMEOUT_MS;
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        if (originalTimeout === undefined) {
+            delete process.env.N8N_WEBHOOK_TIMEOUT_MS;
+        } else {
+            process.env.N8N_WEBHOOK_TIMEOUT_MS = originalTimeout;
         }
+    });
 
-        throw new Error(`Unexpected request: ${method} ${url}`);
+    process.env.N8N_WEBHOOK_TIMEOUT_MS = '200';
+    global.fetch = (async () => {
+        throw new TypeError('fetch failed');
     }) as typeof fetch;
 
-    const response = await handler(buildRequest({
-        firstName: 'Felipe',
-        lastName: 'William',
-        email: 'felipe@example.com',
-        bantSummary: 'Need: Praia | Authority: casal | Budget: 20k | Timeline: setembro',
-        destination: 'Lisboa',
-        utms: {},
-        tracking: {
-            utm_source: null,
-            utm_medium: null,
-            utm_campaign: null,
-            utm_term: null,
-            utm_content: null,
-        },
-    }));
-
-    assert.equal(response.status, 502);
-    const payload = await response.json();
-
-    assert.equal(payload.ok, false);
-    assert.equal(payload.code, 'HUBSPOT_PROPERTY_ERROR');
-    assert.equal(typeof payload.requestId, 'string');
-    assert.ok(payload.requestId.length > 0);
+    await assert.rejects(
+        () => sendLeadToN8n(
+            'https://n8n.example/webhook/submit-lead',
+            'secret-123',
+            'req-network-failure',
+            buildN8nLeadPayload(buildLeadPayloadFixture(), 'req-network-failure'),
+        ),
+        (error: unknown) => error instanceof Error
+            && error.message === 'N8N_WEBHOOK_ERROR:502:Webhook request failed',
+    );
 });
 
-test('submit-lead should not hang when HubSpot enrichment times out', async (t) => {
+test('submit-lead should deliver the validated payload to n8n and return a neutral success response', async (t) => {
     t.after(() => {
         global.fetch = originalFetch;
         restoreEnv();
     });
 
-    process.env.HUBSPOT_TOKEN = 'test-token';
-    process.env.HUBSPOT_DEAL_PIPELINE_ID = 'pipeline-1';
-    process.env.HUBSPOT_DEAL_STAGE_ID = 'stage-1';
-    process.env.HUBSPOT_REQUEST_TIMEOUT_MS = '100';
+    process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL = 'https://n8n.example/webhook/submit-lead';
+    process.env.N8N_WEBHOOK_SECRET = 'secret-123';
+    process.env.N8N_WEBHOOK_TIMEOUT_MS = '200';
+    delete process.env.META_PIXEL_ID;
+    delete process.env.META_ACCESS_TOKEN;
+    delete process.env.GA4_MEASUREMENT_ID;
+    delete process.env.GA4_API_SECRET;
 
-    const calls: MockHubSpotRequest[] = [];
+    const calls: MockN8nRequest[] = [];
+    global.fetch = createMockN8nFetch(calls, new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-    global.fetch = createMockHubSpotFetch(calls, [
-        {
-            matches: ({ url, method }) => url.endsWith('/crm/v3/objects/contacts') && method === 'POST',
-            respond: () => new Response(JSON.stringify({ id: 'contact-timeout' }), { status: 201 }),
-        },
-        {
-            matches: ({ url, method }) => url.endsWith('/crm/v3/objects/contacts/contact-timeout') && method === 'PATCH',
-            respond: () => new Promise<Response>(() => {}),
-        },
-        {
-            matches: ({ url, method }) => url.endsWith('/crm/v3/objects/deals') && method === 'POST',
-            respond: () => new Response(JSON.stringify({ id: 'deal-timeout' }), { status: 201 }),
-        },
-        {
-            matches: ({ url, method }) => url.endsWith('/crm/v4/objects/deals/deal-timeout/associations/default/contacts/contact-timeout') && method === 'PUT',
-            respond: () => new Response(null, { status: 204 }),
-        },
-    ]);
-
-    const response = await handler(buildRequest({
-        firstName: 'Felipe',
-        lastName: 'William',
-        email: 'felipe@example.com',
-        bantSummary: 'Need: Disney | Authority: casal | Budget: 20k | Timeline: junho',
-        destination: 'Orlando',
-        utms: {
-            utm_source: 'google',
-            utm_medium: null,
-            utm_campaign: null,
-            utm_term: null,
-            utm_content: null,
-        },
-        tracking: {
-            cid: 'cid-timeout',
-            utm_source: 'google',
-            utm_medium: null,
-            utm_campaign: null,
-            utm_term: null,
-            utm_content: null,
-        },
-    }));
+    const requestBody = buildLeadPayloadFixture();
+    const response = await handler(buildRequest(requestBody));
 
     assert.equal(response.status, 201);
-    const payload = await response.json();
 
-    assert.equal(payload.ok, true);
-    assert.equal(payload.contactId, 'contact-timeout');
-    assert.equal(payload.dealId, 'deal-timeout');
-    assert.match(payload.warning, /dados de rastreamento\/UTM/i);
-    assert.doesNotMatch(payload.warning, /nota foi registrada/i);
-    assert.equal(calls.some((call) => call.url.endsWith('/crm/v3/objects/notes')), false);
+    const payload = await response.json() as {
+        ok: boolean;
+        requestId: string;
+        message: string;
+        contactId?: string;
+        dealId?: string;
+        warning?: string;
+    };
+
+    assert.deepEqual(payload, {
+        ok: true,
+        requestId: payload.requestId,
+        message: 'Enviado com sucesso',
+    });
+    assert.equal('contactId' in payload, false);
+    assert.equal('dealId' in payload, false);
+    assert.equal('warning' in payload, false);
+
+    assert.equal(calls.length, 1);
+    const request = calls[0]!;
+    assert.equal(request.url, 'https://n8n.example/webhook/submit-lead');
+    assert.equal(request.method, 'POST');
+    assert.equal(request.headers['content-type'], 'application/json');
+    assert.equal(request.headers['x-webhook-secret'], 'secret-123');
+    assert.equal(request.headers['x-request-id'], payload.requestId);
+    assert.equal(request.body?.requestId, payload.requestId);
+    assert.equal(request.body?.source, 'submit-lead');
+    assert.deepEqual(request.body?.lead, {
+        firstName: requestBody.firstName,
+        lastName: requestBody.lastName,
+        email: requestBody.email,
+        eventId: requestBody.event_id,
+        bantSummary: requestBody.bantSummary,
+        destination: requestBody.destination,
+    });
+    assert.deepEqual(request.body?.utms, requestBody.utms);
+    assert.deepEqual(request.body?.tracking, {
+        ...requestBody.tracking,
+        extras: {},
+    });
+    assert.match(String((request.body?.meta as Record<string, unknown> | undefined)?.receivedAt), /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test('submit-lead should return N8N_WEBHOOK_ERROR when the webhook responds with a failure', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL = 'https://n8n.example/webhook/submit-lead';
+    process.env.N8N_WEBHOOK_SECRET = 'secret-123';
+
+    global.fetch = (async () => new Response(JSON.stringify({ error: 'upstream failed' }), { status: 503 })) as typeof fetch;
+
+    const response = await handler(buildRequest(buildLeadPayloadFixture()));
+    const payload = await response.json() as { ok: boolean; code?: string; error?: string };
+
+    assert.equal(response.status, 502);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.code, 'N8N_WEBHOOK_ERROR');
+    assert.equal(payload.error, 'Erro ao enviar lead.');
+});
+
+test('submit-lead should return SERVER_CONFIG_ERROR when n8n config is missing', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    delete process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL;
+    delete process.env.N8N_WEBHOOK_SECRET;
+
+    let fetchCalled = false;
+    global.fetch = (async () => {
+        fetchCalled = true;
+        throw new Error('fetch should not be called when config is missing');
+    }) as typeof fetch;
+
+    const response = await handler(buildRequest(buildLeadPayloadFixture()));
+    const payload = await response.json() as { ok: boolean; code?: string; error?: string };
+
+    assert.equal(fetchCalled, false);
+    assert.equal(response.status, 500);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.code, 'SERVER_CONFIG_ERROR');
+    assert.equal(payload.error, 'Integração de lead indisponível no momento.');
+});
+
+test('submit-lead should return SERVER_CONFIG_ERROR before parsing malformed JSON when n8n config is missing', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    delete process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL;
+    delete process.env.N8N_WEBHOOK_SECRET;
+
+    let fetchCalled = false;
+    global.fetch = (async () => {
+        fetchCalled = true;
+        throw new Error('fetch should not be called when config is missing');
+    }) as typeof fetch;
+
+    const response = await handler(new Request('http://localhost/api/submit-lead', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-real-ip': '127.0.0.201',
+        },
+        body: '{"firstName": "Felipe",',
+    }));
+
+    const payload = await response.json() as { ok: boolean; code?: string; error?: string };
+
+    assert.equal(fetchCalled, false);
+    assert.equal(response.status, 500);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.code, 'SERVER_CONFIG_ERROR');
+    assert.equal(payload.error, 'Integração de lead indisponível no momento.');
+});
+
+test('classifySubmitLeadError should preserve unexpected internal failures', () => {
+    const classified = classifySubmitLeadError(new Error('unexpected database failure'));
+
+    assert.equal(classified.code, 'INTERNAL_ERROR');
+    assert.equal(classified.status, 500);
+    assert.equal(classified.error, 'Erro interno ao processar envio do lead.');
+});
+
+test('submit-lead should enforce rate limiting', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL = 'https://n8n.example/webhook/submit-lead';
+    process.env.N8N_WEBHOOK_SECRET = 'secret-123';
+
+    global.fetch = (async () => new Response(JSON.stringify({ ok: true }), { status: 200 })) as typeof fetch;
+
+    const sharedIP = '9.8.7.6';
+    const buildRateLimitedRequest = () => new Request('http://localhost/api/submit-lead', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-real-ip': sharedIP,
+        },
+        body: JSON.stringify(buildLeadPayloadFixture()),
+    });
+
+    for (let i = 0; i < 5; i++) {
+        const response = await handler(buildRateLimitedRequest());
+        assert.equal(response.status, 201);
+    }
+
+    const response = await handler(buildRateLimitedRequest());
+    assert.equal(response.status, 429);
+
+    const payload = await response.json() as { ok: boolean; code?: string };
+    assert.equal(payload.ok, false);
+    assert.equal(payload.code, 'RATE_LIMIT_EXCEEDED');
+    assert.ok(response.headers.get('Retry-After'));
+    assert.ok(response.headers.get('X-RateLimit-Reset'));
+});
+
+test('submit-lead should not consume rate-limit quota for invalid payloads', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL = 'https://n8n.example/webhook/submit-lead';
+    process.env.N8N_WEBHOOK_SECRET = 'secret-123';
+    process.env.N8N_WEBHOOK_TIMEOUT_MS = '200';
+    delete process.env.META_PIXEL_ID;
+    delete process.env.META_ACCESS_TOKEN;
+    delete process.env.GA4_MEASUREMENT_ID;
+    delete process.env.GA4_API_SECRET;
+
+    const calls: MockN8nRequest[] = [];
+    global.fetch = createMockN8nFetch(calls, new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const sharedIP = '127.0.0.210';
+    const buildSharedRequest = (body: Record<string, unknown>) => new Request('http://localhost/api/submit-lead', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-real-ip': sharedIP,
+        },
+        body: JSON.stringify(body),
+    });
+
+    const validBody = buildLeadPayloadFixture();
+    const invalidBody = {
+        ...validBody,
+        email: 'not-an-email',
+    };
+
+    for (let i = 0; i < 4; i++) {
+        const response = await handler(buildSharedRequest(validBody));
+        assert.equal(response.status, 201);
+    }
+
+    const invalidResponse = await handler(buildSharedRequest(invalidBody));
+    const invalidPayload = await invalidResponse.json() as { ok: boolean; code?: string };
+    assert.equal(invalidResponse.status, 400);
+    assert.equal(invalidPayload.ok, false);
+    assert.equal(invalidPayload.code, 'VALIDATION_ERROR');
+
+    const postInvalidResponse = await handler(buildSharedRequest(validBody));
+    assert.equal(postInvalidResponse.status, 201);
+    assert.equal(calls.length, 5);
 });

--- a/tests/submit-lead.test.ts
+++ b/tests/submit-lead.test.ts
@@ -452,6 +452,33 @@ test('sendLeadToN8n should normalize raw network failures into N8N_WEBHOOK_ERROR
     );
 });
 
+test('sendLeadToN8n should include a sanitized webhook response detail in provider errors', async (t) => {
+    const originalTimeout = process.env.N8N_WEBHOOK_TIMEOUT_MS;
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        if (originalTimeout === undefined) {
+            delete process.env.N8N_WEBHOOK_TIMEOUT_MS;
+        } else {
+            process.env.N8N_WEBHOOK_TIMEOUT_MS = originalTimeout;
+        }
+    });
+
+    process.env.N8N_WEBHOOK_TIMEOUT_MS = '200';
+    global.fetch = (async () => new Response(' upstream failed\nwith extra detail ', { status: 503 })) as typeof fetch;
+
+    await assert.rejects(
+        () => sendLeadToN8n(
+            'https://n8n.example/webhook/submit-lead',
+            'secret-123',
+            'req-upstream-error',
+            buildN8nLeadPayload(buildLeadPayloadFixture(), 'req-upstream-error'),
+        ),
+        (error: unknown) => error instanceof Error
+            && error.message === 'N8N_WEBHOOK_ERROR:503:upstream failed with extra detail',
+    );
+});
+
 test('submit-lead should deliver the validated payload to n8n and return a neutral success response', async (t) => {
     t.after(() => {
         global.fetch = originalFetch;
@@ -601,6 +628,15 @@ test('classifySubmitLeadError should preserve unexpected internal failures', () 
     assert.equal(classified.code, 'INTERNAL_ERROR');
     assert.equal(classified.status, 500);
     assert.equal(classified.error, 'Erro interno ao processar envio do lead.');
+});
+
+test('classifySubmitLeadError should preserve sanitized webhook detail for internal logging', () => {
+    const classified = classifySubmitLeadError(new Error('N8N_WEBHOOK_ERROR:503: upstream failed\nwith extra detail '));
+
+    assert.equal(classified.code, 'N8N_WEBHOOK_ERROR');
+    assert.equal(classified.status, 502);
+    assert.equal(classified.error, 'Erro ao enviar lead.');
+    assert.equal(classified.detail, 'upstream failed with extra detail');
 });
 
 test('submit-lead should enforce rate limiting', async (t) => {

--- a/tests/submit-waitlist.test.ts
+++ b/tests/submit-waitlist.test.ts
@@ -1,14 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import handler from '../api/submit-waitlist.ts';
+import handler, { classifySubmitWaitlistError } from '../api/submit-waitlist.ts';
 
 const originalFetch = global.fetch;
 const originalEnv = {
     ALLOWED_ORIGIN: process.env.ALLOWED_ORIGIN,
-    HUBSPOT_TOKEN: process.env.HUBSPOT_TOKEN,
-    HUBSPOT_LOLLAPALOOZA_LIST_ID: process.env.HUBSPOT_LOLLAPALOOZA_LIST_ID,
-    HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY: process.env.HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY,
-    HUBSPOT_REQUEST_TIMEOUT_MS: process.env.HUBSPOT_REQUEST_TIMEOUT_MS,
+    UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+    UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+    N8N_SUBMIT_WAITLIST_WEBHOOK_URL: process.env.N8N_SUBMIT_WAITLIST_WEBHOOK_URL,
+    N8N_WEBHOOK_SECRET: process.env.N8N_WEBHOOK_SECRET,
+    N8N_WEBHOOK_TIMEOUT_MS: process.env.N8N_WEBHOOK_TIMEOUT_MS,
 };
 
 function restoreEnvValue(key: string, value: string | undefined) {
@@ -22,13 +23,17 @@ function restoreEnvValue(key: string, value: string | undefined) {
 
 function restoreEnv() {
     restoreEnvValue('ALLOWED_ORIGIN', originalEnv.ALLOWED_ORIGIN);
-    restoreEnvValue('HUBSPOT_TOKEN', originalEnv.HUBSPOT_TOKEN);
-    restoreEnvValue('HUBSPOT_LOLLAPALOOZA_LIST_ID', originalEnv.HUBSPOT_LOLLAPALOOZA_LIST_ID);
-    restoreEnvValue('HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY', originalEnv.HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY);
-    restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    restoreEnvValue('UPSTASH_REDIS_REST_URL', originalEnv.UPSTASH_REDIS_REST_URL);
+    restoreEnvValue('UPSTASH_REDIS_REST_TOKEN', originalEnv.UPSTASH_REDIS_REST_TOKEN);
+    restoreEnvValue('N8N_SUBMIT_WAITLIST_WEBHOOK_URL', originalEnv.N8N_SUBMIT_WAITLIST_WEBHOOK_URL);
+    restoreEnvValue('N8N_WEBHOOK_SECRET', originalEnv.N8N_WEBHOOK_SECRET);
+    restoreEnvValue('N8N_WEBHOOK_TIMEOUT_MS', originalEnv.N8N_WEBHOOK_TIMEOUT_MS);
 }
 
-function buildRequest(body: Record<string, unknown>, init?: { headers?: Record<string, string>; method?: string }): Request {
+function buildRequest(
+    body: Record<string, unknown> | string,
+    init?: { headers?: Record<string, string>; method?: string },
+): Request {
     const ipSuffix = Math.floor(Math.random() * 200) + 1;
     const method = init?.method || 'POST';
 
@@ -39,7 +44,11 @@ function buildRequest(body: Record<string, unknown>, init?: { headers?: Record<s
             'x-real-ip': `127.0.0.${ipSuffix}`,
             ...init?.headers,
         },
-        body: method === 'OPTIONS' ? undefined : JSON.stringify(body),
+        body: method === 'OPTIONS'
+            ? undefined
+            : typeof body === 'string'
+                ? body
+                : JSON.stringify(body),
     });
 }
 
@@ -49,408 +58,244 @@ function getUrl(input: RequestInfo | URL): string {
     return input.url;
 }
 
-function requestTargetsHost(rawUrl: string, host: string): boolean {
-    try {
-        return new URL(rawUrl).hostname === host;
-    } catch {
-        return false;
-    }
-}
-
-interface MockHubSpotRequestBody {
-    properties?: Record<string, unknown>;
-    filterGroups?: Array<Record<string, unknown>>;
-}
-
-interface MockHubSpotRequest {
+interface MockN8nRequest {
     url: string;
     method: string;
-    body?: MockHubSpotRequestBody;
+    headers: Record<string, string>;
+    body?: Record<string, unknown>;
 }
 
-interface MockHubSpotRoute {
-    matches: (request: MockHubSpotRequest) => boolean;
-    respond: (request: MockHubSpotRequest) => Response | Promise<Response>;
-}
+function buildMockN8nRequest(input: RequestInfo | URL, init?: RequestInit): MockN8nRequest {
+    const headers = new Headers(init?.headers);
 
-function buildMockHubSpotRequest(input: RequestInfo | URL, init?: RequestInit): MockHubSpotRequest {
     return {
         url: getUrl(input),
         method: init?.method || 'GET',
-        body: init?.body ? JSON.parse(String(init.body)) as MockHubSpotRequestBody : undefined,
+        headers: Object.fromEntries(headers.entries()),
+        body: init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : undefined,
     };
 }
 
-function createMockHubSpotFetch(calls: MockHubSpotRequest[], routes: MockHubSpotRoute[]): typeof fetch {
+function createMockN8nFetch(
+    calls: MockN8nRequest[],
+    response: Response | ((request: MockN8nRequest) => Response | Promise<Response>),
+): typeof fetch {
     return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const request = buildMockHubSpotRequest(input, init);
+        const request = buildMockN8nRequest(input, init);
         calls.push(request);
 
-        for (const route of routes) {
-            if (route.matches(request)) {
-                return await route.respond(request);
-            }
+        if (typeof response === 'function') {
+            return await response(request);
         }
 
-        throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+        return response;
     }) as typeof fetch;
 }
 
-function collectContactPatchProperties(calls: MockHubSpotRequest[], contactId: string): Record<string, unknown> {
-    const patches = calls.filter((call) => call.url.endsWith(`/crm/v3/objects/contacts/${contactId}`) && call.method === 'PATCH');
-    return Object.assign({}, ...patches.map((call) => call.body?.properties || {}));
-}
-
-function collectListMembershipBodies(calls: MockHubSpotRequest[], listId: string): unknown[] {
-    return calls
-        .filter((call) => call.method === 'PUT' && call.url.endsWith(`/crm/v3/lists/${listId}/memberships/add`))
-        .map((call) => call.body);
-}
-
-test('submit-waitlist should reject invalid payloads', async () => {
-    restoreEnv();
-    delete process.env.HUBSPOT_TOKEN;
-
-    const response = await handler(buildRequest({
-        name: '',
-        email: 'felipe@example.com',
-        sourcePage: '/lollapalooza',
-        utms: {},
-        tracking: {},
-    }));
-
-    assert.equal(response.status, 400);
-
-    const payload = await response.json() as { ok: boolean; code?: string };
-    assert.equal(payload.ok, false);
-    assert.equal(payload.code, 'VALIDATION_ERROR');
-});
-
-test('submit-waitlist should use configured allowed origin for POST responses', async () => {
-    restoreEnv();
-    process.env.ALLOWED_ORIGIN = 'https://preview.anhanga.tur.br';
-    delete process.env.HUBSPOT_TOKEN;
-
-    const response = await handler(buildRequest({
-        name: '',
-        email: 'felipe@example.com',
-        sourcePage: '/lollapalooza',
-        utms: {},
-        tracking: {},
-    }, {
-        headers: {
-            origin: 'https://evil.example',
-        },
-    }));
-
-    assert.equal(response.status, 400);
-    assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://preview.anhanga.tur.br');
-});
-
-test('submit-waitlist should use configured allowed origin for OPTIONS preflight', async () => {
-    restoreEnv();
-    process.env.ALLOWED_ORIGIN = 'https://preview.anhanga.tur.br';
-
-    const response = await handler(buildRequest({}, {
-        method: 'OPTIONS',
-        headers: {
-            origin: 'https://evil.example',
-        },
-    }));
-
-    assert.equal(response.status, 204);
-    assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://preview.anhanga.tur.br');
-    assert.equal(response.headers.get('Access-Control-Allow-Methods'), 'POST, OPTIONS');
-});
-
-test('submit-waitlist should create contact, sync tracking, create note, and avoid deals', async (t) => {
-    t.after(() => {
-        global.fetch = originalFetch;
-        restoreEnv();
-    });
-
-    process.env.HUBSPOT_TOKEN = 'hubspot-token';
-    process.env.HUBSPOT_LOLLAPALOOZA_LIST_ID = 'list_lolla_2027';
-    process.env.HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY = 'tracking_payload';
-
-    const calls: MockHubSpotRequest[] = [];
-    global.fetch = createMockHubSpotFetch(calls, [
-        {
-            matches: (request) => request.method === 'POST' && request.url.endsWith('/crm/v3/objects/contacts'),
-            respond: async () => new Response(JSON.stringify({ id: 'contact_waitlist_123' }), { status: 201 }),
-        },
-        {
-            matches: (request) => request.method === 'PATCH' && request.url.endsWith('/crm/v3/objects/contacts/contact_waitlist_123'),
-            respond: async () => new Response(JSON.stringify({ id: 'contact_waitlist_123' }), { status: 200 }),
-        },
-        {
-            matches: (request) => request.method === 'POST' && request.url.endsWith('/crm/v3/objects/notes'),
-            respond: async () => new Response(JSON.stringify({ id: 'note_waitlist_123' }), { status: 201 }),
-        },
-        {
-            matches: (request) => request.method === 'PUT' && request.url.endsWith('/crm/v4/objects/notes/note_waitlist_123/associations/default/contacts/contact_waitlist_123'),
-            respond: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
-        },
-        {
-            matches: (request) => request.method === 'PUT' && request.url.endsWith('/crm/v3/lists/list_lolla_2027/memberships/add'),
-            respond: async () => new Response(JSON.stringify({ recordsAdded: 1 }), { status: 200 }),
-        },
-    ]);
-
-    const response = await handler(buildRequest({
-        name: 'Felipe William',
-        email: 'felipe@example.com',
-        sourcePage: '/lollapalooza',
+function buildDirtyWaitlistPayload() {
+    return {
+        name: '  Ana <Maria>  ',
+        email: '  ANA@example.com  ',
+        sourcePage: ' /lollapalooza?slot=<hero> ',
         utms: {
-            utm_source: 'google',
-            utm_medium: 'cpc',
-            utm_campaign: 'lolla_waitlist',
-            utm_term: null,
-            utm_content: null,
+            utm_source: ' google ',
+            utm_medium: ' cpc ',
+            utm_campaign: ' lolla <2027> ',
+            utm_term: '   ',
+            utm_content: ' hero ad ',
         },
         tracking: {
-            utm_source: 'google',
-            utm_medium: 'cpc',
-            utm_campaign: 'lolla_waitlist',
-            utm_term: null,
-            utm_content: null,
-            gclid: 'test-gclid',
+            fbclid: ' fbclid-123 ',
             extras: {
-                ref: 'hero_cta',
+                ref: ' hero <cta> ',
+                campaign_note: ' hurry > now ',
             },
+            custom_source: ' direct ',
         },
-    }));
-
-    assert.equal(response.status, 201);
-
-    const payload = await response.json() as { ok: boolean; contactId?: string; message?: string };
-    assert.equal(payload.ok, true);
-    assert.equal(payload.contactId, 'contact_waitlist_123');
-    assert.match(payload.message || '', /lista de espera/i);
-
-    const createContactCall = calls.find((call) => call.url.endsWith('/crm/v3/objects/contacts') && call.method === 'POST');
-    assert.deepEqual(createContactCall?.body?.properties, {
-        firstname: 'Felipe',
-        lastname: 'William',
-        email: 'felipe@example.com',
-    });
-
-    const contactProperties = collectContactPatchProperties(calls, 'contact_waitlist_123');
-    assert.equal(contactProperties.ultimo_utm_source, 'google');
-    assert.equal(contactProperties.ultimo_utm_medium, 'cpc');
-    assert.equal(contactProperties.ultimo_utm_campaign, 'lolla_waitlist');
-    assert.equal(contactProperties.hs_google_click_id, 'test-gclid');
-    assert.equal(contactProperties.tracking_payload, JSON.stringify({ ref: 'hero_cta' }));
-
-    const noteCall = calls.find((call) => call.url.endsWith('/crm/v3/objects/notes') && call.method === 'POST');
-    assert.match(String(noteCall?.body?.properties?.hs_note_body || ''), /Lista de Espera Lollapalooza 2027/);
-    assert.match(String(noteCall?.body?.properties?.hs_note_body || ''), /\/lollapalooza/);
-    assert.deepEqual(collectListMembershipBodies(calls, 'list_lolla_2027'), [['contact_waitlist_123']]);
-
-    assert.equal(calls.some((call) => call.url.includes('/crm/v3/objects/deals')), false);
-    assert.equal(calls.some((call) => requestTargetsHost(call.url, 'www.google-analytics.com')), false);
-    assert.equal(calls.some((call) => requestTargetsHost(call.url, 'graph.facebook.com')), false);
-});
-
-test('submit-waitlist should update an existing contact when HubSpot returns duplicate email', async (t) => {
-    t.after(() => {
-        global.fetch = originalFetch;
-        restoreEnv();
-    });
-
-    process.env.HUBSPOT_TOKEN = 'hubspot-token';
-    process.env.HUBSPOT_LOLLAPALOOZA_LIST_ID = 'list_lolla_2027';
-
-    const calls: MockHubSpotRequest[] = [];
-    global.fetch = createMockHubSpotFetch(calls, [
-        {
-            matches: (request) => request.method === 'POST' && request.url.endsWith('/crm/v3/objects/contacts'),
-            respond: async () => new Response(JSON.stringify({ message: 'duplicate' }), { status: 409 }),
-        },
-        {
-            matches: (request) => request.method === 'POST' && request.url.endsWith('/crm/v3/objects/contacts/search'),
-            respond: async () => new Response(JSON.stringify({ results: [{ id: 'contact_existing_456' }] }), { status: 200 }),
-        },
-        {
-            matches: (request) => request.method === 'PATCH' && request.url.endsWith('/crm/v3/objects/contacts/contact_existing_456'),
-            respond: async () => new Response(JSON.stringify({ id: 'contact_existing_456' }), { status: 200 }),
-        },
-        {
-            matches: (request) => request.method === 'POST' && request.url.endsWith('/crm/v3/objects/notes'),
-            respond: async () => new Response(JSON.stringify({ id: 'note_waitlist_456' }), { status: 201 }),
-        },
-        {
-            matches: (request) => request.method === 'PUT' && request.url.endsWith('/crm/v4/objects/notes/note_waitlist_456/associations/default/contacts/contact_existing_456'),
-            respond: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
-        },
-        {
-            matches: (request) => request.method === 'PUT' && request.url.endsWith('/crm/v3/lists/list_lolla_2027/memberships/add'),
-            respond: async () => new Response(JSON.stringify({ recordsAdded: 1 }), { status: 200 }),
-        },
-    ]);
-
-    const response = await handler(buildRequest({
-        name: 'Felipe',
-        email: 'felipe@example.com',
-        sourcePage: '/lollapalooza',
-        utms: {},
-        tracking: {},
-    }));
-
-    assert.equal(response.status, 201);
-
-    const payload = await response.json() as { ok: boolean; contactId?: string };
-    assert.equal(payload.ok, true);
-    assert.equal(payload.contactId, 'contact_existing_456');
-
-    const patchCalls = calls.filter((call) => call.url.endsWith('/crm/v3/objects/contacts/contact_existing_456') && call.method === 'PATCH');
-    assert.equal(patchCalls.length >= 1, true);
-    assert.equal(calls.some((call) => call.url.endsWith('/crm/v3/objects/contacts/search')), true);
-    assert.deepEqual(collectListMembershipBodies(calls, 'list_lolla_2027'), [['contact_existing_456']]);
-});
-
-test('submit-waitlist should still succeed without a configured HubSpot list id', async (t) => {
-    t.after(() => {
-        global.fetch = originalFetch;
-        restoreEnv();
-    });
-
-    const originalConsoleInfo = console.info;
-    const infoCalls: unknown[][] = [];
-    console.info = (...args: unknown[]) => {
-        infoCalls.push(args);
     };
-    t.after(() => {
-        console.info = originalConsoleInfo;
-    });
+}
 
-    process.env.HUBSPOT_TOKEN = 'hubspot-token';
-    delete process.env.HUBSPOT_LOLLAPALOOZA_LIST_ID;
-
-    const calls: MockHubSpotRequest[] = [];
-    global.fetch = createMockHubSpotFetch(calls, [
-        {
-            matches: (request) => request.method === 'POST' && request.url.endsWith('/crm/v3/objects/contacts'),
-            respond: async () => new Response(JSON.stringify({ id: 'contact_waitlist_789' }), { status: 201 }),
-        },
-        {
-            matches: (request) => request.method === 'POST' && request.url.endsWith('/crm/v3/objects/notes'),
-            respond: async () => new Response(JSON.stringify({ id: 'note_waitlist_789' }), { status: 201 }),
-        },
-        {
-            matches: (request) => request.method === 'PUT' && request.url.endsWith('/crm/v4/objects/notes/note_waitlist_789/associations/default/contacts/contact_waitlist_789'),
-            respond: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
-        },
-    ]);
-
-    const response = await handler(buildRequest({
-        name: 'Felipe William',
-        email: 'felipe@example.com',
-        sourcePage: '/lollapalooza',
-        utms: {},
-        tracking: {},
-    }));
-
-    assert.equal(response.status, 201);
-
-    const payload = await response.json() as { ok: boolean; contactId?: string; warning?: string };
-    assert.equal(payload.ok, true);
-    assert.equal(payload.contactId, 'contact_waitlist_789');
-    assert.equal(payload.warning, undefined);
-    assert.equal(calls.some((call) => call.url.includes('/crm/v3/lists/')), false);
-    assert.equal(infoCalls.some((args) => args.some((value) => String(value).includes('waitlist list id is not configured'))), true);
-});
-
-test('submit-waitlist should keep success response when list membership fails', async (t) => {
+test('submit-waitlist should return SERVER_CONFIG_ERROR before parsing malformed JSON when config is missing', async (t) => {
     t.after(() => {
         global.fetch = originalFetch;
         restoreEnv();
     });
 
-    const originalConsoleError = console.error;
-    const errorCalls: unknown[][] = [];
-    console.error = (...args: unknown[]) => {
-        errorCalls.push(args);
-    };
-    t.after(() => {
-        console.error = originalConsoleError;
-    });
+    delete process.env.N8N_SUBMIT_WAITLIST_WEBHOOK_URL;
+    delete process.env.N8N_WEBHOOK_SECRET;
 
-    process.env.HUBSPOT_TOKEN = 'hubspot-token';
-    process.env.HUBSPOT_LOLLAPALOOZA_LIST_ID = 'list_lolla_2027';
+    let fetchCalled = false;
+    global.fetch = (async () => {
+        fetchCalled = true;
+        throw new Error('fetch should not run when config is missing');
+    }) as typeof fetch;
 
-    const calls: MockHubSpotRequest[] = [];
-    global.fetch = createMockHubSpotFetch(calls, [
-        {
-            matches: (request) => request.method === 'POST' && request.url.endsWith('/crm/v3/objects/contacts'),
-            respond: async () => new Response(JSON.stringify({ id: 'contact_waitlist_999' }), { status: 201 }),
-        },
-        {
-            matches: (request) => request.method === 'POST' && request.url.endsWith('/crm/v3/objects/notes'),
-            respond: async () => new Response(JSON.stringify({ id: 'note_waitlist_999' }), { status: 201 }),
-        },
-        {
-            matches: (request) => request.method === 'PUT' && request.url.endsWith('/crm/v4/objects/notes/note_waitlist_999/associations/default/contacts/contact_waitlist_999'),
-            respond: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
-        },
-        {
-            matches: (request) => request.method === 'PUT' && request.url.endsWith('/crm/v3/lists/list_lolla_2027/memberships/add'),
-            respond: async () => new Response(JSON.stringify({ message: 'list unavailable' }), { status: 500 }),
-        },
-    ]);
+    const response = await handler(buildRequest('{"name":"broken"', { method: 'POST' }));
+    const payload = await response.json() as { ok: boolean; code?: string; error?: string };
 
-    const response = await handler(buildRequest({
-        name: 'Felipe William',
-        email: 'felipe@example.com',
-        sourcePage: '/lollapalooza',
-        utms: {},
-        tracking: {},
-    }));
-
-    assert.equal(response.status, 201);
-
-    const payload = await response.json() as { ok: boolean; contactId?: string; warning?: string };
-    assert.equal(payload.ok, true);
-    assert.equal(payload.contactId, 'contact_waitlist_999');
-    assert.equal(payload.warning, undefined);
-    assert.deepEqual(collectListMembershipBodies(calls, 'list_lolla_2027'), [['contact_waitlist_999']]);
-    assert.equal(errorCalls.some((args) => args.some((value) => String(value).includes('failed to add contact to lollapalooza list'))), true);
+    assert.equal(fetchCalled, false);
+    assert.equal(response.status, 500);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.code, 'SERVER_CONFIG_ERROR');
+    assert.equal(payload.error, 'Integração de waitlist indisponível no momento.');
 });
 
-test('submit-waitlist should enforce rate limiting', async () => {
-    restoreEnv();
+test('submit-waitlist should deliver a sanitized payload to n8n and return a neutral success response', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
 
-    const sharedIP = '1.2.3.4';
-    const buildRateLimitedRequest = () => new Request('http://localhost/api/submit-waitlist', {
-        method: 'POST',
+    process.env.N8N_SUBMIT_WAITLIST_WEBHOOK_URL = 'https://n8n.example/webhook/waitlist';
+    process.env.N8N_WEBHOOK_SECRET = 'secret-456';
+    process.env.N8N_WEBHOOK_TIMEOUT_MS = '200';
+
+    const calls: MockN8nRequest[] = [];
+    global.fetch = createMockN8nFetch(calls, new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const response = await handler(buildRequest(buildDirtyWaitlistPayload(), {
         headers: {
-            'Content-Type': 'application/json',
+            'x-real-ip': '127.0.0.41',
+        },
+    }));
+
+    assert.equal(response.status, 201);
+
+    const payload = await response.json() as { ok: boolean; requestId?: string; message?: string; contactId?: string };
+    assert.equal(payload.ok, true);
+    assert.equal(payload.message, 'Enviado com sucesso');
+    assert.equal(payload.contactId, undefined);
+    assert.ok(payload.requestId);
+
+    assert.equal(calls.length, 1);
+    const request = calls[0]!;
+    assert.equal(request.url, 'https://n8n.example/webhook/waitlist');
+    assert.equal(request.method, 'POST');
+
+    const headers = new Headers(request.headers);
+    assert.equal(headers.get('Content-Type'), 'application/json');
+    assert.equal(headers.get('X-Webhook-Secret'), 'secret-456');
+    assert.equal(headers.get('X-Request-Id'), payload.requestId);
+
+    const body = request.body as {
+        requestId: string;
+        source: string;
+        waitlist: { name: string; email: string; sourcePage: string };
+        utms: Record<string, unknown>;
+        tracking: Record<string, unknown>;
+        meta: { receivedAt: string };
+    };
+
+    assert.equal(body.requestId, payload.requestId);
+    assert.equal(body.source, 'submit-waitlist');
+    assert.deepEqual(body.waitlist, {
+        name: 'Ana &lt;Maria&gt;',
+        email: 'ana@example.com',
+        sourcePage: '/lollapalooza?slot=&lt;hero&gt;',
+    });
+    assert.deepEqual(body.utms, {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        utm_campaign: 'lolla &lt;2027&gt;',
+        utm_term: null,
+        utm_content: 'hero ad',
+    });
+    assert.deepEqual(body.tracking, {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        utm_campaign: 'lolla &lt;2027&gt;',
+        utm_term: null,
+        utm_content: 'hero ad',
+        cid: null,
+        sid: null,
+        gclid: null,
+        fbclid: 'fbclid-123',
+        msclkid: null,
+        ttclid: null,
+        wbraid: null,
+        gbraid: null,
+        fbc: null,
+        fbp: null,
+        extras: {
+            ref: 'hero &lt;cta&gt;',
+            campaign_note: 'hurry &gt; now',
+            custom_source: 'direct',
+        },
+    });
+    assert.match(body.meta.receivedAt, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test('submit-waitlist should return VALIDATION_ERROR without consuming rate-limit quota', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    process.env.N8N_SUBMIT_WAITLIST_WEBHOOK_URL = 'https://n8n.example/webhook/waitlist';
+    process.env.N8N_WEBHOOK_SECRET = 'secret-456';
+
+    const calls: MockN8nRequest[] = [];
+    global.fetch = createMockN8nFetch(calls, new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const sharedIP = '127.0.0.142';
+    const buildSharedRequest = (body: Record<string, unknown>) => buildRequest(body, {
+        headers: {
             'x-real-ip': sharedIP,
         },
-        body: JSON.stringify({
-            name: 'Felipe William',
-            email: 'felipe@example.com',
-            sourcePage: '/lollapalooza',
-            utms: {},
-            tracking: {},
-        }),
     });
 
-    // Make 5 successful requests
+    const invalidResponse = await handler(buildSharedRequest({
+        name: 'Ana Maria',
+        email: 'not-an-email',
+        sourcePage: '/lollapalooza',
+        utms: {},
+        tracking: {},
+    }));
+    const invalidPayload = await invalidResponse.json() as { ok: boolean; code?: string };
+
+    assert.equal(invalidResponse.status, 400);
+    assert.equal(invalidPayload.ok, false);
+    assert.equal(invalidPayload.code, 'VALIDATION_ERROR');
+    assert.equal(calls.length, 0);
+
+    const validBody = buildDirtyWaitlistPayload();
     for (let i = 0; i < 5; i++) {
-        const response = await handler(buildRateLimitedRequest());
-        // Since HUBSPOT_TOKEN is not set, it will return 500 SERVER_CONFIG_ERROR,
-        // but it still consumes rate limit.
-        assert.equal(response.status, 500);
+        const response = await handler(buildSharedRequest(validBody));
+        assert.equal(response.status, 201);
     }
 
-    // The 6th request should be rate limited
-    const response = await handler(buildRateLimitedRequest());
-    assert.equal(response.status, 429);
+    assert.equal(calls.length, 5);
+});
 
-    const payload = await response.json() as { ok: boolean; code?: string };
+test('submit-waitlist should map webhook failures to N8N_WEBHOOK_ERROR', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    process.env.N8N_SUBMIT_WAITLIST_WEBHOOK_URL = 'https://n8n.example/webhook/waitlist';
+    process.env.N8N_WEBHOOK_SECRET = 'secret-456';
+    process.env.N8N_WEBHOOK_TIMEOUT_MS = '200';
+
+    global.fetch = (async () => new Response(JSON.stringify({ error: 'upstream failed' }), { status: 503 })) as typeof fetch;
+
+    const response = await handler(buildRequest(buildDirtyWaitlistPayload(), {
+        headers: {
+            'x-real-ip': '127.0.0.43',
+        },
+    }));
+    const payload = await response.json() as { ok: boolean; code?: string; error?: string };
+
+    assert.equal(response.status, 502);
     assert.equal(payload.ok, false);
-    assert.equal(payload.code, 'RATE_LIMIT_EXCEEDED');
-    assert.ok(response.headers.get('Retry-After'));
-    assert.ok(response.headers.get('X-RateLimit-Reset'));
+    assert.equal(payload.code, 'N8N_WEBHOOK_ERROR');
+    assert.equal(payload.error, 'Erro ao enviar inscrição na lista de espera.');
+});
+
+test('classifySubmitWaitlistError should preserve unexpected internal failures', () => {
+    const classified = classifySubmitWaitlistError(new Error('unexpected database failure'));
+
+    assert.equal(classified.code, 'INTERNAL_ERROR');
+    assert.equal(classified.status, 500);
+    assert.equal(classified.error, 'Erro interno ao processar envio da lista de espera.');
 });

--- a/tests/submit-waitlist.test.ts
+++ b/tests/submit-waitlist.test.ts
@@ -299,3 +299,12 @@ test('classifySubmitWaitlistError should preserve unexpected internal failures',
     assert.equal(classified.status, 500);
     assert.equal(classified.error, 'Erro interno ao processar envio da lista de espera.');
 });
+
+test('classifySubmitWaitlistError should preserve sanitized webhook detail for internal handling', () => {
+    const classified = classifySubmitWaitlistError(new Error('N8N_WEBHOOK_ERROR:503: upstream failed\nwith extra detail '));
+
+    assert.equal(classified.code, 'N8N_WEBHOOK_ERROR');
+    assert.equal(classified.status, 502);
+    assert.equal(classified.error, 'Erro ao enviar inscrição na lista de espera.');
+    assert.equal(classified.detail, 'upstream failed with extra detail');
+});

--- a/types/leadCapture.ts
+++ b/types/leadCapture.ts
@@ -39,19 +39,15 @@ export interface SubmitLeadRequest {
 export interface SubmitLeadSuccess {
     ok: true;
     requestId: string;
-    contactId: string;
-    dealId?: string;
     warning?: string;
     message: string;
 }
 
 export type SubmitLeadErrorCode =
     | 'VALIDATION_ERROR'
-    | 'HUBSPOT_UNAUTHORIZED'
-    | 'HUBSPOT_DUPLICATE_CONTACT'
-    | 'HUBSPOT_PROPERTY_ERROR'
-    | 'HUBSPOT_API_ERROR'
+    | 'INTERNAL_ERROR'
     | 'SERVER_CONFIG_ERROR'
+    | 'N8N_WEBHOOK_ERROR'
     | 'METHOD_NOT_ALLOWED'
     | 'RATE_LIMIT_EXCEEDED';
 

--- a/types/waitlist.ts
+++ b/types/waitlist.ts
@@ -11,17 +11,15 @@ export interface SubmitWaitlistRequest {
 export interface SubmitWaitlistSuccess {
     ok: true;
     requestId: string;
-    contactId: string;
     warning?: string;
     message: string;
 }
 
 export type SubmitWaitlistErrorCode =
     | 'VALIDATION_ERROR'
-    | 'HUBSPOT_UNAUTHORIZED'
-    | 'HUBSPOT_PROPERTY_ERROR'
-    | 'HUBSPOT_API_ERROR'
     | 'SERVER_CONFIG_ERROR'
+    | 'N8N_WEBHOOK_ERROR'
+    | 'INTERNAL_ERROR'
     | 'METHOD_NOT_ALLOWED'
     | 'RATE_LIMIT_EXCEEDED';
 


### PR DESCRIPTION
## Summary
- replace direct HubSpot writes in `submit-lead` and `submit-waitlist` with validated server-to-server `n8n` webhook delivery
- add shared `n8n` payload/transport helpers and align public response contracts plus client hooks with neutral success/error handling
- update regression and E2E coverage for the new webhook seam, including sanitized payload delivery and rate-limit/config edge cases

## Test Plan
- [x] `pnpm test:regression`
- [x] `pnpm typecheck`
- [x] `pnpm exec playwright test tests/e2e/chatbot-lead-submit.spec.ts tests/e2e/lollapalooza-waitlist.spec.ts`
