### PR TITLE
Substitui CTAs por fluxo de formulário de contato com n8n

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,14 @@ HUBSPOT_DEAL_STAGE_ID=id_do_stage_deals
 N8N_WEBHOOK_SECRET=seu_segredo_aqui
 
 # =============================================================================
+# REQUIRED (prod) - n8n Webhook de contato rápido
+# =============================================================================
+# Webhook que recebe submissões do formulário de contato rápido (CTAs do site).
+# Nunca use VITE_ — nunca deve ser exposta ao navegador.
+# Autenticação: reutiliza N8N_WEBHOOK_SECRET (já configurado acima).
+N8N_SUBMIT_CONTACT_WEBHOOK_URL=https://seu-n8n.com/webhook/contact-form
+
+# =============================================================================
 # OPTIONAL - Rate Limiting (Upstash Redis)
 # =============================================================================
 # Required for shared rate limiting in serverless environments

--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,7 @@ import { SpeedInsights } from '@vercel/speed-insights/react';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import AIChat from './components/AIChat';
+import ContactModal from './components/ContactModal';
 import { ClientOnly } from './components/ClientOnly';
 import ScrollToTop from './components/ScrollToTop';
 import BackToTop from './components/ui/BackToTop';
@@ -39,6 +40,7 @@ const LandingRouteFallback: React.FC = () => <div className="min-h-screen bg-whi
 const ClientFeatures: React.FC = () => (
   <ClientOnly>
     <AIChat />
+    <ContactModal />
     <BackToTop />
     <Analytics />
     <SpeedInsights />

--- a/api/submit-contact.ts
+++ b/api/submit-contact.ts
@@ -1,0 +1,206 @@
+import type { SubmitContactRequest, SubmitContactResponse } from '../types/contactCapture';
+import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
+import { checkRateLimit } from '../lib/rate-limit';
+import {
+    cleanString,
+    normalizeNullable,
+    normalizeTracking,
+    normalizeUtms,
+    normalizeWhatsappNumber,
+} from '../lib/lead-logic';
+import { buildN8nContactPayload } from '../lib/n8n-payloads';
+import { sendContactToN8n } from '../services/n8n';
+
+export const config = {
+    runtime: 'edge',
+};
+
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS = 5;
+const RATE_LIMIT_KEY_PREFIX = 'ratelimit:submit-contact';
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface ContactConfig {
+    webhookUrl: string;
+    webhookSecret: string;
+}
+
+function getContactConfig(): ContactConfig | null {
+    const webhookUrl = cleanString(process.env.N8N_SUBMIT_CONTACT_WEBHOOK_URL);
+    const webhookSecret = cleanString(process.env.N8N_WEBHOOK_SECRET);
+    if (!webhookUrl || !webhookSecret) return null;
+    return { webhookUrl, webhookSecret };
+}
+
+function buildJsonResponse(
+    body: SubmitContactResponse,
+    status: number,
+    corsHeaders: Record<string, string>,
+): Response {
+    const requestId =
+        'requestId' in body && typeof body.requestId === 'string' ? body.requestId : undefined;
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: {
+            'Content-Type': 'application/json',
+            ...(requestId ? { 'X-Request-Id': requestId } : {}),
+            ...corsHeaders,
+        },
+    });
+}
+
+async function getRateLimitResponse(
+    request: Request,
+    corsHeaders: Record<string, string>,
+    requestId: string,
+): Promise<Response | null> {
+    const clientIP = getClientIP(request);
+    const rateLimitResult = await checkRateLimit(clientIP, {
+        limit: RATE_LIMIT_MAX_REQUESTS,
+        windowMs: RATE_LIMIT_WINDOW_MS,
+        prefix: RATE_LIMIT_KEY_PREFIX,
+    });
+
+    if (rateLimitResult.allowed) return null;
+
+    return buildJsonResponse(
+        {
+            ok: false,
+            requestId,
+            error: 'Muitas requisições. Tente novamente em breve.',
+            code: 'RATE_LIMIT_EXCEEDED',
+        },
+        429,
+        {
+            ...corsHeaders,
+            'Retry-After': String(Math.ceil(rateLimitResult.resetIn / 1000)),
+            'X-RateLimit-Remaining': String(rateLimitResult.remaining),
+            'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimitResult.resetIn) / 1000)),
+        },
+    );
+}
+
+function validateContactRequest(body: unknown): SubmitContactRequest | null {
+    if (!body || typeof body !== 'object') return null;
+    const raw = body as Record<string, unknown>;
+
+    const firstName = cleanString(raw.firstName);
+    const whatsapp = normalizeWhatsappNumber(raw.whatsapp);
+    const email = normalizeNullable(raw.email, 255)?.toLowerCase();
+
+    if (!firstName || !whatsapp) return null;
+    if (firstName.length > 100 || whatsapp.length > 16) return null;
+    if (email && !EMAIL_REGEX.test(email)) return null;
+
+    const utms = normalizeUtms(raw.utms);
+    const tracking = normalizeTracking(raw.tracking, utms);
+
+    return {
+        firstName,
+        lastName: normalizeNullable(raw.lastName, 100) ?? undefined,
+        whatsapp,
+        email,
+        emailOptIn: Boolean(raw.emailOptIn),
+        source: normalizeNullable(raw.source, 128) ?? undefined,
+        destination: normalizeNullable(raw.destination, 255) ?? undefined,
+        eventId: normalizeNullable(raw.eventId, 128) ?? undefined,
+        utms,
+        tracking,
+    };
+}
+
+async function parseRequestBody(
+    request: Request,
+    corsHeaders: Record<string, string>,
+    requestId: string,
+): Promise<unknown | Response> {
+    try {
+        return await request.json();
+    } catch {
+        return buildJsonResponse(
+            {
+                ok: false,
+                requestId,
+                error: 'Corpo da requisição inválido.',
+                code: 'VALIDATION_ERROR',
+            },
+            400,
+            corsHeaders,
+        );
+    }
+}
+
+export default async function handler(request: Request): Promise<Response> {
+    const corsHeaders = buildCorsHeaders();
+    const requestId = createRequestId();
+
+    if (request.method === 'OPTIONS') {
+        return new Response(null, { status: 204, headers: corsHeaders });
+    }
+
+    if (request.method !== 'POST') {
+        return buildJsonResponse(
+            { ok: false, requestId, error: 'Method not allowed.', code: 'METHOD_NOT_ALLOWED' },
+            405,
+            corsHeaders,
+        );
+    }
+
+    const contactConfig = getContactConfig();
+    if (!contactConfig) {
+        return buildJsonResponse(
+            {
+                ok: false,
+                requestId,
+                error: 'Serviço temporariamente indisponível.',
+                code: 'SERVER_CONFIG_ERROR',
+            },
+            503,
+            corsHeaders,
+        );
+    }
+
+    const rateLimitResponse = await getRateLimitResponse(request, corsHeaders, requestId);
+    if (rateLimitResponse) return rateLimitResponse;
+
+    const body = await parseRequestBody(request, corsHeaders, requestId);
+    if (body instanceof Response) return body;
+
+    const payload = validateContactRequest(body);
+    if (!payload) {
+        return buildJsonResponse(
+            {
+                ok: false,
+                requestId,
+                error: 'Nome e WhatsApp são obrigatórios.',
+                code: 'VALIDATION_ERROR',
+            },
+            400,
+            corsHeaders,
+        );
+    }
+
+    try {
+        await sendContactToN8n(
+            contactConfig.webhookUrl,
+            contactConfig.webhookSecret,
+            requestId,
+            buildN8nContactPayload(payload, requestId),
+        );
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        const isWebhookError = message.startsWith('N8N_WEBHOOK_ERROR:');
+        return buildJsonResponse(
+            {
+                ok: false,
+                requestId,
+                error: 'Não foi possível enviar sua mensagem. Tente novamente.',
+                code: isWebhookError ? 'N8N_WEBHOOK_ERROR' : 'INTERNAL_ERROR',
+            },
+            isWebhookError ? 502 : 500,
+            corsHeaders,
+        );
+    }
+
+    return buildJsonResponse({ ok: true, requestId }, 200, corsHeaders);
+}

--- a/api/submit-contact.ts
+++ b/api/submit-contact.ts
@@ -1,4 +1,8 @@
-import type { SubmitContactRequest, SubmitContactResponse } from '../types/contactCapture';
+import type {
+    SubmitContactErrorCode,
+    SubmitContactRequest,
+    SubmitContactResponse,
+} from '../types/contactCapture';
 import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import {
@@ -19,6 +23,7 @@ const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
 const RATE_LIMIT_KEY_PREFIX = 'ratelimit:submit-contact';
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const N8N_WEBHOOK_ERROR_PATTERN = /^N8N_WEBHOOK_ERROR:(\d{3}):/;
 
 interface ContactConfig {
     webhookUrl: string;
@@ -109,6 +114,21 @@ function validateContactRequest(body: unknown): SubmitContactRequest | null {
     };
 }
 
+function classifyContactSubmitError(error: unknown): {
+    code: SubmitContactErrorCode;
+    status: number;
+} {
+    const message = error instanceof Error ? error.message : String(error);
+    const match = message.match(N8N_WEBHOOK_ERROR_PATTERN);
+    if (!match) return { code: 'INTERNAL_ERROR', status: 500 };
+
+    const upstreamStatus = Number.parseInt(match[1], 10);
+    return {
+        code: 'N8N_WEBHOOK_ERROR',
+        status: upstreamStatus === 504 ? 504 : 502,
+    };
+}
+
 async function parseRequestBody(
     request: Request,
     corsHeaders: Record<string, string>,
@@ -140,7 +160,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     if (request.method !== 'POST') {
         return buildJsonResponse(
-            { ok: false, requestId, error: 'Method not allowed.', code: 'METHOD_NOT_ALLOWED' },
+            { ok: false, requestId, error: 'Método não permitido.', code: 'METHOD_NOT_ALLOWED' },
             405,
             corsHeaders,
         );
@@ -188,16 +208,15 @@ export default async function handler(request: Request): Promise<Response> {
             buildN8nContactPayload(payload, requestId),
         );
     } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        const isWebhookError = message.startsWith('N8N_WEBHOOK_ERROR:');
+        const classifiedError = classifyContactSubmitError(error);
         return buildJsonResponse(
             {
                 ok: false,
                 requestId,
                 error: 'Não foi possível enviar sua mensagem. Tente novamente.',
-                code: isWebhookError ? 'N8N_WEBHOOK_ERROR' : 'INTERNAL_ERROR',
+                code: classifiedError.code,
             },
-            isWebhookError ? 502 : 500,
+            classifiedError.status,
             corsHeaders,
         );
     }

--- a/components/CallToAction.tsx
+++ b/components/CallToAction.tsx
@@ -1,61 +1,27 @@
-import React, { useState, useMemo } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
-    ChatCentered,
     AirplaneTilt,
     DeviceMobile,
     WhatsappLogo,
     CheckCircle,
     SpinnerGap,
 } from '@phosphor-icons/react';
-import { openAiChat } from '../utils/aiChat';
-import { useLeadCapture, createLeadEventId } from '../hooks/useLeadCapture';
-import { getWhatsAppLink } from '../utils/whatsapp';
+import { useContactForm } from '../hooks/useContactForm';
 
 type FormState = 'closed' | 'open' | 'submitted';
 
 const CallToAction: React.FC = () => {
-    const { submitLead, isSubmitting, error } = useLeadCapture();
     const [formState, setFormState] = useState<FormState>('closed');
-    const [name, setName] = useState('');
-    const [email, setEmail] = useState('');
+    const { fields, setField, isValid, isSubmitting, error, submitted, submit } =
+        useContactForm({ source: 'cta-homepage' });
 
-    const handleCTAClick = (e: React.MouseEvent) => {
-        e.preventDefault();
-        openAiChat({
-            message: 'Olá! Gostaria de fazer meu check-in e solicitar um orçamento personalizado.'
-        });
-    };
-
-    const handleSecondarySubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        const parts = name.trim().split(/\s+/);
-        const firstName = parts[0] ?? '';
-        const lastName = parts.slice(1).join(' ') || firstName;
-
-        const result = await submitLead(
-            {
-                firstName,
-                lastName,
-                email: email.trim(),
-                bantSummary: 'Interesse inicial capturado via CTA homepage.',
-                destination: 'A definir',
-            },
-            { eventId: createLeadEventId(), pushDataLayerEvent: true },
-        );
-
-        if (result.ok) {
+    useEffect(() => {
+        if (submitted && formState === 'open') {
             setFormState('submitted');
         }
-    };
+    }, [formState, submitted]);
 
-    // Computed only after submission — reads sessionStorage via getWhatsAppLink.
-    const whatsappSuccessUrl = useMemo(
-        () => getWhatsAppLink(
-            `Olá! Me chamo ${name.trim() || 'você'} e acabei de deixar meu contato no site. Gostaria de saber mais sobre como planejar minha viagem.`,
-            { appendTrackingRef: true },
-        ),
-        [name],
-    );
+    const handleOpenForm = () => setFormState('open');
 
     return (
         <section id="contato" className="py-24 bg-brand-light relative overflow-hidden">
@@ -82,112 +48,143 @@ const CallToAction: React.FC = () => {
                             <div className="text-gray-400 font-bold text-xs uppercase">First Class Experience</div>
                         </div>
 
-                        {/* Main Content */}
-                        <div className="mb-8">
-                            <h2 className="text-4xl md:text-5xl font-black text-brand-dark mb-4 leading-tight">
-                                Próxima parada: <br />
-                                <span className="text-brand-vibrant">aquele lugar que você sempre adiou.</span>
-                            </h2>
-                            <p className="text-gray-500 font-medium text-lg max-w-md">
-                                Orçamento gratuito. Roteiro feito do zero, só pra você. A viagem que você vai contar por anos.
-                            </p>
-                        </div>
-
-                        {/* Footer / CTA */}
-                        <div className="flex flex-col gap-4">
-                            <button
-                                onClick={handleCTAClick}
-                                className="btn-whatsapp btn-specialist flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-8 py-4 rounded-xl shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all self-start"
-                                data-tracking="cta-home-footer"
-                            >
-                                <span>Começar minha Viagem</span>
-                                <ChatCentered className="w-5 h-5" weight="fill" />
-                            </button>
-
-                            {/* Botão secundário — captura nome + email para o fluxo de lead */}
-                            {formState === 'closed' && (
+                        {formState === 'closed' && (
+                            <>
+                                <div className="mb-8">
+                                    <h2 className="text-4xl md:text-5xl font-black text-brand-dark mb-4 leading-tight">
+                                        Próxima parada: <br />
+                                        <span className="text-brand-vibrant">aquele lugar que você sempre adiou.</span>
+                                    </h2>
+                                    <p className="text-gray-500 font-medium text-lg max-w-md">
+                                        Orçamento gratuito. Roteiro feito do zero, só pra você.
+                                    </p>
+                                </div>
                                 <button
-                                    onClick={() => setFormState('open')}
-                                    className="flex items-center gap-2 text-gray-500 hover:text-green-600 text-sm font-semibold transition-colors self-start focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 rounded-lg p-1"
-                                    data-tracking="cta-home-footer-whatsapp"
-                                    title="Deixar contato para WhatsApp"
+                                    type="button"
+                                    onClick={handleOpenForm}
+                                    className="btn-specialist flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-8 py-4 rounded-xl shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all self-start"
+                                    data-tracking="cta-home-footer"
                                 >
-                                    <WhatsappLogo className="w-4 h-4" weight="fill" />
-                                    Prefere o WhatsApp? Deixe seu contato →
+                                    Solicitar meu Orçamento
                                 </button>
-                            )}
+                            </>
+                        )}
 
-                            {formState === 'open' && (
-                                <form
-                                    onSubmit={handleSecondarySubmit}
-                                    className="flex flex-col gap-3 w-full max-w-xs"
-                                    noValidate
-                                >
-                                    <div>
-                                        <label htmlFor="cta-name" className="sr-only">Seu nome</label>
+                        {formState === 'open' && (
+                            <form
+                                onSubmit={(event) => event.preventDefault()}
+                                className="flex flex-col gap-3 w-full"
+                                noValidate
+                            >
+                                <p className="text-xs font-black text-gray-500 uppercase tracking-widest mb-1">
+                                    Seus dados para contato
+                                </p>
+
+                                <div className="flex gap-3">
+                                    <div className="flex-1">
+                                        <label htmlFor="cta-firstName" className="sr-only">Nome</label>
                                         <input
-                                            id="cta-name"
+                                            id="cta-firstName"
                                             type="text"
-                                            placeholder="Seu nome"
-                                            value={name}
-                                            onChange={(e) => setName(e.target.value)}
+                                            placeholder="Nome *"
+                                            value={fields.firstName}
+                                            onChange={(event) => setField('firstName', event.target.value)}
                                             required
                                             className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-gray-400"
                                         />
                                     </div>
-                                    <div>
-                                        <label htmlFor="cta-email" className="sr-only">Seu melhor e-mail</label>
+                                    <div className="flex-1">
+                                        <label htmlFor="cta-lastName" className="sr-only">Sobrenome</label>
                                         <input
-                                            id="cta-email"
-                                            type="email"
-                                            placeholder="Seu melhor e-mail"
-                                            value={email}
-                                            onChange={(e) => setEmail(e.target.value)}
-                                            required
+                                            id="cta-lastName"
+                                            type="text"
+                                            placeholder="Sobrenome"
+                                            value={fields.lastName}
+                                            onChange={(event) => setField('lastName', event.target.value)}
                                             className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-gray-400"
                                         />
                                     </div>
-                                    {error && (
-                                        <p className="text-red-500 text-xs font-medium" role="alert">{error}</p>
-                                    )}
+                                </div>
+
+                                <div>
+                                    <label htmlFor="cta-whatsapp" className="sr-only">WhatsApp</label>
+                                    <input
+                                        id="cta-whatsapp"
+                                        type="tel"
+                                        placeholder="WhatsApp *"
+                                        value={fields.whatsapp}
+                                        onChange={(event) => setField('whatsapp', event.target.value)}
+                                        required
+                                        className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-gray-400"
+                                    />
+                                </div>
+
+                                <div>
+                                    <label htmlFor="cta-email" className="sr-only">E-mail</label>
+                                    <input
+                                        id="cta-email"
+                                        type="email"
+                                        placeholder="E-mail (opcional)"
+                                        value={fields.email}
+                                        onChange={(event) => setField('email', event.target.value)}
+                                        className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-gray-400"
+                                    />
+                                </div>
+
+                                <div className="flex items-start gap-2 px-3 py-2.5 bg-blue-50 rounded-xl border border-blue-100">
+                                    <input
+                                        id="cta-optIn"
+                                        type="checkbox"
+                                        checked={fields.emailOptIn}
+                                        onChange={(event) => setField('emailOptIn', event.target.checked)}
+                                        className="mt-0.5 w-4 h-4 rounded border-2 border-brand-vibrant accent-brand-vibrant cursor-pointer flex-shrink-0"
+                                    />
+                                    <label htmlFor="cta-optIn" className="text-xs text-blue-700 leading-relaxed cursor-pointer">
+                                        Quero receber novidades por e-mail.{' '}
+                                        <a href="/politica-privacidade" target="_blank" rel="noopener noreferrer" className="underline">
+                                            Política de Privacidade
+                                        </a>
+                                    </label>
+                                </div>
+
+                                {error && (
+                                    <p className="text-red-500 text-xs font-medium" role="alert">{error}</p>
+                                )}
+
+                                <div className="flex flex-col sm:flex-row gap-3">
                                     <button
-                                        type="submit"
-                                        disabled={isSubmitting || !name.trim() || !email.trim()}
-                                        className="flex items-center justify-center gap-2 bg-green-500 text-white text-sm font-bold px-5 py-2.5 rounded-xl hover:bg-green-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
+                                        type="button"
+                                        onClick={() => void submit('whatsapp')}
+                                        disabled={!isValid || isSubmitting}
+                                        className="w-full sm:flex-1 flex items-center justify-center gap-2 bg-[#25D366] text-white text-sm font-bold px-4 py-2.5 rounded-xl hover:bg-[#1fba59] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                                     >
                                         {isSubmitting ? (
-                                            <>
-                                                <SpinnerGap className="w-4 h-4 animate-spin" weight="bold" />
-                                                Enviando…
-                                            </>
+                                            <SpinnerGap className="w-4 h-4 animate-spin" weight="bold" />
                                         ) : (
-                                            <>
-                                                <WhatsappLogo className="w-4 h-4" weight="fill" />
-                                                Enviar contato
-                                            </>
+                                            <WhatsappLogo className="w-4 h-4" weight="fill" />
                                         )}
+                                        Chamar no WhatsApp
                                     </button>
-                                </form>
-                            )}
-
-                            {formState === 'submitted' && (
-                                <div className="flex flex-col gap-2" role="status" aria-live="polite">
-                                    <p className="flex items-center gap-2 text-green-600 text-sm font-bold">
-                                        <CheckCircle className="w-5 h-5" weight="fill" />
-                                        Recebemos! Nossa equipe entra em contato em breve.
-                                    </p>
-                                    <a
-                                        href={whatsappSuccessUrl}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="flex items-center gap-2 text-green-600 hover:text-green-700 text-sm font-semibold transition-colors"
+                                    <button
+                                        type="button"
+                                        onClick={() => void submit('callback')}
+                                        disabled={!isValid || isSubmitting}
+                                        className="w-full sm:flex-1 bg-brand-dark text-white text-sm font-bold px-4 py-2.5 rounded-xl hover:bg-brand-vibrant disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                                     >
-                                        <WhatsappLogo className="w-4 h-4" weight="fill" />
-                                        Ou fale agora no WhatsApp →
-                                    </a>
+                                        Me chamem
+                                    </button>
                                 </div>
-                            )}
-                        </div>
+                            </form>
+                        )}
+
+                        {formState === 'submitted' && (
+                            <div className="flex flex-col gap-3" role="status" aria-live="polite">
+                                <p className="flex items-center gap-2 text-green-600 text-sm font-bold">
+                                    <CheckCircle className="w-5 h-5" weight="fill" />
+                                    Recebemos! Nossa equipe entra em contato em breve.
+                                </p>
+                            </div>
+                        )}
 
                         {/* Top "Hole" for perforation illusion */}
                         <div className="hidden md:block absolute -right-4 top-[-1.5rem] w-8 h-8 bg-brand-light rounded-full z-20"></div>

--- a/components/CallToAction.tsx
+++ b/components/CallToAction.tsx
@@ -10,7 +10,7 @@ import { useContactForm } from '../hooks/useContactForm';
 
 type FormState = 'closed' | 'open' | 'submitted';
 
-const CallToAction: React.FC = () => {
+const CallToActionComponent: React.FC = () => {
     const [formState, setFormState] = useState<FormState>('closed');
     const { fields, setField, isValid, isSubmitting, error, submitted, submit } =
         useContactForm({ source: 'cta-homepage' });
@@ -73,7 +73,10 @@ const CallToAction: React.FC = () => {
 
                         {formState === 'open' && (
                             <form
-                                onSubmit={(event) => event.preventDefault()}
+                                onSubmit={(event) => {
+                                    event.preventDefault();
+                                    void submit('whatsapp');
+                                }}
                                 className="flex flex-col gap-3 w-full"
                                 noValidate
                             >
@@ -154,8 +157,7 @@ const CallToAction: React.FC = () => {
 
                                 <div className="flex flex-col sm:flex-row gap-3">
                                     <button
-                                        type="button"
-                                        onClick={() => void submit('whatsapp')}
+                                        type="submit"
                                         disabled={!isValid || isSubmitting}
                                         className="w-full sm:flex-1 flex items-center justify-center gap-2 bg-[#25D366] text-white text-sm font-bold px-4 py-2.5 rounded-xl hover:bg-[#1fba59] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                                     >
@@ -316,8 +318,9 @@ const CallToAction: React.FC = () => {
             </div>
         </section>
     );
-});
+};
 
+const CallToAction = React.memo(CallToActionComponent);
 CallToAction.displayName = 'CallToAction';
 
 export default CallToAction;

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -130,13 +130,20 @@ const ContactModal: React.FC = () => {
 
                 {submitted ? (
                     <div className="flex flex-col items-center gap-4 px-6 pb-6 text-center">
-                        <CheckCircle className="h-14 w-14 text-green-600" weight="fill" />
-                        <p className="font-bold text-gray-800">Recebemos seu contato!</p>
-                        <p className="text-sm text-gray-500">
-                            Nossa equipe entra em contato em breve pelo WhatsApp.
-                        </p>
+                        <div
+                            className="flex flex-col items-center gap-4"
+                            role="status"
+                            aria-live="polite"
+                        >
+                            <CheckCircle className="h-14 w-14 text-green-600" weight="fill" />
+                            <p className="font-bold text-gray-800">Recebemos seu contato!</p>
+                            <p className="text-sm text-gray-500">
+                                Nossa equipe entra em contato em breve pelo WhatsApp.
+                            </p>
+                        </div>
                         <button
                             type="button"
+                            autoFocus
                             onClick={close}
                             className="w-full rounded-xl bg-brand-dark py-3 font-bold text-white transition-colors hover:bg-brand-vibrant focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark focus-visible:ring-offset-2"
                         >
@@ -145,7 +152,10 @@ const ContactModal: React.FC = () => {
                     </div>
                 ) : (
                     <form
-                        onSubmit={(event) => event.preventDefault()}
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            void submit('whatsapp');
+                        }}
                         className="flex flex-col gap-3 px-6 pb-6"
                         noValidate
                     >
@@ -242,8 +252,7 @@ const ContactModal: React.FC = () => {
 
                         <div className="flex flex-col gap-2 pt-1">
                             <button
-                                type="button"
-                                onClick={() => void submit('whatsapp')}
+                                type="submit"
                                 disabled={!isValid || isSubmitting}
                                 className="w-full rounded-xl bg-[#25D366] py-3 text-sm font-black text-white transition-colors hover:bg-[#1fba59] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#25D366] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
                             >

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -1,0 +1,268 @@
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { CheckCircle, X } from '@phosphor-icons/react';
+import { useContactForm } from '../hooks/useContactForm';
+import type { ContactModalOptions } from '../utils/contactForm';
+
+const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+const ContactModal: React.FC = () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [options, setOptions] = useState<ContactModalOptions>({});
+    const titleId = useId();
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const firstFieldRef = useRef<HTMLInputElement>(null);
+    const triggerRef = useRef<HTMLElement | null>(null);
+    const previousBodyOverflow = useRef<string>('');
+
+    const { fields, setField, isValid, isSubmitting, error, submitted, submit, reset } =
+        useContactForm(options);
+
+    const close = useCallback(() => {
+        setIsOpen(false);
+        reset();
+        triggerRef.current?.focus();
+    }, [reset]);
+
+    useEffect(() => {
+        const handleOpen = (event: Event) => {
+            triggerRef.current = document.activeElement as HTMLElement | null;
+            setOptions((event as CustomEvent<ContactModalOptions>).detail ?? {});
+            setIsOpen(true);
+        };
+
+        window.addEventListener('open-contact-modal', handleOpen);
+        return () => window.removeEventListener('open-contact-modal', handleOpen);
+    }, []);
+
+    useEffect(() => {
+        if (!isOpen) return;
+
+        firstFieldRef.current?.focus();
+        previousBodyOverflow.current = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            document.body.style.overflow = previousBodyOverflow.current;
+        };
+    }, [isOpen]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                close();
+                return;
+            }
+
+            if (event.key !== 'Tab' || !dialogRef.current) return;
+
+            const focusable = Array.from(
+                dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+            ).filter((element) => element.offsetParent !== null);
+            if (focusable.length === 0) return;
+
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+
+            if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+                return;
+            }
+
+            if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [close, isOpen]);
+
+    if (!isOpen) return null;
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            role="presentation"
+        >
+            <button
+                type="button"
+                className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+                onClick={close}
+                aria-label="Fechar formulário"
+            />
+
+            <div
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                className="relative z-10 w-full max-w-md overflow-hidden rounded-2xl bg-white shadow-[0_24px_60px_rgba(0,0,0,0.3)]"
+            >
+                <div className="flex items-start justify-between p-6 pb-4">
+                    <div>
+                        <p className="mb-1 text-xs font-black uppercase tracking-widest text-brand-vibrant">
+                            Anhangá Viagens
+                        </p>
+                        <h2 id={titleId} className="text-lg font-black text-brand-dark">
+                            Fale com um especialista
+                        </h2>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={close}
+                        className="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                        aria-label="Fechar"
+                    >
+                        <X className="h-5 w-5" weight="bold" />
+                    </button>
+                </div>
+
+                {submitted ? (
+                    <div className="flex flex-col items-center gap-4 px-6 pb-6 text-center">
+                        <CheckCircle className="h-14 w-14 text-green-600" weight="fill" />
+                        <p className="font-bold text-gray-800">Recebemos seu contato!</p>
+                        <p className="text-sm text-gray-500">
+                            Nossa equipe entra em contato em breve pelo WhatsApp.
+                        </p>
+                        <button
+                            type="button"
+                            onClick={close}
+                            className="w-full rounded-xl bg-brand-dark py-3 font-bold text-white transition-colors hover:bg-brand-vibrant focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark focus-visible:ring-offset-2"
+                        >
+                            Fechar
+                        </button>
+                    </div>
+                ) : (
+                    <form
+                        onSubmit={(event) => event.preventDefault()}
+                        className="flex flex-col gap-3 px-6 pb-6"
+                        noValidate
+                    >
+                        <div className="flex gap-3">
+                            <div className="flex-1">
+                                <label htmlFor="contact-firstName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-gray-500">
+                                    Nome *
+                                </label>
+                                <input
+                                    ref={firstFieldRef}
+                                    id="contact-firstName"
+                                    type="text"
+                                    autoComplete="given-name"
+                                    value={fields.firstName}
+                                    onChange={(event) => setField('firstName', event.target.value)}
+                                    required
+                                    className="w-full rounded-xl border-2 border-gray-200 px-3 py-2.5 text-sm font-medium text-gray-800 outline-none transition-colors placeholder-gray-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                                    placeholder="ex: Maria"
+                                />
+                            </div>
+                            <div className="flex-1">
+                                <label htmlFor="contact-lastName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-gray-500">
+                                    Sobrenome
+                                </label>
+                                <input
+                                    id="contact-lastName"
+                                    type="text"
+                                    autoComplete="family-name"
+                                    value={fields.lastName}
+                                    onChange={(event) => setField('lastName', event.target.value)}
+                                    className="w-full rounded-xl border-2 border-gray-200 px-3 py-2.5 text-sm font-medium text-gray-800 outline-none transition-colors placeholder-gray-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                                    placeholder="ex: Silva"
+                                />
+                            </div>
+                        </div>
+
+                        <div>
+                            <label htmlFor="contact-whatsapp" className="mb-1 block text-xs font-bold uppercase tracking-wider text-gray-500">
+                                WhatsApp *
+                            </label>
+                            <input
+                                id="contact-whatsapp"
+                                type="tel"
+                                autoComplete="tel"
+                                value={fields.whatsapp}
+                                onChange={(event) => setField('whatsapp', event.target.value)}
+                                required
+                                className="w-full rounded-xl border-2 border-gray-200 px-3 py-2.5 text-sm font-medium text-gray-800 outline-none transition-colors placeholder-gray-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                                placeholder="+55 (11) 9 0000-0000"
+                            />
+                        </div>
+
+                        <div>
+                            <label htmlFor="contact-email" className="mb-1 block text-xs font-bold uppercase tracking-wider text-gray-500">
+                                E-mail
+                            </label>
+                            <input
+                                id="contact-email"
+                                type="email"
+                                autoComplete="email"
+                                value={fields.email}
+                                onChange={(event) => setField('email', event.target.value)}
+                                className="w-full rounded-xl border-2 border-gray-200 px-3 py-2.5 text-sm font-medium text-gray-800 outline-none transition-colors placeholder-gray-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                                placeholder="seu@email.com (opcional)"
+                            />
+                        </div>
+
+                        <div className="flex items-start gap-2.5 rounded-xl border border-blue-100 bg-blue-50 px-3 py-2.5">
+                            <input
+                                id="contact-optIn"
+                                type="checkbox"
+                                checked={fields.emailOptIn}
+                                onChange={(event) => setField('emailOptIn', event.target.checked)}
+                                className="mt-0.5 h-4 w-4 flex-shrink-0 cursor-pointer rounded border-2 border-brand-vibrant accent-brand-vibrant"
+                            />
+                            <label htmlFor="contact-optIn" className="cursor-pointer text-xs leading-relaxed text-blue-700">
+                                Quero receber novidades e ofertas de viagem por e-mail.{' '}
+                                <a
+                                    href="/politica-privacidade"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="underline hover:text-blue-900"
+                                >
+                                    Política de Privacidade
+                                </a>
+                            </label>
+                        </div>
+
+                        {error ? (
+                            <p className="text-xs font-medium text-red-500" role="alert">
+                                {error}
+                            </p>
+                        ) : null}
+
+                        <div className="flex flex-col gap-2 pt-1">
+                            <button
+                                type="button"
+                                onClick={() => void submit('whatsapp')}
+                                disabled={!isValid || isSubmitting}
+                                className="w-full rounded-xl bg-[#25D366] py-3 text-sm font-black text-white transition-colors hover:bg-[#1fba59] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#25D366] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                                {isSubmitting ? 'Enviando...' : 'Chamar no WhatsApp'}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => void submit('callback')}
+                                disabled={!isValid || isSubmitting}
+                                className="w-full rounded-xl bg-brand-dark py-3 text-sm font-black text-white transition-colors hover:bg-brand-vibrant focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                                {isSubmitting ? 'Enviando...' : 'Me chamem no WhatsApp'}
+                            </button>
+                        </div>
+                    </form>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default ContactModal;

--- a/components/Destinations.tsx
+++ b/components/Destinations.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState, useMemo, memo } from 'react';
-import { getWhatsAppLink } from '../utils/whatsapp';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import MapPin from 'lucide-react/dist/esm/icons/map-pin';
@@ -17,7 +16,7 @@ import Minus from 'lucide-react/dist/esm/icons/minus';
 import Share from 'lucide-react/dist/esm/icons/share';
 import { SocialShare } from './SocialShare';
 import { LazyImage } from './ui/LazyImage';
-import { openAiChat } from '../utils/aiChat';
+import { openContactModal } from '../utils/contactForm';
 import { getDestinationImage } from '../data/mediaConfig';
 import { NOISE_TEXTURE_URL } from '../lib/static-assets';
 
@@ -737,8 +736,9 @@ const Destinations: React.FC = memo(() => {
                                 <button
                                     onClick={(e) => {
                                         e.preventDefault();
-                                        openAiChat({
-                                            message: `Olá! Gostaria de um orçamento para ${selectedDestination.city}.`
+                                        openContactModal({
+                                            source: 'destinations-modal',
+                                            destination: selectedDestination.city,
                                         });
                                         setSelectedDestination(null);
                                     }}

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { List, X, Phone } from '@phosphor-icons/react';
-import { openAiChat } from '../../utils/aiChat';
+import { openContactModal } from '../../utils/contactForm';
 import { DesktopNavigation, MobileNavigationMenu } from './HeaderNavigation';
 import { SITE_URL } from './headerConfig';
 import { BRAND_LOGO_BLUE_URL, BRAND_LOGO_WHITE_URL } from '../../lib/media-assets';
@@ -32,9 +32,7 @@ const Header: React.FC = () => {
 
   const handleContactClick = (e: React.MouseEvent) => {
     e.preventDefault();
-    openAiChat({
-      message: 'Olá! Gostaria de falar com um especialista.'
-    });
+    openContactModal({ source: 'header' });
     setIsMobileMenuOpen(false);
   };
 
@@ -95,7 +93,7 @@ const Header: React.FC = () => {
               aria-label="Fale Conosco"
               data-testid="desktop-fale-conosco-btn"
               data-tracking="navbar-desktop"
-              onClick={(e) => handleNavClick(e, 'contato')}
+              onClick={handleContactClick}
               className={`btn-whatsapp btn-specialist rounded-full font-medium text-sm transition-all duration-500 flex items-center gap-2 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-vibrant ${ctaPaddingClass} ${buttonClass}`}
             >
               <Phone className="w-4 h-4" weight="fill" />

--- a/components/Highlights.tsx
+++ b/components/Highlights.tsx
@@ -9,7 +9,7 @@ import {
   ShieldCheck,
   ArrowRight,
 } from '@phosphor-icons/react';
-import { openAiChat } from '../utils/aiChat';
+import { openContactModal } from '../utils/contactForm';
 
 const fadeUp = {
     hidden: { opacity: 0, y: 32 },
@@ -132,9 +132,7 @@ const Highlights = memo(() => {
                             <button
                                 onClick={(e) => {
                                     e.preventDefault();
-                                    openAiChat({
-                                        message: 'Olá! Quero conhecer a experiência Anhangá.'
-                                    });
+                                    openContactModal({ source: 'highlights' });
                                 }}
                                 className="flex items-center justify-center gap-3 w-full bg-brand-dark text-white px-6 py-4 rounded-xl font-bold transition-all duration-300 ease-spring shadow-[4px_4px_0px_#94a3b8] hover:shadow-[2px_2px_0px_#94a3b8] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none"
                             >

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -9,7 +9,7 @@ import {
   Star,
   Heart,
 } from '@phosphor-icons/react';
-import { openAiChat } from '../utils/aiChat';
+import { openContactModal } from '../utils/contactForm';
 
 // Moved outside component to prevent re-allocation on every render
 const STEPS = [
@@ -175,9 +175,7 @@ const HowItWorks = memo(() => {
                 <button
                     onClick={(e) => {
                         e.preventDefault();
-                        openAiChat({
-                            message: 'Olá! Vi como a mágica acontece e quero meu roteiro personalizado agora!'
-                        });
+                        openContactModal({ source: 'how-it-works' });
                     }}
                     className="relative z-10 flex items-center gap-4 bg-white text-brand-dark px-10 py-6 rounded-full font-black text-xl shadow-[0_20px_50px_rgba(8,_112,_184,_0.15)] hover:shadow-[0_20px_50px_rgba(8,_112,_184,_0.25)] transform transition-all hover:scale-105 active:scale-95 border-4 border-transparent hover:border-brand-yellow text-left"
                 >

--- a/components/blog/BlogPostFinalCTA.tsx
+++ b/components/blog/BlogPostFinalCTA.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PostMeta } from '../../lib/mdx';
-import { getWhatsAppLink } from '../../utils/whatsapp';
+import { openContactModal } from '../../utils/contactForm';
 
 interface BlogPostFinalCTAProps {
     post: PostMeta;
@@ -17,15 +17,17 @@ export const BlogPostFinalCTA: React.FC<BlogPostFinalCTAProps> = ({ post }) => {
             <p className="text-xl text-gray-300 mb-10 max-w-2xl mx-auto relative z-10">
                 Transformamos essas inspirações em um roteiro real e exclusivo para você.
             </p>
-            <a
-                href={getWhatsAppLink(`Olá! Li o post "${post.title}" e gostaria de planejar minha viagem.`, { appendTrackingRef: true })}
-                target="_blank"
-                rel="noopener noreferrer"
+            <button
+                type="button"
+                onClick={() => openContactModal({
+                    source: 'blog-post-footer',
+                    message: `Olá! Li o post "${post.title}" e gostaria de planejar minha viagem.`,
+                })}
                 className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-cyan text-white text-lg font-bold px-10 py-5 rounded-2xl shadow-[4px_4px_0px_#FFD600] hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:shadow-none active:translate-x-[4px] active:translate-y-[4px] transition-all relative z-10"
                 data-tracking="footer-blog-post"
             >
                 Conversar com um Especialista
-            </a>
+            </button>
         </div>
     );
 };

--- a/components/blog/BlogPostSidebar.tsx
+++ b/components/blog/BlogPostSidebar.tsx
@@ -4,7 +4,7 @@ import { PostMeta } from '../../lib/mdx';
 import { getBlogPostUrl } from '../../utils/blog';
 import { optimizeRemoteImageUrl } from '../../data/mediaConfig';
 import { getCategoryColor } from '../../utils/categoryColors';
-import { openAiChat } from '../../utils/aiChat';
+import { openContactModal } from '../../utils/contactForm';
 
 interface BlogPostSidebarProps {
     author: {
@@ -39,9 +39,7 @@ export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, author
                 <button
                     onClick={(e) => {
                         e.preventDefault();
-                        openAiChat({
-                            message: `Olá! Gostaria de falar com o especialista ${author?.name || authorFallbackName} sobre viagens.`
-                        });
+                        openContactModal({ source: 'blog-sidebar' });
                     }}
                     className="btn-whatsapp btn-specialist block w-full py-4 bg-white border-2 border-brand-dark text-brand-dark font-black tracking-wide text-sm uppercase rounded-xl hover:bg-brand-dark hover:text-white transition-colors shadow-[4px_4px_0px_#0f172a] active:shadow-none active:translate-x-[4px] active:translate-y-[4px] text-center"
                     data-tracking="sidebar-blog-post"

--- a/components/blog/ChatCTA.tsx
+++ b/components/blog/ChatCTA.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { openAiChat } from '@/utils/aiChat';
+import { openContactModal } from '@/utils/contactForm';
 
 interface ChatCTAProps {
   destino?: string;
@@ -8,19 +8,17 @@ interface ChatCTAProps {
 }
 
 const ChatCTA: React.FC<ChatCTAProps> = ({ destino, mensagem, label }) => {
-  const message =
-    mensagem ??
-    (destino
-      ? `Olá! Gostaria de planejar uma viagem para ${destino}.`
-      : 'Olá! Gostaria de planejar minha viagem.');
-
   const buttonLabel =
     label ?? (destino ? `Planejar viagem para ${destino}` : 'Planejar minha viagem');
 
   return (
     <div className="not-prose my-8 flex justify-center">
       <button
-        onClick={() => openAiChat({ message })}
+        onClick={() => openContactModal({
+          source: 'blog-inline-cta',
+          destination: destino,
+          message: mensagem,
+        })}
         className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-cyan text-white text-base font-bold px-8 py-4 rounded-2xl shadow-[4px_4px_0px_#003B8E] hover:shadow-none hover:translate-x-[2px] hover:translate-y-[2px] transition-all"
         type="button"
         data-tracking="blog-chat-cta"

--- a/components/landings/beto-carrero/Button.tsx
+++ b/components/landings/beto-carrero/Button.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { MessageCircle } from 'lucide-react';
-import { getWhatsAppLink } from '../../../utils/whatsapp';
-import { WHATSAPP_MESSAGE } from './constants';
-import { openAiChat } from '../../../utils/aiChat';
+import { openContactModal } from '../../../utils/contactForm';
 
 interface ButtonProps {
   text: string;
@@ -70,9 +68,7 @@ const Button: React.FC<ButtonProps> = ({
       <button
         onClick={(e) => {
           e.preventDefault();
-          openAiChat({
-            message: WHATSAPP_MESSAGE
-          });
+          openContactModal({ source: 'beto-carrero' });
           handleClick();
         }}
         className={`btn-whatsapp btn-specialist ${baseStyles} ${variants[variant]} ${fullWidth ? 'w-full' : ''} ${className}`}

--- a/components/landings/beto-carrero/Solution.tsx
+++ b/components/landings/beto-carrero/Solution.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Check, MapPin, Plane, BedDouble, Ticket, MessageCircle, Send, ArrowRight, X, Sun, Fish, Building2, Sparkles } from 'lucide-react';
 import Button from './Button';
-import { openAiChat } from '../../../utils/aiChat';
+import { openContactModal } from '../../../utils/contactForm';
 
 const Solution: React.FC = () => {
    const [isModalOpen, setIsModalOpen] = useState(false);
@@ -120,10 +120,13 @@ const Solution: React.FC = () => {
                      <div
                         role="button"
                         tabIndex={0}
-                        onClick={() => openAiChat({
-                           message: 'Olá! Gostaria de um orçamento para o Beto Carrero incluindo ingressos oficiais.'
-                        })}
-                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') openAiChat({ message: 'Olá! Gostaria de um orçamento para o Beto Carrero incluindo ingressos oficiais.' }); }}
+                        onClick={() => openContactModal({ source: 'beto-carrero-solution' })}
+                        onKeyDown={(e) => {
+                           if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              openContactModal({ source: 'beto-carrero-solution' });
+                           }
+                        }}
                         className="btn-specialist cursor-pointer group bg-white rounded-xl border-2 border-fun-dark shadow-hard transform -rotate-1 hover:rotate-0 transition-transform duration-300 flex overflow-hidden w-full max-w-sm lg:max-w-md"
                         data-tracking="mid-betocarrero"
                      >

--- a/components/landings/lollapalooza/Button.tsx
+++ b/components/landings/lollapalooza/Button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MessageCircle } from 'lucide-react';
-import { openAiChat } from '../../../utils/aiChat';
+import { openContactModal } from '../../../utils/contactForm';
 
 interface ButtonProps {
   text: string;
@@ -53,7 +53,7 @@ const Button: React.FC<ButtonProps> = ({ text, className = '', variant = 'primar
     <button
       onClick={(e) => {
         e.preventDefault();
-        openAiChat();
+        openContactModal({ source: 'lollapalooza' });
       }}
       {...sharedProps}
     >

--- a/components/landings/orlando/OrlandoApp.tsx
+++ b/components/landings/orlando/OrlandoApp.tsx
@@ -8,13 +8,10 @@ import { Link } from "react-router-dom";
 import { getMediaUrl, optimizeRemoteImageUrl } from "../../../data/mediaConfig";
 import { useFooterRuntimeMetadata } from "../../../lib/footer-runtime";
 import { BRAND_LOGO_BLUE_URL } from "../../../lib/media-assets";
-import { getWhatsAppLink } from "../../../utils/whatsapp";
-import { openAiChat } from "../../../utils/aiChat";
+import { openContactModal } from "../../../utils/contactForm";
 
 // --- Constants ---
 const SITE_URL = "https://www.anhanga.tur.br";
-const WHATSAPP_MESSAGE =
-  "Olá! Gostaria de saber mais sobre os pacotes para Orlando.";
 const LOGO_URL = BRAND_LOGO_BLUE_URL;
 
 // --- Components ---
@@ -150,7 +147,7 @@ function OrlandoApp() {
             <button
               onClick={(e) => {
                 e.preventDefault();
-                openAiChat({ message: WHATSAPP_MESSAGE });
+                openContactModal({ source: 'orlando', destination: 'Orlando' });
               }}
               className="btn-whatsapp btn-specialist main-btn"
               data-tracking="hero-orlando"
@@ -701,9 +698,7 @@ function OrlandoApp() {
           <button
             onClick={(e) => {
               e.preventDefault();
-              openAiChat({
-                message: "Olá! Gostaria de ver os pacotes para Orlando.",
-              });
+              openContactModal({ source: 'orlando', destination: 'Orlando' });
             }}
             className="btn-whatsapp btn-specialist main-btn secondary"
             data-tracking="mid-orlando"
@@ -771,10 +766,7 @@ function OrlandoApp() {
             <button
               onClick={(e) => {
                 e.preventDefault();
-                openAiChat({
-                  message:
-                    "Olá! Gostaria de um roteiro personalizado para Orlando baseado na sugestão de 7 dias.",
-                });
+                openContactModal({ source: 'orlando', destination: 'Orlando' });
               }}
               className="btn-whatsapp btn-specialist main-btn"
               data-tracking="itinerary-orlando"
@@ -820,7 +812,7 @@ function OrlandoApp() {
               <button
                 onClick={(e) => {
                   e.preventDefault();
-                  openAiChat({ message: WHATSAPP_MESSAGE });
+                  openContactModal({ source: 'orlando', destination: 'Orlando' });
                 }}
                 className="btn-whatsapp btn-specialist"
                 data-tracking="footer-whatsapp-orlando"

--- a/hooks/useContactForm.ts
+++ b/hooks/useContactForm.ts
@@ -1,0 +1,180 @@
+import { useCallback, useState } from 'react';
+import { cleanString } from '../lib/lead-logic';
+import { getTrackingDataObject, getWhatsAppLink } from '../utils/whatsapp';
+import { createLeadEventId, extractUtms } from './useLeadCapture';
+import type { ContactFormFields, SubmitContactRequest, SubmitContactResponse } from '../types/contactCapture';
+import type { LeadTracking } from '../types/leadCapture';
+import type { ContactModalOptions } from '../utils/contactForm';
+
+const EMPTY_FIELDS: ContactFormFields = {
+    firstName: '',
+    lastName: '',
+    whatsapp: '',
+    email: '',
+    emailOptIn: false,
+};
+
+const KNOWN_TRACKING_KEYS = new Set([
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+    'cid',
+    'sid',
+    'gclid',
+    'fbclid',
+    'msclkid',
+    'ttclid',
+    'wbraid',
+    'gbraid',
+    'fbc',
+    'fbp',
+]);
+
+function toNullable(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const normalized = cleanString(value);
+    return normalized.length > 0 ? normalized : null;
+}
+
+function collectTracking(): { tracking: LeadTracking; utms: SubmitContactRequest['utms'] } {
+    const raw = getTrackingDataObject() ?? {};
+    const extras: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(raw)) {
+        if (KNOWN_TRACKING_KEYS.has(key)) continue;
+        const normalized = toNullable(value);
+        if (normalized) extras[key] = normalized;
+    }
+
+    const tracking: LeadTracking = {
+        utm_source: toNullable(raw.utm_source),
+        utm_medium: toNullable(raw.utm_medium),
+        utm_campaign: toNullable(raw.utm_campaign),
+        utm_term: toNullable(raw.utm_term),
+        utm_content: toNullable(raw.utm_content),
+        cid: toNullable(raw.cid),
+        sid: toNullable(raw.sid),
+        gclid: toNullable(raw.gclid),
+        fbclid: toNullable(raw.fbclid),
+        msclkid: toNullable(raw.msclkid),
+        ttclid: toNullable(raw.ttclid),
+        wbraid: toNullable(raw.wbraid),
+        gbraid: toNullable(raw.gbraid),
+        fbc: toNullable(raw.fbc),
+        fbp: toNullable(raw.fbp),
+        extras: Object.keys(extras).length > 0 ? extras : undefined,
+    };
+
+    return { tracking, utms: extractUtms(tracking) };
+}
+
+function pushContactDataLayerEvent(
+    eventId: string,
+    action: 'whatsapp' | 'callback',
+    source?: string,
+): void {
+    if (typeof window === 'undefined' || !window.dataLayer) return;
+    window.dataLayer.push({
+        event: 'contact_form_submission',
+        event_id: eventId,
+        form_action: action,
+        cta_source: source ?? null,
+        page_location: window.location.href,
+    });
+}
+
+export function useContactForm(options: ContactModalOptions = {}) {
+    const [fields, setFieldsState] = useState<ContactFormFields>(EMPTY_FIELDS);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [submitted, setSubmitted] = useState(false);
+
+    const isValid = Boolean(fields.firstName.trim() && fields.whatsapp.trim());
+
+    const setField = useCallback(
+        (key: keyof ContactFormFields, value: string | boolean) => {
+            setFieldsState((prev) => ({ ...prev, [key]: value }));
+            setError(null);
+        },
+        [],
+    );
+
+    const reset = useCallback(() => {
+        setFieldsState(EMPTY_FIELDS);
+        setIsSubmitting(false);
+        setError(null);
+        setSubmitted(false);
+    }, []);
+
+    const submit = useCallback(
+        async (action: 'whatsapp' | 'callback'): Promise<void> => {
+            if (!isValid || isSubmitting) return;
+
+            const eventId = createLeadEventId();
+            const { tracking, utms } = collectTracking();
+            const whatsappMessage =
+                options.message
+                ?? `Olá! Meu nome é ${fields.firstName.trim()}. Gostaria de saber mais sobre viagens.`;
+            const whatsappUrl = getWhatsAppLink(whatsappMessage, { appendTrackingRef: true });
+
+            if (action === 'whatsapp') {
+                window.open(whatsappUrl, '_blank', 'noopener,noreferrer');
+            }
+
+            const requestBody: SubmitContactRequest = {
+                firstName: fields.firstName.trim(),
+                lastName: fields.lastName.trim() || undefined,
+                whatsapp: fields.whatsapp.trim(),
+                email: fields.email.trim() || undefined,
+                emailOptIn: fields.emailOptIn,
+                source: options.source,
+                destination: options.destination,
+                eventId,
+                utms,
+                tracking,
+            };
+
+            setIsSubmitting(true);
+            setError(null);
+
+            try {
+                const response = await fetch('/api/submit-contact', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(requestBody),
+                    keepalive: true,
+                });
+
+                const data = (await response.json()) as SubmitContactResponse;
+
+                if (!response.ok || !data.ok) {
+                    const errData = data as Extract<SubmitContactResponse, { ok: false }>;
+                    if (action === 'whatsapp') {
+                        console.warn('[submit-contact] tracking failed:', errData.code);
+                        setSubmitted(true);
+                    } else {
+                        setError(errData.error || 'Não foi possível enviar. Tente novamente.');
+                    }
+                    return;
+                }
+
+                pushContactDataLayerEvent(eventId, action, options.source);
+                setSubmitted(true);
+            } catch {
+                if (action === 'whatsapp') {
+                    console.warn('[submit-contact] fetch failed after opening WhatsApp');
+                    setSubmitted(true);
+                } else {
+                    setError('Erro de conexão. Verifique sua internet e tente novamente.');
+                }
+            } finally {
+                setIsSubmitting(false);
+            }
+        },
+        [fields, isSubmitting, isValid, options],
+    );
+
+    return { fields, setField, isValid, isSubmitting, error, submitted, submit, reset };
+}

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -88,7 +88,7 @@ function toNullable(value: unknown): string | null {
     return normalized.length > 0 ? normalized : null;
 }
 
-function extractUtms(tracking: LeadTracking): LeadUtms {
+export function extractUtms(tracking: LeadTracking): LeadUtms {
     return {
         utm_source: tracking.utm_source ?? null,
         utm_medium: tracking.utm_medium ?? null,

--- a/lib/n8n-payloads.ts
+++ b/lib/n8n-payloads.ts
@@ -1,4 +1,5 @@
 import type { SubmitLeadRequest } from '../types/leadCapture';
+import type { SubmitContactRequest } from '../types/contactCapture';
 import type { SubmitWaitlistRequest } from '../types/waitlist';
 import type { SubmitQuizRequest } from '../types/quiz';
 
@@ -50,6 +51,25 @@ export interface N8nWaitlistPayload {
     };
     utms: SubmitWaitlistRequest['utms'];
     tracking: SubmitWaitlistRequest['tracking'];
+    meta: {
+        receivedAt: string;
+    };
+}
+
+export interface N8nContactPayload {
+    requestId: string;
+    source: 'submit-contact';
+    contact: {
+        firstName: string;
+        lastName: string | null;
+        whatsapp: string;
+        email: string | null;
+        emailOptIn: boolean;
+        eventId: string | null;
+        ctaSource: string | null;
+        destination: string | null;
+    };
+    tracking: N8nLeadTracking;
     meta: {
         receivedAt: string;
     };
@@ -111,6 +131,46 @@ export function buildN8nLeadPayload(payload: SubmitLeadRequest, requestId: strin
         },
         utms: payload.utms,
         tracking: buildLeadTracking(payload),
+        meta: {
+            receivedAt: new Date().toISOString(),
+        },
+    };
+}
+
+export function buildN8nContactPayload(payload: SubmitContactRequest, requestId: string): N8nContactPayload {
+    const tracking: N8nLeadTracking = {
+        utm_source: payload.tracking?.utm_source ?? payload.utms.utm_source,
+        utm_medium: payload.tracking?.utm_medium ?? payload.utms.utm_medium,
+        utm_campaign: payload.tracking?.utm_campaign ?? payload.utms.utm_campaign,
+        utm_term: payload.tracking?.utm_term ?? payload.utms.utm_term,
+        utm_content: payload.tracking?.utm_content ?? payload.utms.utm_content,
+        cid: toNullableTrackingValue(payload.tracking?.cid),
+        sid: toNullableTrackingValue(payload.tracking?.sid),
+        gclid: toNullableTrackingValue(payload.tracking?.gclid),
+        fbclid: toNullableTrackingValue(payload.tracking?.fbclid),
+        msclkid: toNullableTrackingValue(payload.tracking?.msclkid),
+        ttclid: toNullableTrackingValue(payload.tracking?.ttclid),
+        wbraid: toNullableTrackingValue(payload.tracking?.wbraid),
+        gbraid: toNullableTrackingValue(payload.tracking?.gbraid),
+        fbc: toNullableTrackingValue(payload.tracking?.fbc),
+        fbp: toNullableTrackingValue(payload.tracking?.fbp),
+        extras: payload.tracking?.extras ?? {},
+    };
+
+    return {
+        requestId,
+        source: 'submit-contact',
+        contact: {
+            firstName: payload.firstName,
+            lastName: payload.lastName ?? null,
+            whatsapp: payload.whatsapp,
+            email: payload.email ?? null,
+            emailOptIn: payload.emailOptIn,
+            eventId: payload.eventId ?? null,
+            ctaSource: payload.source ?? null,
+            destination: payload.destination ?? null,
+        },
+        tracking,
         meta: {
             receivedAt: new Date().toISOString(),
         },

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -5,7 +5,7 @@ import { SEO } from '../components/SEO';
 import { OrganizationSchema } from '../components/schemas/OrganizationSchema';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { LazyImage } from '../components/ui/LazyImage';
-import { openAiChat } from '../utils/aiChat';
+import { openContactModal } from '../utils/contactForm';
 import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
 import Award from 'lucide-react/dist/esm/icons/award';
 import Users from 'lucide-react/dist/esm/icons/users';
@@ -25,8 +25,6 @@ const fadeUp: Variants = {
     },
   }),
 };
-
-const CHAT_MESSAGE_ORCAMENTO = "Olá! Gostaria de conversar sobre um roteiro personalizado.";
 
 const About: React.FC = () => {
   const { hash } = useLocation();
@@ -87,7 +85,7 @@ const About: React.FC = () => {
           </p>
           <div className="flex justify-center">
             <button
-              onClick={() => openAiChat({ message: CHAT_MESSAGE_ORCAMENTO })}
+              onClick={() => openContactModal({ source: 'about' })}
               className="btn-whatsapp btn-specialist bg-brand-vibrant text-white px-8 py-4 rounded-2xl font-black text-lg shadow-xl shadow-brand-vibrant/20 hover:scale-105 transition-transform active:scale-95 flex items-center gap-3"
               data-tracking="hero-about"
             >
@@ -288,7 +286,7 @@ const About: React.FC = () => {
               Seja para um festival épico ou um refúgio relaxante, nós desenhamos a viagem perfeita para você.
             </p>
             <button
-              onClick={() => openAiChat({ message: CHAT_MESSAGE_ORCAMENTO })}
+              onClick={() => openContactModal({ source: 'about' })}
               className="btn-whatsapp btn-specialist bg-brand-vibrant text-white px-10 py-5 rounded-2xl font-black text-lg shadow-xl shadow-brand-vibrant/20 hover:scale-105 transition-transform active:scale-95 flex items-center gap-3 mx-auto"
               data-tracking="footer-about"
             >

--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -12,7 +12,7 @@ import { optimizeRemoteImageUrl } from '../data/mediaConfig';
 import { getCategoryColor } from '../utils/categoryColors';
 import { SEO } from '../components/SEO';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
-import { openAiChat } from '../utils/aiChat';
+import { openContactModal } from '../utils/contactForm';
 
 /**
  * BlogList Page - Optimized with CSS hover
@@ -155,9 +155,7 @@ const BlogList: React.FC = () => {
                     <button
                         onClick={(e) => {
                             e.preventDefault();
-                            openAiChat({
-                                message: 'Olá! Vi o blog da Anhangá e gostaria de solicitar um orçamento personalizado.'
-                            });
+                            openContactModal({ source: 'blog-list' });
                         }}
                         className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-10 py-5 rounded-2xl shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all"
                         data-tracking="footer-blog-list"

--- a/pages/landings/BetoCarreroLanding.tsx
+++ b/pages/landings/BetoCarreroLanding.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { getWhatsAppLink } from '../../utils/whatsapp';
 import BetoCarreroApp from '../../components/landings/beto-carrero/BetoCarreroApp';
 import { SEO } from '../../components/SEO';
 import { LandingFAQ } from '../../components/LandingFAQ';
 import { BreadcrumbSchema } from '../../components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '../../components/schemas/FAQPageSchema';
 import { ServiceSchema } from '../../components/schemas/ServiceSchema';
-import { openAiChat } from '../../utils/aiChat';
+import { openContactModal } from '../../utils/contactForm';
 
 const BETO_FAQ_ITEMS = [
   {
@@ -90,9 +89,7 @@ const BetoCarreroLanding: React.FC = () => {
             <button
               onClick={(e) => {
                 e.preventDefault();
-                openAiChat({
-                  message: 'Olá! Gostaria de um orçamento personalizado para o Beto Carrero.'
-                });
+                openContactModal({ source: 'beto-carrero' });
               }}
               className="btn-whatsapp btn-specialist px-5 py-3 rounded-full bg-brand-cyan text-white font-bold hover:bg-brand-cyan/90 transition-colors"
               data-tracking="footer-betocarrero"

--- a/pages/landings/BrazilPromotionDayLanding.tsx
+++ b/pages/landings/BrazilPromotionDayLanding.tsx
@@ -19,6 +19,7 @@ import {
 import { SEO } from '../../components/SEO';
 import { useLeadCapture, createLeadEventId } from '../../hooks/useLeadCapture';
 import { useWhatsAppLink } from '../../utils/whatsapp';
+import { openContactModal } from '../../utils/contactForm';
 import { BRAND_LOGO_BLUE_URL } from '../../lib/media-assets';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -162,16 +163,15 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                 className="h-12 w-auto object-contain"
                             />
                         </a>
-                        <a
-                            href={whatsappUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                        <button
+                            type="button"
+                            onClick={() => openContactModal({ source: 'brazil-promotion-day' })}
                             className="btn-whatsapp btn-specialist hidden sm:flex items-center gap-2 bg-brand-dark text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all"
                             data-contact-intent
                         >
                             <WhatsappLogo className="w-4 h-4" weight="fill" />
                             Falar no WhatsApp
-                        </a>
+                        </button>
                     </div>
                 </nav>
 
@@ -248,16 +248,15 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                 custom={3}
                                 className="flex flex-col sm:flex-row gap-4"
                             >
-                                <a
-                                    href={whatsappUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
+                                <button
+                                    type="button"
+                                    onClick={() => openContactModal({ source: 'brazil-promotion-day' })}
                                     className="btn-whatsapp btn-specialist flex items-center justify-center gap-3 bg-brand-yellow text-brand-dark px-8 py-4 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(0,0,0,0.2)] hover:shadow-[2px_2px_0px_rgba(0,0,0,0.2)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all"
                                     data-contact-intent
                                 >
                                     <WhatsappLogo className="w-6 h-6" weight="fill" />
                                     Falar com a gente agora
-                                </a>
+                                </button>
                                 <a
                                     href="#contato"
                                     className="btn-specialist flex items-center justify-center gap-2 border-2 border-white/40 text-white px-8 py-4 rounded-2xl font-bold text-lg hover:border-white hover:bg-white/10 transition-all duration-200"
@@ -423,16 +422,15 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                     <span className="text-brand-cyan">Bora conversar.</span>
                                 </h2>
                             </div>
-                            <a
-                                href={whatsappUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
+                            <button
+                                type="button"
+                                onClick={() => openContactModal({ source: 'brazil-promotion-day' })}
                                 className="btn-whatsapp btn-specialist shrink-0 flex items-center gap-3 bg-brand-yellow text-brand-dark px-10 py-5 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(255,255,255,0.15)] hover:shadow-[2px_2px_0px_rgba(255,255,255,0.15)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all whitespace-nowrap"
                                 data-contact-intent
                             >
                                 <WhatsappLogo className="w-6 h-6" weight="fill" />
                                 Abrir WhatsApp
-                            </a>
+                            </button>
                         </div>
                     </div>
                 </section>

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -5,17 +5,13 @@ import { LandingFAQ } from '@/components/LandingFAQ';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
 import { ServiceSchema } from '@/components/schemas/ServiceSchema';
-import { useWhatsAppLink } from '@/utils/whatsapp';
-import { pushWhatsAppCta } from '@/utils/analytics';
+import { openContactModal } from '@/utils/contactForm';
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
 import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
 import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
 import MessageSquare from 'lucide-react/dist/esm/icons/message-square';
 import Users from 'lucide-react/dist/esm/icons/users';
 import Headphones from 'lucide-react/dist/esm/icons/headphones';
-
-const WHATSAPP_MESSAGE = 'Olá! Tenho interesse em consultoria de viagem sob medida.';
-const PAGE_NAME = 'consultoria-de-viagem';
 
 const FAQ_ITEMS = [
   {
@@ -88,8 +84,6 @@ const PILLARS = [
 ];
 
 const ConsultoriaDeViagemLanding: React.FC = () => {
-  const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE, { appendTrackingRef: true });
-
   return (
     <div className="bg-[#fffdf5] min-h-screen font-sans">
       <SEO
@@ -130,15 +124,13 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               Anhangá Viagens
             </span>
           </Link>
-          <a
-            href={whatsappUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => pushWhatsAppCta(PAGE_NAME)}
+          <button
+            type="button"
+            onClick={() => openContactModal({ source: 'consultoria-viagem' })}
             className="btn-whatsapp btn-specialist text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap"
           >
             Falar com consultor
-          </a>
+          </button>
         </div>
       </header>
 
@@ -154,17 +146,15 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
           <p className="text-xl text-gray-600 mb-10 leading-relaxed max-w-2xl">
             Um consultor da Anhangá entende seu perfil, destino, orçamento e restrições para desenhar o melhor caminho antes de você fechar.
           </p>
-          <a
-            href={whatsappUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => pushWhatsAppCta(PAGE_NAME)}
+          <button
+            type="button"
+            onClick={() => openContactModal({ source: 'consultoria-viagem' })}
             className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-blue text-white font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors text-lg shadow-lg"
-            aria-label="Falar com um consultor de viagens via WhatsApp"
+            aria-label="Falar com um consultor de viagens"
           >
             Falar com um consultor
             <ArrowRight className="w-5 h-5" />
-          </a>
+          </button>
           <p className="mt-4 text-sm text-gray-600">Sem taxa de consultoria. Gratuito.</p>
         </div>
       </section>
@@ -296,17 +286,15 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
           <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
             Fale com um consultor agora. Sem taxa, sem compromisso.
           </p>
-          <a
-            href={whatsappUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => pushWhatsAppCta(PAGE_NAME)}
+          <button
+            type="button"
+            onClick={() => openContactModal({ source: 'consultoria-viagem' })}
             className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-black px-10 py-5 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-xl shadow-lg"
-            aria-label="Falar com um consultor via WhatsApp"
+            aria-label="Falar com um consultor"
           >
             Falar com um consultor
             <ArrowRight className="w-6 h-6" />
-          </a>
+          </button>
         </div>
       </section>
 

--- a/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
+++ b/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
@@ -5,17 +5,13 @@ import { LandingFAQ } from '@/components/LandingFAQ';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
 import { ServiceSchema } from '@/components/schemas/ServiceSchema';
-import { useWhatsAppLink } from '@/utils/whatsapp';
-import { pushWhatsAppCta } from '@/utils/analytics';
+import { openContactModal } from '@/utils/contactForm';
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
 import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
 import Compass from 'lucide-react/dist/esm/icons/compass';
 import LayoutGrid from 'lucide-react/dist/esm/icons/layout-grid';
 import CalendarCheck from 'lucide-react/dist/esm/icons/calendar-check';
 import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
-
-const WHATSAPP_MESSAGE = 'Olá! Quero ajuda para escolher o cruzeiro certo no Brasil.';
-const PAGE_NAME = 'curadoria-cruzeiros-brasil';
 
 const FAQ_ITEMS = [
   {
@@ -96,8 +92,6 @@ const HOW_IT_WORKS = [
 ];
 
 const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
-  const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE, { appendTrackingRef: true });
-
   return (
     <div className="bg-anhanga-light min-h-screen font-sans">
       <SEO
@@ -138,15 +132,13 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
               Anhangá Viagens
             </span>
           </Link>
-          <a
-            href={whatsappUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => pushWhatsAppCta(PAGE_NAME)}
+          <button
+            type="button"
+            onClick={() => openContactModal({ source: 'cruzeiros-brasil' })}
             className="btn-whatsapp btn-specialist text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap"
           >
             Falar com especialista
-          </a>
+          </button>
         </div>
       </header>
 
@@ -162,17 +154,15 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
           <p className="text-xl text-gray-600 mb-10 leading-relaxed max-w-2xl">
             Entenda navio, cabine, roteiro, datas e perfil da viagem com uma curadoria consultiva da Anhangá.
           </p>
-          <a
-            href={whatsappUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => pushWhatsAppCta(PAGE_NAME)}
+          <button
+            type="button"
+            onClick={() => openContactModal({ source: 'cruzeiros-brasil' })}
             className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-blue text-white font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors text-lg shadow-lg"
-            aria-label="Falar com um especialista em cruzeiros via WhatsApp"
+            aria-label="Falar com um especialista em cruzeiros"
           >
             Falar com um especialista
             <ArrowRight className="w-5 h-5" />
-          </a>
+          </button>
           <p className="mt-4 text-sm text-gray-600">Sem taxa de curadoria. Gratuito.</p>
         </div>
       </section>
@@ -312,17 +302,15 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
           <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
             Fale com um especialista e resolva a escolha em uma conversa. Sem taxa, sem compromisso.
           </p>
-          <a
-            href={whatsappUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => pushWhatsAppCta(PAGE_NAME)}
+          <button
+            type="button"
+            onClick={() => openContactModal({ source: 'cruzeiros-brasil' })}
             className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-black px-10 py-5 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-xl shadow-lg"
-            aria-label="Falar com um especialista em cruzeiros via WhatsApp"
+            aria-label="Falar com um especialista em cruzeiros"
           >
             Falar com um especialista
             <ArrowRight className="w-6 h-6" />
-          </a>
+          </button>
         </div>
       </section>
 

--- a/pages/landings/LollapaloozaLanding.tsx
+++ b/pages/landings/LollapaloozaLanding.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { SEO } from '../../components/SEO';
 import { LandingFAQ } from '../../components/LandingFAQ';
 import LollapaloozaApp from '../../components/landings/lollapalooza/LollapaloozaApp';
-import { openAiChat } from '../../utils/aiChat';
+import { openContactModal } from '../../utils/contactForm';
 import { WAITLIST_SECTION_ID } from '../../components/landings/lollapalooza/constants';
 import { BreadcrumbSchema } from '../../components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '../../components/schemas/FAQPageSchema';
@@ -106,9 +106,7 @@ const LollapaloozaLanding: React.FC = () => {
             <button
               onClick={(e) => {
                 e.preventDefault();
-                openAiChat({
-                  message: 'Olá! Tenho dúvidas sobre os pacotes do Lollapalooza. Podem me ajudar?'
-                });
+                openContactModal({ source: 'lollapalooza' });
               }}
               className="btn-whatsapp btn-specialist px-5 py-3 rounded-full bg-brand-cyan text-white font-bold hover:bg-brand-cyan/90 transition-colors"
               data-tracking="footer-lollapalooza-whatsapp"

--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -5,7 +5,7 @@ import { LandingFAQ } from '../../components/LandingFAQ';
 import { BreadcrumbSchema } from '../../components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '../../components/schemas/FAQPageSchema';
 import { ServiceSchema } from '../../components/schemas/ServiceSchema';
-import { openAiChat } from '../../utils/aiChat';
+import { openContactModal } from '../../utils/contactForm';
 import { m } from 'framer-motion';
 import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
 import Heart from 'lucide-react/dist/esm/icons/heart';
@@ -66,7 +66,7 @@ const MelhorIdadeLanding: React.FC = () => {
             Anhangá Viagens
           </Link>
           <button 
-            onClick={() => openAiChat({ message: 'Olá! Gostaria de saber mais sobre roteiros para a melhor idade.' })}
+            onClick={() => openContactModal({ source: 'melhor-idade' })}
             className="btn-whatsapp btn-specialist text-xs font-black uppercase tracking-widest bg-brand-dark text-white px-4 py-2 rounded-full hover:bg-brand-cyan transition-colors focus:outline-dashed focus:outline-2 focus:outline-offset-2 focus:outline-brand-cyan"
             data-tracking="header-melhor-idade"
           >
@@ -112,7 +112,7 @@ const MelhorIdadeLanding: React.FC = () => {
               className="flex flex-wrap gap-4"
             >
               <button
-                onClick={() => openAiChat({ message: 'Olá! Quero planejar uma viagem personalizada para o público 50+.' })}
+                onClick={() => openContactModal({ source: 'melhor-idade' })}
                 className="btn-whatsapp btn-specialist bg-brand-vibrant text-white px-8 py-4 rounded-2xl font-black text-lg shadow-xl shadow-brand-vibrant/20 hover:scale-105 transition-transform flex items-center gap-3 focus:outline-dashed focus:outline-2 focus:outline-offset-2 focus:outline-brand-vibrant"
                 data-tracking="hero-melhor-idade"
               >
@@ -206,7 +206,7 @@ const MelhorIdadeLanding: React.FC = () => {
             Fale conosco hoje mesmo e receba uma proposta exclusiva para sua viagem. Segurança, conforto e exclusividade em um só lugar.
           </p>
           <button
-            onClick={() => openAiChat({ message: 'Olá! Sou do público 50+ e gostaria de um orçamento para minha próxima viagem.' })}
+            onClick={() => openContactModal({ source: 'melhor-idade' })}
             className="btn-whatsapp btn-specialist bg-brand-cyan text-white px-10 py-5 rounded-2xl font-black text-xl shadow-2xl shadow-brand-cyan/20 hover:scale-105 transition-transform relative z-10 focus:outline-dashed focus:outline-2 focus:outline-offset-2 focus:outline-white"
             data-tracking="footer-melhor-idade"
           >

--- a/pages/landings/OrlandoLanding.tsx
+++ b/pages/landings/OrlandoLanding.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { getWhatsAppLink } from '../../utils/whatsapp';
 import { SEO } from '../../components/SEO';
 import { LandingFAQ } from '../../components/LandingFAQ';
 import OrlandoApp from '../../components/landings/orlando/OrlandoApp';
 import { BreadcrumbSchema } from '../../components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '../../components/schemas/FAQPageSchema';
 import { ServiceSchema } from '../../components/schemas/ServiceSchema';
-import { openAiChat } from '../../utils/aiChat';
+import { openContactModal } from '../../utils/contactForm';
 import './orlando.css';
 
 const ORLANDO_FAQ_ITEMS = [
@@ -95,9 +94,7 @@ const OrlandoLanding: React.FC = () => {
             <button
               onClick={(e) => {
                 e.preventDefault();
-                openAiChat({
-                  message: 'Olá! Gostaria de um orçamento personalizado para Orlando.'
-                });
+                openContactModal({ source: 'orlando' });
               }}
               className="btn-whatsapp btn-specialist px-5 py-3 rounded-full bg-brand-cyan text-white font-bold hover:bg-brand-cyan/90 transition-colors"
               data-tracking="footer-orlando"

--- a/pages/landings/ViagensParaExecutivosLanding.tsx
+++ b/pages/landings/ViagensParaExecutivosLanding.tsx
@@ -5,16 +5,12 @@ import { LandingFAQ } from '@/components/LandingFAQ';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
 import { ServiceSchema } from '@/components/schemas/ServiceSchema';
-import { useWhatsAppLink } from '@/utils/whatsapp';
-import { pushWhatsAppCta } from '@/utils/analytics';
+import { openContactModal } from '@/utils/contactForm';
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
 import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
 import Search from 'lucide-react/dist/esm/icons/search';
 import LayoutList from 'lucide-react/dist/esm/icons/layout-list';
 import PhoneCall from 'lucide-react/dist/esm/icons/phone-call';
-
-const WHATSAPP_MESSAGE = 'Olá! Quero planejar uma viagem com atendimento consultivo.';
-const PAGE_NAME = 'viagens-para-executivos';
 
 const FAQ_ITEMS = [
   {
@@ -86,8 +82,6 @@ const HOW_IT_WORKS = [
 ];
 
 const ViagensParaExecutivosLanding: React.FC = () => {
-  const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE, { appendTrackingRef: true });
-
   return (
     <div className="bg-white min-h-screen font-sans">
       <SEO
@@ -128,15 +122,13 @@ const ViagensParaExecutivosLanding: React.FC = () => {
               Anhangá Viagens
             </span>
           </Link>
-          <a
-            href={whatsappUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => pushWhatsAppCta(PAGE_NAME)}
+          <button
+            type="button"
+            onClick={() => openContactModal({ source: 'viagens-executivos' })}
             className="btn-whatsapp btn-specialist text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap"
           >
             Falar com consultor
-          </a>
+          </button>
         </div>
       </header>
 
@@ -152,17 +144,15 @@ const ViagensParaExecutivosLanding: React.FC = () => {
           <p className="text-xl text-gray-300 mb-10 leading-relaxed max-w-2xl">
             Para profissionais e famílias que não querem perder tempo comparando opções nem correr risco com detalhes importantes.
           </p>
-          <a
-            href={whatsappUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => pushWhatsAppCta(PAGE_NAME)}
+          <button
+            type="button"
+            onClick={() => openContactModal({ source: 'viagens-executivos' })}
             className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-lg shadow-lg"
-            aria-label="Falar com um consultor de viagens via WhatsApp"
+            aria-label="Falar com um consultor de viagens"
           >
             Falar com um consultor
             <ArrowRight className="w-5 h-5" />
-          </a>
+          </button>
           <p className="mt-4 text-sm text-gray-400">Consultor fixo do início ao fim.</p>
         </div>
       </section>
@@ -283,17 +273,15 @@ const ViagensParaExecutivosLanding: React.FC = () => {
           <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
             Um consultor disponível para cuidar de cada detalhe. Sem chatbot, sem formulário, sem burocracia.
           </p>
-          <a
-            href={whatsappUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => pushWhatsAppCta(PAGE_NAME)}
+          <button
+            type="button"
+            onClick={() => openContactModal({ source: 'viagens-executivos' })}
             className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-white text-anhanga-blue font-black px-10 py-5 rounded-2xl hover:bg-anhanga-light transition-colors text-xl shadow-lg"
-            aria-label="Falar com um consultor de viagens via WhatsApp"
+            aria-label="Falar com um consultor de viagens"
           >
             Falar com um consultor
             <ArrowRight className="w-6 h-6" />
-          </a>
+          </button>
         </div>
       </section>
 

--- a/services/n8n.ts
+++ b/services/n8n.ts
@@ -1,4 +1,4 @@
-import type { N8nLeadPayload, N8nQuizPayload, N8nWaitlistPayload } from '../lib/n8n-payloads';
+import type { N8nContactPayload, N8nLeadPayload, N8nQuizPayload, N8nWaitlistPayload } from '../lib/n8n-payloads';
 
 // 5 seconds gives self-hosted n8n enough headroom for cold-start workflows
 // without hanging the edge function indefinitely. Override with N8N_WEBHOOK_TIMEOUT_MS.
@@ -92,6 +92,15 @@ export function sendLeadToN8n(
     secret: string,
     requestId: string,
     payload: N8nLeadPayload,
+): Promise<Response> {
+    return n8nRequest(url, secret, requestId, payload);
+}
+
+export function sendContactToN8n(
+    url: string,
+    secret: string,
+    requestId: string,
+    payload: N8nContactPayload,
 ): Promise<Response> {
     return n8nRequest(url, secret, requestId, payload);
 }

--- a/tests/e2e/contact-form.spec.ts
+++ b/tests/e2e/contact-form.spec.ts
@@ -25,6 +25,12 @@ const contactDialog = (page: Page) =>
 
 test.describe('Contact form modal', () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(window, 'open', {
+        configurable: true,
+        value: () => null,
+      });
+    });
     await mockSubmitContact(page);
     await page.goto('/');
   });
@@ -59,6 +65,18 @@ test.describe('Contact form modal', () => {
     await page.locator('#contact-firstName').fill('Maria');
     await page.locator('#contact-whatsapp').fill('11987654321');
     await page.getByRole('button', { name: /^me chamem no whatsapp$/i }).click();
+
+    await expect(page.getByText(/recebemos seu contato/i)).toBeVisible();
+    await expect(contactDialog(page).getByRole('status')).toContainText(/recebemos seu contato/i);
+    await expect(contactDialog(page).getByRole('button', { name: /^fechar$/i }).last()).toBeFocused();
+  });
+
+  test('envia o caminho principal ao pressionar Enter', async ({ page, isMobile }) => {
+    await openHeaderContactModal(page, isMobile);
+
+    await page.locator('#contact-firstName').fill('Maria');
+    await page.locator('#contact-whatsapp').fill('11987654321');
+    await page.locator('#contact-whatsapp').press('Enter');
 
     await expect(page.getByText(/recebemos seu contato/i)).toBeVisible();
   });

--- a/tests/e2e/contact-form.spec.ts
+++ b/tests/e2e/contact-form.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function mockSubmitContact(page: Page) {
+  await page.route('**/api/submit-contact', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true, requestId: 'req_contact_e2e' }),
+    }),
+  );
+}
+
+async function openHeaderContactModal(page: Page, isMobile: boolean) {
+  if (isMobile) {
+    await page.locator('button[aria-label="Abrir menu"]').click();
+    await page.getByTestId('mobile-fale-conosco-btn').click();
+    return;
+  }
+
+  await page.getByTestId('desktop-fale-conosco-btn').click();
+}
+
+const contactDialog = (page: Page) =>
+  page.getByRole('dialog', { name: 'Fale com um especialista' });
+
+test.describe('Contact form modal', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSubmitContact(page);
+    await page.goto('/');
+  });
+
+  test('abre o modal ao clicar no CTA do Header', async ({ page, isMobile }) => {
+    await openHeaderContactModal(page, isMobile);
+
+    await expect(contactDialog(page)).toBeVisible();
+    await expect(page.locator('#contact-firstName')).toBeFocused();
+  });
+
+  test('mantém botões desabilitados com campos vazios', async ({ page, isMobile }) => {
+    await openHeaderContactModal(page, isMobile);
+
+    await expect(page.getByRole('button', { name: /^chamar no whatsapp$/i })).toBeDisabled();
+    await expect(page.getByRole('button', { name: /^me chamem no whatsapp$/i })).toBeDisabled();
+  });
+
+  test('habilita botões após preencher nome e WhatsApp', async ({ page, isMobile }) => {
+    await openHeaderContactModal(page, isMobile);
+
+    await page.locator('#contact-firstName').fill('Maria');
+    await page.locator('#contact-whatsapp').fill('11987654321');
+
+    await expect(page.getByRole('button', { name: /^chamar no whatsapp$/i })).toBeEnabled();
+    await expect(page.getByRole('button', { name: /^me chamem no whatsapp$/i })).toBeEnabled();
+  });
+
+  test('envia o pedido de retorno e exibe confirmação', async ({ page, isMobile }) => {
+    await openHeaderContactModal(page, isMobile);
+
+    await page.locator('#contact-firstName').fill('Maria');
+    await page.locator('#contact-whatsapp').fill('11987654321');
+    await page.getByRole('button', { name: /^me chamem no whatsapp$/i }).click();
+
+    await expect(page.getByText(/recebemos seu contato/i)).toBeVisible();
+  });
+
+  test('fecha com tecla Escape', async ({ page, isMobile }) => {
+    await openHeaderContactModal(page, isMobile);
+    await expect(contactDialog(page)).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    await expect(contactDialog(page)).not.toBeVisible();
+  });
+
+  test('fecha ao clicar no overlay', async ({ page, isMobile }) => {
+    await openHeaderContactModal(page, isMobile);
+    await expect(contactDialog(page)).toBeVisible();
+
+    await page.mouse.click(10, 10);
+
+    await expect(contactDialog(page)).not.toBeVisible();
+  });
+});
+
+test.describe('CallToAction inline form', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSubmitContact(page);
+    await page.goto('/#contato');
+  });
+
+  test('expande formulário ao clicar em "Solicitar meu Orçamento"', async ({ page }) => {
+    await page.locator('#contato').scrollIntoViewIfNeeded();
+    await page.getByRole('button', { name: /solicitar meu orçamento/i }).click();
+
+    await expect(page.locator('#cta-firstName')).toBeVisible();
+  });
+
+  test('exibe confirmação após "Me chamem"', async ({ page }) => {
+    await page.locator('#contato').scrollIntoViewIfNeeded();
+    await page.getByRole('button', { name: /solicitar meu orçamento/i }).click();
+
+    await page.locator('#cta-firstName').fill('João');
+    await page.locator('#cta-whatsapp').fill('11999998888');
+    await page.getByRole('button', { name: /^me chamem$/i }).click();
+
+    await expect(page.getByText(/recebemos/i)).toBeVisible();
+  });
+});

--- a/tests/e2e/haptics.spec.ts
+++ b/tests/e2e/haptics.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect, type Page } from '@playwright/test';
-import { HomePage } from './pages/HomePage';
 import { AIChat } from './pages/AIChat';
 
 declare global {
@@ -12,7 +11,7 @@ const readVibrateCalls = async (page: Page) =>
   page.evaluate(() => window.__vibrateCalls ?? []);
 
 test.describe('Haptics', () => {
-  test('should trigger haptic feedback when a CTA opens the chat on Mobile Chrome', async ({ page }, testInfo) => {
+  test('should trigger haptic feedback when the chat opens on Mobile Chrome', async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== 'Mobile Chrome', 'Haptic assertions are scoped to Mobile Chrome.');
 
     await page.addInitScript(() => {
@@ -27,19 +26,10 @@ test.describe('Haptics', () => {
       });
     });
 
-    await page.route('**/api/generate', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ text: 'Resposta automática do CTA.' }),
-      })
-    );
-
-    const homePage = new HomePage(page);
     const aiChat = new AIChat(page);
 
-    await homePage.goto();
-    await homePage.openChat(true);
+    await page.goto('/');
+    await aiChat.open();
     await aiChat.expectVisible();
     await expect.poll(() => readVibrateCalls(page).then(calls => calls.length)).toBe(1);
   });

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
 import { HomePage } from './pages/HomePage';
-import { AIChat } from './pages/AIChat';
 
 test.describe('Smoke Suite', () => {
   test('should load home page and verify key elements', async ({ page, isMobile }) => {
@@ -24,17 +23,19 @@ test.describe('Smoke Suite', () => {
     }
   });
 
-  test('should open AI Chatbot via "Fale Conosco" button', async ({ page, isMobile }) => {
+  test('should open contact modal via "Fale Conosco" button', async ({ page, isMobile }) => {
     await page.goto('/');
     const homePage = new HomePage(page);
-    const aiChat = new AIChat(page);
 
-    await homePage.openChat(isMobile);
+    if (isMobile) {
+      await homePage.openMobileMenu();
+      await homePage.mobileFaleConoscoBtn.click();
+    } else {
+      await homePage.faleConoscoBtn.click();
+    }
 
-    await aiChat.expectVisible();
-    await aiChat.expectOnlineStatus();
-    // Initial greeting is hardcoded in AIChat.tsx state — not AI-generated, so always deterministic
-    await aiChat.expectMessageContaining('Olá! Sou seu guia Anhangá');
+    await expect(page.getByRole('dialog', { name: 'Fale com um especialista' })).toBeVisible();
+    await expect(page.getByText('Fale com um especialista')).toBeVisible();
   });
 
   test('should navigate to basic landing pages', async ({ page }) => {
@@ -60,31 +61,18 @@ test.describe('Smoke Suite', () => {
     await expect(page.locator('#mobile-menu')).toBeVisible();
   });
 
-  test('should trigger chatbot from landing pages CTAs', async ({ page }) => {
-    const aiChat = new AIChat(page);
-
-    // Intercept Gemini proxy so tests are deterministic and don't hit the real API
-    await page.route('**/api/generate', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ text: 'Claro! Posso te ajudar com isso.' }),
-      })
-    );
-
+  test('should open contact modal from landing pages CTAs', async ({ page }) => {
     // Orlando
     await page.goto('/orlando');
     await page.getByTestId('cta-orlando-specialist').click();
-    await aiChat.expectVisible();
-    await aiChat.expectMessageContaining('Orlando');
-    await aiChat.close();
+    await expect(page.getByRole('dialog', { name: 'Fale com um especialista' })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog', { name: 'Fale com um especialista' })).not.toBeVisible();
 
     // Beto Carrero
     await page.goto('/beto-carrero');
     await page.getByTestId('cta-betocarrero-specialist').click();
-    await aiChat.expectVisible();
-    await aiChat.expectMessageContaining('Beto Carrero');
-    await aiChat.close();
+    await expect(page.getByRole('dialog', { name: 'Fale com um especialista' })).toBeVisible();
 
   });
 

--- a/tests/submit-contact.test.ts
+++ b/tests/submit-contact.test.ts
@@ -1,0 +1,148 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const originalEnv = {
+    N8N_SUBMIT_CONTACT_WEBHOOK_URL: process.env.N8N_SUBMIT_CONTACT_WEBHOOK_URL,
+    N8N_WEBHOOK_SECRET: process.env.N8N_WEBHOOK_SECRET,
+};
+
+type CapturedContactBody = {
+    source?: string;
+    contact?: {
+        firstName?: string;
+        ctaSource?: string | null;
+        destination?: string | null;
+    };
+};
+
+function restoreEnvValue(key: string, value: string | undefined) {
+    if (value === undefined) {
+        delete process.env[key];
+        return;
+    }
+
+    process.env[key] = value;
+}
+
+function restoreEnv() {
+    restoreEnvValue('N8N_SUBMIT_CONTACT_WEBHOOK_URL', originalEnv.N8N_SUBMIT_CONTACT_WEBHOOK_URL);
+    restoreEnvValue('N8N_WEBHOOK_SECRET', originalEnv.N8N_WEBHOOK_SECRET);
+}
+
+function buildRequest(
+    body: Record<string, unknown>,
+    opts?: { method?: string; ip?: string },
+): Request {
+    const ipSuffix = Math.floor(Math.random() * 200) + 1;
+    const method = opts?.method ?? 'POST';
+    return new Request('http://localhost/api/submit-contact', {
+        method,
+        headers: {
+            'Content-Type': 'application/json',
+            'x-real-ip': opts?.ip ?? `10.0.0.${ipSuffix}`,
+        },
+        body: method === 'POST' ? JSON.stringify(body) : undefined,
+    });
+}
+
+function validBody(overrides?: Record<string, unknown>) {
+    return {
+        firstName: 'Maria',
+        whatsapp: '+5511987654321',
+        emailOptIn: false,
+        utms: {
+            utm_source: 'google',
+            utm_medium: 'cpc',
+            utm_campaign: null,
+            utm_term: null,
+            utm_content: null,
+        },
+        ...overrides,
+    };
+}
+
+const originalFetch = global.fetch;
+
+test.afterEach(() => {
+    global.fetch = originalFetch;
+    restoreEnv();
+});
+
+test('rejects non-POST requests with 405', async () => {
+    const { default: handler } = await import('../api/submit-contact.ts');
+    const req = buildRequest({}, { method: 'GET' });
+    const res = await handler(req);
+    assert.equal(res.status, 405);
+});
+
+test('returns 503 when N8N_SUBMIT_CONTACT_WEBHOOK_URL is missing', async () => {
+    delete process.env.N8N_SUBMIT_CONTACT_WEBHOOK_URL;
+    delete process.env.N8N_WEBHOOK_SECRET;
+    const { default: handler } = await import('../api/submit-contact.ts');
+    const req = buildRequest(validBody());
+    const res = await handler(req);
+    assert.equal(res.status, 503);
+    const json = await res.json();
+    assert.equal(json.code, 'SERVER_CONFIG_ERROR');
+});
+
+test('returns 400 when firstName is missing', async () => {
+    process.env.N8N_SUBMIT_CONTACT_WEBHOOK_URL = 'https://n8n.example.com/hook';
+    process.env.N8N_WEBHOOK_SECRET = 'secret';
+    const { default: handler } = await import('../api/submit-contact.ts');
+    const req = buildRequest(validBody({ firstName: '' }));
+    const res = await handler(req);
+    assert.equal(res.status, 400);
+    const json = await res.json();
+    assert.equal(json.code, 'VALIDATION_ERROR');
+});
+
+test('returns 400 when whatsapp is missing', async () => {
+    process.env.N8N_SUBMIT_CONTACT_WEBHOOK_URL = 'https://n8n.example.com/hook';
+    process.env.N8N_WEBHOOK_SECRET = 'secret';
+    const { default: handler } = await import('../api/submit-contact.ts');
+    const req = buildRequest(validBody({ whatsapp: '' }));
+    const res = await handler(req);
+    assert.equal(res.status, 400);
+    const json = await res.json();
+    assert.equal(json.code, 'VALIDATION_ERROR');
+});
+
+test('returns 200 and calls n8n webhook on valid request', async () => {
+    process.env.N8N_SUBMIT_CONTACT_WEBHOOK_URL = 'https://n8n.example.com/hook';
+    process.env.N8N_WEBHOOK_SECRET = 'secret';
+
+    let capturedUrl = '';
+    let capturedBody: CapturedContactBody = {};
+
+    global.fetch = (async (input, init) => {
+        capturedUrl = typeof input === 'string' ? input : (input as Request).url;
+        capturedBody = JSON.parse((init?.body as string) ?? '{}') as CapturedContactBody;
+        return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const { default: handler } = await import('../api/submit-contact.ts');
+    const req = buildRequest(validBody({ source: 'header', destination: 'Orlando' }));
+    const res = await handler(req);
+
+    assert.equal(res.status, 200);
+    assert.equal(capturedUrl, 'https://n8n.example.com/hook');
+    assert.equal(capturedBody.source, 'submit-contact');
+    assert.equal(capturedBody.contact?.firstName, 'Maria');
+    assert.equal(capturedBody.contact?.ctaSource, 'header');
+    assert.equal(capturedBody.contact?.destination, 'Orlando');
+});
+
+test('returns 502 when n8n webhook fails', async () => {
+    process.env.N8N_SUBMIT_CONTACT_WEBHOOK_URL = 'https://n8n.example.com/hook';
+    process.env.N8N_WEBHOOK_SECRET = 'secret';
+    global.fetch = (async () => new Response('error', { status: 500 })) as typeof fetch;
+
+    const { default: handler } = await import('../api/submit-contact.ts');
+    const req = buildRequest(validBody());
+    const res = await handler(req);
+
+    assert.equal(res.status, 502);
+    const json = await res.json();
+    assert.equal(json.code, 'N8N_WEBHOOK_ERROR');
+});

--- a/tests/submit-contact.test.ts
+++ b/tests/submit-contact.test.ts
@@ -73,6 +73,8 @@ test('rejects non-POST requests with 405', async () => {
     const req = buildRequest({}, { method: 'GET' });
     const res = await handler(req);
     assert.equal(res.status, 405);
+    const json = await res.json();
+    assert.equal(json.error, 'Método não permitido.');
 });
 
 test('returns 503 when N8N_SUBMIT_CONTACT_WEBHOOK_URL is missing', async () => {
@@ -143,6 +145,20 @@ test('returns 502 when n8n webhook fails', async () => {
     const res = await handler(req);
 
     assert.equal(res.status, 502);
+    const json = await res.json();
+    assert.equal(json.code, 'N8N_WEBHOOK_ERROR');
+});
+
+test('returns 504 when n8n webhook times out upstream', async () => {
+    process.env.N8N_SUBMIT_CONTACT_WEBHOOK_URL = 'https://n8n.example.com/hook';
+    process.env.N8N_WEBHOOK_SECRET = 'secret';
+    global.fetch = (async () => new Response('timeout', { status: 504 })) as typeof fetch;
+
+    const { default: handler } = await import('../api/submit-contact.ts');
+    const req = buildRequest(validBody());
+    const res = await handler(req);
+
+    assert.equal(res.status, 504);
     const json = await res.json();
     assert.equal(json.code, 'N8N_WEBHOOK_ERROR');
 });

--- a/types/contactCapture.ts
+++ b/types/contactCapture.ts
@@ -1,0 +1,44 @@
+import type { LeadTracking, LeadUtms } from './leadCapture';
+
+export interface ContactFormFields {
+    firstName: string;
+    lastName: string;
+    whatsapp: string;
+    email: string;
+    emailOptIn: boolean;
+}
+
+export interface SubmitContactRequest {
+    firstName: string;
+    lastName?: string;
+    whatsapp: string;
+    email?: string;
+    emailOptIn: boolean;
+    source?: string;
+    destination?: string;
+    eventId?: string;
+    utms: LeadUtms;
+    tracking?: LeadTracking;
+}
+
+export type SubmitContactErrorCode =
+    | 'VALIDATION_ERROR'
+    | 'RATE_LIMIT_EXCEEDED'
+    | 'SERVER_CONFIG_ERROR'
+    | 'N8N_WEBHOOK_ERROR'
+    | 'METHOD_NOT_ALLOWED'
+    | 'INTERNAL_ERROR';
+
+export interface SubmitContactSuccess {
+    ok: true;
+    requestId: string;
+}
+
+export interface SubmitContactError {
+    ok: false;
+    requestId: string;
+    error: string;
+    code: SubmitContactErrorCode;
+}
+
+export type SubmitContactResponse = SubmitContactSuccess | SubmitContactError;

--- a/utils/contactForm.ts
+++ b/utils/contactForm.ts
@@ -1,0 +1,10 @@
+export interface ContactModalOptions {
+    source?: string;
+    destination?: string;
+    message?: string;
+}
+
+export function openContactModal(options: ContactModalOptions = {}): void {
+    if (typeof window === 'undefined') return;
+    window.dispatchEvent(new CustomEvent('open-contact-modal', { detail: options }));
+}


### PR DESCRIPTION
## Summary
- Substitui os CTAs que abriam o chat por um fluxo de contato com modal global e formulário inline na homepage.
- Adiciona o endpoint `/api/submit-contact`, os tipos e o payload para webhook n8n, com tracking e validação sanitizada.
- Migra headers, blog, páginas institucionais e landings para `openContactModal()` e mantém o WhatsApp como ação imediata no novo fluxo.
- Atualiza a cobertura com testes de unidade, regressão e E2E para o novo comportamento.

## Testing
- `pnpm typecheck`
- `pnpm test:regression`
- `pnpm build`
- `pnpm test:e2e tests/e2e/contact-form.spec.ts --project=chromium --project="Mobile Chrome"`
- `pnpm test:e2e tests/e2e/smoke.spec.ts tests/e2e/haptics.spec.ts --project=chromium --project="Mobile Chrome"`