### PR TITLE
fix(design): use brand blue token for heading accent in Highlights (#461)

### DIFF
--- a/components/Highlights.tsx
+++ b/components/Highlights.tsx
@@ -160,7 +160,7 @@ const Highlights = memo(() => {
                             </div>
                             <h2 className="text-4xl md:text-5xl font-black text-brand-dark leading-tight mb-6">
                                 Não existe roteiro certo <br />
-                                <span className="text-brand-cyan">
+                                <span className="text-anhanga-blue">
                                     para o viajante errado.
                                 </span>
                             </h2>

--- a/components/Highlights.tsx
+++ b/components/Highlights.tsx
@@ -153,8 +153,8 @@ const Highlights = memo(() => {
                             custom={1}
                         >
                             <div className="inline-block relative mb-4">
-                                <span className="absolute inset-0 bg-blue-100 transform -skew-x-12 rounded-lg"></span>
-                                <span className="relative px-3 py-1 text-blue-600 font-black uppercase tracking-widest text-sm flex items-center gap-2">
+                                <span className="absolute inset-0 bg-anhanga-blue/10 transform -skew-x-12 rounded-lg"></span>
+                                <span className="relative px-3 py-1 text-anhanga-blue font-black uppercase tracking-widest text-sm flex items-center gap-2">
                                     <Sparkle className="w-4 h-4" weight="fill" /> O Jeito Anhangá
                                 </span>
                             </div>


### PR DESCRIPTION
## Resumo

- Substitui `text-brand-cyan` por `text-anhanga-blue` (#0056D2) no span do heading em `components/Highlights.tsx`
- Alinha o token de cor com a recomendação da issue de usar o azul Anhangá como cor sólida para headings

## Critério de aceite

- ✅ Nenhum heading no site principal usa `bg-clip-text`
- ✅ Hierarquia visual mantida
- ✅ Cor do destaque usa token oficial da paleta (`#0056D2`)

Closes #461