### PR TITLE
feat(cms): proteger rota /admin de indexação e reforçar auth (FEL-113)

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -3,6 +3,7 @@ backend:
   repo: felipewilliam2/AV-SITE
   branch: main
   auth_endpoint: api/auth
+  auth_scope: repo
 
 local_backend: true
 site_url: https://www.anhanga.tur.br

--- a/vercel.json
+++ b/vercel.json
@@ -110,6 +110,15 @@
       ]
     },
     {
+      "source": "/admin/:path*",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    },
+    {
       "source": "/.well-known/http-message-signatures-directory",
       "headers": [
         {


### PR DESCRIPTION
## Resumo

- Adiciona header `X-Robots-Tag: noindex, nofollow` para `/admin/:path*` no `vercel.json`, impedindo que buscadores indexem a rota do CMS
- Define `auth_scope: repo` explicitamente no `public/admin/config.yml` do Decap CMS, tornando claro que o OAuth do GitHub requer acesso de escrita ao repositório
- Confirmado que `/admin` não consta no `sitemap.xml`

## Critérios de aceite (FEL-113)

- [x] Usuários sem acesso de escrita ao repositório não conseguem autenticar (comportamento padrão do backend `github`, reforçado pelo `auth_scope: repo`)
- [x] A rota `/admin` não é indexada por buscadores (`X-Robots-Tag: noindex, nofollow`)
- [x] A rota `/admin` não aparece no `sitemap.xml` (verificado — ausente)

## Notas para o revisor

O backend `github` do Decap CMS já restringe o login a colaboradores com acesso ao repositório por padrão. O `auth_scope: repo` torna esse comportamento explícito na configuração e garante que o token OAuth solicitado inclua permissões de escrita.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)