### PR TITLE
fix(design): remove side-tab border anti-patterns (#465)

### DIFF
--- a/components/Destinations.tsx
+++ b/components/Destinations.tsx
@@ -671,7 +671,7 @@ const Destinations: React.FC = memo(() => {
                             <X className="w-5 h-5" />
                         </button>
 
-                        <div className="w-full md:w-1/2 h-64 md:h-auto relative bg-gray-100 border-b-4 md:border-b-0 md:border-r-4 border-white">
+                        <div className="w-full md:w-1/2 h-64 md:h-auto relative bg-gray-100">
                             <LazyImage
                                 src={selectedDestination.image}
                                 alt={selectedDestination.city}

--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -83,7 +83,7 @@ const FAQS = [
                     <li>Duração da viagem</li>
                     <li>Sazonalidade do destino</li>
                 </ul>
-                <p className="shadow-[inset_3px_0_0_#fbbf24] pl-4 italic">
+                <p className="border-t border-amber-200 pt-3 pl-2 italic text-gray-700">
                     <strong>Receba uma cotação personalizada gratuitamente!</strong> <br />
                     Fale com nossa IA agora mesmo no chat!
                 </p>

--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -83,7 +83,7 @@ const FAQS = [
                     <li>Duração da viagem</li>
                     <li>Sazonalidade do destino</li>
                 </ul>
-                <p className="border-t border-amber-200 pt-3 pl-2 italic text-gray-700">
+                <p className="border-t border-amber-200 pt-3 italic">
                     <strong>Receba uma cotação personalizada gratuitamente!</strong> <br />
                     Fale com nossa IA agora mesmo no chat!
                 </p>


### PR DESCRIPTION
## Resumo

- **Destinations.tsx**: remove `border-r-4 border-white` do painel de imagem no modal de destino; a separação de layout vem naturalmente do flex container
- **FAQ.tsx**: substitui `shadow-[inset_3px_0_0_#fbbf24]` (efeito de borda lateral via box-shadow) por `border-t border-amber-200 pt-3` — separador horizontal sutil conforme recomendação da issue

## Critério de aceite

- ✅ Nenhum card usa `border-l-4` ou `border-r-4` como destaque visual principal
- ✅ Hierarquia e legibilidade dos componentes mantidas
- ✅ Sem regressão em estados hover/focus

Closes #465