### PR TITLE
fix(quiz): adicionar campo destinos no payload submit → n8n

### DIFF
--- a/hooks/useQuizCapture.ts
+++ b/hooks/useQuizCapture.ts
@@ -88,7 +88,7 @@ export function useQuizCapture() {
     }, []);
 
     const submitQuiz = async (
-        input: Pick<SubmitQuizRequest, 'firstName' | 'email' | 'whatsapp' | 'profileKey' | 'profileName' | 'bantSummary'>,
+        input: Pick<SubmitQuizRequest, 'firstName' | 'email' | 'whatsapp' | 'profileKey' | 'profileName' | 'bantSummary' | 'destinos'>,
     ): Promise<SubmitQuizResult> => {
         setError(null);
         setIsSubmitting(true);

--- a/lib/n8n-payloads.ts
+++ b/lib/n8n-payloads.ts
@@ -145,6 +145,7 @@ export interface N8nQuizPayload {
         profileName: string;
         bantSummary: string;
         sourcePage: string;
+        destinos: string[];
     };
     utms: SubmitQuizRequest['utms'];
     tracking: SubmitQuizRequest['tracking'];
@@ -165,6 +166,7 @@ export function buildN8nQuizPayload(payload: SubmitQuizRequest, requestId: strin
             profileName: payload.profileName,
             bantSummary: payload.bantSummary,
             sourcePage: payload.sourcePage,
+            destinos: payload.destinos ?? [],
         },
         utms: payload.utms,
         tracking: payload.tracking,

--- a/lib/quiz-logic.ts
+++ b/lib/quiz-logic.ts
@@ -29,7 +29,11 @@ export function validateQuizPayload(
     const whatsapp = normalizeWhatsappNumber(raw.whatsapp) ?? undefined;
 
     const destinos = Array.isArray(raw.destinos)
-        ? raw.destinos.filter((d): d is string => typeof d === 'string').slice(0, 10)
+        ? raw.destinos
+            .filter((d): d is string => typeof d === 'string')
+            .map((d) => d.trim().slice(0, 50))
+            .filter(Boolean)
+            .slice(0, 10)
         : [];
 
     const utms = normalizeUtms(raw.utms);

--- a/lib/quiz-logic.ts
+++ b/lib/quiz-logic.ts
@@ -28,6 +28,10 @@ export function validateQuizPayload(
 
     const whatsapp = normalizeWhatsappNumber(raw.whatsapp) ?? undefined;
 
+    const destinos = Array.isArray(raw.destinos)
+        ? raw.destinos.filter((d): d is string => typeof d === 'string').slice(0, 10)
+        : [];
+
     const utms = normalizeUtms(raw.utms);
     const tracking = normalizeTracking(raw.tracking, utms);
 
@@ -41,6 +45,7 @@ export function validateQuizPayload(
             profileName,
             bantSummary,
             sourcePage,
+            destinos,
             utms,
             tracking,
         },

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -883,6 +883,7 @@ export default function QuizAnhangaLanding() {
             profileKey: pKey,
             profileName: profile.name,
             bantSummary,
+            destinos: answers.destino ?? [],
         });
 
         if (!result.ok) {

--- a/tests/submit-quiz.test.ts
+++ b/tests/submit-quiz.test.ts
@@ -37,6 +37,18 @@ test('validateQuizPayload — destinos com valores não-string são filtrados', 
     assert.deepEqual(result.data.destinos, ['europa', 'latam']);
 });
 
+test('validateQuizPayload — destinos com espaços são normalizados com trim', () => {
+    const result = validateQuizPayload({ ...BASE_PAYLOAD, destinos: ['  europa  ', ' latam'] });
+    assert.ok(result.valid);
+    assert.deepEqual(result.data.destinos, ['europa', 'latam']);
+});
+
+test('validateQuizPayload — destinos com strings vazias após trim são removidos', () => {
+    const result = validateQuizPayload({ ...BASE_PAYLOAD, destinos: ['europa', '   ', 'latam'] });
+    assert.ok(result.valid);
+    assert.deepEqual(result.data.destinos, ['europa', 'latam']);
+});
+
 test('validateQuizPayload — destinos limitado a 10 elementos', () => {
     const destinos = Array.from({ length: 15 }, (_, i) => `destino-${i}`);
     const result = validateQuizPayload({ ...BASE_PAYLOAD, destinos });

--- a/tests/submit-quiz.test.ts
+++ b/tests/submit-quiz.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateQuizPayload } from '../lib/quiz-logic.ts';
+import { buildN8nQuizPayload } from '../lib/n8n-payloads.ts';
+
+const BASE_PAYLOAD = {
+    firstName: 'Maria',
+    email: 'maria@example.com',
+    profileKey: 'aventureiro',
+    profileName: 'Aventureiro',
+    bantSummary: 'Quiz Anhangá · Perfil: Aventureiro · destino=europa',
+    sourcePage: '/quiz',
+    utms: {
+        utm_source: null,
+        utm_medium: null,
+        utm_campaign: null,
+        utm_term: null,
+        utm_content: null,
+    },
+};
+
+test('validateQuizPayload — destinos preenchidos são normalizados e incluídos', () => {
+    const result = validateQuizPayload({ ...BASE_PAYLOAD, destinos: ['europa', 'latam'] });
+    assert.ok(result.valid);
+    assert.deepEqual(result.data.destinos, ['europa', 'latam']);
+});
+
+test('validateQuizPayload — destinos ausente resulta em array vazio', () => {
+    const result = validateQuizPayload({ ...BASE_PAYLOAD });
+    assert.ok(result.valid);
+    assert.deepEqual(result.data.destinos, []);
+});
+
+test('validateQuizPayload — destinos com valores não-string são filtrados', () => {
+    const result = validateQuizPayload({ ...BASE_PAYLOAD, destinos: ['europa', 42, null, 'latam', true] });
+    assert.ok(result.valid);
+    assert.deepEqual(result.data.destinos, ['europa', 'latam']);
+});
+
+test('validateQuizPayload — destinos limitado a 10 elementos', () => {
+    const destinos = Array.from({ length: 15 }, (_, i) => `destino-${i}`);
+    const result = validateQuizPayload({ ...BASE_PAYLOAD, destinos });
+    assert.ok(result.valid);
+    assert.equal(result.data.destinos?.length, 10);
+});
+
+test('buildN8nQuizPayload — inclui destinos no payload do n8n', () => {
+    const payload = { ...BASE_PAYLOAD, destinos: ['europa', 'latam'], tracking: undefined };
+    const n8n = buildN8nQuizPayload(payload, 'req-123');
+    assert.deepEqual(n8n.quiz.destinos, ['europa', 'latam']);
+});
+
+test('buildN8nQuizPayload — destinos ausente resulta em array vazio no payload n8n', () => {
+    const payload = { ...BASE_PAYLOAD, tracking: undefined };
+    const n8n = buildN8nQuizPayload(payload, 'req-456');
+    assert.deepEqual(n8n.quiz.destinos, []);
+});

--- a/types/quiz.ts
+++ b/types/quiz.ts
@@ -8,6 +8,7 @@ export interface SubmitQuizRequest {
     profileName: string;
     bantSummary: string;
     sourcePage: string;
+    destinos?: string[];
     utms: LeadUtms;
     tracking?: LeadTracking;
 }


### PR DESCRIPTION
## Summary

- Adiciona `destinos?: string[]` em `SubmitQuizRequest` (tipo e validação)
- `validateQuizPayload()` extrai, filtra valores não-string e limita a 10 entradas
- `N8nQuizPayload` e `buildN8nQuizPayload()` incluem `destinos: string[]`
- `handleLeadSubmit()` passa `answers.destino ?? []` ao chamar `submitQuiz()`

Closes #422

## Test plan

- [x] `validateQuizPayload` — destinos preenchidos são normalizados
- [x] `validateQuizPayload` — destinos ausente resulta em `[]`
- [x] `validateQuizPayload` — valores não-string são filtrados
- [x] `validateQuizPayload` — limitado a 10 elementos
- [x] `buildN8nQuizPayload` — inclui destinos no payload n8n
- [x] `buildN8nQuizPayload` — ausência de destinos resulta em `[]`
- [x] Suite completa: 218 testes passando (`pnpm test:regression`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)