### PR TITLE
feat: Decap CMS OAuth handler via Vercel Edge (FEL-109)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,17 @@ N8N_WEBHOOK_SECRET=seu_segredo_aqui
 # UPSTASH_REDIS_REST_TOKEN=your_rest_token
 
 # =============================================================================
+# REQUIRED (prod) - Decap CMS — GitHub OAuth (para login em /admin)
+# =============================================================================
+# 1. Crie um OAuth App em: https://github.com/settings/applications/new
+#    - Application name: Anhangá Viagens CMS
+#    - Homepage URL: https://www.anhanga.tur.br
+#    - Authorization callback URL: https://www.anhanga.tur.br/api/auth/callback
+# 2. Adicione as 2 variáveis abaixo no Vercel Dashboard (Production + Preview + Development)
+GITHUB_OAUTH_CLIENT_ID=seu_github_oauth_client_id
+GITHUB_OAUTH_CLIENT_SECRET=seu_github_oauth_client_secret
+
+# =============================================================================
 # REQUIRED (prod) - Keystatic CMS — GitHub OAuth
 # =============================================================================
 # 1. Crie um OAuth App em: https://github.com/settings/applications/new

--- a/api/auth.ts
+++ b/api/auth.ts
@@ -1,0 +1,36 @@
+export const config = {
+    runtime: 'edge',
+};
+
+import { buildJsonError } from '../lib/network';
+
+const GITHUB_OAUTH_URL = 'https://github.com/login/oauth/authorize';
+const OAUTH_SCOPE = 'repo,user';
+const STATE_COOKIE_MAX_AGE_SECONDS = 300;
+
+export default function handler(req: Request): Response {
+    if (req.method !== 'GET') {
+        return buildJsonError(405, 'METHOD_NOT_ALLOWED', 'Method not allowed');
+    }
+
+    const clientId = process.env.GITHUB_OAUTH_CLIENT_ID;
+    if (!clientId) {
+        return buildJsonError(500, 'CONFIGURATION_ERROR', 'OAuth provider not configured');
+    }
+
+    const state = crypto.randomUUID();
+
+    const params = new URLSearchParams({
+        client_id: clientId,
+        scope: OAUTH_SCOPE,
+        state,
+    });
+
+    const cookieAttrs = `HttpOnly; SameSite=Lax; Path=/api/auth; Max-Age=${STATE_COOKIE_MAX_AGE_SECONDS}; Secure`;
+    const headers = new Headers({
+        Location: `${GITHUB_OAUTH_URL}?${params}`,
+        'Set-Cookie': `oauth_state=${state}; ${cookieAttrs}`,
+    });
+
+    return new Response(null, { status: 302, headers });
+}

--- a/api/auth/callback.ts
+++ b/api/auth/callback.ts
@@ -1,0 +1,168 @@
+export const config = {
+    runtime: 'edge',
+};
+
+import { buildJsonError } from '../../lib/network';
+
+const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const GITHUB_TOKEN_TIMEOUT_MS = 8000;
+const PROVIDER = 'github';
+
+function parseCookies(header: string): Record<string, string> {
+    const cookies: Record<string, string> = {};
+    for (const part of header.split(';')) {
+        const eq = part.indexOf('=');
+        if (eq < 0) continue;
+        const key = part.slice(0, eq).trim();
+        const val = part.slice(eq + 1).trim();
+        if (key) cookies[key] = val;
+    }
+    return cookies;
+}
+
+/** Serializes a string as a JSON literal safe for embedding inside a <script> block. */
+function safeJsonString(value: string): string {
+    return JSON.stringify(value)
+        .replace(/</g, '\\u003c')
+        .replace(/>/g, '\\u003e')
+        .replace(/&/g, '\\u0026');
+}
+
+/**
+ * Returns an HTML page that completes the Decap CMS OAuth handshake via postMessage.
+ *
+ * Protocol (canonical Decap CMS flow):
+ *  1. This page fires `window.opener.postMessage('authorizing:github', '*')` — no sensitive payload.
+ *  2. The CMS parent window echoes the same message back.
+ *  3. `e.origin` from that echo is the verified opener origin (set by the browser, not forgeable).
+ *  4. This page replies to `e.source` at `e.origin` with the auth result — never '*'.
+ */
+function buildPostMessageHtml(status: 'success' | 'error', content: string, httpStatus: number): Response {
+    const safeProvider = safeJsonString(PROVIDER);
+    const safeStatus = safeJsonString(status);
+    const safeContent = safeJsonString(content);
+
+    const html = `<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Autenticação</title>
+</head>
+<body>
+<script>
+(function () {
+  var provider = ${safeProvider};
+  var status = ${safeStatus};
+  var content = ${safeContent};
+  var handshake = 'authorizing:' + provider;
+  var message = 'authorization:' + provider + ':' + status + ':' + content;
+
+  if (!window.opener) {
+    document.body.textContent = status === 'error'
+      ? 'Erro de autenticação: ' + content
+      : 'Autenticação concluída. Feche esta janela.';
+    return;
+  }
+
+  function onMessage(e) {
+    if (e.data !== handshake) return;
+    clearTimeout(handshakeTimeout);
+    window.removeEventListener('message', onMessage, false);
+    e.source.postMessage(message, e.origin);
+    window.close();
+  }
+
+  // Guard against opener never responding — clean up listener and surface error.
+  var handshakeTimeout = setTimeout(function () {
+    window.removeEventListener('message', onMessage, false);
+    document.body.textContent = 'Erro: o CMS não respondeu ao handshake. Feche esta janela e tente novamente.';
+  }, 10000);
+
+  window.addEventListener('message', onMessage, false);
+  window.opener.postMessage(handshake, '*');
+}());
+</script>
+</body>
+</html>`;
+
+    return new Response(html, {
+        status: httpStatus,
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+}
+
+export default async function handler(req: Request): Promise<Response> {
+    if (req.method !== 'GET') {
+        return buildJsonError(405, 'METHOD_NOT_ALLOWED', 'Method not allowed');
+    }
+
+    const clientId = process.env.GITHUB_OAUTH_CLIENT_ID;
+    const clientSecret = process.env.GITHUB_OAUTH_CLIENT_SECRET;
+
+    if (!clientId || !clientSecret) {
+        return buildJsonError(500, 'CONFIGURATION_ERROR', 'OAuth provider not configured');
+    }
+
+    const url = new URL(req.url);
+    const code = url.searchParams.get('code');
+    const state = url.searchParams.get('state');
+    const errorParam = url.searchParams.get('error');
+
+    const cookies = parseCookies(req.headers.get('cookie') ?? '');
+    const storedState = cookies['oauth_state'];
+
+    if (errorParam) {
+        const desc = url.searchParams.get('error_description') ?? errorParam;
+        return buildPostMessageHtml('error', desc, 400);
+    }
+
+    if (!state || !storedState || state !== storedState) {
+        return buildPostMessageHtml('error', 'Invalid state parameter', 400);
+    }
+
+    if (!code) {
+        return buildPostMessageHtml('error', 'Missing authorization code', 400);
+    }
+
+    let tokenData: Record<string, unknown>;
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), GITHUB_TOKEN_TIMEOUT_MS);
+
+    try {
+        const tokenRes = await fetch(GITHUB_TOKEN_URL, {
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code }),
+            signal: ac.signal,
+        });
+        clearTimeout(timer);
+
+        if (!tokenRes.ok) {
+            console.error('AUTH_CALLBACK', { stage: 'token_exchange', httpStatus: tokenRes.status });
+            return buildPostMessageHtml('error', 'Token exchange failed', 502);
+        }
+
+        tokenData = (await tokenRes.json()) as Record<string, unknown>;
+    } catch (err) {
+        clearTimeout(timer);
+        const isTimeout = err instanceof Error && err.name === 'AbortError';
+        console.error('AUTH_CALLBACK', { stage: 'token_fetch', error: isTimeout ? 'timeout' : err instanceof Error ? err.message : 'unknown' });
+        return buildPostMessageHtml('error', isTimeout ? 'Token exchange timed out' : 'Token exchange request failed', 502);
+    }
+
+    if (tokenData['error'] || typeof tokenData['access_token'] !== 'string') {
+        console.error('AUTH_CALLBACK', { stage: 'token_parse', error: tokenData['error'] ?? 'missing_token' });
+        return buildPostMessageHtml(
+            'error',
+            String(tokenData['error_description'] ?? 'Token exchange failed'),
+            400,
+        );
+    }
+
+    const successContent = JSON.stringify({ token: tokenData['access_token'], provider: PROVIDER });
+    return buildPostMessageHtml('success', successContent, 200);
+}

--- a/api/auth/callback.ts
+++ b/api/auth/callback.ts
@@ -92,6 +92,42 @@ function buildPostMessageHtml(status: 'success' | 'error', content: string, http
     });
 }
 
+/** Returns the access token string on success, or an error Response on failure. */
+async function exchangeCodeForToken(clientId: string, clientSecret: string, code: string): Promise<Response | string> {
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), GITHUB_TOKEN_TIMEOUT_MS);
+
+    let tokenData: Record<string, unknown>;
+    try {
+        const tokenRes = await fetch(GITHUB_TOKEN_URL, {
+            method: 'POST',
+            headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code }),
+            signal: ac.signal,
+        });
+        clearTimeout(timer);
+
+        if (!tokenRes.ok) {
+            console.error('AUTH_CALLBACK', { stage: 'token_exchange', httpStatus: tokenRes.status });
+            return buildPostMessageHtml('error', 'Token exchange failed', 502);
+        }
+
+        tokenData = (await tokenRes.json()) as Record<string, unknown>;
+    } catch (err) {
+        clearTimeout(timer);
+        const isTimeout = err instanceof Error && err.name === 'AbortError';
+        console.error('AUTH_CALLBACK', { stage: 'token_fetch', error: isTimeout ? 'timeout' : err instanceof Error ? err.message : 'unknown' });
+        return buildPostMessageHtml('error', isTimeout ? 'Token exchange timed out' : 'Token exchange request failed', 502);
+    }
+
+    if (tokenData['error'] || typeof tokenData['access_token'] !== 'string') {
+        console.error('AUTH_CALLBACK', { stage: 'token_parse', error: tokenData['error'] ?? 'missing_token' });
+        return buildPostMessageHtml('error', String(tokenData['error_description'] ?? 'Token exchange failed'), 400);
+    }
+
+    return tokenData['access_token'];
+}
+
 export default async function handler(req: Request): Promise<Response> {
     if (req.method !== 'GET') {
         return buildJsonError(405, 'METHOD_NOT_ALLOWED', 'Method not allowed');
@@ -125,44 +161,9 @@ export default async function handler(req: Request): Promise<Response> {
         return buildPostMessageHtml('error', 'Missing authorization code', 400);
     }
 
-    let tokenData: Record<string, unknown>;
-    const ac = new AbortController();
-    const timer = setTimeout(() => ac.abort(), GITHUB_TOKEN_TIMEOUT_MS);
+    const result = await exchangeCodeForToken(clientId, clientSecret, code);
+    if (result instanceof Response) return result;
 
-    try {
-        const tokenRes = await fetch(GITHUB_TOKEN_URL, {
-            method: 'POST',
-            headers: {
-                Accept: 'application/json',
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code }),
-            signal: ac.signal,
-        });
-        clearTimeout(timer);
-
-        if (!tokenRes.ok) {
-            console.error('AUTH_CALLBACK', { stage: 'token_exchange', httpStatus: tokenRes.status });
-            return buildPostMessageHtml('error', 'Token exchange failed', 502);
-        }
-
-        tokenData = (await tokenRes.json()) as Record<string, unknown>;
-    } catch (err) {
-        clearTimeout(timer);
-        const isTimeout = err instanceof Error && err.name === 'AbortError';
-        console.error('AUTH_CALLBACK', { stage: 'token_fetch', error: isTimeout ? 'timeout' : err instanceof Error ? err.message : 'unknown' });
-        return buildPostMessageHtml('error', isTimeout ? 'Token exchange timed out' : 'Token exchange request failed', 502);
-    }
-
-    if (tokenData['error'] || typeof tokenData['access_token'] !== 'string') {
-        console.error('AUTH_CALLBACK', { stage: 'token_parse', error: tokenData['error'] ?? 'missing_token' });
-        return buildPostMessageHtml(
-            'error',
-            String(tokenData['error_description'] ?? 'Token exchange failed'),
-            400,
-        );
-    }
-
-    const successContent = JSON.stringify({ token: tokenData['access_token'], provider: PROVIDER });
+    const successContent = JSON.stringify({ token: result, provider: PROVIDER });
     return buildPostMessageHtml('success', successContent, 200);
 }

--- a/api/auth/callback.ts
+++ b/api/auth/callback.ts
@@ -88,7 +88,10 @@ function buildPostMessageHtml(status: 'success' | 'error', content: string, http
 
     return new Response(html, {
         status: httpStatus,
-        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+        headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+            'Set-Cookie': 'oauth_state=; Path=/api/auth; Max-Age=0; HttpOnly; SameSite=Lax; Secure',
+        },
     });
 }
 

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -23,6 +23,16 @@ export function buildCorsHeaders(allowedOrigin?: string): Record<string, string>
 }
 
 /**
+ * Builds a structured JSON error response.
+ */
+export function buildJsonError(status: number, code: string, message: string): Response {
+    return new Response(JSON.stringify({ error: code, message }), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+/**
  * Extracts the client IP from the request headers.
  * Specialized for Vercel's environment.
  */

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -2,6 +2,7 @@ backend:
   name: github
   repo: felipewilliam2/AV-SITE
   branch: main
+  auth_endpoint: api/auth
 
 local_backend: true
 site_url: https://www.anhanga.tur.br


### PR DESCRIPTION
## Resumo

Implementa as duas edge functions de OAuth exigidas pelo Decap CMS para autenticar usuários em `/admin` com conta GitHub, sem expor o `client_secret` no browser.

- `api/auth.ts` — inicia o fluxo OAuth redirecionando para o GitHub com estado CSRF
- `api/auth/callback.ts` — recebe o `code`, troca por token, devolve ao CMS via `postMessage`
- `lib/network.ts` — extrai `buildJsonError()` como utilitário compartilhado
- `public/admin/config.yml` — adiciona `auth_endpoint: api/auth`
- `.env.example` — documenta `GITHUB_OAUTH_CLIENT_ID` e `GITHUB_OAUTH_CLIENT_SECRET`

## Decisões de design

**Protocolo postMessage canônico do Decap CMS (handshake de 3 vias)**
O callback nunca usa `'*'` como targetOrigin para payload sensível. O protocolo:
1. Popup anuncia `"authorizing:github"` ao opener com target `*` — sem dado sensível
2. CMS ecoa de volta a mesma string
3. `e.origin` do evento (definido pelo browser, não forjável) é usado como targetOrigin para enviar o token

Isso elimina a necessidade de allowlist de origens hardcoded e faz preview deploys funcionarem automaticamente.

**Sem `base_url` no `config.yml`**
Omitir `base_url` faz o Decap usar `location.origin` automaticamente — o mesmo arquivo funciona em produção e em todos os preview deploys da Vercel.

**AbortController no token exchange**
Timeout de 8 s garante que uma resposta lenta do GitHub não trave o edge worker pelo limite de 25 s do Vercel.

**Listener cleanup timeout**
Timeout de 10 s no `onMessage` do HTML do callback remove o listener e exibe mensagem de erro caso o opener (CMS) nunca responda ao handshake — previne event listener leak.

## Env vars necessárias no Vercel Dashboard

| Variável | Onde obter |
|---|---|
| `GITHUB_OAUTH_CLIENT_ID` | GitHub OAuth App → Client ID |
| `GITHUB_OAUTH_CLIENT_SECRET` | GitHub OAuth App → Client secrets |

O OAuth App deve ter callback configurado como `https://www.anhanga.tur.br/api/auth/callback`.

## Critérios de aceite (FEL-109)

- [x] `/api/auth` inicia fluxo OAuth redirecionando para o GitHub
- [x] `/api/auth/callback` troca `code` por token e devolve via `postMessage`
- [x] Token não exposto em logs ou respostas de erro
- [x] `code` inválido / estado CSRF inválido retorna resposta estruturada de erro (HTTP 400)
- [x] `origin` validado via handshake — nunca `'*'` para payload sensível

🤖 Generated with [Claude Code](https://claude.ai/claude-code)