### PR TITLE
Alinhar Dependabot com política de supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
-    # reviewers: ["your-team"]
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Adiciona cooldown de 7 dias para updates npm/pnpm do Dependabot, alinhando com o minimumReleaseAge do pnpm.
- Adiciona monitoramento de GitHub Actions com a mesma janela de cooldown para reduzir risco de updates recém-publicados em workflows.
- Remove placeholder de reviewers não configurado.

## Testing
- Ruby YAML parse/shape check para .github/dependabot.yml.
- git diff --check.

## Notes
- O cooldown do Dependabot vale para version updates; security updates continuam com fluxo próprio para correções urgentes.