### PR TITLE
feat(blog): links internos cross-article — México, Itália↔Europa, Disney (FEL-149)

### DIFF
--- a/content/blog/5-segredos-da-disney-que-ninguem-conta.mdx
+++ b/content/blog/5-segredos-da-disney-que-ninguem-conta.mdx
@@ -60,7 +60,7 @@ O acesso é exclusivo para membros — a anuidade fica na casa das dezenas de mi
 
 A equipe da Anhangá monta o roteiro completo da Disney — incluindo quais dias ir a cada parque, onde comer sem precisar reservar com 60 dias de antecedência e como usar o Lightning Lane sem desperdiçar dinheiro. Fale com a gente antes de comprar qualquer pacote pronto.
 
-Se você quer saber o que vem por aí no Animal Kingdom, a Disney anunciou o [Tropical Americas — nova área temática dedicada à América Latina](/blog/disney-tropical-americas-animal-kingdom), com abertura prevista para 2027. Para o planejamento da viagem com visto americano e logística além de Orlando, veja nosso [guia da América do Norte para brasileiros](/blog/america-do-norte-destinos-alem-de-nova-york).
+Se você quer saber o que vem por aí no Animal Kingdom, a Disney anunciou a [Tropical Americas — nova área temática dedicada à América Latina](/blog/disney-tropical-americas-animal-kingdom), com abertura prevista para 2027. Para o planejamento da viagem com visto americano e logística além de Orlando, veja nosso [guia da América do Norte para brasileiros](/blog/america-do-norte-destinos-alem-de-nova-york).
 
 ## Como Usar Essas Informações na Prática
 

--- a/content/blog/5-segredos-da-disney-que-ninguem-conta.mdx
+++ b/content/blog/5-segredos-da-disney-que-ninguem-conta.mdx
@@ -60,6 +60,8 @@ O acesso é exclusivo para membros — a anuidade fica na casa das dezenas de mi
 
 A equipe da Anhangá monta o roteiro completo da Disney — incluindo quais dias ir a cada parque, onde comer sem precisar reservar com 60 dias de antecedência e como usar o Lightning Lane sem desperdiçar dinheiro. Fale com a gente antes de comprar qualquer pacote pronto.
 
+Se você quer saber o que vem por aí no Animal Kingdom, a Disney anunciou o [Tropical Americas — nova área temática dedicada à América Latina](/blog/disney-tropical-americas-animal-kingdom), com abertura prevista para 2027. Para o planejamento da viagem com visto americano e logística além de Orlando, veja nosso [guia da América do Norte para brasileiros](/blog/america-do-norte-destinos-alem-de-nova-york).
+
 ## Como Usar Essas Informações na Prática
 
 Esses pontos têm algo em comum: funcionam quando você sabe aplicá-los no momento certo. O Rider Switch só funciona se você avisar o cast member na entrada. Os banheiros alternativos só ajudam se você souber onde ficam antes de precisar.

--- a/content/blog/america-do-norte-destinos-alem-de-nova-york.mdx
+++ b/content/blog/america-do-norte-destinos-alem-de-nova-york.mdx
@@ -24,7 +24,7 @@ A Flórida não é só parques temáticos. **Miami** tem vida própria: South Be
 
 Para quem vai com crianças e quer fazer os parques temáticos, Orlando entrega mais do que a Disney: tem Universal, SeaWorld, Busch Gardens em Tampa, e uma infraestrutura turística que facilita muito a vida.
 
-Combinando com uma parada no Caribe? Confira nosso [guia de destinos caribenhos para brasileiros](/blog/caribe-destinos-para-brasileiros). Se Orlando entra no roteiro, [5 segredos da Disney que fazem diferença na prática](/blog/5-segredos-da-disney-que-ninguem-conta) vai ajudar — e, para quem planeja a partir de 2027, o [Tropical Americas no Animal Kingdom](/blog/disney-tropical-americas-animal-kingdom) já vale estar no radar.
+Combinando com uma parada no Caribe? Confira nosso [guia de destinos caribenhos para brasileiros](/blog/caribe-destinos-para-brasileiros). Se Orlando entra no roteiro, o post [5 segredos da Disney que fazem diferença na prática](/blog/5-segredos-da-disney-que-ninguem-conta) vai ajudar. E para quem planeja a partir de 2027, o [Tropical Americas no Animal Kingdom](/blog/disney-tropical-americas-animal-kingdom) já vale estar no radar.
 
 ### Oeste americano: o roteiro de carro
 

--- a/content/blog/america-do-norte-destinos-alem-de-nova-york.mdx
+++ b/content/blog/america-do-norte-destinos-alem-de-nova-york.mdx
@@ -24,6 +24,8 @@ A Flórida não é só parques temáticos. **Miami** tem vida própria: South Be
 
 Para quem vai com crianças e quer fazer os parques temáticos, Orlando entrega mais do que a Disney: tem Universal, SeaWorld, Busch Gardens em Tampa, e uma infraestrutura turística que facilita muito a vida.
 
+Combinando com uma parada no Caribe? Confira nosso [guia de destinos caribenhos para brasileiros](/blog/caribe-destinos-para-brasileiros). Se Orlando entra no roteiro, [5 segredos da Disney que fazem diferença na prática](/blog/5-segredos-da-disney-que-ninguem-conta) vai ajudar — e, para quem planeja a partir de 2027, o [Tropical Americas no Animal Kingdom](/blog/disney-tropical-americas-animal-kingdom) já vale estar no radar.
+
 ### Oeste americano: o roteiro de carro
 
 O roteiro pelo Oeste americano é um dos mais recomendados por quem viajou para os EUA mais de uma vez. A lógica é alugar carro em Los Angeles ou Las Vegas e conectar os parques nacionais.

--- a/content/blog/caribe-destinos-para-brasileiros.mdx
+++ b/content/blog/caribe-destinos-para-brasileiros.mdx
@@ -86,6 +86,8 @@ Uma forma objetiva de pensar:
 - Quer praia + mergulho de qualidade: **Curaçao**
 - Quer praia + experiência cultural caribenha autêntica: **Jamaica**
 
+Se você está combinando Caribe e EUA no mesmo roteiro, veja nosso [guia dos melhores destinos da América do Norte para brasileiros](/blog/america-do-norte-destinos-alem-de-nova-york).
+
 ## O que perguntar antes de fechar o pacote
 
 Algumas perguntas que fazem diferença na hora de contratar:

--- a/content/blog/disney-tropical-americas-animal-kingdom.mdx
+++ b/content/blog/disney-tropical-americas-animal-kingdom.mdx
@@ -44,4 +44,6 @@ Reservar com 12 a 18 meses de antecedência abre espaço para escolher melhor: h
 
 Se Orlando já estava no seu radar para 2027, hora de parar de falar em hipótese e começar a montar o roteiro.
 
+Para dicas práticas de como aproveitar os parques da Disney sem perder tempo nas filas, veja [5 segredos da Disney que ninguém conta](/blog/5-segredos-da-disney-que-ninguem-conta). Se você está montando um roteiro mais amplo pelos EUA, nosso [guia de destinos da América do Norte para brasileiros](/blog/america-do-norte-destinos-alem-de-nova-york) tem informações sobre visto, custos e o que ver além de Orlando.
+
 **Quer montar um roteiro para o Animal Kingdom com o Tropical Americas?** Conta pra gente o que você tem em mente. O chat aqui embaixo vai direto pra nossa equipe.

--- a/content/blog/europa-gastronomica-roteiro-italia.mdx
+++ b/content/blog/europa-gastronomica-roteiro-italia.mdx
@@ -112,4 +112,6 @@ Segundo, as reservas: os melhores endereços, mesmo os pequenos, precisam de res
 
 Terceiro, o ritmo: não tente cobrir todas as cidades em uma semana. Um roteiro gastronômico funciona melhor com mais tempo em menos lugares — dá para conhecer um mercado de manhã, fazer uma aula de culinária à tarde e jantar em trattoria à noite sem correr.
 
+Para informações sobre ETIAS, orçamento médio e planejamento da viagem à Europa, veja nosso [roteiro completo para brasileiros](/blog/roteiro-europa-brasileiros-2026).
+
 A Anhangá monta roteiros personalizados pela Itália com foco em gastronomia, incluindo indicações de restaurantes, reservas e hospedagem perto dos melhores mercados e bairros gastronômicos de cada cidade.

--- a/data/blogManifest.ts
+++ b/data/blogManifest.ts
@@ -22,7 +22,7 @@ export const BLOG_POST_MANIFEST: PostMeta[] = [
       "parques-tematicos"
     ],
     "slug": "disney-tropical-americas-animal-kingdom",
-    "readingTime": "3 min de leitura"
+    "readingTime": "4 min de leitura"
   },
   {
     "title": "América do Norte: os melhores destinos além de Nova York",
@@ -87,7 +87,7 @@ export const BLOG_POST_MANIFEST: PostMeta[] = [
       "all-inclusive"
     ],
     "slug": "caribe-destinos-para-brasileiros",
-    "readingTime": "5 min de leitura"
+    "readingTime": "6 min de leitura"
   },
   {
     "title": "América do Sul: os destinos que mais valem a viagem saindo do Brasil",


### PR DESCRIPTION
## Summary

- **Cluster México/Caribe:** `caribe-destinos-para-brasileiros` ↔ `america-do-norte-destinos-alem-de-nova-york` com links bidirecionais; informações de visto para o México verificadas e consistentes entre os dois artigos
- **Cluster Itália → Europa:** `europa-gastronomica-roteiro-italia` → `roteiro-europa-brasileiros-2026` com anchor contextual sobre ETIAS e orçamento (seção "Para Planejar o Roteiro")
- **Cluster Disney (3-way):** `5-segredos-da-disney-que-ninguem-conta`, `disney-tropical-americas-animal-kingdom` e `america-do-norte-destinos-alem-de-nova-york` se referenciam mutuamente com anchors distintas, sem loops óbvios
- `blogManifest.ts` regenerado

## Checklist FEL-149

- [x] Links do cluster México/Caribe implementados nos dois artigos
- [x] Informações de visto verificadas e consistentes entre `caribe` e `america-do-norte`
- [x] Link Itália → Europa com anchor contextual (não genérica)
- [x] 3-way links Disney implementados (sem loops óbvios ou anchors idênticas)
- [x] Todos os slugs verificados contra `blogManifest.ts`
- [ ] Revisão humana antes de publicar

## Test plan

- [ ] Abrir cada artigo no blog e confirmar que os links renderizam corretamente
- [ ] Verificar que os 6 slugs de destino retornam 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)