### PR TITLE
[codex] fix quiz hero brand token

### DIFF
--- a/pages/landings/quiz-anhanga.css
+++ b/pages/landings/quiz-anhanga.css
@@ -43,8 +43,6 @@
   --av-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
   --av-ease-out:    cubic-bezier(0.22, 1, 0.36, 1);
 
-  --quiz-turquoise:      #0FB6C5;
-  --quiz-turquoise-deep: #0795a3;
   --layer-4: #FF9100;
 }
 
@@ -94,7 +92,7 @@
 
 /* ============== HERO ============== */
 .quiz-screen-hero {
-  background: var(--quiz-turquoise);
+  background: var(--av-blue);
   color: white;
   position: relative;
   align-items: center;


### PR DESCRIPTION
## Summary

- Replaces the quiz hero background token with the documented Anhangá brand blue token.
- Removes the local undocumented turquoise tokens from `pages/landings/quiz-anhanga.css`.

## Why

The quiz hero used `#0FB6C5`, which is not part of the project design system. Using `var(--av-blue)` keeps the landing page aligned with an existing brand token and preserves WCAG AA contrast against the hero's white text.

Closes #434.

## Validation

- `git diff --check`
- `pnpm typecheck`
- `pnpm run build`
- Contrast check: `#0056D2` against white = `6.44:1`
- Playwright screenshot of `http://127.0.0.1:4175/quiz`