### PR TITLE
[codex] Fix RFC 9727 API catalog discovery

### DIFF
--- a/api/api-catalog.ts
+++ b/api/api-catalog.ts
@@ -1,0 +1,24 @@
+export const config = { runtime: 'edge' };
+
+import {
+    buildApiCatalogDocument,
+    buildCatalogHeaders,
+    buildMethodNotAllowedResponse,
+} from '../lib/api-catalog';
+
+const ALLOWED_METHODS = ['GET', 'HEAD'] as const;
+
+export default async function handler(req: Request): Promise<Response> {
+    if (!ALLOWED_METHODS.includes(req.method as typeof ALLOWED_METHODS[number])) {
+        return buildMethodNotAllowedResponse(ALLOWED_METHODS);
+    }
+
+    const body = req.method === 'HEAD'
+        ? null
+        : JSON.stringify(buildApiCatalogDocument());
+
+    return new Response(body, {
+        status: 200,
+        headers: buildCatalogHeaders(),
+    });
+}

--- a/api/api-docs.ts
+++ b/api/api-docs.ts
@@ -1,0 +1,20 @@
+export const config = { runtime: 'edge' };
+
+import {
+    buildApiDocs,
+    buildMarkdownHeaders,
+    buildMethodNotAllowedResponse,
+} from '../lib/api-catalog';
+
+const ALLOWED_METHODS = ['GET', 'HEAD'] as const;
+
+export default async function handler(req: Request): Promise<Response> {
+    if (!ALLOWED_METHODS.includes(req.method as typeof ALLOWED_METHODS[number])) {
+        return buildMethodNotAllowedResponse(ALLOWED_METHODS);
+    }
+
+    return new Response(req.method === 'HEAD' ? null : buildApiDocs(), {
+        status: 200,
+        headers: buildMarkdownHeaders(),
+    });
+}

--- a/api/health.ts
+++ b/api/health.ts
@@ -1,0 +1,24 @@
+export const config = { runtime: 'edge' };
+
+import {
+    buildHealthDocument,
+    buildJsonHeaders,
+    buildMethodNotAllowedResponse,
+} from '../lib/api-catalog';
+
+const ALLOWED_METHODS = ['GET', 'HEAD'] as const;
+
+export default async function handler(req: Request): Promise<Response> {
+    if (!ALLOWED_METHODS.includes(req.method as typeof ALLOWED_METHODS[number])) {
+        return buildMethodNotAllowedResponse(ALLOWED_METHODS);
+    }
+
+    const body = req.method === 'HEAD'
+        ? null
+        : JSON.stringify(buildHealthDocument());
+
+    return new Response(body, {
+        status: 200,
+        headers: buildJsonHeaders(),
+    });
+}

--- a/api/openapi.ts
+++ b/api/openapi.ts
@@ -1,0 +1,24 @@
+export const config = { runtime: 'edge' };
+
+import {
+    buildJsonHeaders,
+    buildMethodNotAllowedResponse,
+    buildOpenApiDocument,
+} from '../lib/api-catalog';
+
+const ALLOWED_METHODS = ['GET', 'HEAD'] as const;
+
+export default async function handler(req: Request): Promise<Response> {
+    if (!ALLOWED_METHODS.includes(req.method as typeof ALLOWED_METHODS[number])) {
+        return buildMethodNotAllowedResponse(ALLOWED_METHODS);
+    }
+
+    const body = req.method === 'HEAD'
+        ? null
+        : JSON.stringify(buildOpenApiDocument());
+
+    return new Response(body, {
+        status: 200,
+        headers: buildJsonHeaders(),
+    });
+}

--- a/lib/api-catalog.ts
+++ b/lib/api-catalog.ts
@@ -5,7 +5,102 @@ const OPENAPI_PATH = '/.well-known/openapi.json';
 const HEALTH_PATH = '/api/health';
 const RFC_9727_PROFILE = 'https://www.rfc-editor.org/info/rfc9727';
 
-const API_ENDPOINTS = [
+type JsonSchema = Record<string, unknown>;
+type OpenApiJsonContent = {
+    'application/json': {
+        schema: JsonSchema;
+    };
+};
+
+interface OpenApiRequestBody {
+    required?: boolean;
+    content: {
+        'application/json': {
+            schema: JsonSchema;
+        };
+    };
+}
+
+interface OpenApiResponseDefinition {
+    description: string;
+    content?: OpenApiJsonContent;
+}
+
+export interface ApiEndpointDefinition {
+    anchor: string;
+    method: string;
+    summary: string;
+    description: string;
+    requestBody?: OpenApiRequestBody;
+    responses: Record<string, OpenApiResponseDefinition>;
+}
+
+const GENERIC_JSON_OBJECT_SCHEMA: JsonSchema = {
+    type: 'object',
+    additionalProperties: true,
+};
+
+const GENERATE_SUCCESS_SCHEMA: JsonSchema = {
+    type: 'object',
+    required: ['text'],
+    properties: {
+        text: { type: 'string' },
+        chips: {
+            type: 'array',
+            items: { type: 'string' },
+        },
+        functionCall: {
+            type: 'object',
+            additionalProperties: true,
+        },
+        handoff: {
+            type: 'object',
+            additionalProperties: true,
+        },
+    },
+    additionalProperties: false,
+};
+
+const SUBMIT_SUCCESS_SCHEMA: JsonSchema = {
+    type: 'object',
+    required: ['ok', 'requestId', 'message'],
+    properties: {
+        ok: { type: 'boolean' },
+        requestId: { type: 'string' },
+        message: { type: 'string' },
+    },
+    additionalProperties: true,
+};
+
+const ERROR_RESPONSE_SCHEMA: JsonSchema = {
+    type: 'object',
+    required: ['error'],
+    properties: {
+        ok: { type: 'boolean' },
+        requestId: { type: 'string' },
+        code: { type: 'string' },
+        error: { type: 'string' },
+        retryAfter: { type: 'number' },
+    },
+    additionalProperties: true,
+};
+
+function buildJsonContent(schema: JsonSchema = GENERIC_JSON_OBJECT_SCHEMA): OpenApiJsonContent {
+    return {
+        'application/json': {
+            schema,
+        },
+    };
+}
+
+function buildJsonResponse(description: string, schema: JsonSchema = GENERIC_JSON_OBJECT_SCHEMA): OpenApiResponseDefinition {
+    return {
+        description,
+        content: buildJsonContent(schema),
+    };
+}
+
+const API_ENDPOINTS: readonly ApiEndpointDefinition[] = [
     {
         anchor: `${SITE_ORIGIN}/api/generate`,
         method: 'post',
@@ -35,18 +130,10 @@ const API_ENDPOINTS = [
             },
         },
         responses: {
-            '200': {
-                description: 'Generated assistant response payload.',
-            },
-            '400': {
-                description: 'Invalid request body.',
-            },
-            '429': {
-                description: 'Rate limit exceeded.',
-            },
-            '500': {
-                description: 'Server or upstream model failure.',
-            },
+            '200': buildJsonResponse('Generated assistant response payload.', GENERATE_SUCCESS_SCHEMA),
+            '400': buildJsonResponse('Invalid request body.', ERROR_RESPONSE_SCHEMA),
+            '429': buildJsonResponse('Rate limit exceeded.', ERROR_RESPONSE_SCHEMA),
+            '500': buildJsonResponse('Server or upstream model failure.', ERROR_RESPONSE_SCHEMA),
         },
     },
     {
@@ -83,18 +170,10 @@ const API_ENDPOINTS = [
             },
         },
         responses: {
-            '201': {
-                description: 'Lead accepted.',
-            },
-            '400': {
-                description: 'Invalid lead payload.',
-            },
-            '429': {
-                description: 'Rate limit exceeded.',
-            },
-            '500': {
-                description: 'Server or upstream integration failure.',
-            },
+            '201': buildJsonResponse('Lead accepted.', SUBMIT_SUCCESS_SCHEMA),
+            '400': buildJsonResponse('Invalid lead payload.', ERROR_RESPONSE_SCHEMA),
+            '429': buildJsonResponse('Rate limit exceeded.', ERROR_RESPONSE_SCHEMA),
+            '500': buildJsonResponse('Server or upstream integration failure.', ERROR_RESPONSE_SCHEMA),
         },
     },
     {
@@ -128,21 +207,13 @@ const API_ENDPOINTS = [
             },
         },
         responses: {
-            '201': {
-                description: 'Waitlist registration accepted.',
-            },
-            '400': {
-                description: 'Invalid waitlist payload.',
-            },
-            '429': {
-                description: 'Rate limit exceeded.',
-            },
-            '500': {
-                description: 'Server or upstream integration failure.',
-            },
+            '201': buildJsonResponse('Waitlist registration accepted.', SUBMIT_SUCCESS_SCHEMA),
+            '400': buildJsonResponse('Invalid waitlist payload.', ERROR_RESPONSE_SCHEMA),
+            '429': buildJsonResponse('Rate limit exceeded.', ERROR_RESPONSE_SCHEMA),
+            '500': buildJsonResponse('Server or upstream integration failure.', ERROR_RESPONSE_SCHEMA),
         },
     },
-] as const;
+];
 
 function buildLinkHeader(): string {
     return `</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="${RFC_9727_PROFILE}"`;
@@ -214,24 +285,27 @@ export function buildApiCatalogDocument(): {
     };
 }
 
-export function buildOpenApiDocument(): Record<string, unknown> {
-    const paths: Record<string, Record<string, unknown>> = Object.fromEntries(
-        API_ENDPOINTS.map((endpoint) => {
-            const path = new URL(endpoint.anchor).pathname;
+export function buildOpenApiPaths(endpoints: readonly ApiEndpointDefinition[]): Record<string, Record<string, unknown>> {
+    const paths: Record<string, Record<string, unknown>> = {};
 
-            return [
-                path,
-                {
-                    [endpoint.method]: {
-                        summary: endpoint.summary,
-                        description: endpoint.description,
-                        requestBody: endpoint.requestBody,
-                        responses: endpoint.responses,
-                    },
-                },
-            ];
-        }),
-    );
+    for (const endpoint of endpoints) {
+        const path = new URL(endpoint.anchor).pathname;
+        paths[path] = {
+            ...paths[path],
+            [endpoint.method]: {
+                summary: endpoint.summary,
+                description: endpoint.description,
+                requestBody: endpoint.requestBody,
+                responses: endpoint.responses,
+            },
+        };
+    }
+
+    return paths;
+}
+
+export function buildOpenApiDocument(): Record<string, unknown> {
+    const paths = buildOpenApiPaths(API_ENDPOINTS);
 
     paths[HEALTH_PATH] = {
         get: {

--- a/lib/api-catalog.ts
+++ b/lib/api-catalog.ts
@@ -1,0 +1,318 @@
+const SITE_ORIGIN = 'https://www.anhanga.tur.br';
+const API_CATALOG_PATH = '/.well-known/api-catalog';
+const API_DOCS_PATH = '/.well-known/api-docs';
+const OPENAPI_PATH = '/.well-known/openapi.json';
+const HEALTH_PATH = '/api/health';
+const RFC_9727_PROFILE = 'https://www.rfc-editor.org/info/rfc9727';
+
+const API_ENDPOINTS = [
+    {
+        anchor: `${SITE_ORIGIN}/api/generate`,
+        method: 'post',
+        summary: 'Generate travel assistant responses',
+        description: 'Accepts the website chat history and returns the next assistant response plus optional chips and handoff data.',
+        requestBody: {
+            required: true,
+            content: {
+                'application/json': {
+                    schema: {
+                        type: 'object',
+                        required: ['contents'],
+                        properties: {
+                            contents: {
+                                type: 'array',
+                                minItems: 1,
+                                items: {
+                                    type: 'object',
+                                    additionalProperties: true,
+                                },
+                                description: 'Conversation history forwarded from the first-party travel assistant UI.',
+                            },
+                        },
+                        additionalProperties: false,
+                    },
+                },
+            },
+        },
+        responses: {
+            '200': {
+                description: 'Generated assistant response payload.',
+            },
+            '400': {
+                description: 'Invalid request body.',
+            },
+            '429': {
+                description: 'Rate limit exceeded.',
+            },
+            '500': {
+                description: 'Server or upstream model failure.',
+            },
+        },
+    },
+    {
+        anchor: `${SITE_ORIGIN}/api/submit-lead`,
+        method: 'post',
+        summary: 'Submit a qualified travel lead',
+        description: 'Receives normalized lead data from the first-party chatbot flow and forwards it to configured downstream systems.',
+        requestBody: {
+            required: true,
+            content: {
+                'application/json': {
+                    schema: {
+                        type: 'object',
+                        required: ['firstName', 'lastName', 'email', 'whatsapp', 'bantSummary', 'destination'],
+                        properties: {
+                            firstName: { type: 'string' },
+                            lastName: { type: 'string' },
+                            email: { type: 'string', format: 'email' },
+                            whatsapp: { type: 'string' },
+                            bantSummary: { type: 'string' },
+                            destination: { type: 'string' },
+                            utms: {
+                                type: 'object',
+                                additionalProperties: true,
+                            },
+                            tracking: {
+                                type: 'object',
+                                additionalProperties: true,
+                            },
+                        },
+                        additionalProperties: true,
+                    },
+                },
+            },
+        },
+        responses: {
+            '201': {
+                description: 'Lead accepted.',
+            },
+            '400': {
+                description: 'Invalid lead payload.',
+            },
+            '429': {
+                description: 'Rate limit exceeded.',
+            },
+            '500': {
+                description: 'Server or upstream integration failure.',
+            },
+        },
+    },
+    {
+        anchor: `${SITE_ORIGIN}/api/submit-waitlist`,
+        method: 'post',
+        summary: 'Submit a waitlist registration',
+        description: 'Accepts first-party waitlist registrations and forwards the sanitized payload to the configured automation endpoint.',
+        requestBody: {
+            required: true,
+            content: {
+                'application/json': {
+                    schema: {
+                        type: 'object',
+                        required: ['name', 'email'],
+                        properties: {
+                            name: { type: 'string' },
+                            email: { type: 'string', format: 'email' },
+                            sourcePage: { type: 'string' },
+                            utms: {
+                                type: 'object',
+                                additionalProperties: true,
+                            },
+                            tracking: {
+                                type: 'object',
+                                additionalProperties: true,
+                            },
+                        },
+                        additionalProperties: true,
+                    },
+                },
+            },
+        },
+        responses: {
+            '201': {
+                description: 'Waitlist registration accepted.',
+            },
+            '400': {
+                description: 'Invalid waitlist payload.',
+            },
+            '429': {
+                description: 'Rate limit exceeded.',
+            },
+            '500': {
+                description: 'Server or upstream integration failure.',
+            },
+        },
+    },
+] as const;
+
+function buildLinkHeader(): string {
+    return `</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="${RFC_9727_PROFILE}"`;
+}
+
+function buildBaseHeaders(contentType: string): HeadersInit {
+    return {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+        'Link': buildLinkHeader(),
+    };
+}
+
+export function buildMethodNotAllowedResponse(allowedMethods: readonly string[]): Response {
+    return new Response(JSON.stringify({
+        error: 'Method not allowed',
+        allowed: allowedMethods,
+    }), {
+        status: 405,
+        headers: {
+            ...buildBaseHeaders('application/json; charset=utf-8'),
+            'Allow': allowedMethods.join(', '),
+        },
+    });
+}
+
+export function buildCatalogHeaders(): HeadersInit {
+    return buildBaseHeaders(`application/linkset+json; profile="${RFC_9727_PROFILE}"`);
+}
+
+export function buildJsonHeaders(): HeadersInit {
+    return buildBaseHeaders('application/json; charset=utf-8');
+}
+
+export function buildMarkdownHeaders(): HeadersInit {
+    return buildBaseHeaders('text/markdown; charset=utf-8');
+}
+
+export function buildApiCatalogDocument(): {
+    linkset: Array<{
+        anchor: string;
+        'service-desc': Array<{ href: string; type: string }>;
+        'service-doc': Array<{ href: string; type: string }>;
+        status: Array<{ href: string; type: string }>;
+    }>;
+} {
+    return {
+        linkset: API_ENDPOINTS.map(({ anchor }) => ({
+            anchor,
+            'service-desc': [
+                {
+                    href: `${SITE_ORIGIN}${OPENAPI_PATH}`,
+                    type: 'application/json',
+                },
+            ],
+            'service-doc': [
+                {
+                    href: `${SITE_ORIGIN}${API_DOCS_PATH}`,
+                    type: 'text/markdown',
+                },
+            ],
+            status: [
+                {
+                    href: `${SITE_ORIGIN}${HEALTH_PATH}`,
+                    type: 'application/json',
+                },
+            ],
+        })),
+    };
+}
+
+export function buildOpenApiDocument(): Record<string, unknown> {
+    const paths: Record<string, Record<string, unknown>> = Object.fromEntries(
+        API_ENDPOINTS.map((endpoint) => {
+            const path = new URL(endpoint.anchor).pathname;
+
+            return [
+                path,
+                {
+                    [endpoint.method]: {
+                        summary: endpoint.summary,
+                        description: endpoint.description,
+                        requestBody: endpoint.requestBody,
+                        responses: endpoint.responses,
+                    },
+                },
+            ];
+        }),
+    );
+
+    paths[HEALTH_PATH] = {
+        get: {
+            summary: 'Read service health',
+            description: 'Returns a simple status document used by the RFC 9727 status relation in the API catalog.',
+            responses: {
+                '200': {
+                    description: 'Healthy status payload.',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                type: 'object',
+                                required: ['status', 'service'],
+                                properties: {
+                                    status: {
+                                        type: 'string',
+                                        const: 'ok',
+                                    },
+                                    service: {
+                                        type: 'string',
+                                    },
+                                },
+                                additionalProperties: false,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    return {
+        openapi: '3.1.0',
+        info: {
+            title: 'Anhangá Viagens Public API',
+            version: '1.0.0',
+            description: 'Public discovery document for the website APIs published via RFC 9727.',
+        },
+        servers: [
+            {
+                url: SITE_ORIGIN,
+            },
+        ],
+        paths,
+    };
+}
+
+export function buildApiDocs(): string {
+    return `# Anhangá Viagens Public API
+
+Automated discovery surface for the public website APIs, published via RFC 9727.
+
+## Discovery
+
+- API catalog: ${SITE_ORIGIN}${API_CATALOG_PATH}
+- OpenAPI description: ${SITE_ORIGIN}${OPENAPI_PATH}
+- Health status: ${SITE_ORIGIN}${HEALTH_PATH}
+
+## Endpoints
+
+### POST /api/generate
+
+Powers the first-party travel assistant chat experience and returns the next assistant message plus optional structured handoff data.
+
+### POST /api/submit-lead
+
+Accepts qualified travel lead data captured by the first-party chatbot experience.
+
+### POST /api/submit-waitlist
+
+Accepts first-party waitlist registrations for campaign-specific landing pages.
+
+### GET /api/health
+
+Returns a simple JSON status document used by the API catalog \`status\` relation.
+`;
+}
+
+export function buildHealthDocument(): { status: string; service: string } {
+    return {
+        status: 'ok',
+        service: 'anhanga-viagens-public-api',
+    };
+}

--- a/tests/api-catalog.test.ts
+++ b/tests/api-catalog.test.ts
@@ -6,6 +6,7 @@ import apiCatalogHandler from '../api/api-catalog.ts';
 import apiDocsHandler from '../api/api-docs.ts';
 import healthHandler from '../api/health.ts';
 import openapiHandler from '../api/openapi.ts';
+import { buildOpenApiPaths, type ApiEndpointDefinition } from '../lib/api-catalog.ts';
 
 interface LinkTarget {
     href?: string;
@@ -97,6 +98,82 @@ test('openapi handler should publish the machine-readable API description used b
     assert.ok(payload.paths?.['/api/submit-lead']);
     assert.ok(payload.paths?.['/api/submit-waitlist']);
     assert.ok(payload.paths?.['/api/health']);
+
+    const generatePath = payload.paths?.['/api/generate'] as {
+        post?: {
+            responses?: Record<string, { content?: Record<string, { schema?: unknown }> }>;
+        };
+    };
+    const submitLeadPath = payload.paths?.['/api/submit-lead'] as {
+        post?: {
+            responses?: Record<string, { content?: Record<string, { schema?: unknown }> }>;
+        };
+    };
+
+    assert.ok(generatePath.post?.responses?.['200']?.content?.['application/json']?.schema);
+    assert.ok(generatePath.post?.responses?.['400']?.content?.['application/json']?.schema);
+    assert.ok(submitLeadPath.post?.responses?.['201']?.content?.['application/json']?.schema);
+    assert.ok(submitLeadPath.post?.responses?.['500']?.content?.['application/json']?.schema);
+});
+
+test('buildOpenApiPaths should preserve multiple HTTP methods for the same path', () => {
+    const endpoints: ApiEndpointDefinition[] = [
+        {
+            anchor: 'https://www.anhanga.tur.br/api/example',
+            method: 'get',
+            summary: 'Read example',
+            description: 'Reads an example resource.',
+            responses: {
+                '200': {
+                    description: 'Read response.',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                type: 'object',
+                                additionalProperties: true,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        {
+            anchor: 'https://www.anhanga.tur.br/api/example',
+            method: 'post',
+            summary: 'Create example',
+            description: 'Creates an example resource.',
+            requestBody: {
+                required: true,
+                content: {
+                    'application/json': {
+                        schema: {
+                            type: 'object',
+                            additionalProperties: true,
+                        },
+                    },
+                },
+            },
+            responses: {
+                '201': {
+                    description: 'Created response.',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                type: 'object',
+                                additionalProperties: true,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    ];
+
+    const paths = buildOpenApiPaths(endpoints);
+    const examplePath = paths['/api/example'] as Record<string, unknown>;
+
+    assert.ok(examplePath.get);
+    assert.ok(examplePath.post);
 });
 
 test('api-docs handler should publish human-readable documentation for the cataloged APIs', async () => {
@@ -155,4 +232,6 @@ test('vite dev routing should expose the same discovery endpoints locally', asyn
     assert.match(viteConfig, /'\/\.well-known\/api-catalog'/);
     assert.match(viteConfig, /'\/\.well-known\/openapi\.json'/);
     assert.match(viteConfig, /'\/\.well-known\/api-docs'/);
+    assert.match(viteConfig, /let pathname = '\/';/);
+    assert.match(viteConfig, /if \(req\.url\) \{/);
 });

--- a/tests/api-catalog.test.ts
+++ b/tests/api-catalog.test.ts
@@ -1,0 +1,158 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import apiCatalogHandler from '../api/api-catalog.ts';
+import apiDocsHandler from '../api/api-docs.ts';
+import healthHandler from '../api/health.ts';
+import openapiHandler from '../api/openapi.ts';
+
+interface LinkTarget {
+    href?: string;
+    type?: string;
+}
+
+interface LinksetEntry {
+    anchor?: string;
+    'service-desc'?: LinkTarget[];
+    'service-doc'?: LinkTarget[];
+    status?: LinkTarget[];
+}
+
+function buildRequest(url: string, method = 'GET'): Request {
+    return new Request(url, { method });
+}
+
+test('api-catalog should return application/linkset+json with required RFC 9727 relations', async () => {
+    const response = await apiCatalogHandler(buildRequest('http://localhost/.well-known/api-catalog'));
+
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('Content-Type') ?? '', /^application\/linkset\+json\b/);
+
+    const payload = await response.json() as { linkset?: LinksetEntry[] };
+
+    assert.ok(Array.isArray(payload.linkset));
+    assert.deepEqual(
+        payload.linkset.map((entry) => entry.anchor),
+        [
+            'https://www.anhanga.tur.br/api/generate',
+            'https://www.anhanga.tur.br/api/submit-lead',
+            'https://www.anhanga.tur.br/api/submit-waitlist',
+        ],
+    );
+
+    for (const entry of payload.linkset) {
+        assert.ok(Array.isArray(entry['service-desc']));
+        assert.ok(Array.isArray(entry['service-doc']));
+        assert.ok(Array.isArray(entry.status));
+
+        assert.deepEqual(entry['service-desc'], [
+            {
+                href: 'https://www.anhanga.tur.br/.well-known/openapi.json',
+                type: 'application/json',
+            },
+        ]);
+        assert.deepEqual(entry['service-doc'], [
+            {
+                href: 'https://www.anhanga.tur.br/.well-known/api-docs',
+                type: 'text/markdown',
+            },
+        ]);
+        assert.deepEqual(entry.status, [
+            {
+                href: 'https://www.anhanga.tur.br/api/health',
+                type: 'application/json',
+            },
+        ]);
+    }
+});
+
+test('api-catalog should answer HEAD with api-catalog discovery headers', async () => {
+    const response = await apiCatalogHandler(buildRequest('http://localhost/.well-known/api-catalog', 'HEAD'));
+
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('Content-Type') ?? '', /^application\/linkset\+json\b/);
+    assert.match(response.headers.get('Link') ?? '', /rel="api-catalog"/);
+    assert.match(response.headers.get('Link') ?? '', /application\/linkset\+json/);
+    assert.equal(await response.text(), '');
+});
+
+test('openapi handler should publish the machine-readable API description used by the catalog', async () => {
+    const response = await openapiHandler(buildRequest('http://localhost/.well-known/openapi.json'));
+
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('Content-Type') ?? '', /^application\/json\b/);
+
+    const payload = await response.json() as {
+        openapi?: string;
+        info?: { title?: string };
+        servers?: Array<{ url?: string }>;
+        paths?: Record<string, unknown>;
+    };
+
+    assert.equal(payload.openapi, '3.1.0');
+    assert.equal(payload.info?.title, 'Anhangá Viagens Public API');
+    assert.deepEqual(payload.servers, [{ url: 'https://www.anhanga.tur.br' }]);
+    assert.ok(payload.paths?.['/api/generate']);
+    assert.ok(payload.paths?.['/api/submit-lead']);
+    assert.ok(payload.paths?.['/api/submit-waitlist']);
+    assert.ok(payload.paths?.['/api/health']);
+});
+
+test('api-docs handler should publish human-readable documentation for the cataloged APIs', async () => {
+    const response = await apiDocsHandler(buildRequest('http://localhost/.well-known/api-docs'));
+
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('Content-Type') ?? '', /^text\/markdown\b/);
+
+    const body = await response.text();
+    assert.match(body, /^# Anhangá Viagens Public API/m);
+    assert.match(body, /\/api\/generate/);
+    assert.match(body, /\/api\/submit-lead/);
+    assert.match(body, /\/api\/submit-waitlist/);
+    assert.match(body, /\/api\/health/);
+});
+
+test('health handler should return a simple JSON status document for the catalog status relation', async () => {
+    const response = await healthHandler(buildRequest('http://localhost/api/health'));
+
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('Content-Type') ?? '', /^application\/json\b/);
+    assert.deepEqual(await response.json(), {
+        status: 'ok',
+        service: 'anhanga-viagens-public-api',
+    });
+});
+
+test('deployment config should route well-known discovery URLs to the new handlers', async () => {
+    const vercelConfig = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8')) as {
+        rewrites?: Array<{ source?: string; destination?: string }>;
+        headers?: Array<{ source?: string; headers?: Array<{ key?: string; value?: string }> }>;
+    };
+
+    assert.ok(
+        vercelConfig.rewrites?.some((rule) =>
+            rule.source === '/.well-known/api-catalog' && rule.destination === '/api/api-catalog'),
+    );
+    assert.ok(
+        vercelConfig.rewrites?.some((rule) =>
+            rule.source === '/.well-known/openapi.json' && rule.destination === '/api/openapi'),
+    );
+    assert.ok(
+        vercelConfig.rewrites?.some((rule) =>
+            rule.source === '/.well-known/api-docs' && rule.destination === '/api/api-docs'),
+    );
+
+    const globalHeaders = vercelConfig.headers?.find((entry) => entry.source === '/(.*)');
+    const apiCatalogLinkHeader = globalHeaders?.headers?.find((header) => header.key === 'Link');
+    assert.match(apiCatalogLinkHeader?.value ?? '', /rel="api-catalog"/);
+    assert.match(apiCatalogLinkHeader?.value ?? '', /application\/linkset\+json/);
+});
+
+test('vite dev routing should expose the same discovery endpoints locally', async () => {
+    const viteConfig = await readFile(new URL('../vite.config.ts', import.meta.url), 'utf8');
+
+    assert.match(viteConfig, /'\/\.well-known\/api-catalog'/);
+    assert.match(viteConfig, /'\/\.well-known\/openapi\.json'/);
+    assert.match(viteConfig, /'\/\.well-known\/api-docs'/);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -55,6 +55,18 @@
   ],
   "rewrites": [
     {
+      "source": "/.well-known/api-catalog",
+      "destination": "/api/api-catalog"
+    },
+    {
+      "source": "/.well-known/api-docs",
+      "destination": "/api/api-docs"
+    },
+    {
+      "source": "/.well-known/openapi.json",
+      "destination": "/api/openapi"
+    },
+    {
       "source": "/api/keystatic/:path*",
       "destination": "/api/keystatic/[...params]"
     },
@@ -89,20 +101,11 @@
         },
         {
           "key": "Link",
-          "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/json\""
+          "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\"; profile=\"https://www.rfc-editor.org/info/rfc9727\""
         },
         {
           "key": "Vary",
           "value": "Accept"
-        }
-      ]
-    },
-    {
-      "source": "/.well-known/api-catalog",
-      "headers": [
-        {
-          "key": "Content-Type",
-          "value": "application/json"
         }
       ]
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -88,7 +88,10 @@ function apiDevPlugin() {
     apply: 'serve' as const,
     configureServer(server: { middlewares: { use: (handler: (req: IncomingMessage, res: ServerResponse, next: () => void) => void | Promise<void>) => void }, ssrFixStacktrace?: (error: Error) => void }) {
       server.middlewares.use(async (req, res, next) => {
-        const pathname = new URL(req.url, 'http://vite.local').pathname;
+        let pathname = '/';
+        if (req.url) {
+          pathname = new URL(req.url, 'http://vite.local').pathname;
+        }
         const loadHandler = DEV_API_ROUTES[pathname];
 
         if (!loadHandler) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,8 +12,12 @@ import { stripYamlFrontmatter } from './lib/mdx-frontmatter.ts';
 type ApiHandler = (request: Request) => Promise<Response> | Response;
 
 const DEV_API_ROUTES: Record<string, () => Promise<{ default: ApiHandler }>> = {
+  '/.well-known/api-catalog': () => import('./api/api-catalog.ts'),
+  '/.well-known/api-docs': () => import('./api/api-docs.ts'),
+  '/.well-known/openapi.json': () => import('./api/openapi.ts'),
   '/api/markdown': () => import('./api/markdown.ts'),
   '/api/generate': () => import('./api/generate.ts'),
+  '/api/health': () => import('./api/health.ts'),
   '/api/submit-lead': () => import('./api/submit-lead.ts'),
   '/api/submit-waitlist': () => import('./api/submit-waitlist.ts'),
   '/api/hubspot-webhook': () => import('./api/hubspot-webhook.ts'),
@@ -84,11 +88,6 @@ function apiDevPlugin() {
     apply: 'serve' as const,
     configureServer(server: { middlewares: { use: (handler: (req: IncomingMessage, res: ServerResponse, next: () => void) => void | Promise<void>) => void }, ssrFixStacktrace?: (error: Error) => void }) {
       server.middlewares.use(async (req, res, next) => {
-        if (!req.url?.startsWith('/api/')) {
-          next();
-          return;
-        }
-
         const pathname = new URL(req.url, 'http://vite.local').pathname;
         const loadHandler = DEV_API_ROUTES[pathname];
 


### PR DESCRIPTION
## Summary
- publish `/.well-known/api-catalog` as `application/linkset+json` with RFC 9727-compliant `linkset` entries
- add supporting discovery documents and endpoints for OpenAPI, human docs, and health status
- wire the new well-known routes in Vercel and local Vite dev routing, with regression coverage for the discovery surface

## Root cause
The site already advertised an API catalog via the `Link` header, but the endpoint did not expose the RFC 9264 `linkset` array or the correct media type expected by RFC 9727 discovery clients.

## Impact
- automated API discovery clients can now resolve the catalog and follow `service-desc`, `service-doc`, and `status` relations to real resources
- local development and production routing now expose the same discovery endpoints

## Validation
- `pnpm test:regression`
- `pnpm typecheck`
- `pnpm build`
