### PR TITLE
[codex] fix: use quiz progress color token

### DIFF
--- a/pages/landings/quiz-anhanga.css
+++ b/pages/landings/quiz-anhanga.css
@@ -1089,7 +1089,7 @@
   font-family: var(--av-font-display);
   font-weight: 800;
   font-size: 13px;
-  color: #ea580c;
+  color: var(--av-orange-600);
   animation: qMilestoneIn 400ms var(--av-ease-spring) both;
   white-space: nowrap;
 }


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `#ea580c` color in `.quiz-progress-milestone` with the existing `--av-orange-600` CSS token.
- Keeps the visual output unchanged while removing duplicated color source of truth.

## Root Cause

The quiz landing CSS already defined `--av-orange-600`, but the progress milestone still referenced the raw hex value directly.

## Validation

- `git diff --check`
- `pnpm run build`

Closes #437