### PR TITLE
ci: add workflow to auto-regenerate blogManifest.ts on content push

### DIFF
--- a/.github/workflows/generate-blog-manifest.yml
+++ b/.github/workflows/generate-blog-manifest.yml
@@ -1,0 +1,47 @@
+name: Generate Blog Manifest
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "content/blog/**"
+
+permissions:
+  contents: write
+
+jobs:
+  generate-manifest:
+    name: Regenerate blogManifest.ts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 22.13.1
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.13.1"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate blog manifest
+        run: pnpm run generate:blog-manifest
+
+      - name: Commit updated manifest
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/blogManifest.ts
+          if git diff --cached --quiet; then
+            echo "No changes to blogManifest.ts — skipping commit."
+          else
+            git commit -m "chore: regenerate blogManifest.ts [skip ci]"
+            git push origin main
+          fi


### PR DESCRIPTION
Triggers on push to main when content/blog/** changes. Installs deps,
runs generate:blog-manifest, and commits data/blogManifest.ts with
[skip ci] to avoid loop. Uses GITHUB_TOKEN with contents:write.

https://claude.ai/code/session_01Qo7DrPvHQoWD9jLPUVYMDf