### PR TITLE
feat(quiz): landing page /quiz com quiz de destinos e lead capture via n8n

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,6 +30,7 @@ const ViagensParaExecutivosLanding = lazy(() => import('./pages/landings/Viagens
 const CuradoriaCruzeirosBrasilLanding = lazy(() => import('./pages/landings/CuradoriaCruzeirosBrasilLanding'));
 const KeystaticPage = lazy(() => import('./pages/KeystaticPage'));
 const NPS = lazy(() => import('./pages/NPS'));
+const QuizAnhangaLanding = lazy(() => import('./pages/landings/QuizAnhangaLanding'));
 
 const MainRouteFallback: React.FC = () => <section className="min-h-[40vh] bg-white" aria-hidden="true" />;
 const LandingRouteFallback: React.FC = () => <div className="min-h-screen bg-white" aria-hidden="true" />;
@@ -86,6 +87,7 @@ const AppLayout: React.FC<{ includeClientFeatures: boolean }> = ({ includeClient
           <Route path="/viagens-para-executivos" element={<ViagensParaExecutivosLanding />} />
           <Route path="/curadoria-cruzeiros-brasil" element={<CuradoriaCruzeirosBrasilLanding />} />
           <Route path="/nps" element={<NPS />} />
+          <Route path="/quiz" element={<QuizAnhangaLanding />} />
           <Route path="/*" element={<MainSiteShell />} />
         </Routes>
       </Suspense>

--- a/api/submit-quiz.ts
+++ b/api/submit-quiz.ts
@@ -98,10 +98,20 @@ export default async function handler(request: Request): Promise<Response> {
     });
 
     if (!rateLimitResult.allowed) {
-        return buildJsonResponse(
-            { ok: false, requestId, error: 'Muitas tentativas. Aguarde um momento.', code: 'RATE_LIMIT_EXCEEDED' },
-            429,
-            corsHeaders,
+        const retryAfterSec = Math.ceil(rateLimitResult.resetIn / 1000);
+        return new Response(
+            JSON.stringify({ ok: false, requestId, error: 'Muitas tentativas. Aguarde um momento.', code: 'RATE_LIMIT_EXCEEDED' }),
+            {
+                status: 429,
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Request-Id': requestId,
+                    'Retry-After': String(retryAfterSec),
+                    'X-RateLimit-Remaining': '0',
+                    'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimitResult.resetIn) / 1000)),
+                    ...corsHeaders,
+                },
+            },
         );
     }
 

--- a/api/submit-quiz.ts
+++ b/api/submit-quiz.ts
@@ -1,0 +1,147 @@
+import type { SubmitQuizRequest, SubmitQuizResponse } from '../types/quiz';
+import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
+import { checkRateLimit } from '../lib/rate-limit';
+import { cleanString } from '../lib/lead-logic';
+import { buildN8nQuizPayload } from '../lib/n8n-payloads';
+import { validateQuizPayload } from '../lib/quiz-logic';
+import { sendQuizToN8n } from '../services/n8n';
+
+export const config = {
+    runtime: 'edge',
+};
+
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS = 5;
+
+interface SubmitQuizConfig {
+    webhookUrl: string;
+    webhookSecret: string;
+}
+
+function buildJsonResponse(body: SubmitQuizResponse, status: number, corsHeaders: Record<string, string>): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: {
+            'Content-Type': 'application/json',
+            'X-Request-Id': body.requestId,
+            ...corsHeaders,
+        },
+    });
+}
+
+function getSubmitQuizConfig(): SubmitQuizConfig | null {
+    const webhookUrl = cleanString(process.env.N8N_SUBMIT_QUIZ_WEBHOOK_URL);
+    const webhookSecret = cleanString(process.env.N8N_WEBHOOK_SECRET);
+
+    if (!webhookUrl || !webhookSecret) {
+        return null;
+    }
+
+    return { webhookUrl, webhookSecret };
+}
+
+function classifySubmitQuizError(error: unknown): {
+    code: 'N8N_WEBHOOK_ERROR' | 'INTERNAL_ERROR';
+    status: number;
+    error: string;
+} {
+    const message = error instanceof Error ? error.message : String(error);
+    const match = message.match(/^N8N_WEBHOOK_ERROR:(\d+):(.*)$/s);
+
+    if (match) {
+        const httpStatus = Number.parseInt(match[1], 10);
+        const detail = match[2]?.trim().slice(0, 200) || 'Erro no webhook';
+        return {
+            code: 'N8N_WEBHOOK_ERROR',
+            status: httpStatus >= 400 && httpStatus < 600 ? httpStatus : 502,
+            error: detail,
+        };
+    }
+
+    return {
+        code: 'INTERNAL_ERROR',
+        status: 500,
+        error: 'Erro interno ao processar o quiz.',
+    };
+}
+
+export default async function handler(request: Request): Promise<Response> {
+    const requestId = createRequestId();
+    const corsHeaders = buildCorsHeaders();
+
+    if (request.method === 'OPTIONS') {
+        return new Response(null, { status: 204, headers: corsHeaders });
+    }
+
+    if (request.method !== 'POST') {
+        return buildJsonResponse(
+            { ok: false, requestId, error: 'Método não permitido.', code: 'METHOD_NOT_ALLOWED' },
+            405,
+            corsHeaders,
+        );
+    }
+
+    const config = getSubmitQuizConfig();
+    if (!config) {
+        return buildJsonResponse(
+            { ok: false, requestId, error: 'Serviço de quiz temporariamente indisponível.', code: 'SERVER_CONFIG_ERROR' },
+            503,
+            corsHeaders,
+        );
+    }
+
+    const clientIp = getClientIP(request);
+    const rateLimitResult = await checkRateLimit(clientIp, {
+        limit: RATE_LIMIT_MAX_REQUESTS,
+        windowMs: RATE_LIMIT_WINDOW_MS,
+        prefix: 'quiz',
+    });
+
+    if (!rateLimitResult.allowed) {
+        return buildJsonResponse(
+            { ok: false, requestId, error: 'Muitas tentativas. Aguarde um momento.', code: 'RATE_LIMIT_EXCEEDED' },
+            429,
+            corsHeaders,
+        );
+    }
+
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return buildJsonResponse(
+            { ok: false, requestId, error: 'Corpo da requisição inválido.', code: 'VALIDATION_ERROR' },
+            400,
+            corsHeaders,
+        );
+    }
+
+    const validation = validateQuizPayload(body);
+    if (validation.valid === false) {
+        return buildJsonResponse(
+            { ok: false, requestId, error: validation.error, code: 'VALIDATION_ERROR' },
+            400,
+            corsHeaders,
+        );
+    }
+
+    const payload: SubmitQuizRequest = validation.data;
+    const n8nPayload = buildN8nQuizPayload(payload, requestId);
+
+    try {
+        await sendQuizToN8n(config.webhookUrl, config.webhookSecret, requestId, n8nPayload);
+
+        return buildJsonResponse(
+            { ok: true, requestId, message: 'Perfil registrado com sucesso.' },
+            200,
+            corsHeaders,
+        );
+    } catch (error: unknown) {
+        const classified = classifySubmitQuizError(error);
+        return buildJsonResponse(
+            { ok: false, requestId, error: classified.error, code: classified.code },
+            classified.status,
+            corsHeaders,
+        );
+    }
+}

--- a/hooks/useQuizCapture.ts
+++ b/hooks/useQuizCapture.ts
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+import { getTrackingDataObject } from '../utils/whatsapp';
+import type { LeadTracking, LeadUtms } from '../types/leadCapture';
+import type { SubmitQuizRequest, SubmitQuizResponse } from '../types/quiz';
+
+export type SubmitQuizResult =
+    | { ok: true; requestId: string; warning?: string }
+    | { ok: false; requestId?: string; error: string; code: string; status?: number };
+
+function toNullable(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
+}
+
+function captureTrackingState(): { tracking: LeadTracking; utms: LeadUtms } {
+    const source = getTrackingDataObject() || {};
+    const extras: Record<string, string> = {};
+    const knownKeys = new Set([
+        'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content',
+        'cid', 'sid', 'gclid', 'fbclid', 'msclkid', 'ttclid', 'wbraid', 'gbraid', 'fbc', 'fbp',
+    ]);
+
+    for (const [key, value] of Object.entries(source)) {
+        if (knownKeys.has(key) || typeof value !== 'string') continue;
+        const normalized = value.trim();
+        if (!normalized) continue;
+        extras[key] = normalized;
+    }
+
+    const utms: LeadUtms = {
+        utm_source: toNullable(source.utm_source),
+        utm_medium: toNullable(source.utm_medium),
+        utm_campaign: toNullable(source.utm_campaign),
+        utm_term: toNullable(source.utm_term),
+        utm_content: toNullable(source.utm_content),
+    };
+
+    return {
+        utms,
+        tracking: {
+            ...utms,
+            cid: toNullable(source.cid),
+            sid: toNullable(source.sid),
+            gclid: toNullable(source.gclid),
+            fbclid: toNullable(source.fbclid),
+            msclkid: toNullable(source.msclkid),
+            ttclid: toNullable(source.ttclid),
+            wbraid: toNullable(source.wbraid),
+            gbraid: toNullable(source.gbraid),
+            fbc: toNullable(source.fbc),
+            fbp: toNullable(source.fbp),
+            extras: Object.keys(extras).length > 0 ? extras : undefined,
+        },
+    };
+}
+
+function pushQuizDataLayerEvent(payload: SubmitQuizRequest): void {
+    if (typeof window === 'undefined' || !window.dataLayer) return;
+
+    window.dataLayer.push({
+        event: 'quiz_lead',
+        quiz_profile: payload.profileKey,
+        quiz_profile_name: payload.profileName,
+        utm_source: payload.utms.utm_source,
+        utm_medium: payload.utms.utm_medium,
+        utm_campaign: payload.utms.utm_campaign,
+        ga_client_id: payload.tracking?.cid,
+        ga_session_id: payload.tracking?.sid,
+        page_location: window.location.href,
+    });
+
+    window.dataLayer.push({
+        event: 'form_submission',
+        form_type: 'quiz_lead',
+        form_id: 'quiz_anhanga',
+        page_location: window.location.href,
+    });
+}
+
+export function useQuizCapture() {
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [trackingState, setTrackingState] = useState(() => captureTrackingState());
+
+    useEffect(() => {
+        setTrackingState(captureTrackingState());
+    }, []);
+
+    const submitQuiz = async (
+        input: Pick<SubmitQuizRequest, 'firstName' | 'email' | 'whatsapp' | 'profileKey' | 'profileName' | 'bantSummary'>,
+    ): Promise<SubmitQuizResult> => {
+        setError(null);
+        setIsSubmitting(true);
+
+        const latest = captureTrackingState();
+        setTrackingState(latest);
+
+        const payload: SubmitQuizRequest = {
+            ...input,
+            email: input.email.trim().toLowerCase(),
+            firstName: input.firstName.trim(),
+            sourcePage: typeof window !== 'undefined' ? window.location.pathname : '/quiz',
+            utms: latest.utms,
+            tracking: latest.tracking,
+        };
+
+        try {
+            const response = await fetch('/api/submit-quiz', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+
+            const data = await response.json().catch(() => ({})) as Partial<SubmitQuizResponse> & Record<string, unknown>;
+
+            if (!response.ok) {
+                const errMsg = typeof data.error === 'string'
+                    ? data.error
+                    : `Falha ao registrar (status ${response.status}).`;
+                const errCode = typeof data.code === 'string' ? data.code : 'API_ERROR';
+                setError(errMsg);
+                setIsSubmitting(false);
+                return { ok: false, error: errMsg, code: errCode, status: response.status };
+            }
+
+            pushQuizDataLayerEvent(payload);
+            setIsSubmitting(false);
+
+            return {
+                ok: true,
+                requestId: String(data.requestId || response.headers.get('X-Request-Id') || 'unknown'),
+                warning: typeof data.warning === 'string' ? data.warning : undefined,
+            };
+        } catch (requestError: unknown) {
+            const message = requestError instanceof Error
+                ? requestError.message
+                : 'Falha de rede ao enviar resultado.';
+            setError(message);
+            setIsSubmitting(false);
+            return { ok: false, error: message, code: 'NETWORK_ERROR' };
+        }
+    };
+
+    return {
+        tracking: trackingState.tracking,
+        utms: trackingState.utms,
+        isSubmitting,
+        error,
+        submitQuiz,
+    };
+}

--- a/lib/n8n-payloads.ts
+++ b/lib/n8n-payloads.ts
@@ -1,5 +1,6 @@
 import type { SubmitLeadRequest } from '../types/leadCapture';
 import type { SubmitWaitlistRequest } from '../types/waitlist';
+import type { SubmitQuizRequest } from '../types/quiz';
 
 export interface N8nLeadTracking {
     utm_source: string | null;
@@ -123,6 +124,46 @@ export function buildN8nWaitlistPayload(payload: SubmitWaitlistRequest, requestI
         waitlist: {
             name: payload.name,
             email: payload.email,
+            sourcePage: payload.sourcePage,
+        },
+        utms: payload.utms,
+        tracking: payload.tracking,
+        meta: {
+            receivedAt: new Date().toISOString(),
+        },
+    };
+}
+
+export interface N8nQuizPayload {
+    requestId: string;
+    source: 'submit-quiz';
+    quiz: {
+        firstName: string;
+        email: string;
+        whatsapp: string | null;
+        profileKey: string;
+        profileName: string;
+        bantSummary: string;
+        sourcePage: string;
+    };
+    utms: SubmitQuizRequest['utms'];
+    tracking: SubmitQuizRequest['tracking'];
+    meta: {
+        receivedAt: string;
+    };
+}
+
+export function buildN8nQuizPayload(payload: SubmitQuizRequest, requestId: string): N8nQuizPayload {
+    return {
+        requestId,
+        source: 'submit-quiz',
+        quiz: {
+            firstName: payload.firstName,
+            email: payload.email,
+            whatsapp: payload.whatsapp ?? null,
+            profileKey: payload.profileKey,
+            profileName: payload.profileName,
+            bantSummary: payload.bantSummary,
             sourcePage: payload.sourcePage,
         },
         utms: payload.utms,

--- a/lib/quiz-logic.ts
+++ b/lib/quiz-logic.ts
@@ -1,0 +1,53 @@
+import { normalizeNullable, normalizeTracking, normalizeUtms } from './lead-logic';
+import type { SubmitQuizRequest } from '../types/quiz';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const WHATSAPP_MIN_DIGITS = 10;
+
+export function validateQuizPayload(
+    payload: unknown,
+): { valid: true; data: SubmitQuizRequest } | { valid: false; error: string } {
+    if (!payload || typeof payload !== 'object') {
+        return { valid: false, error: 'Payload inválido.' };
+    }
+
+    const raw = payload as Record<string, unknown>;
+    const firstName = normalizeNullable(raw.firstName, 100);
+    const email = normalizeNullable(raw.email)?.toLowerCase() ?? null;
+    const profileKey = normalizeNullable(raw.profileKey, 50);
+    const profileName = normalizeNullable(raw.profileName, 100);
+    const bantSummary = normalizeNullable(raw.bantSummary, 1000);
+    const sourcePage = normalizeNullable(raw.sourcePage, 255) ?? '/quiz';
+
+    if (!firstName || !email || !profileKey || !profileName || !bantSummary) {
+        return { valid: false, error: 'Campos obrigatórios ausentes.' };
+    }
+
+    if (!EMAIL_REGEX.test(email)) {
+        return { valid: false, error: 'Email inválido.' };
+    }
+
+    const rawWhatsapp = typeof raw.whatsapp === 'string' ? raw.whatsapp : '';
+    const whatsappDigits = rawWhatsapp.replace(/\D/g, '');
+    const whatsapp = whatsappDigits.length >= WHATSAPP_MIN_DIGITS
+        ? whatsappDigits
+        : undefined;
+
+    const utms = normalizeUtms(raw.utms);
+    const tracking = normalizeTracking(raw.tracking, utms);
+
+    return {
+        valid: true,
+        data: {
+            firstName,
+            email,
+            whatsapp,
+            profileKey,
+            profileName,
+            bantSummary,
+            sourcePage,
+            utms,
+            tracking,
+        },
+    };
+}

--- a/lib/quiz-logic.ts
+++ b/lib/quiz-logic.ts
@@ -1,8 +1,7 @@
-import { normalizeNullable, normalizeTracking, normalizeUtms } from './lead-logic';
+import { normalizeNullable, normalizeTracking, normalizeUtms, normalizeWhatsappNumber } from './lead-logic';
 import type { SubmitQuizRequest } from '../types/quiz';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const WHATSAPP_MIN_DIGITS = 10;
 
 export function validateQuizPayload(
     payload: unknown,
@@ -27,11 +26,7 @@ export function validateQuizPayload(
         return { valid: false, error: 'Email inválido.' };
     }
 
-    const rawWhatsapp = typeof raw.whatsapp === 'string' ? raw.whatsapp : '';
-    const whatsappDigits = rawWhatsapp.replace(/\D/g, '');
-    const whatsapp = whatsappDigits.length >= WHATSAPP_MIN_DIGITS
-        ? whatsappDigits
-        : undefined;
+    const whatsapp = normalizeWhatsappNumber(raw.whatsapp) ?? undefined;
 
     const utms = normalizeUtms(raw.utms);
     const tracking = normalizeTracking(raw.tracking, utms);

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -362,9 +362,17 @@ interface QuestionScreenProps {
 function QuestionScreen({ q, qIndex, total, value, onChange, onNext, onBack }: QuestionScreenProps) {
     const selected: string[] = value ?? [];
     const [pendingId, setPendingId] = useState<string | null>(null);
+    const advanceTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    // reset pending when question changes
-    useEffect(() => { setPendingId(null); }, [q.id]);
+    // reset pending when question changes and clear any pending timer
+    useEffect(() => {
+        setPendingId(null);
+        return () => {
+            if (advanceTimerRef.current !== null) {
+                clearTimeout(advanceTimerRef.current);
+            }
+        };
+    }, [q.id]);
 
     function toggle(optId: string) {
         if (q.multi) {
@@ -376,7 +384,8 @@ function QuestionScreen({ q, qIndex, total, value, onChange, onNext, onBack }: Q
             onChange([optId]);
             setPendingId(optId);
             // 500ms gives visual confirmation + small undo window before advancing
-            setTimeout(() => {
+            advanceTimerRef.current = setTimeout(() => {
+                advanceTimerRef.current = null;
                 setPendingId(null);
                 onNext();
             }, 500);

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -605,7 +605,7 @@ function getPolaroidImage(imageKey: string): string {
     return `${QUIZ_IMG_BASE}/${imageKey}.webp`;
 }
 
-function Polaroid({ dest, index, accent }: { dest: TravelerDestination; index: number; accent: string }) {
+function Polaroid({ dest, index }: { dest: TravelerDestination; index: number }) {
     const tilts = [-2.4, 1.6, -1.2, 2, -1.8];
     const tilt = tilts[index % tilts.length];
     const imgSrc = getPolaroidImage(dest.imageKey);
@@ -777,7 +777,7 @@ function ResultScreen({ profile, lead, onRestart, baseWaUrl, submitFailed }: Res
                     </div>
                     <div className="quiz-dest-grid">
                         {profile.destinations.map((d, i) => (
-                            <Polaroid key={d.name} dest={d} index={i} accent={profile.color} />
+                            <Polaroid key={d.name} dest={d} index={i} />
                         ))}
                     </div>
                 </div>

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -1,0 +1,953 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { SEO } from '../../components/SEO';
+import { useQuizCapture } from '../../hooks/useQuizCapture';
+import { getWhatsAppLink } from '../../utils/whatsapp';
+import './quiz-anhanga.css';
+
+/* ==========================================================================
+   Dados do quiz
+   ========================================================================== */
+
+interface QuizOption {
+    id: string;
+    label: string;
+    hint?: string;
+    emoji?: string;
+}
+
+interface QuizQuestion {
+    id: string;
+    eyebrow: string;
+    title: string;
+    subtitle?: string;
+    multi: boolean;
+    options: QuizOption[];
+}
+
+const QUIZ_QUESTIONS: QuizQuestion[] = [
+    {
+        id: 'destino',
+        eyebrow: 'Pergunta 01',
+        title: 'Qual canto do mundo te chama?',
+        subtitle: 'Pode escolher mais de um — a gente entende.',
+        multi: true,
+        options: [
+            { id: 'europa',    label: 'Europa',           hint: 'Cidades, vinho, história',      emoji: 'EU' },
+            { id: 'america-n', label: 'América do Norte', hint: 'Parques, road trips, NY',       emoji: 'NA' },
+            { id: 'cruzeiros', label: 'Cruzeiros',        hint: 'Vários destinos, uma cabine',   emoji: 'CR' },
+            { id: 'asia',      label: 'Ásia',             hint: 'Templos, mercado, sushi',       emoji: 'AS' },
+            { id: 'latam',     label: 'América Latina',   hint: 'Cultura viva, vizinho querido', emoji: 'LA' },
+            { id: 'brasil',    label: 'Brasil',           hint: 'O nosso quintal continental',   emoji: 'BR' },
+            { id: 'caribe',    label: 'Caribe',           hint: 'Águas turquesa, ilha em ilha',  emoji: 'CA' },
+        ],
+    },
+    {
+        id: 'perfil',
+        eyebrow: 'Pergunta 02',
+        title: 'Como você gosta de viajar?',
+        subtitle: 'Marca o que mais combina com você.',
+        multi: false,
+        options: [
+            { id: 'aventura', label: 'Aventura & autenticidade', hint: 'Trilhas, locais, fora do mapa' },
+            { id: 'familia',  label: 'Família',                  hint: 'Roteiro pra todas as idades' },
+            { id: 'luxo',     label: 'Luxo & wellness',          hint: 'Spa, vista e silêncio bom' },
+            { id: 'micro',    label: 'Microescapadas',           hint: '3-4 dias e bora' },
+            { id: 'praia',    label: 'Praia',                    hint: 'Pé na areia, descanso' },
+            { id: 'cultural', label: 'Cultural',                 hint: 'Museus, ruas, conversas' },
+        ],
+    },
+    {
+        id: 'companhia',
+        eyebrow: 'Pergunta 03',
+        title: 'Quem vai com você?',
+        multi: false,
+        options: [
+            { id: 'sozinho', label: 'Só eu',           hint: 'Modo livre' },
+            { id: 'casal',   label: 'Eu e meu par',    hint: 'A dois' },
+            { id: 'familia', label: 'Família',          hint: 'Crianças e/ou pais' },
+            { id: 'amigos',  label: 'Turma de amigos', hint: 'Quanto mais, melhor' },
+        ],
+    },
+    {
+        id: 'ritmo',
+        eyebrow: 'Pergunta 04',
+        title: 'Qual o ritmo da viagem?',
+        multi: false,
+        options: [
+            { id: 'corrido',       label: 'Corrido',       hint: 'Quero ver o máximo possível' },
+            { id: 'equilibrado',   label: 'Equilibrado',   hint: 'Um pouco de tudo' },
+            { id: 'contemplativo', label: 'Contemplativo', hint: 'Devagar, com calma' },
+        ],
+    },
+    {
+        id: 'quando',
+        eyebrow: 'Pergunta 05',
+        title: 'Quando você pensa em ir?',
+        multi: false,
+        options: [
+            { id: 'logo',     label: 'Nos próximos 3 meses', hint: 'A mala já tá quase pronta' },
+            { id: 'semestre', label: 'Daqui 3 a 6 meses',    hint: 'Tem tempo de planejar bem' },
+            { id: 'ano',      label: 'Esse ano ainda',       hint: 'Sem pressa, sem preguiça' },
+            { id: 'sonhando', label: 'Só sonhando ainda',    hint: 'Plantando a sementinha' },
+        ],
+    },
+];
+
+interface TravelerDestination {
+    name: string;
+    region: string;
+    tag: string;
+    imageKey: string;
+}
+
+interface TravelerProfile {
+    name: string;
+    tagline: string;
+    description: string;
+    color: 'orange' | 'emerald' | 'blue' | 'sky' | 'yellow';
+    icon: string;
+    destinations: TravelerDestination[];
+}
+
+type ProfileKey = 'aventureiro' | 'contemplativo' | 'cultural' | 'praiano' | 'familia' | 'sibarita';
+
+// imageKey maps to: https://media.anhanga.tur.br/{imageKey}.webp
+const TRAVELER_PROFILES: Record<ProfileKey, TravelerProfile> = {
+    aventureiro: {
+        name: 'Aventureiro',
+        tagline: 'Você troca lobby por trilha sem pensar duas vezes.',
+        description: 'Seu mapa tem mais picos que praias. Procura o local, a comida que ninguém indicou, a história que só quem foi sabe contar. A Anhangá tem gente que viveu esses lugares — e sabe quando te empurrar pro próximo desafio.',
+        color: 'orange',
+        icon: '⛰',
+        destinations: [
+            { name: 'Patagônia',  region: 'Argentina · Chile', tag: 'Trilha + glaciar',    imageKey: 'patagonia' },
+            { name: 'Marrocos',   region: 'África do Norte',   tag: 'Deserto + medina',    imageKey: 'marrocos' },
+            { name: 'Chapada',    region: 'Bahia · Brasil',    tag: 'Cachoeira + cerrado', imageKey: 'chapada' },
+        ],
+    },
+    contemplativo: {
+        name: 'Contemplativo',
+        tagline: 'Você viaja pra desacelerar, não pra colecionar carimbo.',
+        description: 'Prefere uma manhã longa de café numa varanda do que três cidades em três dias. Busca silêncio, vista e gente sem pressa. A Anhangá curadora pousadas onde o wi-fi é fraquinho de propósito.',
+        color: 'emerald',
+        icon: '◐',
+        destinations: [
+            { name: 'Toscana',  region: 'Itália',          tag: 'Vinho + colina', imageKey: 'toscana' },
+            { name: 'Bali',     region: 'Indonésia',       tag: 'Arrozal + spa',  imageKey: 'bali' },
+            { name: 'Trancoso', region: 'Bahia · Brasil',  tag: 'Quadrado + mar', imageKey: 'trancoso' },
+        ],
+    },
+    cultural: {
+        name: 'Curioso Cultural',
+        tagline: 'Você lê o cardápio inteiro antes de pedir — e faz o mesmo com a cidade.',
+        description: 'Museu de manhã, mercado à tarde, restaurante de bairro à noite. Quer entender o lugar, não só ver. A Anhangá monta dia-a-dia com guia que conversa, não que recita.',
+        color: 'blue',
+        icon: '✦',
+        destinations: [
+            { name: 'Lisboa',           region: 'Portugal', tag: 'Bairro + fado', imageKey: 'lisboa' },
+            { name: 'Cidade do México', region: 'México',   tag: 'Arte + tacos',  imageKey: 'cdmx' },
+            { name: 'Quioto',           region: 'Japão',    tag: 'Templo + chá',  imageKey: 'quioto' },
+        ],
+    },
+    praiano: {
+        name: 'Praiano de Alma',
+        tagline: 'Pé na areia é onde sua mente desliga.',
+        description: 'A viagem ideal tem som de onda no fundo. Quer um lugar bonito, água que valha a pena entrar, e jantar com vista pro pôr-do-sol. A Anhangá conhece a praia certa pro seu ritmo — sem turistada.',
+        color: 'sky',
+        icon: '~',
+        destinations: [
+            { name: 'Maragogi', region: 'Alagoas · Brasil',  tag: 'Piscina natural',    imageKey: 'maragogi' },
+            { name: 'Aruba',    region: 'Caribe',            tag: 'Vento + areia branca', imageKey: 'aruba' },
+            { name: 'Maldivas', region: 'Oceano Índico',     tag: 'Bangalô + recife',   imageKey: 'maldivas' },
+        ],
+    },
+    familia: {
+        name: 'Família em Movimento',
+        tagline: 'Viajar com os seus é diversão pra todo mundo, inclusive você.',
+        description: 'Quer um roteiro que funciona pra criança, pra avó e pra você também. Atividade pra todo mundo, hora de descanso, e nada de "espera aí, mais 30 minutinhos". A Anhangá calibra cada dia pra família inteira voltar feliz.',
+        color: 'yellow',
+        icon: '♥',
+        destinations: [
+            { name: 'Orlando',         region: 'EUA',            tag: 'Parque + temático', imageKey: 'orlando' },
+            { name: 'Bariloche',       region: 'Argentina',      tag: 'Neve + lago',       imageKey: 'bariloche' },
+            { name: 'Costa do Sauípe', region: 'Bahia · Brasil', tag: 'Resort + criança',  imageKey: 'sauipe' },
+        ],
+    },
+    sibarita: {
+        name: 'Sibarita',
+        tagline: 'A viagem é um spa contínuo — e você merece.',
+        description: 'Quer suíte com vista, jantar premiado, hora de spa, transfer privativo. Não é luxo gratuito — é tempo bem cuidado. A Anhangá tem a hotelaria que a gente já dormiu, e sabe o quarto certo pra pedir.',
+        color: 'emerald',
+        icon: '◆',
+        destinations: [
+            { name: 'Provence', region: 'França',        tag: 'Château + lavanda', imageKey: 'provence' },
+            { name: 'Mendoza',  region: 'Argentina',     tag: 'Vinho + vinhedo',   imageKey: 'mendoza' },
+            { name: 'Maldivas', region: 'Oceano Índico', tag: 'Bangalô + spa',     imageKey: 'maldivas' },
+        ],
+    },
+};
+
+type QuizAnswers = Record<string, string[]>;
+
+function matchProfile(answers: QuizAnswers): ProfileKey {
+    const perfil = answers.perfil?.[0];
+    const ritmo  = answers.ritmo?.[0];
+    const comp   = answers.companhia?.[0];
+
+    if (perfil === 'familia' || comp === 'familia') return 'familia';
+    if (perfil === 'luxo')    return 'sibarita';
+    if (perfil === 'aventura' && ritmo !== 'contemplativo') return 'aventureiro';
+    if (perfil === 'praia')   return 'praiano';
+    if (perfil === 'cultural') return 'cultural';
+    if (ritmo === 'contemplativo') return 'contemplativo';
+    if (perfil === 'micro')   return 'cultural';
+    return 'aventureiro';
+}
+
+function buildAnswersSummary(answers: QuizAnswers): string {
+    const labels: Record<string, Record<string, string>> = {
+        destino:   { 'europa': 'Europa', 'america-n': 'América do Norte', 'cruzeiros': 'Cruzeiros', 'asia': 'Ásia', 'latam': 'América Latina', 'brasil': 'Brasil', 'caribe': 'Caribe' },
+        perfil:    { aventura: 'Aventura', familia: 'Família', luxo: 'Luxo', micro: 'Microescapadas', praia: 'Praia', cultural: 'Cultural' },
+        companhia: { sozinho: 'Solo', casal: 'Casal', familia: 'Família', amigos: 'Amigos' },
+        ritmo:     { corrido: 'Corrido', equilibrado: 'Equilibrado', contemplativo: 'Contemplativo' },
+        quando:    { logo: 'Até 3 meses', semestre: '3-6 meses', ano: 'Esse ano', sonhando: 'Sonhando' },
+    };
+    return Object.entries(answers)
+        .filter(([, sel]) => sel?.length)
+        .map(([qId, sel]) => {
+            const map = labels[qId];
+            if (!map) return null;
+            return sel.map((id) => map[id] ?? id).join(', ');
+        })
+        .filter(Boolean)
+        .join(' · ');
+}
+
+/* ==========================================================================
+   Tipos do orquestrador
+   ========================================================================== */
+
+type Stage =
+    | { kind: 'hero' }
+    | { kind: 'question'; index: number }
+    | { kind: 'lead' }
+    | { kind: 'result' };
+
+interface LeadForm {
+    nome: string;
+    email: string;
+    aceite: boolean;
+}
+
+/* ==========================================================================
+   Componente: ChunkyQuiz
+   ========================================================================== */
+
+function ChunkyQuiz() {
+    const letters = ['Q', 'U', 'I', 'Z', '!'];
+    const layerColors = ['#FFD600', '#FFB800', '#FF9100', '#F97316', '#EA580C'];
+
+    return (
+        <div className="quiz-chunky-wrap">
+            <div className="quiz-chunky quiz-chunky-layered">
+                {layerColors.map((c, idx) => (
+                    <div
+                        key={idx}
+                        className="quiz-ch-layer"
+                        aria-hidden="true"
+                        style={{
+                            transform: `translate(${(layerColors.length - idx) * 6}px, ${(layerColors.length - idx) * 6}px)`,
+                            color: c,
+                            zIndex: idx,
+                        }}
+                    >
+                        {letters.map((l, i) => <span key={i} className="quiz-ch-letter">{l}</span>)}
+                    </div>
+                ))}
+                <div className="quiz-ch-front" style={{ zIndex: 99 }}>
+                    {letters.map((l, i) => <span key={i} className="quiz-ch-letter">{l}</span>)}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/* ==========================================================================
+   Componente: HeroScreen
+   ========================================================================== */
+
+function HeroScreen({ onStart }: { onStart: () => void }) {
+    return (
+        <div className="quiz-screen quiz-screen-hero">
+            <div className="quiz-hero-deco-stars" aria-hidden="true">
+                <span className="quiz-deco-star quiz-deco-star-1">✦</span>
+                <span className="quiz-deco-star quiz-deco-star-2">✦</span>
+                <span className="quiz-deco-star quiz-deco-star-3">✦</span>
+                <span className="quiz-deco-star quiz-deco-star-4">✦</span>
+            </div>
+            <div className="quiz-hero-content">
+                <div className="quiz-hero-eyebrow">
+                    <span className="quiz-pill-hero">
+                        <span className="dot" />
+                        ANHANGÁ VIAGENS
+                    </span>
+                </div>
+                <h1 className="quiz-hero-h1">
+                    <span className="quiz-h1-line--top">Descubra seu</span>
+                    <span className="quiz-h1-keyword">próximo destino</span>
+                </h1>
+                <div className="quiz-chunky-block">
+                    <ChunkyQuiz />
+                </div>
+                <p className="quiz-hero-sub">
+                    5 perguntinhas rápidas. No final, a gente revela seu{' '}
+                    <em>perfil de viajante</em> e os destinos que combinam com você.
+                </p>
+                <div className="quiz-hero-cta">
+                    <button className="quiz-btn quiz-btn-primary quiz-btn-lg quiz-btn--hero" onClick={onStart}>
+                        Bora começar
+                        <span className="quiz-arrow">→</span>
+                    </button>
+                    <span className="quiz-hero-meta">⏱ 90 segundos · 100% gratuito</span>
+                </div>
+                <div className="quiz-hero-tape" aria-hidden="true">
+                    <span className="quiz-tape-tilt">PARA QUEM AINDA NÃO SABE PRA ONDE IR</span>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/* ==========================================================================
+   Componente: Progress
+   ========================================================================== */
+
+const PROGRESS_MILESTONES: Record<number, string> = {
+    3: 'Na metade!',
+    5: 'Última!',
+};
+
+function Progress({ current, total }: { current: number; total: number }) {
+    const pct = (current / total) * 100;
+    const milestone = PROGRESS_MILESTONES[current];
+    return (
+        <div className="quiz-progress">
+            <div className="quiz-progress-text" aria-live="polite">
+                {milestone
+                    ? <span key={current} className="quiz-progress-milestone">{milestone}</span>
+                    : `${current}/${total}`
+                }
+            </div>
+            <div className="quiz-progress-bar" role="progressbar" aria-valuenow={current} aria-valuemin={1} aria-valuemax={total}>
+                <div className="quiz-progress-fill" style={{ width: `${pct}%` }} />
+            </div>
+        </div>
+    );
+}
+
+/* ==========================================================================
+   Componente: QuestionScreen — auto-avanço com feedback visual de 500ms
+   ========================================================================== */
+
+interface QuestionScreenProps {
+    q: QuizQuestion;
+    qIndex: number;
+    total: number;
+    value: string[] | undefined;
+    onChange: (v: string[]) => void;
+    onNext: () => void;
+    onBack: () => void;
+}
+
+function QuestionScreen({ q, qIndex, total, value, onChange, onNext, onBack }: QuestionScreenProps) {
+    const selected: string[] = value ?? [];
+    const [pendingId, setPendingId] = useState<string | null>(null);
+
+    // reset pending when question changes
+    useEffect(() => { setPendingId(null); }, [q.id]);
+
+    function toggle(optId: string) {
+        if (q.multi) {
+            const next = selected.includes(optId)
+                ? selected.filter((x) => x !== optId)
+                : [...selected, optId];
+            onChange(next);
+        } else {
+            onChange([optId]);
+            setPendingId(optId);
+            // 500ms gives visual confirmation + small undo window before advancing
+            setTimeout(() => {
+                setPendingId(null);
+                onNext();
+            }, 500);
+        }
+    }
+
+    const isSelected = (optId: string) => selected.includes(optId);
+    const isTight = q.options.length > 4;
+
+    return (
+        <div className="quiz-screen quiz-screen-question">
+            <div className="quiz-q-top">
+                <button className="quiz-q-back" onClick={onBack} aria-label="Voltar">
+                    ← voltar
+                </button>
+                <Progress current={qIndex + 1} total={total} />
+            </div>
+            <div className="quiz-q-body">
+                <div className="quiz-q-eyebrow">
+                    <span className="quiz-pill-q">{q.eyebrow}</span>
+                </div>
+                <h2 className="quiz-q-title">{q.title}</h2>
+                {q.subtitle && <p className="quiz-q-subtitle">{q.subtitle}</p>}
+
+                <div className={`quiz-opt-grid quiz-opt-grid--pills quiz-opt-grid--${isTight ? 'tight' : 'roomy'}`}>
+                    {q.options.map((opt, i) => (
+                        <button
+                            key={opt.id}
+                            className={[
+                                'quiz-opt quiz-opt--pills',
+                                isSelected(opt.id) ? 'is-selected' : '',
+                                pendingId === opt.id ? 'is-confirming' : '',
+                            ].join(' ').trim()}
+                            onClick={() => !pendingId && toggle(opt.id)}
+                            disabled={!q.multi && pendingId !== null && pendingId !== opt.id}
+                            style={{ ['--opt-i' as string]: i }}
+                        >
+                            <span className="quiz-opt-label">{opt.label}</span>
+                            <span className="quiz-opt-check" aria-hidden="true">✓</span>
+                        </button>
+                    ))}
+                </div>
+
+                {q.multi && (
+                    <div className="quiz-q-foot">
+                        <button
+                            className="quiz-btn quiz-btn-primary"
+                            disabled={selected.length === 0}
+                            onClick={onNext}
+                        >
+                            Próxima
+                            <span className="quiz-arrow">→</span>
+                        </button>
+                        <span className="quiz-q-foot-meta">
+                            {selected.length === 1 ? '1 escolhido' : `${selected.length} escolhidos`}
+                        </span>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+/* ==========================================================================
+   Componente: PreLeadScreen — passo 1: nome + email antes do resultado
+   ========================================================================== */
+
+interface PreLeadScreenProps {
+    onSubmit: (form: LeadForm) => void;
+    onBack: () => void;
+    isSubmitting: boolean;
+}
+
+function PreLeadScreen({ onSubmit, onBack, isSubmitting }: PreLeadScreenProps) {
+    const [form, setForm] = useState<LeadForm>({ nome: '', email: '', aceite: false });
+    const [errors, setErrors] = useState<Partial<Record<keyof LeadForm, string>>>({});
+
+    function update<K extends keyof LeadForm>(k: K, v: LeadForm[K]) {
+        setForm((f) => ({ ...f, [k]: v }));
+        setErrors((e) => ({ ...e, [k]: undefined }));
+    }
+
+    function submit(e: React.FormEvent) {
+        e.preventDefault();
+        const errs: typeof errors = {};
+        if (!form.nome.trim()) errs.nome = 'Conta pra gente seu nome';
+        if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(form.email)) errs.email = 'E-mail inválido';
+        if (!form.aceite) errs.aceite = 'Precisa do aceite pra continuar';
+        if (Object.keys(errs).length) { setErrors(errs); return; }
+        onSubmit(form);
+    }
+
+    return (
+        <div className="quiz-screen quiz-screen-lead">
+            <div className="quiz-q-top">
+                <button className="quiz-q-back" onClick={onBack} aria-label="Voltar">← voltar</button>
+                <span className="quiz-q-step">Último passo!</span>
+            </div>
+
+            <div className="quiz-lead-card">
+                <span className="quiz-stamp-lead">QUASE LÁ</span>
+                <h2 className="quiz-lead-title">A quem entregamos seu perfil?</h2>
+                <p className="quiz-lead-sub">
+                    Só falta um detalhe. Coloca seu nome e e-mail e a gente mostra tudo.
+                    Sem spam, palavra de viajante.
+                </p>
+
+                <form className="quiz-lead-form" onSubmit={submit}>
+                    <div className="quiz-field">
+                        <label htmlFor="quiz-nome">Como podemos te chamar?</label>
+                        <input
+                            id="quiz-nome"
+                            type="text"
+                            placeholder="Seu nome"
+                            value={form.nome}
+                            onChange={(e) => update('nome', e.target.value)}
+                            className={errors.nome ? 'has-error' : ''}
+                            disabled={isSubmitting}
+                            autoComplete="given-name"
+                        />
+                        {errors.nome && <span className="quiz-err">{errors.nome}</span>}
+                    </div>
+
+                    <div className="quiz-field">
+                        <label htmlFor="quiz-email">E-mail</label>
+                        <input
+                            id="quiz-email"
+                            type="email"
+                            placeholder="voce@email.com"
+                            value={form.email}
+                            onChange={(e) => update('email', e.target.value)}
+                            className={errors.email ? 'has-error' : ''}
+                            disabled={isSubmitting}
+                            autoComplete="email"
+                        />
+                        {errors.email && <span className="quiz-err">{errors.email}</span>}
+                    </div>
+
+                    <label className="quiz-check">
+                        <input
+                            type="checkbox"
+                            checked={form.aceite}
+                            onChange={(e) => update('aceite', e.target.checked)}
+                            disabled={isSubmitting}
+                        />
+                        <span className="quiz-check-box" aria-hidden="true" />
+                        <span className="quiz-check-label">
+                            Topo receber novidades e ofertas da Anhangá. Posso cancelar quando quiser.
+                            Veja nossa <a href="/politica-privacidade">política de privacidade</a>.
+                        </span>
+                    </label>
+                    {errors.aceite && <span className="quiz-err quiz-err-block">É só marcar a caixinha acima para continuar.</span>}
+
+                    <button type="submit" className="quiz-btn quiz-btn-primary quiz-btn-lg" disabled={isSubmitting}>
+                        {isSubmitting ? 'Calculando seu perfil…' : 'Ver meu perfil'}
+                        {!isSubmitting && <span className="quiz-arrow">→</span>}
+                    </button>
+                </form>
+            </div>
+        </div>
+    );
+}
+
+/* ==========================================================================
+   Componente: Confetti
+   ========================================================================== */
+
+interface ConfettiPiece {
+    id: number; left: number; delay: number; duration: number;
+    rotate: number; drift: number; size: number; color: string;
+    shape: 'paper' | 'circle' | 'star';
+}
+
+const CONF_SHAPES: ConfettiPiece['shape'][] = [
+    'paper', 'paper', 'paper', 'circle', 'star',
+    'paper', 'circle', 'paper', 'paper', 'star',
+];
+
+function Confetti({ active }: { active: boolean }) {
+    const pieces = useMemo<ConfettiPiece[]>(() => {
+        return Array.from({ length: 70 }).map((_, i) => ({
+            id: i,
+            left: Math.random() * 100,
+            delay: Math.random() * 0.5,
+            duration: 2.2 + Math.random() * 2.2,
+            rotate: Math.random() * 720 - 360,
+            drift: (Math.random() - 0.5) * 240,
+            size: 7 + Math.random() * 11,
+            color: ['#FFD600', '#0ea5e9', '#ea580c', '#10b981', '#f97316', '#ffffff'][i % 6],
+            shape: CONF_SHAPES[i % CONF_SHAPES.length],
+        }));
+    }, []);
+
+    if (!active) return null;
+
+    return (
+        <div className="quiz-confetti" aria-hidden="true">
+            {pieces.map((p) => (
+                <span
+                    key={p.id}
+                    className={`quiz-conf quiz-conf--${p.shape}`}
+                    style={{
+                        left: `${p.left}%`,
+                        animationDelay: `${p.delay}s`,
+                        animationDuration: `${p.duration}s`,
+                        ['--rot' as string]: `${p.rotate}deg`,
+                        ['--drift' as string]: `${p.drift}px`,
+                        ['--size' as string]: `${p.size}px`,
+                        ['--color' as string]: p.color,
+                    }}
+                >
+                    {p.shape === 'star' ? '★' : null}
+                </span>
+            ))}
+        </div>
+    );
+}
+
+/* ==========================================================================
+   Componente: Polaroid — com imagem Cloudflare
+   ========================================================================== */
+
+const QUIZ_IMG_BASE = 'https://media.anhanga.tur.br';
+
+function getPolaroidImage(imageKey: string): string {
+    return `${QUIZ_IMG_BASE}/${imageKey}.webp`;
+}
+
+function Polaroid({ dest, index, accent }: { dest: TravelerDestination; index: number; accent: string }) {
+    const tilts = [-2.4, 1.6, -1.2, 2, -1.8];
+    const tilt = tilts[index % tilts.length];
+    const imgSrc = getPolaroidImage(dest.imageKey);
+
+    return (
+        <div
+            className="quiz-polaroid"
+            style={{ ['--tilt' as string]: `${tilt}deg`, ['--delay' as string]: `${index * 120}ms` }}
+        >
+            <div className="quiz-pol-tape" aria-hidden="true" />
+            <div className="quiz-pol-img quiz-pol-img--photo">
+                <img
+                    src={imgSrc}
+                    alt={dest.name}
+                    loading={index === 0 ? 'eager' : 'lazy'}
+                    decoding="async"
+                    width={440}
+                    height={330}
+                />
+                <span className="quiz-pol-img-label">{dest.region.toUpperCase()}</span>
+            </div>
+            <div className="quiz-pol-cap">
+                <strong>{dest.name}</strong>
+                <em>{dest.tag}</em>
+            </div>
+        </div>
+    );
+}
+
+/* ==========================================================================
+   Componente: WhatsAppUpgrade — passo 2: WhatsApp opcional no resultado
+   ========================================================================== */
+
+interface WhatsAppUpgradeProps {
+    profileName: string;
+    firstName: string;
+    baseWaUrl: string;
+}
+
+function WhatsAppUpgrade({ profileName, firstName, baseWaUrl }: WhatsAppUpgradeProps) {
+    const [phone, setPhone] = useState('');
+    const [submitted, setSubmitted] = useState(false);
+
+    function maskPhone(v: string): string {
+        const d = v.replace(/\D/g, '').slice(0, 11);
+        if (d.length <= 2) return d;
+        if (d.length <= 6) return `(${d.slice(0, 2)}) ${d.slice(2)}`;
+        if (d.length <= 10) return `(${d.slice(0, 2)}) ${d.slice(2, 6)}-${d.slice(6)}`;
+        return `(${d.slice(0, 2)}) ${d.slice(2, 7)}-${d.slice(7)}`;
+    }
+
+    const digits = phone.replace(/\D/g, '');
+    const isValid = digits.length >= 10;
+
+    const waUrl = isValid && submitted
+        ? getWhatsAppLink(
+            `Oi! Sou ${firstName} e meu perfil é ${profileName}. Bora montar minha viagem?`,
+            { appendTrackingRef: true },
+          )
+        : baseWaUrl;
+
+    if (submitted) {
+        return (
+            <div className="quiz-wa-upgrade quiz-wa-upgrade--done">
+                <p className="quiz-wa-upgrade-done">
+                    Perfeito! Agora é só abrir o WhatsApp.
+                </p>
+                <a
+                    className="quiz-btn quiz-btn-primary quiz-btn-lg"
+                    href={waUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Montar minha viagem
+                    <span className="quiz-arrow">→</span>
+                </a>
+            </div>
+        );
+    }
+
+    return (
+        <div className="quiz-wa-upgrade">
+            <p className="quiz-wa-upgrade-label">
+                Quer guardar seu perfil no WhatsApp?
+            </p>
+            <div className="quiz-wa-upgrade-row">
+                <input
+                    type="tel"
+                    className="quiz-wa-input"
+                    placeholder="(11) 99999-9999"
+                    value={phone}
+                    onChange={(e) => setPhone(maskPhone(e.target.value))}
+                    aria-label="Número de WhatsApp (opcional)"
+                />
+                <button
+                    type="button"
+                    className={`quiz-btn quiz-btn-primary ${isValid ? 'quiz-btn--ready' : ''}`}
+                    onClick={() => isValid && setSubmitted(true)}
+                    disabled={!isValid}
+                >
+                    Enviar
+                </button>
+            </div>
+            <a
+                className="quiz-wa-skip"
+                href={baseWaUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                Ir pro WhatsApp sem deixar número →
+            </a>
+        </div>
+    );
+}
+
+/* ==========================================================================
+   Componente: ResultScreen — reveal escalonado + upgrade de WhatsApp
+   ========================================================================== */
+
+interface ResultScreenProps {
+    profile: TravelerProfile;
+    lead: LeadForm;
+    onRestart: () => void;
+    baseWaUrl: string;
+    submitFailed: boolean;
+}
+
+function ResultScreen({ profile, lead, onRestart, baseWaUrl, submitFailed }: ResultScreenProps) {
+    const [reveal, setReveal] = useState(false);
+    const firstName = lead.nome.trim().split(/\s+/)[0] || 'Viajante';
+
+    useEffect(() => {
+        const t = setTimeout(() => setReveal(true), 300);
+        return () => clearTimeout(t);
+    }, []);
+
+    const revealed = reveal ? 'is-revealed' : '';
+
+    return (
+        <div className="quiz-screen quiz-screen-result">
+            <Confetti active={reveal} />
+
+            <div className={`quiz-result-inner ${revealed}`} aria-live="polite" aria-atomic="false">
+
+                {/* Bloco 0 — pill de eyebrow */}
+                <div className="quiz-reveal-block quiz-result-eyebrow" style={{ ['--reveal-delay' as string]: '0ms' }}>
+                    <span className="quiz-pill-result">RESULTADO · {firstName}</span>
+                </div>
+
+                {/* Bloco 1 — "Você é um(a)..." + nome do perfil — PICO EMOCIONAL */}
+                <div className="quiz-reveal-block quiz-result-peak" style={{ ['--reveal-delay' as string]: '180ms' }}>
+                    <p className="quiz-result-lead">Você é:</p>
+                    <div className={`quiz-result-name quiz-result-color--${profile.color}`}>
+                        <span className="quiz-result-icon" aria-hidden="true">{profile.icon}</span>
+                        <h2 className="quiz-result-h2">{profile.name}</h2>
+                    </div>
+                </div>
+
+                {/* Bloco 2 — tagline + descrição */}
+                <div className="quiz-reveal-block" style={{ ['--reveal-delay' as string]: '480ms' }}>
+                    <p className="quiz-result-tagline">{profile.tagline}</p>
+                    <p className="quiz-result-desc">{profile.description}</p>
+                </div>
+
+                {/* Bloco 3 — destinos */}
+                <div className="quiz-reveal-block" style={{ ['--reveal-delay' as string]: '680ms' }}>
+                    <div className="quiz-result-eyebrow quiz-result-eyebrow--mid">
+                        <span className="quiz-pill-soft">DESTINOS QUE COMBINAM</span>
+                    </div>
+                    <div className="quiz-dest-grid">
+                        {profile.destinations.map((d, i) => (
+                            <Polaroid key={d.name} dest={d} index={i} accent={profile.color} />
+                        ))}
+                    </div>
+                </div>
+
+                {/* Bloco 4 — upgrade WhatsApp + CTA */}
+                <div className="quiz-reveal-block" style={{ ['--reveal-delay' as string]: '900ms' }}>
+                    <WhatsAppUpgrade
+                        profileName={profile.name}
+                        firstName={firstName}
+                        baseWaUrl={baseWaUrl}
+                    />
+                    <button className="quiz-btn quiz-btn-ghost quiz-result-restart" onClick={onRestart}>
+                        Refazer o quiz
+                    </button>
+                </div>
+
+                {/* Bloco 5 — fineprint + erro de API */}
+                <div className="quiz-reveal-block" style={{ ['--reveal-delay' as string]: '1000ms' }}>
+                    {submitFailed ? (
+                        <p className="quiz-result-fineprint quiz-result-fineprint--warn">
+                            Algo deu errado ao salvar seus dados. Use o WhatsApp acima para garantir o contato.
+                        </p>
+                    ) : (
+                        <p className="quiz-result-fineprint">
+                            Nossa equipe entra em contato pelo e-mail que você informou em breve.
+                        </p>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/* ==========================================================================
+   Componente principal
+   ========================================================================== */
+
+export default function QuizAnhangaLanding() {
+    const [stage, setStage] = useState<Stage>({ kind: 'hero' });
+    const [direction, setDirection] = useState<'forward' | 'back'>('forward');
+    const [answers, setAnswers] = useState<QuizAnswers>({});
+    const [leadForm, setLeadForm] = useState<LeadForm | null>(null);
+    const [profileKey, setProfileKey] = useState<ProfileKey | null>(null);
+    const [baseWaUrl, setBaseWaUrl] = useState('');
+    const [submitFailed, setSubmitFailed] = useState(false);
+    const { submitQuiz, isSubmitting } = useQuizCapture();
+
+    const go = useCallback((next: Stage, dir: 'forward' | 'back' = 'forward') => {
+        setDirection(dir);
+        setStage(next);
+        window.scrollTo(0, 0);
+    }, []);
+
+    function start() { go({ kind: 'question', index: 0 }); }
+
+    function answerQ(qId: string, value: string[]) {
+        setAnswers((a) => ({ ...a, [qId]: value }));
+    }
+
+    function nextQ(currentIndex: number) {
+        if (currentIndex + 1 >= QUIZ_QUESTIONS.length) {
+            go({ kind: 'lead' });
+        } else {
+            go({ kind: 'question', index: currentIndex + 1 });
+        }
+    }
+
+    function backQ(currentIndex: number) {
+        if (currentIndex === 0) go({ kind: 'hero' }, 'back');
+        else go({ kind: 'question', index: currentIndex - 1 }, 'back');
+    }
+
+    async function handleLeadSubmit(form: LeadForm) {
+        const pKey = matchProfile(answers);
+        const profile = TRAVELER_PROFILES[pKey];
+
+        const names = form.nome.trim().split(/\s+/);
+        const firstName = names[0] || form.nome.trim();
+        const bantSummary = `Quiz Anhangá · Perfil: ${profile.name} · ${buildAnswersSummary(answers)}`;
+
+        const waMsg = `Oi! Sou ${form.nome} e descobri no Quiz da Anhangá que sou um(a) ${profile.name}. Bora montar minha viagem?`;
+        const waUrl = getWhatsAppLink(waMsg, { appendTrackingRef: true });
+
+        // Avança para o resultado imediatamente — API roda em paralelo
+        setLeadForm(form);
+        setProfileKey(pKey);
+        setBaseWaUrl(waUrl);
+        setSubmitFailed(false);
+        go({ kind: 'result' });
+
+        const result = await submitQuiz({
+            firstName,
+            email: form.email,
+            profileKey: pKey,
+            profileName: profile.name,
+            bantSummary,
+        });
+
+        if (!result.ok) {
+            setSubmitFailed(true);
+        }
+    }
+
+    function restart() {
+        setAnswers({});
+        setLeadForm(null);
+        setProfileKey(null);
+        setBaseWaUrl('');
+        setSubmitFailed(false);
+        go({ kind: 'hero' }, 'back');
+    }
+
+    const stageKey = stage.kind === 'question' ? `q-${stage.index}` : stage.kind;
+
+    function renderStage() {
+        if (stage.kind === 'hero') return <HeroScreen onStart={start} />;
+        if (stage.kind === 'question') {
+            const q = QUIZ_QUESTIONS[stage.index];
+            return (
+                <QuestionScreen
+                    q={q}
+                    qIndex={stage.index}
+                    total={QUIZ_QUESTIONS.length}
+                    value={answers[q.id]}
+                    onChange={(v) => answerQ(q.id, v)}
+                    onNext={() => nextQ(stage.index)}
+                    onBack={() => backQ(stage.index)}
+                />
+            );
+        }
+        if (stage.kind === 'lead') {
+            return (
+                <PreLeadScreen
+                    onSubmit={handleLeadSubmit}
+                    onBack={() => go({ kind: 'question', index: QUIZ_QUESTIONS.length - 1 }, 'back')}
+                    isSubmitting={isSubmitting}
+                />
+            );
+        }
+        if (stage.kind === 'result' && profileKey && leadForm) {
+            return (
+                <ResultScreen
+                    profile={TRAVELER_PROFILES[profileKey]}
+                    lead={leadForm}
+                    onRestart={restart}
+                    baseWaUrl={baseWaUrl}
+                    submitFailed={submitFailed}
+                />
+            );
+        }
+        return null;
+    }
+
+    return (
+        <>
+            <SEO
+                title="Quiz de Destinos | Descubra seu próximo rolê — Anhangá Viagens"
+                description="5 perguntas rápidas para descobrir seu perfil de viajante e os destinos que mais combinam com você. Gratuito e sem compromisso."
+                canonical="https://www.anhanga.tur.br/quiz/"
+                noHreflang
+            />
+            <div className="quiz-page">
+                <div className="quiz-app">
+                    <div className={`quiz-stage quiz-stage--slide quiz-stage--${direction}`}>
+                        <div className="quiz-stage-inner" key={stageKey}>
+                            {renderStage()}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/pages/landings/quiz-anhanga.css
+++ b/pages/landings/quiz-anhanga.css
@@ -398,7 +398,6 @@
 .quiz-opt--pills {
   border-radius: 9999px;
   padding: 16px 28px 16px 30px;
-  min-height: 48px;
   display: inline-flex;
   flex-direction: row;
   align-items: center;

--- a/pages/landings/quiz-anhanga.css
+++ b/pages/landings/quiz-anhanga.css
@@ -1,0 +1,1046 @@
+/* ==========================================================================
+   Anhangá Quiz — Estilos da landing page /quiz
+   Tokens baseados em colors_and_type.css do design system
+   ========================================================================== */
+
+:root {
+  --av-blue:          #0056D2;
+  --av-action:        #0ea5e9;
+  --av-action-dark:   #0284c7;
+  --av-yellow:        #FFD600;
+  --av-yellow-hover:  #E5C000;
+  --av-dark:          #0f172a;
+  --av-light:         #F4F8FF;
+  --av-cream:         #fffdf5;
+
+  --av-orange-100:    #ffedd5;
+  --av-orange-200:    #fed7aa;
+  --av-orange-600:    #ea580c;
+  --av-emerald-100:   #d1fae5;
+  --av-emerald-200:   #a7f3d0;
+  --av-emerald-500:   #10b981;
+  --av-blue-100:      #dbeafe;
+  --av-blue-200:      #bfdbfe;
+  --av-sky-200:       #bae6fd;
+  --av-yellow-200:    #fef08a;
+  --av-red-500:       #ef4444;
+
+  --av-gray-200:      #e5e7eb;
+  --av-gray-400:      #9ca3af;
+  --av-gray-500:      #6b7280;
+  --av-gray-600:      #4b5563;
+
+  --av-fg-1:          var(--av-dark);
+  --av-fg-2:          var(--av-gray-600);
+  --av-fg-3:          var(--av-gray-500);
+  --av-border:        var(--av-gray-200);
+
+  --av-font-display:  'Poppins', ui-sans-serif, system-ui, sans-serif;
+  --av-font-body:     'Poppins', ui-sans-serif, system-ui, sans-serif;
+  --av-font-serif:    'Merriweather', Georgia, serif;
+  --av-font-mono:     ui-monospace, 'SF Mono', Menlo, Monaco, Consolas, monospace;
+
+  --av-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --av-ease-out:    cubic-bezier(0.22, 1, 0.36, 1);
+
+  --quiz-turquoise:      #0FB6C5;
+  --quiz-turquoise-deep: #0795a3;
+  --layer-4: #FF9100;
+}
+
+/* ============== LAYOUT ============== */
+.quiz-page * { box-sizing: border-box; }
+
+.quiz-app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--av-cream);
+}
+
+/* ============== STAGE / TRANSITIONS ============== */
+.quiz-stage {
+  flex: 1;
+  display: flex;
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  perspective: 1600px;
+}
+.quiz-stage-inner {
+  flex: 1;
+  width: 100%;
+  display: flex;
+}
+.quiz-stage--slide.quiz-stage--forward .quiz-stage-inner {
+  animation: qSlideInFwd 520ms var(--av-ease-out) both;
+}
+.quiz-stage--slide.quiz-stage--back .quiz-stage-inner {
+  animation: qSlideInBack 520ms var(--av-ease-out) both;
+}
+.quiz-stage--fade .quiz-stage-inner {
+  animation: qFadeIn 520ms var(--av-ease-out) both;
+}
+.quiz-stage--flip .quiz-stage-inner {
+  transform-style: preserve-3d;
+  animation: qFlipIn 700ms var(--av-ease-out) both;
+}
+@keyframes qSlideInFwd  { from { transform: translateX(60px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes qSlideInBack { from { transform: translateX(-60px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes qFadeIn      { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes qFlipIn      { from { transform: rotateY(28deg) scale(0.94); opacity: 0; } to { transform: rotateY(0) scale(1); opacity: 1; } }
+
+.quiz-screen { flex: 1; width: 100%; display: flex; flex-direction: column; }
+
+/* ============== HERO ============== */
+.quiz-screen-hero {
+  background: var(--quiz-turquoise);
+  color: white;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 32px;
+  background-image:
+    radial-gradient(circle at 12% 18%, rgba(255,255,255,0.10), transparent 40%),
+    radial-gradient(circle at 88% 78%, rgba(15,23,42,0.10), transparent 50%);
+}
+.quiz-hero-content {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  max-width: 1100px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+.quiz-pill-hero {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: rgba(255,255,255,0.95);
+  color: var(--av-dark);
+  border: 2px solid var(--av-dark);
+  padding: 10px 20px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  box-shadow: 4px 4px 0 var(--av-dark);
+  font-family: var(--av-font-display);
+  text-transform: uppercase;
+  white-space: nowrap;
+  line-height: 1;
+}
+.quiz-pill-hero .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--av-yellow); flex-shrink: 0; }
+
+.quiz-hero-h1 {
+  font-family: var(--av-font-display);
+  font-weight: 800;
+  font-size: clamp(28px, 3.6vw, 44px);
+  line-height: 1;
+  color: white;
+  letter-spacing: -0.025em;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  text-shadow: 2px 2px 0 rgba(15,23,42,0.18);
+}
+.quiz-h1-line--top {
+  font-weight: 600;
+  font-style: italic;
+  font-family: var(--av-font-serif);
+  font-size: clamp(20px, 2.2vw, 28px);
+  letter-spacing: 0;
+  color: rgba(255,255,255,0.92);
+  text-shadow: none;
+}
+.quiz-h1-keyword {
+  position: relative;
+  display: inline-block;
+  padding: 4px 14px;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  text-transform: uppercase;
+  color: var(--av-dark);
+  background: var(--av-yellow);
+  border: 3px solid var(--av-dark);
+  border-radius: 10px;
+  box-shadow: 5px 5px 0 var(--av-dark);
+  transform: rotate(-1.5deg);
+  text-shadow: none;
+}
+.quiz-hero-sub {
+  font-size: clamp(16px, 1.6vw, 20px);
+  color: rgba(255,255,255,0.95);
+  max-width: 620px;
+  font-weight: 500;
+  line-height: 1.5;
+  margin: 0;
+}
+.quiz-hero-sub em {
+  font-family: var(--av-font-serif);
+  font-style: italic;
+  color: var(--av-yellow);
+  font-weight: 700;
+}
+.quiz-hero-cta { display: flex; flex-direction: column; align-items: center; gap: 14px; margin-top: 8px; }
+.quiz-hero-meta { font-size: 13px; color: rgba(255,255,255,0.85); font-weight: 600; letter-spacing: 0.04em; }
+.quiz-hero-tape { margin-top: 32px; }
+.quiz-tape-tilt {
+  display: inline-block;
+  background: var(--av-yellow);
+  color: var(--av-dark);
+  font-family: var(--av-font-display);
+  font-weight: 800;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  padding: 8px 18px;
+  border: 2px solid var(--av-dark);
+  transform: rotate(-1.5deg);
+  box-shadow: 3px 3px 0 var(--av-dark);
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+.quiz-hero-deco-stars { position: absolute; inset: 0; pointer-events: none; z-index: 1; }
+.quiz-deco-star {
+  position: absolute;
+  font-family: var(--av-font-display);
+  font-weight: 800;
+  color: var(--av-yellow);
+  opacity: 0.9;
+  animation: qStarWiggle 4s ease-in-out infinite;
+}
+.quiz-deco-star-1 { top: 10%;  left: 8%;   font-size: 32px; animation-delay: 0s; }
+.quiz-deco-star-2 { top: 18%;  right: 12%; font-size: 22px; animation-delay: 0.6s; color: white; }
+.quiz-deco-star-3 { bottom: 16%; left: 14%; font-size: 26px; animation-delay: 1.2s; color: white; }
+.quiz-deco-star-4 { bottom: 22%; right: 9%; font-size: 36px; animation-delay: 1.8s; }
+@keyframes qStarWiggle { 0%,100%{ transform: rotate(-8deg) scale(1);} 50%{ transform: rotate(8deg) scale(1.1);} }
+
+/* ============== CHUNKY QUIZ! ============== */
+.quiz-chunky-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin: 12px 0 28px;
+}
+.quiz-chunky-wrap {
+  --cq-scale: 1;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding-right: 30px;
+}
+.quiz-chunky {
+  position: relative;
+  display: inline-block;
+  font-family: var(--av-font-display);
+  font-weight: 800;
+  font-size: clamp(110px, 18vw, 220px);
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  font-style: italic;
+  transform: scale(var(--cq-scale));
+}
+.quiz-chunky .quiz-ch-letter { display: inline-block; }
+.quiz-chunky-layered { filter: drop-shadow(2px 2px 0 rgba(15,23,42,0.25)); }
+.quiz-chunky-layered .quiz-ch-front { position: relative; color: white; -webkit-text-stroke: 3px var(--av-dark); }
+.quiz-chunky-layered .quiz-ch-layer { position: absolute; top: 0; left: 0; pointer-events: none; -webkit-text-stroke: 3px var(--av-dark); }
+.quiz-chunky-outline { color: transparent; -webkit-text-stroke: 5px white; }
+.quiz-chunky-solid { color: var(--av-yellow); -webkit-text-stroke: 4px var(--av-dark); text-shadow: 8px 8px 0 var(--av-dark); }
+
+.quiz-chunky .quiz-ch-letter { animation: qLetterPop 600ms var(--av-ease-spring) both; }
+.quiz-chunky .quiz-ch-letter:nth-child(1){ animation-delay: 60ms; }
+.quiz-chunky .quiz-ch-letter:nth-child(2){ animation-delay: 140ms; }
+.quiz-chunky .quiz-ch-letter:nth-child(3){ animation-delay: 220ms; }
+.quiz-chunky .quiz-ch-letter:nth-child(4){ animation-delay: 300ms; }
+.quiz-chunky .quiz-ch-letter:nth-child(5){ animation-delay: 380ms; }
+@keyframes qLetterPop { from { opacity: 0; transform: translateY(40px) scale(.7); } to { opacity: 1; transform: translateY(0) scale(1); } }
+
+/* ============== BUTTONS ============== */
+.quiz-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 10px;
+  border: 2px solid var(--av-dark);
+  border-radius: 9999px;
+  padding: 14px 28px;
+  font-family: var(--av-font-display);
+  font-weight: 800;
+  font-size: 15px;
+  cursor: pointer;
+  text-decoration: none;
+  color: var(--av-dark);
+  transition: transform .2s var(--av-ease-spring), box-shadow .2s ease, background .2s;
+  background: none;
+}
+.quiz-btn-lg { padding: 18px 36px; font-size: 17px; }
+.quiz-btn-primary { background: var(--av-yellow); box-shadow: 4px 4px 0 var(--av-dark); }
+.quiz-btn-primary:hover:not(:disabled) { transform: translate(-2px,-2px); box-shadow: 6px 6px 0 var(--av-dark); background: var(--av-yellow-hover); }
+.quiz-btn-primary:disabled { opacity: 0.45; cursor: not-allowed; }
+.quiz-btn-ghost { background: white; box-shadow: 4px 4px 0 var(--av-dark); }
+.quiz-btn-ghost:hover { transform: translate(-2px,-2px); box-shadow: 6px 6px 0 var(--av-dark); }
+.quiz-arrow { display: inline-block; transition: transform .2s var(--av-ease-spring); }
+.quiz-btn:hover:not(:disabled) .quiz-arrow { transform: translateX(4px); }
+
+/* ============== QUESTION ============== */
+.quiz-screen-question {
+  background: var(--av-cream);
+  padding: 28px 32px 64px;
+  align-items: center;
+}
+.quiz-q-top {
+  width: 100%;
+  max-width: 880px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 36px;
+}
+.quiz-q-back {
+  background: white;
+  border: 2px solid var(--av-dark);
+  border-radius: 9999px;
+  padding: 8px 18px;
+  font-family: var(--av-font-display);
+  font-weight: 700;
+  font-size: 13px;
+  color: var(--av-dark);
+  cursor: pointer;
+  box-shadow: 3px 3px 0 var(--av-dark);
+  transition: transform .15s var(--av-ease-spring), box-shadow .15s ease;
+}
+.quiz-q-back:hover { transform: translate(-1px,-1px); box-shadow: 4px 4px 0 var(--av-dark); }
+
+.quiz-progress { display: flex; align-items: center; gap: 12px; }
+.quiz-progress-text { font-family: var(--av-font-display); font-weight: 800; font-size: 14px; color: var(--av-dark); }
+.quiz-progress-bar {
+  width: 180px; height: 10px;
+  background: white;
+  border: 2px solid var(--av-dark);
+  border-radius: 9999px;
+  overflow: hidden;
+  box-shadow: 3px 3px 0 var(--av-dark);
+}
+.quiz-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--av-yellow), var(--layer-4));
+  transition: width 0.55s var(--av-ease-spring);
+  border-right: 2px solid var(--av-dark);
+}
+
+.quiz-q-body { width: 100%; max-width: 880px; display: flex; flex-direction: column; align-items: center; text-align: center; }
+.quiz-q-eyebrow { margin-bottom: 16px; }
+.quiz-pill-q {
+  display: inline-block;
+  background: var(--av-yellow);
+  color: var(--av-dark);
+  border: 2px solid var(--av-dark);
+  padding: 8px 18px;
+  border-radius: 9999px;
+  font-family: var(--av-font-display);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  box-shadow: 3px 3px 0 var(--av-dark);
+  white-space: nowrap;
+  line-height: 1;
+}
+.quiz-q-title {
+  font-family: var(--av-font-display);
+  font-weight: 800;
+  font-size: clamp(28px, 4vw, 48px);
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  color: var(--av-dark);
+  margin: 0;
+  text-wrap: balance;
+  max-width: 20ch;
+}
+.quiz-q-subtitle { margin-top: 12px; font-size: 16px; color: var(--av-fg-2); font-weight: 500; }
+
+/* Option grids */
+.quiz-opt-grid { margin-top: 36px; width: 100%; display: grid; gap: 16px; }
+.quiz-opt-grid--cards.quiz-opt-grid--roomy { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.quiz-opt-grid--cards.quiz-opt-grid--tight { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+.quiz-opt-grid--pills { display: flex; flex-wrap: wrap; justify-content: center; gap: 14px; max-width: 760px; margin-left: auto; margin-right: auto; }
+.quiz-opt-grid--chips { display: flex; flex-wrap: wrap; justify-content: center; gap: 10px; }
+
+.quiz-opt {
+  position: relative;
+  background: white;
+  border: 2px solid var(--av-dark);
+  font-family: var(--av-font-display);
+  cursor: pointer;
+  text-align: left;
+  color: var(--av-dark);
+  transition: transform .18s var(--av-ease-spring), box-shadow .18s ease, background .15s;
+  animation: qOptIn 500ms var(--av-ease-spring) both;
+  animation-delay: calc(var(--opt-i, 0) * 60ms + 100ms);
+}
+@keyframes qOptIn { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: translateY(0); } }
+.quiz-opt:hover { transform: translate(-2px,-2px); }
+.quiz-opt.is-selected { background: var(--av-yellow); transform: translate(-2px,-2px); }
+
+/* Cards */
+.quiz-opt--cards { border-radius: 20px; padding: 20px 22px; display: flex; flex-direction: column; gap: 6px; box-shadow: 4px 4px 0 var(--av-dark); min-height: 110px; }
+.quiz-opt--cards:hover, .quiz-opt--cards.is-selected { box-shadow: 6px 6px 0 var(--av-dark); }
+.quiz-opt--cards .quiz-opt-emoji { font-family: var(--av-font-mono); font-size: 11px; font-weight: 700; letter-spacing: 0.16em; color: var(--av-fg-3); margin-bottom: 4px; align-self: flex-start; padding: 3px 7px; background: var(--av-cream); border-radius: 4px; }
+.quiz-opt--cards .quiz-opt-label { font-size: 18px; font-weight: 800; letter-spacing: -0.01em; }
+.quiz-opt--cards .quiz-opt-hint { font-size: 13px; font-weight: 500; color: var(--av-fg-2); font-family: var(--av-font-body); }
+.quiz-opt--cards.is-selected .quiz-opt-emoji { background: white; color: var(--av-dark); }
+
+/* Pills */
+.quiz-opt--pills {
+  border-radius: 9999px;
+  padding: 16px 28px 16px 30px;
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  box-shadow: 4px 4px 0 var(--av-dark);
+  min-height: 56px;
+  background: white;
+  border: 2.5px solid var(--av-dark);
+  font-family: var(--av-font-display);
+  text-align: center;
+  line-height: 1;
+  transition: transform .18s var(--av-ease-spring), box-shadow .18s var(--av-ease-out), background .18s;
+}
+.quiz-opt--pills:hover { box-shadow: 6px 6px 0 var(--av-dark); }
+.quiz-opt--pills.is-selected { background: var(--av-yellow); box-shadow: 6px 6px 0 var(--av-dark); }
+.quiz-opt--pills .quiz-opt-emoji { display: none; }
+.quiz-opt--pills .quiz-opt-hint { display: none; }
+.quiz-opt--pills .quiz-opt-label { font-size: 16px; font-weight: 700; letter-spacing: -0.005em; color: var(--av-dark); display: inline-flex; align-items: center; line-height: 1; }
+.quiz-opt--pills .quiz-opt-check {
+  position: static;
+  width: 18px; height: 18px;
+  font-size: 11px;
+  background: var(--av-dark);
+  color: var(--av-yellow);
+  border: none;
+  border-radius: 9999px;
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  opacity: 0;
+  transform: scale(0.4);
+  margin-left: -4px;
+  transition: opacity .2s, transform .2s var(--av-ease-spring);
+}
+.quiz-opt--pills.is-selected .quiz-opt-check { opacity: 1; transform: scale(1); }
+
+/* Chips */
+.quiz-opt--chips { border-radius: 12px; padding: 10px 18px; display: inline-flex; align-items: center; gap: 10px; box-shadow: 2px 2px 0 var(--av-dark); }
+.quiz-opt--chips:hover, .quiz-opt--chips.is-selected { box-shadow: 3px 3px 0 var(--av-dark); }
+.quiz-opt--chips .quiz-opt-emoji { font-family: var(--av-font-mono); font-size: 10px; font-weight: 800; letter-spacing: 0.14em; color: var(--av-fg-3); background: var(--av-cream); padding: 2px 6px; border-radius: 4px; }
+.quiz-opt--chips .quiz-opt-label { font-size: 14px; font-weight: 700; }
+.quiz-opt--chips .quiz-opt-hint { display: none; }
+
+/* Check mark (cards + chips) */
+.quiz-opt-check {
+  position: absolute;
+  top: 12px; right: 12px;
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  background: var(--av-dark);
+  color: var(--av-yellow);
+  font-size: 13px;
+  font-weight: 800;
+  display: flex; align-items: center; justify-content: center;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: opacity .2s, transform .2s var(--av-ease-spring);
+}
+.quiz-opt.is-selected .quiz-opt-check { opacity: 1; transform: scale(1); }
+
+.quiz-q-foot { margin-top: 36px; display: flex; flex-direction: column; align-items: center; gap: 10px; }
+.quiz-q-foot-meta { font-size: 13px; color: var(--av-fg-3); font-weight: 600; }
+
+/* ============== LEAD ============== */
+.quiz-screen-lead {
+  background: var(--av-cream);
+  padding: 28px 32px 64px;
+  align-items: center;
+}
+.quiz-q-step { font-family: var(--av-font-display); font-weight: 800; font-size: 12px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--av-fg-2); }
+.quiz-lead-card {
+  width: 100%;
+  max-width: 560px;
+  margin: 12px auto 0;
+  background: white;
+  border: 2px solid var(--av-dark);
+  border-radius: 28px;
+  padding: 40px 36px 36px;
+  box-shadow: 8px 8px 0 var(--av-dark);
+  position: relative;
+}
+.quiz-stamp-lead {
+  position: absolute;
+  top: -22px; right: -16px;
+  background: var(--av-yellow);
+  border: 2px dashed var(--av-dark);
+  border-radius: 9999px;
+  padding: 10px 20px;
+  font-family: var(--av-font-display);
+  font-weight: 800;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  color: var(--av-dark);
+  transform: rotate(8deg);
+  box-shadow: 3px 3px 0 var(--av-dark);
+  white-space: nowrap;
+  line-height: 1;
+}
+.quiz-lead-title {
+  font-family: var(--av-font-display);
+  font-weight: 800;
+  font-size: clamp(26px, 3.4vw, 34px);
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  margin: 0 0 10px;
+  color: var(--av-dark);
+}
+.quiz-lead-sub { color: var(--av-fg-2); font-size: 15px; margin-bottom: 28px; line-height: 1.55; }
+.quiz-lead-form { display: flex; flex-direction: column; gap: 16px; }
+
+.quiz-field { display: flex; flex-direction: column; gap: 6px; }
+.quiz-field label { font-family: var(--av-font-display); font-weight: 700; font-size: 13px; color: var(--av-dark); letter-spacing: 0.02em; }
+.quiz-field input {
+  font-family: var(--av-font-body);
+  font-size: 15px;
+  padding: 13px 16px;
+  border-radius: 12px;
+  border: 2px solid var(--av-border);
+  background: white;
+  color: var(--av-dark);
+  transition: border-color .2s, box-shadow .2s;
+  width: 100%;
+}
+.quiz-field input:focus { outline: none; border-color: var(--av-action); box-shadow: 0 0 0 4px rgba(14,165,233,.18); }
+.quiz-field input.has-error { border-color: var(--av-red-500); }
+.quiz-err { font-size: 12px; color: var(--av-red-500); font-weight: 600; }
+.quiz-err-block { display: block; margin-top: -8px; }
+
+.quiz-check { display: flex; align-items: flex-start; gap: 10px; cursor: pointer; padding: 6px 0; user-select: none; }
+.quiz-check input { position: absolute; opacity: 0; pointer-events: none; }
+.quiz-check-box {
+  width: 22px; height: 22px;
+  border: 2px solid var(--av-dark);
+  border-radius: 6px;
+  background: white;
+  flex-shrink: 0;
+  position: relative;
+  transition: background .15s;
+  margin-top: 1px;
+}
+.quiz-check-box::after {
+  content: "✓";
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%,-50%) scale(.5);
+  color: var(--av-dark);
+  font-weight: 800;
+  font-size: 14px;
+  opacity: 0;
+  transition: all .15s var(--av-ease-spring);
+}
+.quiz-check input:checked + .quiz-check-box { background: var(--av-yellow); }
+.quiz-check input:checked + .quiz-check-box::after { opacity: 1; transform: translate(-50%,-50%) scale(1); }
+.quiz-check-label { font-size: 13px; color: var(--av-fg-2); line-height: 1.45; }
+.quiz-check-label a { color: var(--av-action); text-decoration: underline; }
+
+.quiz-lead-form .quiz-btn-primary { margin-top: 12px; align-self: stretch; }
+.quiz-lead-submitting { opacity: 0.7; }
+
+/* ============== REVEAL STAGGER ============== */
+.quiz-reveal-block {
+  width: 100%;
+  opacity: 0;
+  transform: translateY(18px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.quiz-result-inner.is-revealed .quiz-reveal-block {
+  animation: qRevealBlock 600ms var(--av-ease-spring) both;
+  animation-delay: var(--reveal-delay, 0ms);
+}
+@keyframes qRevealBlock {
+  from { opacity: 0; transform: translateY(18px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ============== RESULT ============== */
+.quiz-screen-result {
+  background: var(--av-cream);
+  padding: 28px 32px 80px;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+.quiz-result-inner {
+  width: 100%;
+  max-width: 920px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  position: relative;
+  z-index: 2;
+  gap: 0;
+}
+.quiz-result-peak { margin-bottom: 8px; }
+
+.quiz-result-eyebrow { margin-bottom: 18px; }
+.quiz-result-eyebrow--mid { margin-top: 48px; margin-bottom: 22px; }
+.quiz-pill-result {
+  display: inline-block;
+  background: var(--av-dark);
+  color: var(--av-yellow);
+  border: 2px solid var(--av-dark);
+  padding: 8px 18px;
+  border-radius: 9999px;
+  font-family: var(--av-font-display);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  box-shadow: 3px 3px 0 var(--av-yellow);
+  white-space: nowrap;
+  line-height: 1;
+}
+.quiz-pill-soft {
+  display: inline-block;
+  background: white;
+  color: var(--av-dark);
+  border: 2px solid var(--av-dark);
+  padding: 8px 18px;
+  border-radius: 9999px;
+  font-family: var(--av-font-display);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  box-shadow: 3px 3px 0 var(--av-dark);
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.quiz-result-lead {
+  font-family: var(--av-font-serif);
+  font-style: italic;
+  font-size: 18px;
+  color: var(--av-fg-2);
+  margin: 0 0 18px;
+  display: block;
+  width: 100%;
+  text-align: center;
+}
+
+.quiz-result-name {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  margin: 0 0 24px;
+  flex-wrap: wrap;
+}
+.quiz-result-icon {
+  font-family: var(--av-font-display);
+  font-size: clamp(48px, 6vw, 72px);
+  width: 1.2em; height: 1.2em;
+  line-height: 1.2em;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--av-yellow);
+  border: 3px solid var(--av-dark);
+  border-radius: 9999px;
+  transform: rotate(-6deg);
+  box-shadow: 5px 5px 0 var(--av-dark);
+}
+.quiz-result-h2 {
+  font-family: var(--av-font-display);
+  font-weight: 800;
+  font-size: clamp(40px, 7vw, 84px);
+  line-height: 1;
+  letter-spacing: -0.035em;
+  color: var(--av-dark);
+  margin: 0;
+}
+.quiz-result-color--orange .quiz-result-icon  { background: var(--av-orange-200); }
+.quiz-result-color--emerald .quiz-result-icon { background: var(--av-emerald-200); }
+.quiz-result-color--blue .quiz-result-icon    { background: var(--av-blue-200); }
+.quiz-result-color--sky .quiz-result-icon     { background: var(--av-sky-200); }
+.quiz-result-color--yellow .quiz-result-icon  { background: var(--av-yellow); }
+
+.quiz-result-tagline {
+  font-family: var(--av-font-serif);
+  font-style: italic;
+  font-size: clamp(18px, 2.4vw, 24px);
+  line-height: 1.4;
+  color: var(--av-dark);
+  max-width: 36ch;
+  margin: 0 auto 36px;
+  text-wrap: balance;
+  position: relative;
+  z-index: 1;
+}
+.quiz-result-desc { font-size: 16px; color: var(--av-fg-2); max-width: 56ch; line-height: 1.6; margin: 0 auto; position: relative; z-index: 1; }
+
+/* Polaroids */
+.quiz-dest-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 32px;
+  width: 100%;
+  margin-top: 8px;
+  padding: 16px 8px 32px;
+}
+.quiz-polaroid {
+  position: relative;
+  background: white;
+  border: 2px solid var(--av-dark);
+  border-radius: 8px;
+  padding: 12px 12px 18px;
+  box-shadow: 8px 8px 0 var(--av-dark);
+  transform: rotate(var(--tilt, -2deg));
+  animation: qPolDrop 700ms var(--av-ease-spring) both;
+  animation-delay: var(--delay, 0ms);
+}
+@keyframes qPolDrop { from { opacity: 0; transform: rotate(var(--tilt)) translateY(-30px) scale(.92); } to { opacity: 1; transform: rotate(var(--tilt)) translateY(0) scale(1); } }
+
+.quiz-pol-tape {
+  position: absolute;
+  top: -12px; left: 50%;
+  width: 90px; height: 26px;
+  background: rgba(254, 249, 195, 0.92);
+  transform: translateX(-50%) rotate(-3deg);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+.quiz-pol-img {
+  aspect-ratio: 4/3;
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
+}
+.quiz-pol-img--orange  { background: linear-gradient(135deg, #fed7aa, #f97316); }
+.quiz-pol-img--emerald { background: linear-gradient(135deg, #a7f3d0, #10b981); }
+.quiz-pol-img--blue    { background: linear-gradient(135deg, #bfdbfe, #2563eb); }
+.quiz-pol-img--sky     { background: linear-gradient(135deg, #bae6fd, #0ea5e9); }
+.quiz-pol-img--yellow  { background: linear-gradient(135deg, #fef08a, #FFD600); }
+.quiz-pol-img-label {
+  position: absolute;
+  bottom: 8px; left: 8px;
+  font-family: var(--av-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--av-dark);
+  background: rgba(255,255,255,0.92);
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+.quiz-pol-cap {
+  margin-top: 14px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.quiz-pol-cap strong { font-family: var(--av-font-display); font-weight: 800; font-size: 18px; color: var(--av-dark); }
+.quiz-pol-cap em { font-family: var(--av-font-serif); font-style: italic; font-size: 13px; color: var(--av-fg-2); }
+
+.quiz-result-cta { display: flex; flex-wrap: wrap; gap: 14px; justify-content: center; margin-top: 16px; }
+.quiz-result-fineprint { margin-top: 24px; font-size: 13px; color: var(--av-fg-3); max-width: 50ch; }
+
+/* ============== CONFETTI ============== */
+.quiz-confetti { position: absolute; inset: 0; pointer-events: none; overflow: hidden; z-index: 3; }
+.quiz-conf {
+  position: absolute;
+  top: -40px;
+  width: var(--size);
+  height: var(--size);
+  background: var(--color);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  animation: qConfFall var(--dur, 3s) linear forwards;
+}
+@keyframes qConfFall {
+  0%   { transform: translate(0, 0) rotate(0); opacity: 1; }
+  90%  { opacity: 1; }
+  100% { transform: translate(var(--drift), 100vh) rotate(var(--rot)); opacity: 0; }
+}
+.quiz-conf--paper {}
+.quiz-conf--stars { background: transparent; color: var(--color); font-size: var(--size); line-height: 1; }
+.quiz-conf--balloons { background: var(--color); border-radius: 50%; box-shadow: inset -3px -4px 0 rgba(0,0,0,0.15); }
+.quiz-conf--balloons::after {
+  content: "";
+  position: absolute;
+  bottom: -10px; left: 50%;
+  width: 1px; height: 14px;
+  background: rgba(15,23,42,0.4);
+}
+
+/* ============== RING ANIMATION (auto-advance feedback) ============== */
+.quiz-opt--pills.is-confirming {
+  box-shadow: 0 0 0 0 rgba(255, 214, 0, 0.7);
+  animation: qSelectRing 500ms var(--av-ease-out) forwards;
+}
+@keyframes qSelectRing {
+  0%   { box-shadow: 0 0 0 0 rgba(255, 214, 0, 0.8); }
+  70%  { box-shadow: 0 0 0 10px rgba(255, 214, 0, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(255, 214, 0, 0); }
+}
+
+/* ============== SUBMIT ERROR (lead screen) ============== */
+.quiz-submit-error {
+  font-size: 13px;
+  color: var(--av-red-500);
+  background: rgba(239, 68, 68, 0.06);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 10px;
+  padding: 12px 16px;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+/* ============== POLAROID COM FOTO ============== */
+.quiz-pol-img--photo {
+  background: var(--av-cream);
+  display: flex;
+  align-items: stretch;
+  position: relative;
+}
+.quiz-pol-img--photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  border-radius: 4px;
+}
+
+/* ============== WHATSAPP UPGRADE ============== */
+.quiz-wa-upgrade {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  max-width: 480px;
+  padding: 28px 24px;
+  background: white;
+  border: 2px solid var(--av-dark);
+  border-radius: 20px;
+  box-shadow: 6px 6px 0 var(--av-dark);
+}
+.quiz-wa-upgrade-label {
+  font-family: var(--av-font-display);
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--av-dark);
+  text-align: center;
+  margin: 0;
+}
+.quiz-wa-upgrade-row {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+}
+.quiz-wa-input {
+  flex: 1;
+  font-family: var(--av-font-body);
+  font-size: 15px;
+  padding: 13px 16px;
+  border-radius: 12px;
+  border: 2px solid var(--av-border);
+  background: white;
+  color: var(--av-dark);
+  transition: border-color .2s, box-shadow .2s;
+  min-width: 0;
+}
+.quiz-wa-input:focus { outline: none; border-color: var(--av-action); box-shadow: 0 0 0 4px rgba(14,165,233,.18); }
+.quiz-wa-skip {
+  font-size: 13px;
+  color: var(--av-fg-3);
+  font-weight: 600;
+  text-decoration: none;
+  transition: color .2s;
+}
+.quiz-wa-skip:hover { color: var(--av-dark); }
+.quiz-wa-upgrade--done {
+  border-color: var(--av-emerald-500);
+  box-shadow: 6px 6px 0 var(--av-emerald-500);
+}
+.quiz-wa-upgrade-done {
+  font-family: var(--av-font-display);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--av-emerald-500);
+  text-align: center;
+  margin: 0;
+}
+
+/* ============== RESULT RESTART ============== */
+.quiz-result-restart { margin-top: 14px; }
+
+/* ============== RESULT FINEPRINT ============== */
+.quiz-result-fineprint--warn { color: var(--av-red-500); font-weight: 600; }
+
+/* ============== DELIGHT ============== */
+
+/* --- Hero CTA: pulso suave após 2.5s de ociosidade --- */
+.quiz-btn--hero {
+  animation: qHeroPulse 0.6s var(--av-ease-spring) 2.5s both;
+}
+@keyframes qHeroPulse {
+  0%   { transform: none; }
+  35%  { transform: translateY(-5px); box-shadow: 6px 9px 0 var(--av-dark); }
+  65%  { transform: translateY(-2px); box-shadow: 5px 7px 0 var(--av-dark); }
+  100% { transform: none; box-shadow: 4px 4px 0 var(--av-dark); }
+}
+
+/* --- Botões: press tátil --- */
+.quiz-btn:active:not(:disabled) {
+  transform: translate(2px, 2px) !important;
+  box-shadow: 2px 2px 0 var(--av-dark) !important;
+  transition: transform 0.08s ease-out, box-shadow 0.08s ease-out;
+}
+
+/* --- Botão ativo quando WhatsApp válido --- */
+@keyframes qBtnReady {
+  0%   { box-shadow: 4px 4px 0 var(--av-dark); }
+  50%  { box-shadow: 5px 5px 0 var(--av-dark), 0 0 0 4px rgba(255,214,0,0.3); }
+  100% { box-shadow: 4px 4px 0 var(--av-dark); }
+}
+.quiz-btn--ready { animation: qBtnReady 0.5s var(--av-ease-spring) 0.1s both; }
+
+/* --- Progresso: mensagem de marco --- */
+.quiz-progress-milestone {
+  display: inline-block;
+  font-family: var(--av-font-display);
+  font-weight: 800;
+  font-size: 13px;
+  color: #ea580c;
+  animation: qMilestoneIn 400ms var(--av-ease-spring) both;
+  white-space: nowrap;
+}
+@keyframes qMilestoneIn {
+  from { opacity: 0; transform: scale(0.6) translateY(4px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* --- Checkbox: pulse ao marcar --- */
+.quiz-check input:checked + .quiz-check-box {
+  animation: qCheckPulse 350ms var(--av-ease-spring);
+}
+@keyframes qCheckPulse {
+  0%   { transform: scale(1); }
+  45%  { transform: scale(1.22); }
+  100% { transform: scale(1); }
+}
+
+/* --- Polaroid: lift ao hover (recompensa de descoberta) --- */
+.quiz-polaroid {
+  transition: transform 0.28s var(--av-ease-spring), box-shadow 0.28s ease-out;
+  cursor: default;
+}
+.quiz-polaroid:hover {
+  transform: rotate(0deg) translateY(-10px) scale(1.04);
+  box-shadow: 14px 18px 0 var(--av-dark);
+  z-index: 10;
+  position: relative;
+}
+
+/* --- Ícone do perfil: bounce de celebração após reveal --- */
+.quiz-result-inner.is-revealed .quiz-result-icon {
+  animation: qIconCelebrate 700ms var(--av-ease-spring) 580ms both;
+}
+@keyframes qIconCelebrate {
+  0%   { transform: rotate(-6deg) scale(1); }
+  30%  { transform: rotate(-14deg) scale(1.3); }
+  60%  { transform: rotate(-2deg) scale(0.92); }
+  80%  { transform: rotate(-8deg) scale(1.06); }
+  100% { transform: rotate(-6deg) scale(1); }
+}
+
+/* --- Confete: formas adicionais --- */
+.quiz-conf--circle {
+  border-radius: 50%;
+}
+.quiz-conf--star {
+  background: transparent;
+  color: var(--color);
+  font-size: var(--size);
+  line-height: 1;
+  width: auto;
+  height: auto;
+}
+
+/* ============== FOCUS RINGS ============== */
+.quiz-btn:focus-visible,
+.quiz-q-back:focus-visible,
+.quiz-opt:focus-visible,
+.quiz-wa-input:focus-visible,
+.quiz-check input:focus-visible + .quiz-check-box {
+  outline: 3px solid var(--av-dark);
+  outline-offset: 3px;
+}
+.quiz-screen-hero .quiz-btn:focus-visible { outline-color: white; }
+
+/* ============== TOUCH TARGETS ============== */
+.quiz-opt--pills { min-height: 48px; }
+.quiz-q-back { min-height: 44px; min-width: 80px; }
+.quiz-btn { min-height: 48px; }
+.quiz-btn-lg { min-height: 56px; }
+
+/* ============== POLAROID IMAGE CLS PREVENTION ============== */
+.quiz-pol-img--photo {
+  aspect-ratio: 4 / 3;
+}
+.quiz-pol-img--photo img {
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+/* ============== WA INPUT TRANSITION ============== */
+.quiz-wa-input { transition: border-color .2s, box-shadow .2s; }
+
+/* ============== PREFERS REDUCED MOTION ============== */
+@media (prefers-reduced-motion: reduce) {
+  .quiz-stage-inner,
+  .quiz-chunky .quiz-ch-letter,
+  .quiz-opt,
+  .quiz-polaroid,
+  .quiz-conf,
+  .quiz-reveal-block,
+  .quiz-result-inner,
+  .quiz-progress-fill,
+  .quiz-deco-star,
+  .quiz-arrow,
+  .quiz-btn--hero,
+  .quiz-btn--ready,
+  .quiz-progress-milestone,
+  .quiz-result-inner .quiz-result-icon,
+  .quiz-check input:checked + .quiz-check-box { animation: none !important; transition: none !important; }
+  .quiz-result-inner { opacity: 1; transform: none; }
+  .quiz-reveal-block { opacity: 1; transform: none; }
+  .quiz-chunky .quiz-ch-letter { opacity: 1; transform: none; }
+  .quiz-polaroid:hover { transform: rotate(var(--tilt, -2deg)); box-shadow: 8px 8px 0 var(--av-dark); }
+}
+
+/* ============== RESPONSIVE ============== */
+@media (max-width: 640px) {
+  .quiz-screen-hero { padding: 32px 20px; }
+  .quiz-chunky { font-size: clamp(72px, 22vw, 120px); }
+  .quiz-deco-star { display: none; }
+  .quiz-deco-star-1, .quiz-deco-star-3 { display: block; }
+  .quiz-pol-img { aspect-ratio: 1.2/1; }
+  .quiz-lead-card { padding: 32px 24px 28px; }
+  .quiz-stamp-lead { right: 12px; top: -16px; }
+  .quiz-progress-bar { width: 100px; }
+}

--- a/pages/landings/quiz-anhanga.css
+++ b/pages/landings/quiz-anhanga.css
@@ -245,14 +245,12 @@
   font-style: italic;
   transform: scale(var(--cq-scale));
 }
-.quiz-chunky .quiz-ch-letter { display: inline-block; }
+.quiz-chunky .quiz-ch-letter { display: inline-block; animation: qLetterPop 600ms var(--av-ease-spring) both; }
 .quiz-chunky-layered { filter: drop-shadow(2px 2px 0 rgba(15,23,42,0.25)); }
 .quiz-chunky-layered .quiz-ch-front { position: relative; color: white; -webkit-text-stroke: 3px var(--av-dark); }
 .quiz-chunky-layered .quiz-ch-layer { position: absolute; top: 0; left: 0; pointer-events: none; -webkit-text-stroke: 3px var(--av-dark); }
 .quiz-chunky-outline { color: transparent; -webkit-text-stroke: 5px white; }
 .quiz-chunky-solid { color: var(--av-yellow); -webkit-text-stroke: 4px var(--av-dark); text-shadow: 8px 8px 0 var(--av-dark); }
-
-.quiz-chunky .quiz-ch-letter { animation: qLetterPop 600ms var(--av-ease-spring) both; }
 .quiz-chunky .quiz-ch-letter:nth-child(1){ animation-delay: 60ms; }
 .quiz-chunky .quiz-ch-letter:nth-child(2){ animation-delay: 140ms; }
 .quiz-chunky .quiz-ch-letter:nth-child(3){ animation-delay: 220ms; }
@@ -266,6 +264,7 @@
   border: 2px solid var(--av-dark);
   border-radius: 9999px;
   padding: 14px 28px;
+  min-height: 48px;
   font-family: var(--av-font-display);
   font-weight: 800;
   font-size: 15px;
@@ -275,7 +274,7 @@
   transition: transform .2s var(--av-ease-spring), box-shadow .2s ease, background .2s;
   background: none;
 }
-.quiz-btn-lg { padding: 18px 36px; font-size: 17px; }
+.quiz-btn-lg { padding: 18px 36px; font-size: 17px; min-height: 56px; }
 .quiz-btn-primary { background: var(--av-yellow); box-shadow: 4px 4px 0 var(--av-dark); }
 .quiz-btn-primary:hover:not(:disabled) { transform: translate(-2px,-2px); box-shadow: 6px 6px 0 var(--av-dark); background: var(--av-yellow-hover); }
 .quiz-btn-primary:disabled { opacity: 0.45; cursor: not-allowed; }
@@ -304,6 +303,8 @@
   border: 2px solid var(--av-dark);
   border-radius: 9999px;
   padding: 8px 18px;
+  min-height: 44px;
+  min-width: 80px;
   font-family: var(--av-font-display);
   font-weight: 700;
   font-size: 13px;
@@ -397,6 +398,7 @@
 .quiz-opt--pills {
   border-radius: 9999px;
   padding: 16px 28px 16px 30px;
+  min-height: 48px;
   display: inline-flex;
   flex-direction: row;
   align-items: center;
@@ -548,7 +550,7 @@
   opacity: 0;
   transition: all .15s var(--av-ease-spring);
 }
-.quiz-check input:checked + .quiz-check-box { background: var(--av-yellow); }
+.quiz-check input:checked + .quiz-check-box { background: var(--av-yellow); animation: qCheckPulse 350ms var(--av-ease-spring); }
 .quiz-check input:checked + .quiz-check-box::after { opacity: 1; transform: translate(-50%,-50%) scale(1); }
 .quiz-check-label { font-size: 13px; color: var(--av-fg-2); line-height: 1.45; }
 .quiz-check-label a { color: var(--av-action); text-decoration: underline; }
@@ -707,6 +709,8 @@
   padding: 12px 12px 18px;
   box-shadow: 8px 8px 0 var(--av-dark);
   transform: rotate(var(--tilt, -2deg));
+  transition: transform 0.28s var(--av-ease-spring), box-shadow 0.28s ease-out;
+  cursor: default;
   animation: qPolDrop 700ms var(--av-ease-spring) both;
   animation-delay: var(--delay, 0ms);
 }
@@ -774,7 +778,7 @@
   90%  { opacity: 1; }
   100% { transform: translate(var(--drift), 100vh) rotate(var(--rot)); opacity: 0; }
 }
-.quiz-conf--paper {}
+/* .quiz-conf--paper uses the default square shape from .quiz-conf */
 .quiz-conf--stars { background: transparent; color: var(--color); font-size: var(--size); line-height: 1; }
 .quiz-conf--balloons { background: var(--color); border-radius: 50%; box-shadow: inset -3px -4px 0 rgba(0,0,0,0.15); }
 .quiz-conf--balloons::after {
@@ -814,6 +818,7 @@
   display: flex;
   align-items: stretch;
   position: relative;
+  aspect-ratio: 4 / 3;
 }
 .quiz-pol-img--photo img {
   width: 100%;
@@ -821,6 +826,7 @@
   object-fit: cover;
   display: block;
   border-radius: 4px;
+  aspect-ratio: 4 / 3;
 }
 
 /* ============== WHATSAPP UPGRADE ============== */
@@ -935,9 +941,6 @@
 }
 
 /* --- Checkbox: pulse ao marcar --- */
-.quiz-check input:checked + .quiz-check-box {
-  animation: qCheckPulse 350ms var(--av-ease-spring);
-}
 @keyframes qCheckPulse {
   0%   { transform: scale(1); }
   45%  { transform: scale(1.22); }
@@ -945,10 +948,6 @@
 }
 
 /* --- Polaroid: lift ao hover (recompensa de descoberta) --- */
-.quiz-polaroid {
-  transition: transform 0.28s var(--av-ease-spring), box-shadow 0.28s ease-out;
-  cursor: default;
-}
 .quiz-polaroid:hover {
   transform: rotate(0deg) translateY(-10px) scale(1.04);
   box-shadow: 14px 18px 0 var(--av-dark);
@@ -991,24 +990,6 @@
   outline-offset: 3px;
 }
 .quiz-screen-hero .quiz-btn:focus-visible { outline-color: white; }
-
-/* ============== TOUCH TARGETS ============== */
-.quiz-opt--pills { min-height: 48px; }
-.quiz-q-back { min-height: 44px; min-width: 80px; }
-.quiz-btn { min-height: 48px; }
-.quiz-btn-lg { min-height: 56px; }
-
-/* ============== POLAROID IMAGE CLS PREVENTION ============== */
-.quiz-pol-img--photo {
-  aspect-ratio: 4 / 3;
-}
-.quiz-pol-img--photo img {
-  aspect-ratio: 4 / 3;
-  object-fit: cover;
-}
-
-/* ============== WA INPUT TRANSITION ============== */
-.quiz-wa-input { transition: border-color .2s, box-shadow .2s; }
 
 /* ============== PREFERS REDUCED MOTION ============== */
 @media (prefers-reduced-motion: reduce) {

--- a/services/n8n.ts
+++ b/services/n8n.ts
@@ -1,4 +1,4 @@
-import type { N8nLeadPayload, N8nWaitlistPayload } from '../lib/n8n-payloads';
+import type { N8nLeadPayload, N8nQuizPayload, N8nWaitlistPayload } from '../lib/n8n-payloads';
 
 // 5 seconds gives self-hosted n8n enough headroom for cold-start workflows
 // without hanging the edge function indefinitely. Override with N8N_WEBHOOK_TIMEOUT_MS.
@@ -101,6 +101,15 @@ export function sendWaitlistToN8n(
     secret: string,
     requestId: string,
     payload: N8nWaitlistPayload,
+): Promise<Response> {
+    return n8nRequest(url, secret, requestId, payload);
+}
+
+export function sendQuizToN8n(
+    url: string,
+    secret: string,
+    requestId: string,
+    payload: N8nQuizPayload,
 ): Promise<Response> {
     return n8nRequest(url, secret, requestId, payload);
 }

--- a/types/quiz.ts
+++ b/types/quiz.ts
@@ -1,0 +1,37 @@
+import type { LeadTracking, LeadUtms } from './leadCapture';
+
+export interface SubmitQuizRequest {
+    firstName: string;
+    email: string;
+    whatsapp?: string;
+    profileKey: string;
+    profileName: string;
+    bantSummary: string;
+    sourcePage: string;
+    utms: LeadUtms;
+    tracking?: LeadTracking;
+}
+
+export interface SubmitQuizSuccess {
+    ok: true;
+    requestId: string;
+    warning?: string;
+    message: string;
+}
+
+export type SubmitQuizErrorCode =
+    | 'VALIDATION_ERROR'
+    | 'SERVER_CONFIG_ERROR'
+    | 'N8N_WEBHOOK_ERROR'
+    | 'INTERNAL_ERROR'
+    | 'METHOD_NOT_ALLOWED'
+    | 'RATE_LIMIT_EXCEEDED';
+
+export interface SubmitQuizError {
+    ok: false;
+    requestId: string;
+    error: string;
+    code: SubmitQuizErrorCode;
+}
+
+export type SubmitQuizResponse = SubmitQuizSuccess | SubmitQuizError;


### PR DESCRIPTION
## Resumo

Landing page `/quiz` completa — quiz interativo de 5 perguntas que revela o perfil de viajante do usuário e captura lead (nome + e-mail) antes do resultado, com WhatsApp como upgrade opcional.

## O que muda

### Nova rota `/quiz`
- Adicionada em `App.tsx` no branch de landings (sem Header/Footer), com lazy-load

### Telas do quiz
- **Hero** turquesa com "QUIZ!" em camadas amarelo→laranja, estrelas animadas e tape amarela
- **5 perguntas** com pills animadas; seleção única auto-avança em 500ms com ring animation de confirmação; multi-seleção tem botão "Próxima"; mensagens de marco no progresso ("Na metade!" / "Última!")
- **Captura de lead** (passo 1): nome + e-mail + aceite LGPD antes do resultado — API roda em background, resultado aparece imediatamente
- **Resultado** com reveal escalonado em 6 blocos (0–1000ms stagger), confete com 3 formas (papel, círculo, estrela ★), bounce do ícone do perfil, polaroids com imagens reais de `media.anhanga.tur.br`, upgrade opcional de WhatsApp (passo 2)
- **6 perfis de viajante** com destinos curados: Aventureiro, Contemplativo, Curioso Cultural, Praiano de Alma, Família em Movimento, Sibarita

### Infraestrutura de lead (padrão Lollapalooza/n8n)
| Arquivo | Responsabilidade |
|---|---|
| `types/quiz.ts` | Contrato SubmitQuizRequest/Response |
| `lib/quiz-logic.ts` | Validação server-side |
| `lib/n8n-payloads.ts` | N8nQuizPayload + buildN8nQuizPayload (adicionados ao existente) |
| `services/n8n.ts` | sendQuizToN8n (adicionado ao existente) |
| `api/submit-quiz.ts` | Edge function: rate limit, validação, webhook n8n |
| `hooks/useQuizCapture.ts` | Hook com GTM dataLayer events |

### Qualidade
- TypeScript estrito, zero erros de compilação
- `prefers-reduced-motion` cobre todos os `@keyframes`
- `focus-visible` rings em todos os interativos
- Touch targets mínimos de 48px
- `aria-live` no resultado, `role="progressbar"` na barra
- Falha de API surfaceada ao usuário via fineprint contextual (não silencia erros)
- Erro de e-mail, nome e aceite LGPD com mensagens humanas e específicas

## Variável de ambiente necessária

```
N8N_SUBMIT_QUIZ_WEBHOOK_URL=<url do webhook n8n para o quiz>
```

`N8N_WEBHOOK_SECRET` já existe e é compartilhado entre os endpoints.

## Imagens

Polaroids carregam de `https://media.anhanga.tur.br/{imageKey}.webp` — 17 imagens já subidas no CDN.

## Checklist de revisão

- [x] Configurar `N8N_SUBMIT_QUIZ_WEBHOOK_URL` no Vercel antes do deploy
- [x] Criar workflow n8n para o quiz (sugestão: clonar o de waitlist e adaptar o payload)
- [ ] Testar fluxo completo em preview (hero → perguntas → lead → resultado → WhatsApp)
- [ ] Verificar GTM events `quiz_lead` e `form_submission` no Tag Assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)