### PR TITLE
fix(security): warn when Redis is missing on Vercel Edge Runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,9 +79,11 @@ N8N_WEBHOOK_SECRET=seu_segredo_aqui
 N8N_SUBMIT_CONTACT_WEBHOOK_URL=https://seu-n8n.com/webhook/contact-form
 
 # =============================================================================
-# OPTIONAL - Rate Limiting (Upstash Redis)
+# REQUIRED (prod) - Rate Limiting (Upstash Redis)
 # =============================================================================
-# Required for shared rate limiting in serverless environments
+# Vercel Edge Functions run in isolated V8 contexts — module-level state resets
+# on every request. Without Redis, rate limiting is non-functional in production
+# and the Gemini proxy (/api/generate) is unprotected against quota abuse.
 # Get your credentials at: https://console.upstash.com/
 # UPSTASH_REDIS_REST_URL=https://your-instance.upstash.io
 # UPSTASH_REDIS_REST_TOKEN=your_rest_token

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -14,14 +14,33 @@ interface RedisLike {
   expire(key: string, seconds: number): Promise<unknown>;
 }
 
+// On Vercel Edge Runtime, each request runs in an isolated V8 context.
+// Module-level state does NOT persist across concurrent requests, making
+// this Map non-functional as a shared rate limiter without Redis.
+// It is kept only as a local-dev convenience (single-process, single-isolate).
 const inMemoryStore = new Map<string, RateLimitEntry>();
 const IN_MEMORY_MAX_ENTRIES = 2500;
+
+// True when running inside Vercel (production, preview, or development deployment).
+// process.env.VERCEL_ENV is injected automatically by Vercel at build/runtime.
+const IS_VERCEL_RUNTIME = Boolean(process.env.VERCEL_ENV);
 
 async function getRedisClient(): Promise<RedisLike | null> {
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
 
   if (!url || !token) {
+    if (IS_VERCEL_RUNTIME) {
+      // Each Vercel Edge invocation gets a fresh V8 isolate — the in-memory Map
+      // above resets on every request and provides no real protection.
+      // Configure UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN to enable
+      // shared rate limiting across all Edge instances.
+      console.error(
+        'RateLimit: Upstash Redis not configured. ' +
+        'In-memory fallback is non-functional on Vercel Edge Runtime (isolated V8 contexts per request). ' +
+        'Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN in your Vercel environment variables.'
+      );
+    }
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Detects `VERCEL_ENV` em `lib/rate-limit.ts` e emite `console.error` explícito quando Upstash Redis não está configurado no ambiente Vercel
- Adiciona comentário explicando por que `inMemoryStore` é não-funcional no Edge Runtime (V8 isolates por request)
- Corrige classificação de Upstash no `.env.example` de `OPTIONAL` para `REQUIRED (prod)` com justificativa

## Contexto (SEC-001)

No Vercel Edge Runtime, cada request executa em um isolate V8 independente — o estado de módulo não persiste entre requests concorrentes. O `inMemoryStore` (Map module-level) reinicia a cada request, tornando o rate limiter silenciosamente ineficaz sem Redis. Sem Upstash configurado, `/api/generate` (proxy Gemini) fica sem proteção contra abuso de cota.

O fix não altera o comportamento funcional: em dev local (sem `VERCEL_ENV`), o fallback in-memory continua operando normalmente. Em Vercel sem Redis, um `console.error` aparece nos Function Logs a cada cold-start, forçando visibilidade do gap antes que cause impacto em produção.

## Test plan

- [x] `pnpm typecheck` — sem erros
- [x] `pnpm test:regression` — 261 testes passando, 0 falhas
- [ ] Confirmar que `UPSTASH_REDIS_REST_URL` está configurado no Vercel Dashboard (Production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)