### PR TITLE
feat: 3 landing pages de serviço (consultoria, executivos, cruzeiros)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,6 +25,9 @@ const LollapaloozaLanding = lazy(() => import('./pages/landings/LollapaloozaLand
 const OrlandoLanding = lazy(() => import('./pages/landings/OrlandoLanding'));
 const MelhorIdadeLanding = lazy(() => import('./pages/landings/MelhorIdadeLanding'));
 const BrazilPromotionDayLanding = lazy(() => import('./pages/landings/BrazilPromotionDayLanding'));
+const ConsultoriaDeViagemLanding = lazy(() => import('./pages/landings/ConsultoriaDeViagemLanding'));
+const ViagensParaExecutivosLanding = lazy(() => import('./pages/landings/ViagensParaExecutivosLanding'));
+const CuradoriaCruzeirosBrasilLanding = lazy(() => import('./pages/landings/CuradoriaCruzeirosBrasilLanding'));
 const KeystaticPage = lazy(() => import('./pages/KeystaticPage'));
 const NPS = lazy(() => import('./pages/NPS'));
 
@@ -79,6 +82,9 @@ const AppLayout: React.FC<{ includeClientFeatures: boolean }> = ({ includeClient
           <Route path="/orlando" element={<OrlandoLanding />} />
           <Route path="/melhor-idade" element={<MelhorIdadeLanding />} />
           <Route path="/brazil-promotion-day" element={<BrazilPromotionDayLanding />} />
+          <Route path="/consultoria-de-viagem" element={<ConsultoriaDeViagemLanding />} />
+          <Route path="/viagens-para-executivos" element={<ViagensParaExecutivosLanding />} />
+          <Route path="/curadoria-cruzeiros-brasil" element={<CuradoriaCruzeirosBrasilLanding />} />
           <Route path="/nps" element={<NPS />} />
           <Route path="/*" element={<MainSiteShell />} />
         </Routes>

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
 import { ServiceSchema } from '@/components/schemas/ServiceSchema';
 import { useWhatsAppLink } from '@/utils/whatsapp';
+import { pushWhatsAppCta } from '@/utils/analytics';
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
 import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
 import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
@@ -89,11 +90,6 @@ const PILLARS = [
 const ConsultoriaDeViagemLanding: React.FC = () => {
   const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE, { appendTrackingRef: true });
 
-  const handleCtaClick = () => {
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({ event: 'whatsapp_cta_click', page: PAGE_NAME });
-  };
-
   return (
     <div className="bg-[#fffdf5] min-h-screen font-sans">
       <SEO
@@ -121,8 +117,8 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       {/* Mini Header */}
       <header className="bg-white/90 backdrop-blur-sm border-b border-gray-100 sticky top-0 z-50 py-3">
         <div className="max-w-5xl mx-auto px-6 flex items-center justify-between">
-          <a
-            href="https://www.anhanga.tur.br/"
+          <Link
+            to="/"
             className="inline-flex items-center gap-2 group"
             aria-label="Voltar para o site principal da Anhangá Viagens"
           >
@@ -133,12 +129,12 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
               Anhangá Viagens
             </span>
-          </a>
+          </Link>
           <a
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={handleCtaClick}
+            onClick={() => pushWhatsAppCta(PAGE_NAME)}
             className="text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap"
           >
             Falar com consultor
@@ -162,7 +158,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={handleCtaClick}
+            onClick={() => pushWhatsAppCta(PAGE_NAME)}
             className="inline-flex items-center gap-3 bg-anhanga-blue text-white font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors text-lg shadow-lg"
             aria-label="Falar com um consultor de viagens via WhatsApp"
           >
@@ -179,7 +175,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
             Por que consultoria?
           </h2>
-          <p className="text-gray-500 text-lg mb-12">
+          <p className="text-gray-600 text-lg mb-12">
             Porque viajar bem não é só escolher um destino.
           </p>
           <div className="grid md:grid-cols-3 gap-6">
@@ -234,7 +230,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               <blockquote className="text-xl text-anhanga-dark font-semibold leading-relaxed">
                 "A Anhangá cuidou de cada detalhe. Só precisei aparecer no aeroporto."
               </blockquote>
-              <p className="mt-4 text-gray-500 text-sm">
+              <p className="mt-4 text-gray-600 text-sm">
                 R.M. · São Paulo · Viagem para Portugal, 2025
               </p>
             </div>
@@ -284,7 +280,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             ].map(({ label, value }) => (
               <div key={label}>
                 <div className="text-4xl font-black text-anhanga-blue">{value}</div>
-                <div className="text-sm text-gray-500 mt-1">{label}</div>
+                <div className="text-sm text-gray-600 mt-1">{label}</div>
               </div>
             ))}
           </div>
@@ -304,7 +300,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={handleCtaClick}
+            onClick={() => pushWhatsAppCta(PAGE_NAME)}
             className="inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-black px-10 py-5 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-xl shadow-lg"
             aria-label="Falar com um consultor via WhatsApp"
           >
@@ -326,7 +322,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Viagens para Executivos
               </div>
-              <div className="text-sm text-gray-500 mt-1">
+              <div className="text-sm text-gray-600 mt-1">
                 Planejamento com precisão para profissionais
               </div>
             </Link>
@@ -337,7 +333,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Curadoria de Cruzeiros
               </div>
-              <div className="text-sm text-gray-500 mt-1">
+              <div className="text-sm text-gray-600 mt-1">
                 Escolha o navio e a cabine certos para você
               </div>
             </Link>
@@ -348,7 +344,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Site principal
               </div>
-              <div className="text-sm text-gray-500 mt-1">
+              <div className="text-sm text-gray-600 mt-1">
                 Conheça todos os serviços da Anhangá
               </div>
             </a>

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -1,0 +1,375 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { SEO } from '@/components/SEO';
+import { LandingFAQ } from '@/components/LandingFAQ';
+import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
+import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
+import { ServiceSchema } from '@/components/schemas/ServiceSchema';
+import { useWhatsAppLink } from '@/utils/whatsapp';
+import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
+import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
+import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
+import MessageSquare from 'lucide-react/dist/esm/icons/message-square';
+import Users from 'lucide-react/dist/esm/icons/users';
+import Headphones from 'lucide-react/dist/esm/icons/headphones';
+
+const WHATSAPP_MESSAGE = 'Olá! Tenho interesse em consultoria de viagem sob medida.';
+const PAGE_NAME = 'consultoria-de-viagem';
+
+const FAQ_ITEMS = [
+  {
+    question: 'O que é uma consultoria de viagem?',
+    answer: 'É uma sessão com um consultor humano da Anhangá para entender seu perfil, destino e orçamento e montar o melhor roteiro — sem pacote pronto e sem improviso.'
+  },
+  {
+    question: 'Quanto custa a consultoria?',
+    answer: 'Sem taxa de consultoria no momento. Você fala com um consultor gratuitamente e decide se quer fechar sua viagem com a Anhangá.'
+  },
+  {
+    question: 'Vocês fazem viagens internacionais?',
+    answer: 'Sim. A Anhangá Viagens planeja viagens internacionais para Europa, América do Norte, América do Sul, Ásia e Caribe, com foco em roteiros personalizados e suporte durante toda a viagem.'
+  },
+  {
+    question: 'Qual o diferencial da Anhangá?',
+    answer: 'Atendimento boutique com consultor fixo do início ao fim, roteiro feito do zero para o seu perfil e suporte 24h via WhatsApp durante a viagem.'
+  },
+  {
+    question: 'Qual o prazo para montar um roteiro?',
+    answer: 'Entre 2 e 5 dias úteis após a conversa inicial, dependendo da complexidade do destino e do número de viajantes.'
+  }
+];
+
+const FOR_WHO = [
+  'Quem quer viajar bem sem precisar cuidar de cada detalhe',
+  'Famílias que buscam conforto e segurança no roteiro',
+  'Casais planejando viagem especial ou lua de mel',
+  'Viajantes frequentes que querem uma agência de confiança',
+  'Profissionais sem tempo para pesquisar e comparar opções',
+];
+
+const HOW_IT_WORKS = [
+  {
+    step: '01',
+    title: 'Conversa inicial',
+    desc: 'Você fala com um consultor e conta o que precisa. Sem formulário, sem burocracia.'
+  },
+  {
+    step: '02',
+    title: 'Roteiro personalizado',
+    desc: 'Em até 5 dias úteis, você recebe um roteiro feito do zero para o seu perfil.'
+  },
+  {
+    step: '03',
+    title: 'Suporte durante a viagem',
+    desc: 'WhatsApp 24h com o mesmo consultor. Qualquer imprevisto tem resposta imediata.'
+  },
+];
+
+const PILLARS = [
+  {
+    icon: MessageSquare,
+    title: 'Sem pacote pronto',
+    desc: 'Cada roteiro começa do zero, no perfil de quem vai viajar. Nada de escolher entre opções genéricas.',
+    variant: 'light' as const
+  },
+  {
+    icon: Users,
+    title: 'Atendimento humano',
+    desc: 'Um consultor real do início ao fim. Não um chatbot, não um formulário.',
+    variant: 'filled' as const
+  },
+  {
+    icon: Headphones,
+    title: 'Suporte completo',
+    desc: 'Antes, durante e depois da viagem. WhatsApp direto com seu consultor para qualquer imprevisto.',
+    variant: 'light' as const
+  },
+];
+
+const ConsultoriaDeViagemLanding: React.FC = () => {
+  const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE, { appendTrackingRef: true });
+
+  const handleCtaClick = () => {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ event: 'whatsapp_cta_click', page: PAGE_NAME });
+  };
+
+  return (
+    <div className="bg-[#fffdf5] min-h-screen font-sans">
+      <SEO
+        title="Consultoria de Viagem Sob Medida em SP — Anhangá Viagens"
+        description="Planeje sua viagem com consultores humanos. Sem pacote pronto, sem improviso. Roteiro personalizado com suporte antes, durante e depois."
+        canonical="https://www.anhanga.tur.br/consultoria-de-viagem/"
+        noHreflang
+      />
+      <ServiceSchema
+        name="Consultoria de Viagem Sob Medida"
+        description="Planejamento personalizado de viagens com consultor humano, sem pacote pronto. Atendimento boutique com suporte antes, durante e depois da viagem."
+        serviceUrl="https://www.anhanga.tur.br/consultoria-de-viagem/"
+        serviceType="Consultoria de Viagem"
+        areaServed="São Paulo e Brasil"
+        keywords={['consultoria de viagem', 'viagem sob medida', 'planejamento de viagem personalizado', 'agência boutique SP']}
+      />
+      <BreadcrumbSchema
+        items={[
+          { name: 'Home', item: 'https://www.anhanga.tur.br/' },
+          { name: 'Consultoria de Viagem', item: 'https://www.anhanga.tur.br/consultoria-de-viagem/' }
+        ]}
+      />
+      <FAQPageSchema items={FAQ_ITEMS} />
+
+      {/* Mini Header */}
+      <header className="bg-white/90 backdrop-blur-sm border-b border-gray-100 sticky top-0 z-50 py-3">
+        <div className="max-w-5xl mx-auto px-6 flex items-center justify-between">
+          <a
+            href="https://www.anhanga.tur.br/"
+            className="inline-flex items-center gap-2 group"
+            aria-label="Voltar para o site principal da Anhangá Viagens"
+          >
+            <ArrowLeft className="w-4 h-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
+            <span className="w-7 h-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
+              <img src="/favicon.svg" alt="" aria-hidden="true" className="w-4 h-4" />
+            </span>
+            <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+              Anhangá Viagens
+            </span>
+          </a>
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleCtaClick}
+            className="text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap"
+          >
+            Falar com consultor
+          </a>
+        </div>
+      </header>
+
+      {/* Hero */}
+      <section className="pt-16 pb-20 px-6">
+        <div className="max-w-3xl mx-auto">
+          <p className="text-sm font-semibold text-anhanga-blue mb-4 tracking-wide uppercase">
+            Agência boutique · São Paulo
+          </p>
+          <h1 className="text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1] font-serif">
+            Planeje uma viagem sob medida sem depender de pacote pronto
+          </h1>
+          <p className="text-xl text-gray-600 mb-10 leading-relaxed max-w-2xl">
+            Um consultor da Anhangá entende seu perfil, destino, orçamento e restrições para desenhar o melhor caminho antes de você fechar.
+          </p>
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleCtaClick}
+            className="inline-flex items-center gap-3 bg-anhanga-blue text-white font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors text-lg shadow-lg"
+            aria-label="Falar com um consultor de viagens via WhatsApp"
+          >
+            Falar com um consultor
+            <ArrowRight className="w-5 h-5" />
+          </a>
+          <p className="mt-4 text-sm text-gray-600">Sem taxa de consultoria. Gratuito.</p>
+        </div>
+      </section>
+
+      {/* Por que consultoria? */}
+      <section className="py-20 bg-white">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
+            Por que consultoria?
+          </h2>
+          <p className="text-gray-500 text-lg mb-12">
+            Porque viajar bem não é só escolher um destino.
+          </p>
+          <div className="grid md:grid-cols-3 gap-6">
+            {PILLARS.map(({ icon: Icon, title, desc, variant }) => (
+              <div
+                key={title}
+                className={`p-8 rounded-2xl ${
+                  variant === 'filled'
+                    ? 'bg-anhanga-blue text-white'
+                    : 'bg-[#fffdf5]'
+                }`}
+              >
+                <div
+                  className={`w-11 h-11 rounded-xl flex items-center justify-center mb-5 ${
+                    variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
+                  }`}
+                >
+                  <Icon
+                    className={`w-5 h-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`}
+                  />
+                </div>
+                <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
+                  {title}
+                </h3>
+                <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-gray-600 leading-relaxed'}>
+                  {desc}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Para quem é */}
+      <section className="py-20 bg-[#fffdf5]">
+        <div className="max-w-5xl mx-auto px-6">
+          <div className="md:grid md:grid-cols-2 md:gap-16 items-start">
+            <div>
+              <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-8 font-serif">
+                Para quem é
+              </h2>
+              <ul className="space-y-4">
+                {FOR_WHO.map(item => (
+                  <li key={item} className="flex items-start gap-3">
+                    <CheckCircle className="w-5 h-5 text-anhanga-blue flex-shrink-0 mt-0.5" aria-hidden="true" />
+                    <span className="text-gray-700 leading-snug">{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="mt-12 md:mt-0 bg-white rounded-3xl p-8 shadow-float">
+              <blockquote className="text-xl text-anhanga-dark font-semibold leading-relaxed">
+                "A Anhangá cuidou de cada detalhe. Só precisei aparecer no aeroporto."
+              </blockquote>
+              <p className="mt-4 text-gray-500 text-sm">
+                R.M. · São Paulo · Viagem para Portugal, 2025
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Como funciona */}
+      <section className="py-20 bg-white">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
+            Como funciona
+          </h2>
+          <div className="space-y-0">
+            {HOW_IT_WORKS.map(({ step, title, desc }, idx) => (
+              <div
+                key={step}
+                className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-gray-100' : ''}`}
+              >
+                <div className="flex-shrink-0 w-12 h-12 rounded-full bg-anhanga-blue/10 flex items-center justify-center">
+                  <span className="text-sm font-black text-anhanga-blue">{step}</span>
+                </div>
+                <div>
+                  <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
+                  <p className="text-gray-600 leading-relaxed max-w-xl">{desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Sobre a Anhangá */}
+      <section className="py-20 bg-[#fffdf5]">
+        <div className="max-w-4xl mx-auto px-6 text-center">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
+            Sobre a Anhangá Viagens
+          </h2>
+          <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mx-auto">
+            Agência boutique em São Paulo, especializada em viagens personalizadas desde 2018. Atendimento humano, nota 5.0 no Google e consultor fixo do início ao fim da sua viagem.
+          </p>
+          <div className="mt-12 flex flex-wrap justify-center gap-12">
+            {[
+              { label: 'Fundada em', value: '2018' },
+              { label: 'Nota Google', value: '5.0' },
+              { label: 'Atendimento', value: 'Humano' },
+            ].map(({ label, value }) => (
+              <div key={label}>
+                <div className="text-4xl font-black text-anhanga-blue">{value}</div>
+                <div className="text-sm text-gray-500 mt-1">{label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Final */}
+      <section className="py-20 bg-anhanga-blue">
+        <div className="max-w-3xl mx-auto px-6 text-center">
+          <h2 className="text-3xl md:text-5xl font-black text-white mb-6 font-serif">
+            Pronto para planejar sua viagem?
+          </h2>
+          <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
+            Fale com um consultor agora. Sem taxa, sem compromisso.
+          </p>
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleCtaClick}
+            className="inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-black px-10 py-5 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-xl shadow-lg"
+            aria-label="Falar com um consultor via WhatsApp"
+          >
+            Falar com um consultor
+            <ArrowRight className="w-6 h-6" />
+          </a>
+        </div>
+      </section>
+
+      {/* Outros serviços */}
+      <section className="py-16 bg-[#fffdf5]">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
+          <div className="grid md:grid-cols-3 gap-4">
+            <Link
+              to="/viagens-para-executivos"
+              className="block p-5 rounded-xl bg-[#fffdf5] hover:bg-anhanga-blue/5 transition-colors group"
+            >
+              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                Viagens para Executivos
+              </div>
+              <div className="text-sm text-gray-500 mt-1">
+                Planejamento com precisão para profissionais
+              </div>
+            </Link>
+            <Link
+              to="/curadoria-cruzeiros-brasil"
+              className="block p-5 rounded-xl bg-[#fffdf5] hover:bg-anhanga-blue/5 transition-colors group"
+            >
+              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                Curadoria de Cruzeiros
+              </div>
+              <div className="text-sm text-gray-500 mt-1">
+                Escolha o navio e a cabine certos para você
+              </div>
+            </Link>
+            <a
+              href="https://www.anhanga.tur.br/"
+              className="block p-5 rounded-xl bg-[#fffdf5] hover:bg-anhanga-blue/5 transition-colors group"
+            >
+              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                Site principal
+              </div>
+              <div className="text-sm text-gray-500 mt-1">
+                Conheça todos os serviços da Anhangá
+              </div>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <LandingFAQ
+        items={FAQ_ITEMS}
+        title="Dúvidas sobre consultoria de viagem"
+        subtitle="Tire suas dúvidas sobre como funciona a consultoria personalizada da Anhangá."
+      />
+
+      {/* Footer */}
+      <footer className="py-8 bg-[#fffdf5] border-t border-gray-100 text-center text-sm text-gray-600">
+        <p>Anhangá Viagens · Agência boutique em São Paulo</p>
+        <p className="mt-1">Atualizado em abril de 2026</p>
+      </footer>
+    </div>
+  );
+};
+
+export default ConsultoriaDeViagemLanding;

--- a/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
+++ b/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
@@ -1,0 +1,391 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { SEO } from '@/components/SEO';
+import { LandingFAQ } from '@/components/LandingFAQ';
+import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
+import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
+import { ServiceSchema } from '@/components/schemas/ServiceSchema';
+import { useWhatsAppLink } from '@/utils/whatsapp';
+import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
+import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
+import Compass from 'lucide-react/dist/esm/icons/compass';
+import LayoutGrid from 'lucide-react/dist/esm/icons/layout-grid';
+import CalendarCheck from 'lucide-react/dist/esm/icons/calendar-check';
+import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
+
+const WHATSAPP_MESSAGE = 'Olá! Quero ajuda para escolher o cruzeiro certo no Brasil.';
+const PAGE_NAME = 'curadoria-cruzeiros-brasil';
+
+const FAQ_ITEMS = [
+  {
+    question: 'Qual o melhor cruzeiro para primeira vez?',
+    answer: 'Depende do seu perfil — casal, família, solo, orçamento, preferência de roteiro. É exatamente isso que a curadoria resolve: encontrar o navio e a cabine certos para você antes de fechar.'
+  },
+  {
+    question: 'Cabine interna ou com varanda?',
+    answer: 'Para a primeira vez, a cabine com varanda vale muito pelo conforto e pela experiência visual durante o roteiro. Mas depende do orçamento e do navio. Explicamos tudo na conversa.'
+  },
+  {
+    question: 'Quais saídas de porto vocês trabalham?',
+    answer: 'Principalmente Santos, que é o maior porto de cruzeiros do Brasil. Também trabalhamos com saídas do Rio de Janeiro e outros portos conforme disponibilidade.'
+  },
+  {
+    question: 'Tem cruzeiro bom para família com criança pequena?',
+    answer: 'Sim. Alguns navios têm estrutura kids excelente com monitores, piscinas infantis e programação específica. Indicamos o certo para a faixa etária dos seus filhos.'
+  },
+  {
+    question: 'Como é cobrado o serviço?',
+    answer: 'Sem taxa de curadoria no momento. Você fala com um especialista gratuitamente e decide se quer fechar seu cruzeiro com a Anhangá.'
+  }
+];
+
+const FOR_WHO = [
+  { title: 'Primeiro cruzeiro', desc: 'Quer entender o que esperar antes de comprar a passagem.' },
+  { title: 'Casal', desc: 'Busca a combinação certa de navio, cabine e roteiro para uma viagem especial.' },
+  { title: 'Família com crianças', desc: 'Precisa de um navio com boa estrutura kids e cabine que caiba todo mundo.' },
+  { title: 'Quem já foi', desc: 'Quer melhorar a experiência, subir de categoria ou experimentar outro roteiro.' },
+];
+
+const WHAT_WE_ANALYZE = [
+  'Navio e companhia (MSC, Costa, Carnival, Royal Caribbean)',
+  'Tipo de cabine: interna, oceanview, varanda ou suíte',
+  'Roteiro: Santos, Búzios, Ilhéus, Salvador, Ilha Grande',
+  'Datas e temporada (alto vs. baixo)',
+  'Perfil da viagem: romântica, familiar, solo, grupos',
+  'Orçamento total incluindo pacotes e extras a bordo',
+];
+
+const PILLARS = [
+  {
+    icon: Compass,
+    title: 'Navio certo para seu perfil',
+    desc: 'Cada companhia tem um DNA diferente. Indicamos o que combina com o que você quer viver a bordo.',
+    variant: 'light' as const,
+  },
+  {
+    icon: LayoutGrid,
+    title: 'Cabine sem arrependimento',
+    desc: 'Interna, oceanview, varanda ou suíte: explicamos o que cada categoria entrega e o que vale para o seu caso.',
+    variant: 'filled' as const,
+  },
+  {
+    icon: CalendarCheck,
+    title: 'Roteiro e datas ideais',
+    desc: 'Temporada, roteiro e disponibilidade fazem diferença no preço e na experiência. Analisamos tudo junto.',
+    variant: 'light' as const,
+  },
+];
+
+const HOW_IT_WORKS = [
+  {
+    step: '01',
+    title: 'Conversa com especialista',
+    desc: 'Você conta o que busca — perfil, orçamento, datas — e o especialista faz as perguntas certas.'
+  },
+  {
+    step: '02',
+    title: 'Curadoria personalizada',
+    desc: 'Com base no seu perfil, indicamos o navio, a cabine e o roteiro que mais fazem sentido para você.'
+  },
+  {
+    step: '03',
+    title: 'Reserva e suporte',
+    desc: 'Quando decidir, cuidamos da reserva e estamos disponíveis até você embarcar.'
+  },
+];
+
+const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
+  const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE, { appendTrackingRef: true });
+
+  const handleCtaClick = () => {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ event: 'whatsapp_cta_click', page: PAGE_NAME });
+  };
+
+  return (
+    <div className="bg-anhanga-light min-h-screen font-sans">
+      <SEO
+        title="Curadoria de Cruzeiros no Brasil — Anhangá Viagens"
+        description="Escolha navio, cabine e roteiro certos para o seu perfil. Curadoria consultiva para quem quer fazer o cruzeiro certo na primeira vez."
+        canonical="https://www.anhanga.tur.br/curadoria-cruzeiros-brasil/"
+        noHreflang
+      />
+      <ServiceSchema
+        name="Curadoria de Cruzeiros no Brasil"
+        description="Ajuda especializada para escolher navio, cabine, roteiro e datas ideais para seu cruzeiro no Brasil. Atendimento consultivo para casais, famílias e primeira viagem."
+        serviceUrl="https://www.anhanga.tur.br/curadoria-cruzeiros-brasil/"
+        serviceType="Curadoria de Cruzeiros"
+        areaServed="Brasil"
+        keywords={['cruzeiro no brasil', 'cruzeiro saindo de santos', 'como escolher cruzeiro', 'curadoria de cruzeiro', 'primeiro cruzeiro']}
+      />
+      <BreadcrumbSchema
+        items={[
+          { name: 'Home', item: 'https://www.anhanga.tur.br/' },
+          { name: 'Curadoria de Cruzeiros', item: 'https://www.anhanga.tur.br/curadoria-cruzeiros-brasil/' }
+        ]}
+      />
+      <FAQPageSchema items={FAQ_ITEMS} />
+
+      {/* Mini Header */}
+      <header className="bg-white/90 backdrop-blur-sm border-b border-anhanga-blue/10 sticky top-0 z-50 py-3">
+        <div className="max-w-5xl mx-auto px-6 flex items-center justify-between">
+          <a
+            href="https://www.anhanga.tur.br/"
+            className="inline-flex items-center gap-2 group"
+            aria-label="Voltar para o site principal da Anhangá Viagens"
+          >
+            <ArrowLeft className="w-4 h-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
+            <span className="w-7 h-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
+              <img src="/favicon.svg" alt="" aria-hidden="true" className="w-4 h-4" />
+            </span>
+            <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+              Anhangá Viagens
+            </span>
+          </a>
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleCtaClick}
+            className="text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap"
+          >
+            Falar com especialista
+          </a>
+        </div>
+      </header>
+
+      {/* Hero */}
+      <section className="pt-16 pb-20 px-6 bg-anhanga-light">
+        <div className="max-w-3xl mx-auto">
+          <p className="text-sm font-semibold text-anhanga-blue mb-4 tracking-wide uppercase">
+            Cruzeiros no Brasil · Curadoria consultiva
+          </p>
+          <h1 className="text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1] font-serif">
+            Escolha o cruzeiro certo no Brasil antes de fechar
+          </h1>
+          <p className="text-xl text-gray-600 mb-10 leading-relaxed max-w-2xl">
+            Entenda navio, cabine, roteiro, datas e perfil da viagem com uma curadoria consultiva da Anhangá.
+          </p>
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleCtaClick}
+            className="inline-flex items-center gap-3 bg-anhanga-blue text-white font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors text-lg shadow-lg"
+            aria-label="Falar com um especialista em cruzeiros via WhatsApp"
+          >
+            Falar com um especialista
+            <ArrowRight className="w-5 h-5" />
+          </a>
+          <p className="mt-4 text-sm text-gray-600">Sem taxa de curadoria. Gratuito.</p>
+        </div>
+      </section>
+
+      {/* O que analisamos juntos — posição 2: informação mais diferenciadora */}
+      <section className="py-20 bg-white">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4 font-serif">
+            O que analisamos juntos
+          </h2>
+          <p className="text-gray-500 text-lg mb-10">
+            Na curadoria, passamos por todos esses pontos antes de você decidir.
+          </p>
+          <div className="grid sm:grid-cols-2 gap-4">
+            {WHAT_WE_ANALYZE.map(item => (
+              <div key={item} className="flex items-start gap-3 p-4 rounded-xl bg-anhanga-light">
+                <CheckCircle className="w-5 h-5 text-anhanga-blue flex-shrink-0 mt-0.5" aria-hidden="true" />
+                <span className="text-gray-700">{item}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Por que curadoria? */}
+      <section className="py-20 bg-anhanga-light">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
+            Por que curadoria?
+          </h2>
+          <p className="text-gray-500 text-lg mb-12">
+            Porque escolher um cruzeiro envolve mais variáveis do que parece.
+          </p>
+          <div className="grid md:grid-cols-3 gap-6">
+            {PILLARS.map(({ icon: Icon, title, desc, variant }) => (
+              <div
+                key={title}
+                className={`p-8 rounded-2xl ${
+                  variant === 'filled'
+                    ? 'bg-anhanga-blue text-white'
+                    : 'bg-white'
+                }`}
+              >
+                <div
+                  className={`w-11 h-11 rounded-xl flex items-center justify-center mb-5 ${
+                    variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
+                  }`}
+                >
+                  <Icon
+                    className={`w-5 h-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`}
+                  />
+                </div>
+                <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
+                  {title}
+                </h3>
+                <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-gray-600 leading-relaxed'}>
+                  {desc}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Para quem é */}
+      <section className="py-20 bg-white">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
+            Para quem é
+          </h2>
+          <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-5">
+            {FOR_WHO.map(({ title, desc }) => (
+              <div key={title} className="bg-anhanga-light rounded-2xl p-6">
+                <h3 className="font-black text-anhanga-dark mb-2">{title}</h3>
+                <p className="text-gray-600 text-sm leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Como funciona */}
+      <section className="py-20 bg-anhanga-light">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
+            Como funciona
+          </h2>
+          <div className="space-y-0">
+            {HOW_IT_WORKS.map(({ step, title, desc }, idx) => (
+              <div
+                key={step}
+                className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-anhanga-blue/10' : ''}`}
+              >
+                <div className="flex-shrink-0 w-12 h-12 rounded-full bg-white flex items-center justify-center shadow-sm">
+                  <span className="text-sm font-black text-anhanga-blue">{step}</span>
+                </div>
+                <div>
+                  <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
+                  <p className="text-gray-600 leading-relaxed max-w-xl">{desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Sobre a Anhangá */}
+      <section className="py-20 bg-white">
+        <div className="max-w-4xl mx-auto px-6 text-center">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
+            Sobre a Anhangá Viagens
+          </h2>
+          <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mx-auto">
+            Agência boutique em São Paulo desde 2018, com especialistas em cruzeiros no Brasil e roteiros personalizados. Nota 5.0 no Google e atendimento humano do início ao fim.
+          </p>
+          <div className="mt-12 flex flex-wrap justify-center gap-12">
+            {[
+              { label: 'Fundada em', value: '2018' },
+              { label: 'Nota Google', value: '5.0' },
+              { label: 'Especialistas', value: 'Em cruzeiros' },
+            ].map(({ label, value }) => (
+              <div key={label}>
+                <div className="text-4xl font-black text-anhanga-blue">{value}</div>
+                <div className="text-sm text-gray-500 mt-1">{label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Final */}
+      <section className="py-20 bg-anhanga-blue">
+        <div className="max-w-3xl mx-auto px-6 text-center">
+          <h2 className="text-3xl md:text-5xl font-black text-white mb-6 font-serif">
+            Descubra o cruzeiro certo para você.
+          </h2>
+          <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
+            Fale com um especialista e resolva a escolha em uma conversa. Sem taxa, sem compromisso.
+          </p>
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleCtaClick}
+            className="inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-black px-10 py-5 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-xl shadow-lg"
+            aria-label="Falar com um especialista em cruzeiros via WhatsApp"
+          >
+            Falar com um especialista
+            <ArrowRight className="w-6 h-6" />
+          </a>
+        </div>
+      </section>
+
+      {/* Outros serviços */}
+      <section className="py-16 bg-anhanga-light">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
+          <div className="grid md:grid-cols-3 gap-4">
+            <Link
+              to="/consultoria-de-viagem"
+              className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
+            >
+              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                Consultoria de Viagem
+              </div>
+              <div className="text-sm text-gray-500 mt-1">
+                Roteiro sob medida com consultor humano
+              </div>
+            </Link>
+            <Link
+              to="/viagens-para-executivos"
+              className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
+            >
+              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                Viagens para Executivos
+              </div>
+              <div className="text-sm text-gray-500 mt-1">
+                Planejamento com precisão para profissionais
+              </div>
+            </Link>
+            <a
+              href="https://www.anhanga.tur.br/"
+              className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
+            >
+              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                Site principal
+              </div>
+              <div className="text-sm text-gray-500 mt-1">
+                Conheça todos os serviços da Anhangá
+              </div>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <LandingFAQ
+        items={FAQ_ITEMS}
+        title="Dúvidas sobre cruzeiros no Brasil"
+        subtitle="Tire suas dúvidas antes de escolher seu cruzeiro."
+      />
+
+      {/* Footer */}
+      <footer className="py-8 bg-anhanga-light border-t border-anhanga-blue/10 text-center text-sm text-gray-600">
+        <p>Anhangá Viagens · Agência boutique em São Paulo</p>
+        <p className="mt-1">Atualizado em abril de 2026</p>
+      </footer>
+    </div>
+  );
+};
+
+export default CuradoriaCruzeirosBrasilLanding;

--- a/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
+++ b/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
 import { ServiceSchema } from '@/components/schemas/ServiceSchema';
 import { useWhatsAppLink } from '@/utils/whatsapp';
+import { pushWhatsAppCta } from '@/utils/analytics';
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
 import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
 import Compass from 'lucide-react/dist/esm/icons/compass';
@@ -97,11 +98,6 @@ const HOW_IT_WORKS = [
 const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
   const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE, { appendTrackingRef: true });
 
-  const handleCtaClick = () => {
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({ event: 'whatsapp_cta_click', page: PAGE_NAME });
-  };
-
   return (
     <div className="bg-anhanga-light min-h-screen font-sans">
       <SEO
@@ -129,8 +125,8 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
       {/* Mini Header */}
       <header className="bg-white/90 backdrop-blur-sm border-b border-anhanga-blue/10 sticky top-0 z-50 py-3">
         <div className="max-w-5xl mx-auto px-6 flex items-center justify-between">
-          <a
-            href="https://www.anhanga.tur.br/"
+          <Link
+            to="/"
             className="inline-flex items-center gap-2 group"
             aria-label="Voltar para o site principal da Anhangá Viagens"
           >
@@ -141,12 +137,12 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
             <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
               Anhangá Viagens
             </span>
-          </a>
+          </Link>
           <a
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={handleCtaClick}
+            onClick={() => pushWhatsAppCta(PAGE_NAME)}
             className="text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap"
           >
             Falar com especialista
@@ -170,7 +166,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={handleCtaClick}
+            onClick={() => pushWhatsAppCta(PAGE_NAME)}
             className="inline-flex items-center gap-3 bg-anhanga-blue text-white font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors text-lg shadow-lg"
             aria-label="Falar com um especialista em cruzeiros via WhatsApp"
           >
@@ -187,7 +183,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4 font-serif">
             O que analisamos juntos
           </h2>
-          <p className="text-gray-500 text-lg mb-10">
+          <p className="text-gray-600 text-lg mb-10">
             Na curadoria, passamos por todos esses pontos antes de você decidir.
           </p>
           <div className="grid sm:grid-cols-2 gap-4">
@@ -207,7 +203,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
             Por que curadoria?
           </h2>
-          <p className="text-gray-500 text-lg mb-12">
+          <p className="text-gray-600 text-lg mb-12">
             Porque escolher um cruzeiro envolve mais variáveis do que parece.
           </p>
           <div className="grid md:grid-cols-3 gap-6">
@@ -300,7 +296,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
             ].map(({ label, value }) => (
               <div key={label}>
                 <div className="text-4xl font-black text-anhanga-blue">{value}</div>
-                <div className="text-sm text-gray-500 mt-1">{label}</div>
+                <div className="text-sm text-gray-600 mt-1">{label}</div>
               </div>
             ))}
           </div>
@@ -320,7 +316,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={handleCtaClick}
+            onClick={() => pushWhatsAppCta(PAGE_NAME)}
             className="inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-black px-10 py-5 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-xl shadow-lg"
             aria-label="Falar com um especialista em cruzeiros via WhatsApp"
           >
@@ -342,7 +338,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Consultoria de Viagem
               </div>
-              <div className="text-sm text-gray-500 mt-1">
+              <div className="text-sm text-gray-600 mt-1">
                 Roteiro sob medida com consultor humano
               </div>
             </Link>
@@ -353,7 +349,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Viagens para Executivos
               </div>
-              <div className="text-sm text-gray-500 mt-1">
+              <div className="text-sm text-gray-600 mt-1">
                 Planejamento com precisão para profissionais
               </div>
             </Link>
@@ -364,7 +360,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Site principal
               </div>
-              <div className="text-sm text-gray-500 mt-1">
+              <div className="text-sm text-gray-600 mt-1">
                 Conheça todos os serviços da Anhangá
               </div>
             </a>

--- a/pages/landings/ViagensParaExecutivosLanding.tsx
+++ b/pages/landings/ViagensParaExecutivosLanding.tsx
@@ -1,0 +1,362 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { SEO } from '@/components/SEO';
+import { LandingFAQ } from '@/components/LandingFAQ';
+import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
+import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
+import { ServiceSchema } from '@/components/schemas/ServiceSchema';
+import { useWhatsAppLink } from '@/utils/whatsapp';
+import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
+import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
+import Search from 'lucide-react/dist/esm/icons/search';
+import LayoutList from 'lucide-react/dist/esm/icons/layout-list';
+import PhoneCall from 'lucide-react/dist/esm/icons/phone-call';
+
+const WHATSAPP_MESSAGE = 'Olá! Quero planejar uma viagem com atendimento consultivo.';
+const PAGE_NAME = 'viagens-para-executivos';
+
+const FAQ_ITEMS = [
+  {
+    question: 'Vocês atendem viagens de última hora?',
+    answer: 'Sim, dentro do possível. Quanto mais cedo o contato, mais opções de voos, hotéis e preços melhores. Mas não deixe de entrar em contato mesmo com prazo curto.'
+  },
+  {
+    question: 'Posso ter um consultor fixo?',
+    answer: 'Sim. O mesmo profissional acompanha sua viagem do início ao fim — da conversa inicial ao suporte durante o embarque.'
+  },
+  {
+    question: 'Fazem viagens corporativas?',
+    answer: 'No momento focamos em viagens pessoais e familiares premium. Se você busca uma experiência de alto padrão para sua família ou para si mesmo, estamos prontos para ajudar.'
+  },
+  {
+    question: 'Têm experiência com destinos de luxo?',
+    answer: 'Sim. A Anhangá planeja viagens para Europa, Caribe, Japão, Maldivas e outros destinos premium, com curadoria de hotéis, transfers e experiências exclusivas.'
+  },
+  {
+    question: 'Como é o suporte durante a viagem?',
+    answer: 'WhatsApp 24h com o mesmo consultor que planejou sua viagem. Qualquer imprevisto — hotel, voo, roteiro — você tem um humano para resolver.'
+  }
+];
+
+const FOR_WHO_PROFILES = [
+  'Médicos e profissionais de saúde',
+  'Advogados e sócios de escritórios',
+  'Executivos e gestores de alta liderança',
+  'Empresários e sócios-fundadores',
+  'Famílias que valorizam tempo e conforto',
+  'Profissionais com agenda imprevisível',
+];
+
+const WHAT_WE_RESOLVE = [
+  {
+    icon: Search,
+    title: 'Pesquisa e comparação',
+    desc: 'Você não precisa comparar voos, hotéis e transfers. Fazemos isso por você e entregamos a melhor opção para o seu perfil e orçamento.',
+  },
+  {
+    icon: LayoutList,
+    title: 'Logística completa',
+    desc: 'Voos, traslados, hotéis, passeios e seguros organizados em um roteiro claro. Cada ponto de conexão verificado antes de você embarcar.',
+    variant: 'filled' as const,
+  },
+  {
+    icon: PhoneCall,
+    title: 'Suporte durante a viagem',
+    desc: 'Se algo muda — voo cancelado, hotel com problema, roteiro que precisa ajustar — você tem um consultor humano disponível para resolver.',
+  },
+];
+
+const HOW_IT_WORKS = [
+  {
+    step: '01',
+    title: 'Conversa inicial',
+    desc: 'Você fala com um consultor, conta o que precisa e define prioridades. Nenhum formulário, nenhuma espera.'
+  },
+  {
+    step: '02',
+    title: 'Roteiro e reservas',
+    desc: 'Em até 5 dias úteis, o consultor entrega o roteiro completo e cuida de todas as reservas.'
+  },
+  {
+    step: '03',
+    title: 'Suporte 24h durante a viagem',
+    desc: 'WhatsApp direto com quem planejou. Qualquer imprevisto resolvido sem você precisar ligar para uma central.'
+  },
+];
+
+const ViagensParaExecutivosLanding: React.FC = () => {
+  const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE, { appendTrackingRef: true });
+
+  const handleCtaClick = () => {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ event: 'whatsapp_cta_click', page: PAGE_NAME });
+  };
+
+  return (
+    <div className="bg-white min-h-screen font-sans">
+      <SEO
+        title="Viagens Para Executivos e Profissionais — Anhangá Viagens"
+        description="Planejamento de viagem com precisão para quem não tem tempo a perder. Atendimento consultivo, roteiro sob medida e suporte real."
+        canonical="https://www.anhanga.tur.br/viagens-para-executivos/"
+        noHreflang
+      />
+      <ServiceSchema
+        name="Viagens Para Executivos e Profissionais"
+        description="Planejamento de viagens premium para profissionais e famílias que valorizam tempo, conforto e zero margem de erro."
+        serviceUrl="https://www.anhanga.tur.br/viagens-para-executivos/"
+        serviceType="Planejamento de Viagem Premium"
+        areaServed="São Paulo e Brasil"
+        keywords={['viagens para executivos', 'agência de viagens confiável SP', 'consultor de viagem', 'planejamento de viagem internacional']}
+      />
+      <BreadcrumbSchema
+        items={[
+          { name: 'Home', item: 'https://www.anhanga.tur.br/' },
+          { name: 'Viagens para Executivos', item: 'https://www.anhanga.tur.br/viagens-para-executivos/' }
+        ]}
+      />
+      <FAQPageSchema items={FAQ_ITEMS} />
+
+      {/* Mini Header */}
+      <header className="bg-white border-b border-gray-100 sticky top-0 z-50 py-3">
+        <div className="max-w-5xl mx-auto px-6 flex items-center justify-between">
+          <a
+            href="https://www.anhanga.tur.br/"
+            className="inline-flex items-center gap-2 group"
+            aria-label="Voltar para o site principal da Anhangá Viagens"
+          >
+            <ArrowLeft className="w-4 h-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
+            <span className="w-7 h-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
+              <img src="/favicon.svg" alt="" aria-hidden="true" className="w-4 h-4" />
+            </span>
+            <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+              Anhangá Viagens
+            </span>
+          </a>
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleCtaClick}
+            className="text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap"
+          >
+            Falar com consultor
+          </a>
+        </div>
+      </header>
+
+      {/* Hero */}
+      <section className="pt-16 pb-20 px-6 bg-anhanga-dark">
+        <div className="max-w-3xl mx-auto">
+          <p className="text-sm font-semibold text-anhanga-yellow mb-8 tracking-widest uppercase">
+            Atendimento consultivo premium
+          </p>
+          <h1 className="text-4xl md:text-6xl font-black text-white mb-6 leading-[1.1] font-serif">
+            Sua viagem planejada com precisão, conforto e atendimento humano
+          </h1>
+          <p className="text-xl text-gray-300 mb-10 leading-relaxed max-w-2xl">
+            Para profissionais e famílias que não querem perder tempo comparando opções nem correr risco com detalhes importantes.
+          </p>
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleCtaClick}
+            className="inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-lg shadow-lg"
+            aria-label="Falar com um consultor de viagens via WhatsApp"
+          >
+            Falar com um consultor
+            <ArrowRight className="w-5 h-5" />
+          </a>
+          <p className="mt-4 text-sm text-gray-500">Consultor fixo do início ao fim.</p>
+        </div>
+      </section>
+
+      {/* Para quem é */}
+      <section className="py-20 bg-white">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4 font-serif">
+            Para quem é
+          </h2>
+          <p className="text-gray-500 text-lg mb-10">
+            Profissionais e famílias que valorizam tempo e têm aversão a erro.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            {FOR_WHO_PROFILES.map(profile => (
+              <span
+                key={profile}
+                className="px-4 py-2 rounded-full bg-anhanga-light text-anhanga-dark font-semibold text-sm"
+              >
+                {profile}
+              </span>
+            ))}
+          </div>
+          <p className="mt-8 text-gray-600 max-w-2xl leading-relaxed">
+            Se você tem uma viagem importante para planejar e não quer perder tempo com pesquisa, comparação e burocracia, a Anhangá cuida de tudo enquanto você se concentra no que importa.
+          </p>
+        </div>
+      </section>
+
+      {/* O que a gente resolve */}
+      <section className="py-20 bg-[#fffdf5]">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
+            O que a gente resolve
+          </h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            {WHAT_WE_RESOLVE.map(({ icon: Icon, title, desc, variant }) => (
+              <div
+                key={title}
+                className={`p-8 rounded-2xl ${variant === 'filled' ? 'bg-anhanga-dark text-white' : 'bg-white'}`}
+              >
+                <div
+                  className={`w-11 h-11 rounded-xl flex items-center justify-center mb-5 ${
+                    variant === 'filled' ? 'bg-anhanga-yellow/20' : 'bg-anhanga-blue/10'
+                  }`}
+                >
+                  <Icon
+                    className={`w-5 h-5 ${variant === 'filled' ? 'text-anhanga-yellow' : 'text-anhanga-blue'}`}
+                  />
+                </div>
+                <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
+                  {title}
+                </h3>
+                <p className={variant === 'filled' ? 'text-gray-400 leading-relaxed' : 'text-gray-600 leading-relaxed'}>
+                  {desc}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Como funciona */}
+      <section className="py-20 bg-white">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
+            Como funciona
+          </h2>
+          <div className="space-y-0">
+            {HOW_IT_WORKS.map(({ step, title, desc }, idx) => (
+              <div
+                key={step}
+                className={`flex gap-8 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-gray-100' : ''}`}
+              >
+                <div className="flex-shrink-0 w-12 h-12 rounded-full bg-anhanga-blue/10 flex items-center justify-center">
+                  <span className="text-sm font-black text-anhanga-blue">{step}</span>
+                </div>
+                <div>
+                  <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
+                  <p className="text-gray-600 leading-relaxed max-w-xl">{desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Sobre a Anhangá */}
+      <section className="py-20 bg-[#fffdf5]">
+        <div className="max-w-4xl mx-auto px-6">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
+            Sobre a Anhangá Viagens
+          </h2>
+          <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mb-10">
+            Agência boutique em São Paulo desde 2018, especializada em viagens sob medida. Consultor fixo do início ao fim, nota 5.0 no Google, atendimento sem robôs e sem formulários.
+          </p>
+          <div className="flex flex-wrap gap-12">
+            {[
+              { label: 'Fundada em', value: '2018' },
+              { label: 'Nota Google', value: '5.0' },
+              { label: 'Consultor fixo', value: 'Do início ao fim' },
+            ].map(({ label, value }) => (
+              <div key={label}>
+                <div className="text-3xl font-black text-anhanga-dark">{value}</div>
+                <div className="text-sm text-gray-500 mt-1">{label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Final */}
+      <section className="py-20 bg-anhanga-blue">
+        <div className="max-w-3xl mx-auto px-6 text-center">
+          <h2 className="text-3xl md:text-5xl font-black text-white mb-6 font-serif">
+            Você merece uma viagem sem erro.
+          </h2>
+          <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
+            Um consultor disponível para cuidar de cada detalhe. Sem chatbot, sem formulário, sem burocracia.
+          </p>
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleCtaClick}
+            className="inline-flex items-center gap-3 bg-white text-anhanga-blue font-black px-10 py-5 rounded-2xl hover:bg-anhanga-light transition-colors text-xl shadow-lg"
+            aria-label="Falar com um consultor de viagens via WhatsApp"
+          >
+            Falar com um consultor
+            <ArrowRight className="w-6 h-6" />
+          </a>
+        </div>
+      </section>
+
+      {/* Outros serviços */}
+      <section className="py-16 bg-[#fffdf5]">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
+          <div className="grid md:grid-cols-3 gap-4">
+            <Link
+              to="/consultoria-de-viagem"
+              className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/5 transition-colors group"
+            >
+              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                Consultoria de Viagem
+              </div>
+              <div className="text-sm text-gray-500 mt-1">
+                Roteiro sob medida com consultor humano
+              </div>
+            </Link>
+            <Link
+              to="/curadoria-cruzeiros-brasil"
+              className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/5 transition-colors group"
+            >
+              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                Curadoria de Cruzeiros
+              </div>
+              <div className="text-sm text-gray-500 mt-1">
+                Escolha o navio e a cabine certos para você
+              </div>
+            </Link>
+            <a
+              href="https://www.anhanga.tur.br/"
+              className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/5 transition-colors group"
+            >
+              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                Site principal
+              </div>
+              <div className="text-sm text-gray-500 mt-1">
+                Conheça todos os serviços da Anhangá
+              </div>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <LandingFAQ
+        items={FAQ_ITEMS}
+        title="Dúvidas sobre viagens para executivos"
+        subtitle="Tire suas dúvidas sobre o planejamento consultivo da Anhangá."
+      />
+
+      {/* Footer */}
+      <footer className="py-8 bg-[#fffdf5] border-t border-gray-100 text-center text-sm text-gray-600">
+        <p>Anhangá Viagens · Agência boutique em São Paulo</p>
+        <p className="mt-1">Atualizado em abril de 2026</p>
+      </footer>
+    </div>
+  );
+};
+
+export default ViagensParaExecutivosLanding;

--- a/pages/landings/ViagensParaExecutivosLanding.tsx
+++ b/pages/landings/ViagensParaExecutivosLanding.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
 import { ServiceSchema } from '@/components/schemas/ServiceSchema';
 import { useWhatsAppLink } from '@/utils/whatsapp';
+import { pushWhatsAppCta } from '@/utils/analytics';
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
 import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
 import Search from 'lucide-react/dist/esm/icons/search';
@@ -87,11 +88,6 @@ const HOW_IT_WORKS = [
 const ViagensParaExecutivosLanding: React.FC = () => {
   const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE, { appendTrackingRef: true });
 
-  const handleCtaClick = () => {
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({ event: 'whatsapp_cta_click', page: PAGE_NAME });
-  };
-
   return (
     <div className="bg-white min-h-screen font-sans">
       <SEO
@@ -117,10 +113,10 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       <FAQPageSchema items={FAQ_ITEMS} />
 
       {/* Mini Header */}
-      <header className="bg-white border-b border-gray-100 sticky top-0 z-50 py-3">
+      <header className="bg-white/90 backdrop-blur-sm border-b border-gray-100 sticky top-0 z-50 py-3">
         <div className="max-w-5xl mx-auto px-6 flex items-center justify-between">
-          <a
-            href="https://www.anhanga.tur.br/"
+          <Link
+            to="/"
             className="inline-flex items-center gap-2 group"
             aria-label="Voltar para o site principal da Anhangá Viagens"
           >
@@ -131,12 +127,12 @@ const ViagensParaExecutivosLanding: React.FC = () => {
             <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
               Anhangá Viagens
             </span>
-          </a>
+          </Link>
           <a
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={handleCtaClick}
+            onClick={() => pushWhatsAppCta(PAGE_NAME)}
             className="text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap"
           >
             Falar com consultor
@@ -160,14 +156,14 @@ const ViagensParaExecutivosLanding: React.FC = () => {
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={handleCtaClick}
+            onClick={() => pushWhatsAppCta(PAGE_NAME)}
             className="inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-lg shadow-lg"
             aria-label="Falar com um consultor de viagens via WhatsApp"
           >
             Falar com um consultor
             <ArrowRight className="w-5 h-5" />
           </a>
-          <p className="mt-4 text-sm text-gray-500">Consultor fixo do início ao fim.</p>
+          <p className="mt-4 text-sm text-gray-400">Consultor fixo do início ao fim.</p>
         </div>
       </section>
 
@@ -177,7 +173,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4 font-serif">
             Para quem é
           </h2>
-          <p className="text-gray-500 text-lg mb-10">
+          <p className="text-gray-600 text-lg mb-10">
             Profissionais e famílias que valorizam tempo e têm aversão a erro.
           </p>
           <div className="flex flex-wrap gap-3">
@@ -271,7 +267,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
             ].map(({ label, value }) => (
               <div key={label}>
                 <div className="text-3xl font-black text-anhanga-dark">{value}</div>
-                <div className="text-sm text-gray-500 mt-1">{label}</div>
+                <div className="text-sm text-gray-600 mt-1">{label}</div>
               </div>
             ))}
           </div>
@@ -291,7 +287,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={handleCtaClick}
+            onClick={() => pushWhatsAppCta(PAGE_NAME)}
             className="inline-flex items-center gap-3 bg-white text-anhanga-blue font-black px-10 py-5 rounded-2xl hover:bg-anhanga-light transition-colors text-xl shadow-lg"
             aria-label="Falar com um consultor de viagens via WhatsApp"
           >
@@ -313,7 +309,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Consultoria de Viagem
               </div>
-              <div className="text-sm text-gray-500 mt-1">
+              <div className="text-sm text-gray-600 mt-1">
                 Roteiro sob medida com consultor humano
               </div>
             </Link>
@@ -324,7 +320,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Curadoria de Cruzeiros
               </div>
-              <div className="text-sm text-gray-500 mt-1">
+              <div className="text-sm text-gray-600 mt-1">
                 Escolha o navio e a cabine certos para você
               </div>
             </Link>
@@ -335,7 +331,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Site principal
               </div>
-              <div className="text-sm text-gray-500 mt-1">
+              <div className="text-sm text-gray-600 mt-1">
                 Conheça todos os serviços da Anhangá
               </div>
             </a>

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,0 +1,4 @@
+export const pushWhatsAppCta = (page: string) => {
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({ event: 'whatsapp_cta_click', page });
+};


### PR DESCRIPTION
## Summary

- Adiciona `ConsultoriaDeViagemLanding` → rota `/consultoria-de-viagem`
- Adiciona `ViagensParaExecutivosLanding` → rota `/viagens-para-executivos`
- Adiciona `CuradoriaCruzeirosBrasilLanding` → rota `/curadoria-cruzeiros-brasil`
- Registra as 3 rotas em `App.tsx` como lazy imports no `AppLayout`

## Detalhes técnicos

Cada página inclui:
- `SEO` com título, descrição, canonical e `noHreflang`
- `ServiceSchema` + `BreadcrumbSchema` + `FAQPageSchema`
- `useWhatsAppLink()` com push GTM `whatsapp_cta_click` no clique
- Mini-header com logo favicon + "Anhangá Viagens" linkando para o site principal
- Seção "Outros serviços" com links cruzados entre as 3 páginas
- `LandingFAQ` com 5 itens por página
- Rodapé "Atualizado em abril de 2026"

## Identidades visuais

| Página | Hero | Diferencial de layout |
|---|---|---|
| Consultoria | Creme `#fffdf5` | Checklist + quote card em 2 colunas |
| Executivos | Escuro `#0f1117` + badge amarelo | Chips de perfil + lista horizontal numerada |
| Cruzeiros | Azul claro `anhanga-light` | "O que analisamos juntos" como posição 2 |

## Correções de design aplicadas

- Contraste WCAG: `text-gray-400` → `text-gray-600` em microcopy e rodapés
- "Como funciona" unificado com círculos numerados nas 3 páginas
- Mini-header com logo/marca nas 3 páginas
- Botão "Falar com especialista" com `whitespace-nowrap` no Cruzeiros
- Seção "O que analisamos juntos" promovida para posição 2 no Cruzeiros
- "Outros serviços" com fundo alternado para separar do FAQ

## Test Plan

- [ ] Abrir `/consultoria-de-viagem`, `/viagens-para-executivos`, `/curadoria-cruzeiros-brasil` no browser
- [ ] Verificar que o mini-header exibe logo + nome e não quebra em mobile
- [ ] Clicar no CTA WhatsApp e confirmar evento GTM `whatsapp_cta_click` no dataLayer
- [ ] Verificar links "Outros serviços" navegam corretamente entre as 3 páginas
- [ ] Inspecionar meta tags (título, description, canonical) em cada rota
- [ ] `pnpm test:regression` — 186 testes passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)