### PR TITLE
refactor(quiz): extrair lógica de scoring Plog para lib/ com testes unitários

### DIFF
--- a/lib/quiz-scoring.ts
+++ b/lib/quiz-scoring.ts
@@ -1,0 +1,48 @@
+// Plog psychocentricity model — P1+P2+P3+P4+P6 (P5/horizonte is BANT, excluded from score).
+// Multi-select fields (P1/destino) use the rounded average of selected option scores.
+
+export type ProfileKey =
+    | 'escapista'
+    | 'bon-vivant'
+    | 'viajante-de-verdade'
+    | 'desbravador'
+    | 'nomade-de-alma';
+
+export const NEUTRAL_SCORE = 3;
+
+// Keys must match question IDs in QUIZ_QUESTIONS. Unknown option IDs fall back to NEUTRAL_SCORE.
+export const SCORES: Record<string, Record<string, number>> = {
+    destino: {
+        'europa': 3, 'america-norte': 3, 'latam': 4,
+        'caribe': 1, 'asia': 5, 'africa-oriente': 5, 'surpresa': 3,
+    },
+    cena: {
+        'aventura': 5, 'familia': 2, 'luxo': 2,
+        'microescapada': 3, 'natureza': 4, 'wellness': 1,
+    },
+    companhia: { 'solo': 5, 'familia': 1, 'parceiro': 3, 'variado': 3 },
+    frustracao: {
+        'sem-liberdade': 5, 'multidao': 4, 'hotel-ruim': 2,
+        'genericas': 3, 'caro-demais': 2,
+    },
+    ritmo: { 'planejado': 1, 'semi-planejado': 3, 'quase-livre': 4, 'livre': 5 },
+};
+
+export function scoreField(fieldScores: Record<string, number>, selected: string[]): number {
+    if (!selected.length) return 0;
+    const total = selected.reduce((sum, id) => sum + (fieldScores[id] ?? NEUTRAL_SCORE), 0);
+    return Math.round(total / selected.length);
+}
+
+export function matchProfile(answers: Record<string, string[]>): ProfileKey {
+    const score = Object.keys(SCORES).reduce(
+        (sum, field) => sum + scoreField(SCORES[field], answers[field] ?? []),
+        0,
+    );
+
+    if (score <= 9)  return 'escapista';
+    if (score <= 13) return 'bon-vivant';
+    if (score <= 17) return 'viajante-de-verdade';
+    if (score <= 21) return 'desbravador';
+    return 'nomade-de-alma';
+}

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { SEO } from '../../components/SEO';
 import { useQuizCapture } from '../../hooks/useQuizCapture';
 import { getWhatsAppLink } from '../../utils/whatsapp';
+import { matchProfile, type ProfileKey } from '../../lib/quiz-scoring';
 import './quiz-anhanga.css';
 
 /* ==========================================================================
@@ -123,8 +124,6 @@ interface TravelerProfile {
     destinations: TravelerDestination[];
 }
 
-type ProfileKey = 'escapista' | 'bon-vivant' | 'viajante-de-verdade' | 'desbravador' | 'nomade-de-alma';
-
 // imageKey maps to: https://media.anhanga.tur.br/{imageKey}.webp
 const TRAVELER_PROFILES: Record<ProfileKey, TravelerProfile> = {
     'escapista': {
@@ -191,27 +190,6 @@ const TRAVELER_PROFILES: Record<ProfileKey, TravelerProfile> = {
 
 type QuizAnswers = Record<string, string[]>;
 
-// Score table: Plog psicocentricity model — P1+P2+P3+P4+P6 (P5/quando is BANT, excluded)
-// Keys here must match question IDs in QUIZ_QUESTIONS; missing IDs fall back to NEUTRAL_SCORE.
-const SCORES: Record<string, Record<string, number>> = {
-    destino: {
-        'europa': 3, 'america-norte': 3, 'latam': 4,
-        'caribe': 1, 'asia': 5, 'africa-oriente': 5, 'surpresa': 3,
-    },
-    cena: {
-        'aventura': 5, 'familia': 2, 'luxo': 2,
-        'microescapada': 3, 'natureza': 4, 'wellness': 1,
-    },
-    companhia: { 'solo': 5, 'familia': 1, 'parceiro': 3, 'variado': 3 },
-    frustracao: {
-        'sem-liberdade': 5, 'multidao': 4, 'hotel-ruim': 2,
-        'genericas': 3, 'caro-demais': 2,
-    },
-    ritmo: { 'planejado': 1, 'semi-planejado': 3, 'quase-livre': 4, 'livre': 5 },
-};
-
-const NEUTRAL_SCORE = 3;
-
 const SUMMARY_LABELS: Record<string, Record<string, string>> = {
     destino: {
         'europa': 'Europa', 'america-norte': 'América do Norte', 'latam': 'América Latina',
@@ -232,25 +210,6 @@ const SUMMARY_LABELS: Record<string, Record<string, string>> = {
         'quase-livre': 'Quase livre', 'livre': 'Livre',
     },
 };
-
-function scoreField(fieldScores: Record<string, number>, selected: string[]): number {
-    if (!selected.length) return 0;
-    const total = selected.reduce((sum, id) => sum + (fieldScores[id] ?? NEUTRAL_SCORE), 0);
-    return Math.round(total / selected.length);
-}
-
-function matchProfile(answers: QuizAnswers): ProfileKey {
-    const score = Object.keys(SCORES).reduce(
-        (sum, field) => sum + scoreField(SCORES[field], answers[field] ?? []),
-        0,
-    );
-
-    if (score <= 9)  return 'escapista';
-    if (score <= 13) return 'bon-vivant';
-    if (score <= 17) return 'viajante-de-verdade';
-    if (score <= 21) return 'desbravador';
-    return 'nomade-de-alma';
-}
 
 function buildAnswersSummary(answers: QuizAnswers): string {
     return Object.entries(answers)

--- a/tests/quiz-scoring.test.ts
+++ b/tests/quiz-scoring.test.ts
@@ -1,0 +1,210 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { scoreField, matchProfile, SCORES, NEUTRAL_SCORE } from '../lib/quiz-scoring';
+
+// ---------------------------------------------------------------------------
+// scoreField
+// ---------------------------------------------------------------------------
+
+test('scoreField returns the direct score for a single known option', () => {
+    assert.equal(scoreField(SCORES.destino, ['caribe']), 1);
+    assert.equal(scoreField(SCORES.destino, ['asia']), 5);
+    assert.equal(scoreField(SCORES.ritmo, ['planejado']), 1);
+    assert.equal(scoreField(SCORES.ritmo, ['livre']), 5);
+});
+
+test('scoreField averages and rounds for multi-select', () => {
+    // caribe=1, asia=5 → avg 3.0
+    assert.equal(scoreField(SCORES.destino, ['caribe', 'asia']), 3);
+    // europa=3, latam=4, africa-oriente=5 → avg 4.0
+    assert.equal(scoreField(SCORES.destino, ['europa', 'latam', 'africa-oriente']), 4);
+    // caribe=1, surpresa=3 → avg 2.0
+    assert.equal(scoreField(SCORES.destino, ['caribe', 'surpresa']), 2);
+});
+
+test('scoreField falls back to NEUTRAL_SCORE for unknown option ids', () => {
+    assert.equal(scoreField(SCORES.destino, ['desconhecido']), NEUTRAL_SCORE);
+    // mix of known and unknown: (1 + NEUTRAL_SCORE) / 2 = 2.0
+    assert.equal(scoreField(SCORES.destino, ['caribe', 'desconhecido']), Math.round((1 + NEUTRAL_SCORE) / 2));
+});
+
+test('scoreField returns 0 for empty selection', () => {
+    assert.equal(scoreField(SCORES.destino, []), 0);
+});
+
+// ---------------------------------------------------------------------------
+// matchProfile — boundary conditions
+// ---------------------------------------------------------------------------
+
+// Builds answers that produce exactly the requested total Plog score.
+// Uses single-choice fields only (P2–P4, P6) plus a single destino pick, for simplicity.
+// destino: caribe=1, surpresa=3, latam=4, asia=5
+// cena: wellness=1, familia=2, microescapada=3, natureza=4, aventura=5
+// companhia: familia=1, parceiro=3, variado=3, solo=5
+// frustracao: hotel-ruim=2, caro-demais=2, genericas=3, multidao=4, sem-liberdade=5
+// ritmo: planejado=1, semi-planejado=3, quase-livre=4, livre=5
+
+function answersForScore(target: number): Record<string, string[]> {
+    // Fixed partial: cena=1, companhia=1, frustracao=2, ritmo=1 → base = 5
+    // We vary destino to hit the target (target - 5 + 1 = destino contribution we need).
+    // Available destino: caribe=1, surpresa=3, latam=4, asia=5
+    const base = 1 + 1 + 2 + 1; // 5
+    const needed = target - base;
+    let destino: string;
+    if (needed <= 1) destino = 'caribe';
+    else if (needed <= 3) destino = 'surpresa';
+    else if (needed <= 4) destino = 'latam';
+    else destino = 'asia';
+
+    return {
+        destino: [destino],
+        cena: ['wellness'],
+        companhia: ['familia'],
+        frustracao: ['hotel-ruim'],
+        horizonte: ['budget'], // BANT field — must not affect score
+        ritmo: ['planejado'],
+    };
+}
+
+test('matchProfile returns escapista for score at upper boundary (9)', () => {
+    // cena=wellness(1) + companhia=familia(1) + frustracao=hotel-ruim(2) + ritmo=planejado(1) + destino=asia(5) = 10, overshoot
+    // Use: destino=latam(4)+cena=wellness(1)+companhia=familia(1)+frustracao=hotel-ruim(2)+ritmo=planejado(1) = 9
+    const answers = {
+        destino: ['latam'],
+        cena: ['wellness'],
+        companhia: ['familia'],
+        frustracao: ['hotel-ruim'],
+        horizonte: ['tempo'],
+        ritmo: ['planejado'],
+    };
+    assert.equal(matchProfile(answers), 'escapista');
+});
+
+test('matchProfile returns bon-vivant at lower boundary (10)', () => {
+    // destino=asia(5)+cena=wellness(1)+companhia=familia(1)+frustracao=hotel-ruim(2)+ritmo=planejado(1) = 10
+    const answers = {
+        destino: ['asia'],
+        cena: ['wellness'],
+        companhia: ['familia'],
+        frustracao: ['hotel-ruim'],
+        horizonte: ['destino'],
+        ritmo: ['planejado'],
+    };
+    assert.equal(matchProfile(answers), 'bon-vivant');
+});
+
+test('matchProfile returns bon-vivant at upper boundary (13)', () => {
+    // destino=surpresa(3)+cena=familia(2)+companhia=variado(3)+frustracao=genericas(3)+ritmo=semi-planejado(3) = 14, overshoot
+    // destino=surpresa(3)+cena=familia(2)+companhia=parceiro(3)+frustracao=hotel-ruim(2)+ritmo=semi-planejado(3) = 13
+    const answers = {
+        destino: ['surpresa'],
+        cena: ['familia'],
+        companhia: ['parceiro'],
+        frustracao: ['hotel-ruim'],
+        horizonte: ['budget'],
+        ritmo: ['semi-planejado'],
+    };
+    assert.equal(matchProfile(answers), 'bon-vivant');
+});
+
+test('matchProfile returns viajante-de-verdade at lower boundary (14)', () => {
+    // destino=surpresa(3)+cena=familia(2)+companhia=variado(3)+frustracao=genericas(3)+ritmo=semi-planejado(3) = 14
+    const answers = {
+        destino: ['surpresa'],
+        cena: ['familia'],
+        companhia: ['variado'],
+        frustracao: ['genericas'],
+        horizonte: ['companhia'],
+        ritmo: ['semi-planejado'],
+    };
+    assert.equal(matchProfile(answers), 'viajante-de-verdade');
+});
+
+test('matchProfile returns viajante-de-verdade at upper boundary (17)', () => {
+    // destino=latam(4)+cena=natureza(4)+companhia=variado(3)+frustracao=multidao(4)+ritmo=semi-planejado(3) = 18, overshoot
+    // destino=latam(4)+cena=natureza(4)+companhia=variado(3)+frustracao=hotel-ruim(2)+ritmo=semi-planejado(3) = 16, undershoot
+    // destino=latam(4)+cena=natureza(4)+companhia=variado(3)+frustracao=genericas(3)+ritmo=semi-planejado(3) = 17
+    const answers = {
+        destino: ['latam'],
+        cena: ['natureza'],
+        companhia: ['variado'],
+        frustracao: ['genericas'],
+        horizonte: ['tempo'],
+        ritmo: ['semi-planejado'],
+    };
+    assert.equal(matchProfile(answers), 'viajante-de-verdade');
+});
+
+test('matchProfile returns desbravador at lower boundary (18)', () => {
+    // destino=latam(4)+cena=natureza(4)+companhia=variado(3)+frustracao=multidao(4)+ritmo=semi-planejado(3) = 18
+    const answers = {
+        destino: ['latam'],
+        cena: ['natureza'],
+        companhia: ['variado'],
+        frustracao: ['multidao'],
+        horizonte: ['destino'],
+        ritmo: ['semi-planejado'],
+    };
+    assert.equal(matchProfile(answers), 'desbravador');
+});
+
+test('matchProfile returns desbravador at upper boundary (21)', () => {
+    // destino=africa-oriente(5)+cena=aventura(5)+companhia=solo(5)+frustracao=sem-liberdade(5)+ritmo=quase-livre(4) = 24, overshoot
+    // destino=latam(4)+cena=aventura(5)+companhia=solo(5)+frustracao=sem-liberdade(5)+ritmo=semi-planejado(3) = 22, overshoot
+    // destino=surpresa(3)+cena=aventura(5)+companhia=solo(5)+frustracao=multidao(4)+ritmo=semi-planejado(3) = 20, undershoot
+    // destino=latam(4)+cena=aventura(5)+companhia=solo(5)+frustracao=hotel-ruim(2)+ritmo=quase-livre(4) = 20, undershoot
+    // destino=latam(4)+cena=aventura(5)+companhia=solo(5)+frustracao=multidao(4)+ritmo=semi-planejado(3) = 21
+    const answers = {
+        destino: ['latam'],
+        cena: ['aventura'],
+        companhia: ['solo'],
+        frustracao: ['multidao'],
+        horizonte: ['budget'],
+        ritmo: ['semi-planejado'],
+    };
+    assert.equal(matchProfile(answers), 'desbravador');
+});
+
+test('matchProfile returns nomade-de-alma for score above 21 (22)', () => {
+    // destino=latam(4)+cena=aventura(5)+companhia=solo(5)+frustracao=sem-liberdade(5)+ritmo=semi-planejado(3) = 22
+    const answers = {
+        destino: ['latam'],
+        cena: ['aventura'],
+        companhia: ['solo'],
+        frustracao: ['sem-liberdade'],
+        horizonte: ['destino'],
+        ritmo: ['semi-planejado'],
+    };
+    assert.equal(matchProfile(answers), 'nomade-de-alma');
+});
+
+// ---------------------------------------------------------------------------
+// horizonte (P5/BANT) must not affect score
+// ---------------------------------------------------------------------------
+
+test('matchProfile is not affected by horizonte field (BANT excluded)', () => {
+    const base = {
+        destino: ['surpresa'],
+        cena: ['wellness'],
+        companhia: ['familia'],
+        frustracao: ['hotel-ruim'],
+        ritmo: ['planejado'],
+    };
+    const bantValues = ['budget', 'tempo', 'companhia', 'destino'];
+    const results = bantValues.map((v) => matchProfile({ ...base, horizonte: [v] }));
+    assert.ok(results.every((r) => r === results[0]), 'horizonte value must not change the profile');
+});
+
+// ---------------------------------------------------------------------------
+// SCORES does not include horizonte (structural guarantee)
+// ---------------------------------------------------------------------------
+
+test('SCORES table excludes the horizonte/BANT field', () => {
+    assert.ok(!('horizonte' in SCORES), 'horizonte must not be in SCORES');
+    assert.ok('destino' in SCORES);
+    assert.ok('cena' in SCORES);
+    assert.ok('companhia' in SCORES);
+    assert.ok('frustracao' in SCORES);
+    assert.ok('ritmo' in SCORES);
+    assert.equal(Object.keys(SCORES).length, 5);
+});

--- a/tests/quiz-scoring.test.ts
+++ b/tests/quiz-scoring.test.ts
@@ -36,35 +36,12 @@ test('scoreField returns 0 for empty selection', () => {
 // matchProfile — boundary conditions
 // ---------------------------------------------------------------------------
 
-// Builds answers that produce exactly the requested total Plog score.
-// Uses single-choice fields only (P2–P4, P6) plus a single destino pick, for simplicity.
+// Score reference for boundary tests:
 // destino: caribe=1, surpresa=3, latam=4, asia=5
 // cena: wellness=1, familia=2, microescapada=3, natureza=4, aventura=5
 // companhia: familia=1, parceiro=3, variado=3, solo=5
 // frustracao: hotel-ruim=2, caro-demais=2, genericas=3, multidao=4, sem-liberdade=5
 // ritmo: planejado=1, semi-planejado=3, quase-livre=4, livre=5
-
-function answersForScore(target: number): Record<string, string[]> {
-    // Fixed partial: cena=1, companhia=1, frustracao=2, ritmo=1 → base = 5
-    // We vary destino to hit the target (target - 5 + 1 = destino contribution we need).
-    // Available destino: caribe=1, surpresa=3, latam=4, asia=5
-    const base = 1 + 1 + 2 + 1; // 5
-    const needed = target - base;
-    let destino: string;
-    if (needed <= 1) destino = 'caribe';
-    else if (needed <= 3) destino = 'surpresa';
-    else if (needed <= 4) destino = 'latam';
-    else destino = 'asia';
-
-    return {
-        destino: [destino],
-        cena: ['wellness'],
-        companhia: ['familia'],
-        frustracao: ['hotel-ruim'],
-        horizonte: ['budget'], // BANT field — must not affect score
-        ritmo: ['planejado'],
-    };
-}
 
 test('matchProfile returns escapista for score at upper boundary (9)', () => {
     // cena=wellness(1) + companhia=familia(1) + frustracao=hotel-ruim(2) + ritmo=planejado(1) + destino=asia(5) = 10, overshoot


### PR DESCRIPTION
## Contexto

A issue #420 implementou o sistema de scoring Plog no quiz, mas a lógica ficou embutida no componente `QuizAnhangaLanding.tsx` sem testes unitários — violação do testing standard, que exige testes para toda mudança de comportamento.

## O que mudou

### `lib/quiz-scoring.ts` (novo)
Extrai de `QuizAnhangaLanding.tsx` para um módulo puro e testável:
- `SCORES` — tabela de pontuação P1+P2+P3+P4+P6
- `NEUTRAL_SCORE` — fallback para opções desconhecidas
- `scoreField()` — calcula o score de um campo (média arredondada para multi-select)
- `matchProfile()` — mapeia a soma de scores para um dos 5 perfis Plog
- `ProfileKey` — tipo exportado

### `pages/landings/QuizAnhangaLanding.tsx`
Remove as ~20 linhas de lógica, importa de `lib/quiz-scoring`.

### `tests/quiz-scoring.test.ts` (novo)
14 testes cobrindo:
- `scoreField`: seleção única, multi-select (média), fallback `NEUTRAL_SCORE`, array vazio
- `matchProfile`: 8 fronteiras de score (9, 10, 13, 14, 17, 18, 21, 22)
- Garantia de que `horizonte` (P5/BANT) não afeta o resultado
- Garantia estrutural de que `SCORES` tem exatamente os 5 campos esperados

## Verificação

```
pnpm test:regression  → 212 pass, 0 fail
pnpm typecheck        → sem erros
```

Closes #420