### PR TITLE
feat(blog): reescrita editorial de tom — Maldivas e NY Natal (FEL-146)

### DIFF
--- a/content/blog/lua-de-mel-nas-maldivas.mdx
+++ b/content/blog/lua-de-mel-nas-maldivas.mdx
@@ -14,7 +14,7 @@ tags: ["maldivas", "lua-de-mel", "romance", "luxo", "asia"]
 
 As Maldivas têm uma característica estrutural que nenhum outro destino de lua de mel replica com a mesma consistência: cada resort ocupa uma ilha inteira. Privacidade não depende de sorte de quarto ou de andar — está garantida por padrão.
 
-A logística para chegar é o primeiro ponto a considerar. Do Brasil, o trajeto leva 20 a 24 horas com ao menos uma conexão (as rotas mais comuns passam por Dubai via Emirates, Doha via Qatar Airways ou Istambul via Turkish Airlines). Ao chegar em Malé, o transfer ao resort é de lancha rápida (15 minutos a 1h30 dependendo da localização) ou hidroavião — custo varia bastante e alguns resorts incluem no pacote.
+A logística para chegar é o primeiro ponto a considerar. Do Brasil, o trajeto leva 20 a 24 horas com ao menos uma conexão (as rotas mais comuns passam por Dubai via Emirates, Doha via Qatar Airways ou Istambul via Turkish Airlines). Ao chegar em Malé, o transfer ao resort é de lancha rápida (15 minutos a 1h30 dependendo da localização) ou hidroavião — o custo varia bastante e alguns resorts incluem no pacote.
 
 Este guia cobre o que diferencia as Maldivas de outros destinos de romance, as diferenças práticas entre overwater villa e beach villa, os resorts com melhor custo-benefício e quanto esperar gastar.
 
@@ -22,7 +22,7 @@ Este guia cobre o que diferencia as Maldivas de outros destinos de romance, as d
 
 -   **Isolamento por estrutura:** Cada resort ocupa uma ilha inteira. Não há outros condomínios, restaurantes externos ou passantes — todos os hóspedes são do mesmo resort.
 -   **Acesso direto a recifes de coral:** Na maioria dos resorts, o recife começa no píer ou na beira d'água, sem necessidade de barco para fazer snorkel. Visibilidade subaquática de 10 a 30 metros em condições normais.
--   **Variedade de experiências aquáticas:** Mergulho com tubarões-baleia (sazonais, de junho a novembro), jantar em sandbank (banco de areia isolado no meio do oceano), refeição subaquática disponível no Ithaa Undersea Restaurant do Conrad Maldives, spa overwater.
+-   **Variedade de experiências aquáticas:** Mergulho com tubarões-baleia (sazonais, de junho a novembro), jantar em sandbank (banco de areia isolado no meio do oceano), refeição subaquática no Ithaa Undersea Restaurant do Conrad Maldives e tratamentos em spas overwater.
 -   **Ausência de atrito logístico:** Sem cidades para navegar, sem transporte diário, sem decisões de roteiro fora do resort. A estrutura da ilha resolve a maior parte do programa.
 
 ## Quando Ir: Escolhendo a Época Perfeita
@@ -120,4 +120,4 @@ Pode não fazer sentido se você prefere:
 -   Destinos com variedade cultural, gastronômica ou urbana fora do hotel
 -   Viagens com deslocamentos, explorações e roteiros variados por dia
 -   Orçamento abaixo de US$ 10.000 o casal para uma semana
--   Viagem com crianças pequenas: a maioria dos resorts de luxo não é projetado para famílias e alguns têm restrições de idade
+-   Viagem com crianças pequenas: a maioria dos resorts de luxo não é projetada para famílias e alguns têm restrições de idade

--- a/content/blog/lua-de-mel-nas-maldivas.mdx
+++ b/content/blog/lua-de-mel-nas-maldivas.mdx
@@ -12,18 +12,18 @@ chatCTADestination: "Maldivas"
 tags: ["maldivas", "lua-de-mel", "romance", "luxo", "asia"]
 ---
 
-Imagine acordar em uma cabana sobre águas cristalinas tão azuis que parecem irreais. Abrir a porta do quarto e mergulhar direto no oceano Índico. Tomar café da manhã flutuante enquanto peixes coloridos nadam ao redor. Assistir ao pôr do sol mais lindo da sua vida, só vocês dois, sem ninguém por perto.
+As Maldivas têm uma característica estrutural que nenhum outro destino de lua de mel replica com a mesma consistência: cada resort ocupa uma ilha inteira. Privacidade não depende de sorte de quarto ou de andar — está garantida por padrão.
 
-As Maldivas não são apenas um destino de lua de mel. São o cenário perfeito para começar uma nova história juntos, cercados por uma beleza natural que tira o fôlego a cada segundo.
+A logística para chegar é o primeiro ponto a considerar. Do Brasil, o trajeto leva 20 a 24 horas com ao menos uma conexão (as rotas mais comuns passam por Dubai via Emirates, Doha via Qatar Airways ou Istambul via Turkish Airlines). Ao chegar em Malé, o transfer ao resort é de lancha rápida (15 minutos a 1h30 dependendo da localização) ou hidroavião — custo varia bastante e alguns resorts incluem no pacote.
 
-Se você está planejando a viagem mais especial da sua vida, este guia vai te mostrar tudo o que você precisa saber para transformar sua lua de mel em uma experiência inesquecível.
+Este guia cobre o que diferencia as Maldivas de outros destinos de romance, as diferenças práticas entre overwater villa e beach villa, os resorts com melhor custo-benefício e quanto esperar gastar.
 
 ## Por Que as Maldivas São o Destino Perfeito Para Lua de Mel
 
--   **Privacidade absoluta:** Cada resort ocupa uma ilha inteira. Isso significa que você não vai dividir espaço com multidões de turistas. É só vocês dois, areia branca e mar turquesa.
--   **Beleza incomparável:** As Maldivas têm alguns dos cenários mais fotografados do mundo. Águas tão claras que você vê o fundo a metros de profundidade. Vida marinha vibrante. Praias desertas que parecem ter sido feitas sob medida para o momento de vocês.
--   **Experiências únicas:** Jantar em uma mesa no meio do oceano. Mergulhar com tubarões-baleia. Spa flutuante. Banho de espuma na banheira com vista para o infinito. Cada detalhe é pensado para criar memórias eternas.
--   **Romantismo natural:** Não precisa forçar nada. O ambiente já entrega toda a atmosfera romântica que vocês merecem.
+-   **Isolamento por estrutura:** Cada resort ocupa uma ilha inteira. Não há outros condomínios, restaurantes externos ou passantes — todos os hóspedes são do mesmo resort.
+-   **Acesso direto a recifes de coral:** Na maioria dos resorts, o recife começa no píer ou na beira d'água, sem necessidade de barco para fazer snorkel. Visibilidade subaquática de 10 a 30 metros em condições normais.
+-   **Variedade de experiências aquáticas:** Mergulho com tubarões-baleia (sazonais, de junho a novembro), jantar em sandbank (banco de areia isolado no meio do oceano), refeição subaquática disponível no Ithaa Undersea Restaurant do Conrad Maldives, spa overwater.
+-   **Ausência de atrito logístico:** Sem cidades para navegar, sem transporte diário, sem decisões de roteiro fora do resort. A estrutura da ilha resolve a maior parte do programa.
 
 ## Quando Ir: Escolhendo a Época Perfeita
 
@@ -37,7 +37,7 @@ Se você está planejando a viagem mais especial da sua vida, este guia vai te m
 
 Existem mais de 150 resorts nas Maldivas. Cada um com sua personalidade. Aqui estão os estilos principais para você escolher o que combina mais com vocês:
 
--   **Luxo máximo (US$ 1.500+ por noite):** Soneva Jani, St. Regis Maldives, Conrad Maldives. Overwater villas gigantes, piscina privativa, mordomo pessoal, gastronomia premiada.
+-   **Luxo máximo (US$ 2.500+ por noite):** Soneva Jani, St. Regis Maldives, Conrad Maldives. Overwater villas gigantes, piscina privativa, mordomo pessoal, gastronomia premiada.
 -   **Luxo acessível (US$ 800 a 1.500 por noite):** Anantara Dhigu, Coco Bodu Hithi, Velassaru. Excelente custo-benefício, bangalôs lindos, ótima estrutura.
 -   **Romântico e intimista (US$ 600 a 1.000 por noite):** Baros Maldives, Lily Beach, Constance Moofushi. Resorts menores, mais exclusivos, perfeitos para quem quer sossego total.
 
@@ -53,7 +53,7 @@ Existem mais de 150 resorts nas Maldivas. Cada um com sua personalidade. Aqui es
 -   **Mergulho e snorkel:** As Maldivas têm alguns dos melhores pontos de mergulho do mundo. Você vai nadar com tartarugas, arraias-manta, tubarões de recife e milhares de peixes tropicais. Mesmo quem nunca mergulhou consegue fazer snorkel tranquilamente.
 -   **Passeio de barco ao pôr do sol:** Navegue em um dhoni tradicional (barco maldivo) ou em um iate privativo enquanto o sol se põe no horizonte. Muitos resorts servem champanhe durante o passeio.
 -   **Jantar privativo:** Mesa montada na praia, sob as estrelas, com chef preparando menu especial só para vocês. Ou jantar flutuante no meio do oceano. Ou ainda no sandbank, um banco de areia no meio do nada.
--   **Spa para casal:** Tratamentos com vista para o mar, massagens sincronizadas, banhos relaxantes. Puro momento zen a dois.
+-   **Spa para casal:** Tratamentos com vista para o mar, massagens sincronizadas, banhos relaxantes. A maioria dos resorts 5 estrelas tem estrutura de spa overwater, que é a versão mais cara mas também a mais diferente do que existe no Brasil.
 -   **Excursão para ilha local:** Conhecer vilarejos maldivos, entender a cultura, comprar artesanato. Contraste interessante com o luxo do resort.
 -   **Pesca noturna:** Tradição local. Pescar à noite e o chef do resort prepara seu peixe para o jantar no dia seguinte.
 
@@ -100,16 +100,24 @@ Existem mais de 150 resorts nas Maldivas. Cada um com sua personalidade. Aqui es
 
 Uma lua de mel de 7 dias nas Maldivas para um casal geralmente fica entre:
 
--   **Econômico:** US$ 8.000 a 12.000 (resort 4 estrelas, meia pensão, voos em classe econômica)
+-   **Econômico:** US$ 10.000 a 15.000 (resort 4 estrelas como Centara Ras Fushi ou Cinnamon Dhonveli, meia pensão, voos em classe econômica)
 -   **Confortável:** US$ 15.000 a 25.000 (resort 5 estrelas, all-inclusive, voos em executiva ou econômica premium)
 -   **Luxo:** US$ 30.000+ (resort 5 estrelas deluxe, overwater villa top, experiências exclusivas, voos primeira classe)
 
 *Valores incluem passagens aéreas, hospedagem, refeições conforme plano escolhido e transfer. Não incluem passeios extras, spa e compras.*
 
-## Vale Cada Centavo?
+## As Maldivas Fazem Sentido Para Você?
 
-Lua de mel é um momento único. Não vai se repetir. E as Maldivas entregam uma experiência que nenhum outro destino consegue replicar.
+Faz sentido se você busca:
 
-É acordar e dormir ouvindo o mar. É nadar em águas que parecem piscina natural. É ter privacidade absoluta para curtir esse momento só de vocês. É voltar para casa com histórias que vão contar para os filhos e netos.
+-   Isolamento real: sem outras atrações próximas, sem cidade para explorar fora do resort
+-   Foco total em mar, recife e estrutura de resort
+-   Privacidade garantida por padrão, não por custo de upgrade
+-   Disposição para 20+ horas de voo — o que torna viagens curtas pouco vantajosas (mínimo recomendado: 5 noites)
 
-Não é só uma viagem. É o começo da vida de casados em um dos lugares mais lindos do planeta.
+Pode não fazer sentido se você prefere:
+
+-   Destinos com variedade cultural, gastronômica ou urbana fora do hotel
+-   Viagens com deslocamentos, explorações e roteiros variados por dia
+-   Orçamento abaixo de US$ 10.000 o casal para uma semana
+-   Viagem com crianças pequenas: a maioria dos resorts de luxo não é projetado para famílias e alguns têm restrições de idade

--- a/content/blog/nova-york-no-natal.mdx
+++ b/content/blog/nova-york-no-natal.mdx
@@ -14,7 +14,7 @@ tags: ["nova-york", "eua", "natal", "inverno", "america-do-norte"]
 
 Nova York entre o Thanksgiving (última quinta-feira de novembro) e o início de janeiro tem diferenças práticas em relação ao resto do ano: atrações sazonais específicas, mais turistas, preços de hotel mais altos e clima entre -5°C e 5°C com possibilidade de neve.
 
-O que muda de verdade nesse período: a árvore do Rockefeller Center (acesa no início de dezembro), o Winter Village do Bryant Park com quiosques de artesanato e pista de patinação gratuita, os displays elaborados das vitrines da Fifth Avenue e Dyker Heights — bairro residencial no Brooklyn onde moradores competem em decorações exageradas, gratuito e muito diferente de qualquer coisa no Brasil.
+O que muda de verdade nesse período: a árvore do Rockefeller Center (acesa no início de dezembro), o Winter Village do Bryant Park com quiosques de artesanato e pista de patinação gratuita, os displays elaborados das vitrines da Fifth Avenue e Dyker Heights — bairro residencial no Brooklyn onde moradores competem em decorações exageradas, com visitação gratuita e uma atmosfera muito diferente de qualquer coisa no Brasil.
 
 Este roteiro de 5 dias cobre o que vale a visita específica nessa época, o que é mais hype do que entrega e o que realmente não depende da estação.
 
@@ -22,7 +22,7 @@ Este roteiro de 5 dias cobre o que vale a visita específica nessa época, o que
 
 Entre meados de novembro e início de janeiro, algumas atrações específicas entram em operação: o Winter Village do Bryant Park, a árvore do Rockefeller Center, os displays das vitrines da Fifth Avenue e Dyker Heights. As pistas de patinação no gelo — Rockefeller e Bryant Park — funcionam de outubro a março, portanto antes e depois desse período também.
 
-O movimento de turistas é intenso entre 20 de dezembro e 1º de janeiro. Restaurantes lotam, ingressos de Broadway ficam mais caros e pistas de patinação têm fila considerável. Reservas com antecedência fazem diferença nessa janela.
+O movimento de turistas é intenso entre 20 de dezembro e 1º de janeiro. Restaurantes lotam, ingressos da Broadway ficam mais caros e pistas de patinação têm fila considerável. Reservas com antecedência fazem diferença nessa janela.
 
 **Melhor período:** Final de novembro (após o Thanksgiving) até primeira semana de janeiro. Evite 24 e 25 de dezembro se quiser encontrar lojas e atrações abertas.
 

--- a/content/blog/nova-york-no-natal.mdx
+++ b/content/blog/nova-york-no-natal.mdx
@@ -12,21 +12,21 @@ chatCTADestination: "Nova York"
 tags: ["nova-york", "eua", "natal", "inverno", "america-do-norte"]
 ---
 
-Existe algo no ar de Nova York durante o Natal que não dá para explicar. Talvez seja a neve caindo suavemente sobre o Central Park. Ou as vitrines da Fifth Avenue transformadas em verdadeiras obras de arte. Ou ainda aquele cheiro de castanhas assadas misturado com chocolate quente que invade as esquinas.
+Nova York entre o Thanksgiving (última quinta-feira de novembro) e o início de janeiro tem diferenças práticas em relação ao resto do ano: atrações sazonais específicas, mais turistas, preços de hotel mais altos e clima entre -5°C e 5°C com possibilidade de neve.
 
-A verdade é que Nova York no Natal não é apenas um destino. É uma experiência que parece ter saído direto de um filme romântico, daqueles que você assiste repetidamente todo dezembro.
+O que muda de verdade nesse período: a árvore do Rockefeller Center (acesa no início de dezembro), o Winter Village do Bryant Park com quiosques de artesanato e pista de patinação gratuita, os displays elaborados das vitrines da Fifth Avenue e Dyker Heights — bairro residencial no Brooklyn onde moradores competem em decorações exageradas, gratuito e muito diferente de qualquer coisa no Brasil.
 
-Se você sempre sonhou em viver esse momento mágico, este roteiro foi feito para você.
+Este roteiro de 5 dias cobre o que vale a visita específica nessa época, o que é mais hype do que entrega e o que realmente não depende da estação.
 
 ## Por Que Nova York no Natal é Tão Especial
 
-Entre meados de novembro e início de janeiro, a cidade que nunca dorme se transforma completamente. Luzes piscam em cada quarteirão. Árvores de Natal gigantes aparecem em pontos icônicos. Pistas de patinação no gelo surgem no meio de arranha-céus.
+Entre meados de novembro e início de janeiro, algumas atrações específicas entram em operação: o Winter Village do Bryant Park, a árvore do Rockefeller Center, os displays das vitrines da Fifth Avenue e Dyker Heights. As pistas de patinação no gelo — Rockefeller e Bryant Park — funcionam de outubro a março, portanto antes e depois desse período também.
 
-Mas o que realmente torna essa época única é a energia contagiante. Novaiorquinos correndo com sacolas de presentes. Turistas encantados fotografando tudo. Coros cantando canções natalinas nas estações de metrô. É impossível não se deixar envolver pela magia.
+O movimento de turistas é intenso entre 20 de dezembro e 1º de janeiro. Restaurantes lotam, ingressos de Broadway ficam mais caros e pistas de patinação têm fila considerável. Reservas com antecedência fazem diferença nessa janela.
 
 **Melhor período:** Final de novembro (após o Thanksgiving) até primeira semana de janeiro. Evite 24 e 25 de dezembro se quiser encontrar lojas e atrações abertas.
 
-## Roteiro de 5 Dias: Do Clássico ao Inesquecível
+## Roteiro de 5 Dias: Atrações, Bairros e Logística
 
 ### Dia 1: Rockefeller Center e Fifth Avenue
 
@@ -44,7 +44,7 @@ Bryant Park se transforma no Winter Village, um mercado de Natal gratuito com ma
 
 A pista de patinação aqui é gratuita (você paga apenas o aluguel dos patins). Menos turística que a do Rockefeller, mas igualmente charmosa.
 
-**Aproveitando o dia:** Visite a New York Public Library logo ao lado. Se tiver sorte e estiver nevando, a fachada com leões cobertos de neve é de tirar o fôlego.
+**Aproveitando o dia:** Visite a New York Public Library logo ao lado. Se estiver nevando, a fachada com os leões cobertos de neve é um dos melhores pontos fotográficos gratuitos da cidade.
 
 À tarde, explore as lojas de departamento. Macy's Herald Square tem vitrines animadas e uma seção inteira dedicada ao Natal.
 
@@ -58,7 +58,7 @@ Acorde cedo e vá para o Central Park. Com sorte, você vai encontrar o parque c
 
 -   Bethesda Fountain congelada
 -   Bow Bridge com vista para os prédios nevados
--   The Mall, aquela alameda arborizada que fica mágica no inverno
+-   The Mall, alameda arborizada com árvores nuas cobertas de neve no inverno
 
 Se estiver muito frio, faça uma pausa no Loeb Boathouse para um chocolate quente com vista para o lago.
 
@@ -68,7 +68,7 @@ Se estiver muito frio, faça uma pausa no Loeb Boathouse para um chocolate quent
 
 ### Dia 4: Brooklyn e DUMBO no Natal
 
-Atravesse a Brooklyn Bridge a pé pela manhã. A vista de Manhattan com possíveis flocos de neve caindo é inesquecível.
+Atravesse a Brooklyn Bridge a pé pela manhã. A vista de Manhattan a partir da ponte é boa em qualquer época — com neve, é particularmente fotogênica.
 
 Do outro lado, explore o bairro DUMBO (Down Under the Manhattan Bridge Overpass). As ruas de paralelepípedos decoradas para o Natal têm um charme especial.
 
@@ -90,7 +90,7 @@ Use a manhã para compras finais ou visitar pontos que ficaram pendentes.
 -   Chelsea Market para souvenirs gourmet
 -   Strand Book Store para livros únicos
 
-**Última experiência mágica:** Termine o dia no Top of the Rock (observatório do Rockefeller Center) ao pôr do sol. Ver a cidade acender suas luzes natalinas de cima é o encerramento perfeito.
+**Para encerrar:** Termine o dia no Top of the Rock (observatório do Rockefeller Center) ao pôr do sol. Em dezembro, a cidade começa a acender as luzes natalinas cedo — a vista de cima pega esse momento.
 
 ## Experiências Extras Que Valem a Pena
 
@@ -117,8 +117,10 @@ Além das roupas de frio óbvias, não esqueça:
 -   Protetor labial (lábios ressecam muito)
 -   Calçados impermeáveis e antiderrapantes
 
-## A Magia Que Você Leva Para Casa
+## Antes de Fechar as Passagens
 
-No final, não são só as fotos perfeitas ou os presentes comprados que ficam. É o sabor daquele chocolate quente tomado debaixo de neve. O brilho nos olhos de quem patina pela primeira vez. A sensação de estar dentro de um cenário natalino que você só via em filmes.
+Nova York no Natal tem custo alto e logística densa. Mas para quem gosta de cidade, inverno e atmosfera urbana, o período entre o Thanksgiving e o Ano Novo é o mais completo do ano em termos de atrações simultâneas.
 
-Nova York no Natal mexe com algo dentro da gente. Te faz acreditar em magia novamente, nem que seja só por alguns dias.
+Se a dúvida é entre dezembro e uma data fora de temporada: preços de hotel caem substancialmente em janeiro e fevereiro, mas você perde o Winter Village, as vitrines especiais e Dyker Heights. Para ver neve sem o custo do Natal, fevereiro costuma ter o clima mais frio e menos turistas.
+
+Para montar o roteiro de acordo com o seu orçamento e as suas datas, a Anhangá pode comparar as opções de hospedagem e passeios.


### PR DESCRIPTION
## Resumo

Sprint 4.1 do `blog-review-2026-05`. Reescrita editorial dos dois artigos com score 6/10 por clichê IA/listicle. Tom ajustado para a voz Anhangá: direta, específica, sem emoção performática.

**Linear:** FEL-146

## Mudanças

### `lua-de-mel-nas-maldivas.mdx`
- Abertura substituída: narrativa imagética → apresentação estrutural (privacidade por resort-ilha, logística de 20-24h de voo, proposta do guia)
- Seção "Por Que as Maldivas…": bullets com adjetivo emocional em negrito → fatos funcionais (isolamento, acesso a recife, experiências específicas com sazonalidade e nomes reais)
- Seção "Vale Cada Centavo?" → "As Maldivas Fazem Sentido Para Você?" com checklist bilateral
- Preços corrigidos: econômico US$ 8-12k → **US$ 10-15k** com Centara Ras Fushi e Cinnamon Dhonveli; Soneva Jani **US$ 2.500+**/noite (era 1.500+)
- "Puro momento zen a dois" removido; spa descrito funcionalmente

### `nova-york-no-natal.mdx`
- Abertura substituída: "não dá para explicar" + "filme romântico" → diferenças práticas do período (atrações, lotação, clima)
- Seção "Por Que é Tão Especial": "energia contagiante" + "magia" → atrações específicas + aviso de lotação com datas
- Heading de roteiro: "Do Clássico ao Inesquecível" → "Atrações, Bairros e Logística"
- Leões da NYPL, The Mall, Brooklyn Bridge: superlativos → observações descritivas
- "Última experiência mágica:" → "Para encerrar:"
- Final "A Magia Que Você Leva Para Casa" → "Antes de Fechar as Passagens" com orientação prática e transição orgânica para o ChatCTA

## Critérios de aceite

- [x] Abertura sem metáfora emocional nos primeiros 2 parágrafos
- [x] Seção final sem promessa de experiência transcendente
- [x] Nenhum bullet com frase emocional em negrito
- [x] "o Central Park" (masculino) em todas as ocorrências
- [x] Coerência de preços em `lua-de-mel-nas-maldivas` corrigida
- [x] `dateModified: "2026-05-05"` em ambos os arquivos

## Test plan

- [ ] Revisar abertura de cada artigo no blog renderizado
- [ ] Confirmar que o checklist de decisão das Maldivas está legível em mobile
- [ ] Verificar que a seção final de NY transita naturalmente para o ChatCTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)