### PR TITLE
[codex] Remove hidden nav from prerender template (FEL-88)

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,12 +70,6 @@
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T2KGS86G" height="0" width="0"
       style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
-  <nav class="sr-only" aria-label="Links principais">
-    <a href="/">Home</a>
-    <a href="/orlando/">Orlando</a>
-    <a href="/sobre/">Sobre Nós</a>
-    <a href="/mapa-do-site/">Mapa</a>
-  </nav>
   <div id="root"></div>
   <script type="module" src="/index.tsx"></script>
   <!-- Defer third-party scripts to protect mobile TBT -->

--- a/tests/seo-prerender-contract.test.ts
+++ b/tests/seo-prerender-contract.test.ts
@@ -9,15 +9,30 @@ const PACKAGE_JSON_PATH = path.join(PROJECT_ROOT, 'package.json');
 const PRERENDER_SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/prerender.mjs');
 const VERCEL_CONFIG_PATH = path.join(PROJECT_ROOT, 'vercel.json');
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(raw);
+  return isRecord(parsed) ? parsed : {};
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
 test('build pipeline keeps prerender enabled for Vercel deploys', async () => {
   const [packageJson, prerenderScript, vercelConfig] = await Promise.all([
     readFile(PACKAGE_JSON_PATH, 'utf8'),
     readFile(PRERENDER_SCRIPT_PATH, 'utf8'),
     readFile(VERCEL_CONFIG_PATH, 'utf8')
   ]);
-  const { scripts } = JSON.parse(packageJson) as { scripts?: Record<string, string> };
-  const buildScript = scripts?.build ?? '';
-  const { buildCommand } = JSON.parse(vercelConfig) as { buildCommand?: string };
+  const packageData = parseJsonObject(packageJson);
+  const scripts = isRecord(packageData.scripts) ? packageData.scripts : {};
+  const buildScript = readString(scripts.build);
+  const vercelData = parseJsonObject(vercelConfig);
+  const buildCommand = readString(vercelData.buildCommand);
 
   assert.match(buildScript, /node scripts\/prerender\.mjs/);
   assert.equal(buildCommand, 'pnpm run build');

--- a/tests/seo-prerender-contract.test.ts
+++ b/tests/seo-prerender-contract.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+const PROJECT_ROOT = process.cwd();
+const INDEX_TEMPLATE_PATH = path.join(PROJECT_ROOT, 'index.html');
+const PACKAGE_JSON_PATH = path.join(PROJECT_ROOT, 'package.json');
+const PRERENDER_SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/prerender.mjs');
+const VERCEL_CONFIG_PATH = path.join(PROJECT_ROOT, 'vercel.json');
+
+test('build pipeline keeps prerender enabled for Vercel deploys', async () => {
+  const [packageJson, prerenderScript, vercelConfig] = await Promise.all([
+    readFile(PACKAGE_JSON_PATH, 'utf8'),
+    readFile(PRERENDER_SCRIPT_PATH, 'utf8'),
+    readFile(VERCEL_CONFIG_PATH, 'utf8')
+  ]);
+  const { scripts } = JSON.parse(packageJson) as { scripts?: Record<string, string> };
+  const buildScript = scripts?.build ?? '';
+  const { buildCommand } = JSON.parse(vercelConfig) as { buildCommand?: string };
+
+  assert.match(buildScript, /node scripts\/prerender\.mjs/);
+  assert.equal(buildCommand, 'pnpm run build');
+  assert.match(prerenderScript, /validateHtml/);
+  assert.match(prerenderScript, /process\.exit\(1\)/);
+});
+
+test('index template does not hide crawlable navigation links', async () => {
+  const html = await readFile(INDEX_TEMPLATE_PATH, 'utf8');
+
+  assert.doesNotMatch(html, /<nav class="sr-only" aria-label="Links principais">/);
+});


### PR DESCRIPTION
## Summary
- remove the hidden `nav.sr-only` block from the base prerender template to eliminate hidden crawlable links from the initial HTML
- add a regression test that locks the Vercel prerender contract and prevents the hidden navigation block from returning
- preserve the existing SSR/prerender pipeline and verify the generated HTML still ships with content inside `#root`

## Why
The main SEO risk reproduced in this change set was the hidden navigation block in the initial HTML. The prerender pipeline was already active, so the safest fix was to remove the hidden links and add a regression around that contract instead of refactoring SSR unnecessarily.

## Test Plan
- [x] `pnpm test:regression`
- [x] `pnpm typecheck`
- [x] `pnpm build`
