### PR TITLE
fix(design): use brand blue for MelhorIdade heading accent (#462)

### DIFF
--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -90,7 +90,7 @@ const MelhorIdadeLanding: React.FC = () => {
               className="text-5xl md:text-7xl font-black text-brand-dark mb-8 leading-[1.1]"
             >
               O mundo no seu ritmo, <br />
-              <span className="text-brand-cyan">
+              <span className="text-anhanga-blue">
                 com o cuidado que você merece.
               </span>
             </m.h1>


### PR DESCRIPTION
## Resumo

- Substitui `text-brand-cyan` por `text-anhanga-blue` (#0056D2) no `h1` da landing MelhorIdade
- Segue a recomendação da issue: "MelhorIdade: azul da marca ou branco" para substituir gradiente por cor sólida

## Critério de aceite

- ✅ Nenhuma landing usa `bg-clip-text` em headings
- ✅ Identidade visual da landing preservada
- ✅ Cor do destaque usa token oficial da paleta Anhangá

Closes #462