### PR TITLE
fix(design): replace bounce/elastic easing on Beto Carrero landing

### DIFF
--- a/components/landings/beto-carrero/Features.tsx
+++ b/components/landings/beto-carrero/Features.tsx
@@ -12,7 +12,7 @@ const features: Feature[] = [
     tooltipText: "Agilidade Total"
   },
   {
-    icon: <Smile size={48} className="text-white group-hover:animate-bounce" />,
+    icon: <Smile size={48} className="text-white group-hover:animate-pulse" />,
     title: "Mais Diversão",
     description: "Casais, famílias e grupos. Você aproveita cada momento sem se preocupar com logística.",
     color: "bg-fun-pink",

--- a/components/landings/beto-carrero/Hero.tsx
+++ b/components/landings/beto-carrero/Hero.tsx
@@ -53,7 +53,7 @@ const Hero: React.FC = () => {
             </div>
 
             {/* Hand-drawn Arrow pointing to button (Hidden on mobile to save space) */}
-            <div className="hidden lg:block text-fun-dark absolute lg:left-[380px] lg:-top-14 xl:left-[480px] xl:-top-8 animate-bounce z-30">
+            <div className="hidden lg:block text-fun-dark absolute lg:left-[380px] lg:-top-14 xl:left-[480px] xl:-top-8 animate-float z-30">
               <div className="font-handwriting font-bold text-2xl mb-0 transform -rotate-6 whitespace-nowrap">
                 Comece aqui!
               </div>
@@ -147,7 +147,7 @@ const Hero: React.FC = () => {
 
       {/* --- Floating Scroll Connector (Overlapping the ZigZag) --- */}
       <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-1/2 z-40 w-full flex justify-center pointer-events-none">
-        <div className="bg-white px-6 py-3 rounded-full border-4 border-fun-dark shadow-hard flex items-center gap-3 animate-bounce pointer-events-auto cursor-pointer group hover:scale-105 transition-transform">
+        <div className="bg-white px-6 py-3 rounded-full border-4 border-fun-dark shadow-hard flex items-center gap-3 animate-pulse pointer-events-auto cursor-pointer group hover:scale-105 transition-transform">
           <span className="font-sans font-bold text-fun-dark text-sm md:text-lg whitespace-nowrap">
             O pesadelo de planejar
           </span>

--- a/components/landings/beto-carrero/Problem.tsx
+++ b/components/landings/beto-carrero/Problem.tsx
@@ -68,7 +68,7 @@ const Problem: React.FC = () => {
                   </div>
 
                   {/* Floating Cursor */}
-                  <MousePointer2 className="absolute top-1/2 right-1/4 md:right-[20%] text-fun-dark w-8 h-8 lg:w-12 lg:h-12 fill-white stroke-[1.5px] z-40 animate-bounce" />
+                  <MousePointer2 className="absolute top-1/2 right-1/4 md:right-[20%] text-fun-dark w-8 h-8 lg:w-12 lg:h-12 fill-white stroke-[1.5px] z-40 animate-float" />
 
                   {/* Floating Question Marks */}
                   <HelpCircle className="absolute top-0 right-10 md:right-[15%] lg:right-0 text-gray-300 w-12 h-12 lg:w-20 lg:h-20 transform rotate-12" />

--- a/components/landings/beto-carrero/Solution.tsx
+++ b/components/landings/beto-carrero/Solution.tsx
@@ -297,7 +297,7 @@ const Solution: React.FC = () => {
                ></div>
 
                {/* Modal Content */}
-               <div className="relative bg-white w-full max-w-lg rounded-3xl border-4 border-fun-dark shadow-hard-lg p-6 md:p-8 animate-[scaleIn_0.3s_cubic-bezier(0.16,1,0.3,1)] overflow-hidden">
+               <div className="relative bg-white w-full max-w-lg rounded-3xl border-4 border-fun-dark shadow-hard-lg p-6 md:p-8 animate-pop-in overflow-hidden">
 
                   {/* Close Button */}
                   <button

--- a/components/landings/beto-carrero/Solution.tsx
+++ b/components/landings/beto-carrero/Solution.tsx
@@ -297,7 +297,7 @@ const Solution: React.FC = () => {
                ></div>
 
                {/* Modal Content */}
-               <div className="relative bg-white w-full max-w-lg rounded-3xl border-4 border-fun-dark shadow-hard-lg p-6 md:p-8 animate-[scaleIn_0.3s_cubic-bezier(0.34,1.56,0.64,1)] overflow-hidden">
+               <div className="relative bg-white w-full max-w-lg rounded-3xl border-4 border-fun-dark shadow-hard-lg p-6 md:p-8 animate-[scaleIn_0.3s_cubic-bezier(0.16,1,0.3,1)] overflow-hidden">
 
                   {/* Close Button */}
                   <button

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,5 +1,7 @@
 import typography from '@tailwindcss/typography';
 
+const EASE_OUT_EXPO = 'cubic-bezier(0.16, 1, 0.3, 1)';
+
 /** @type {import('tailwindcss').Config} */
 export default {
     content: [
@@ -57,7 +59,7 @@ export default {
             animation: {
                 'fade-in-up': 'fadeInUp 0.8s cubic-bezier(0.16, 1, 0.3, 1) forwards',
                 'fade-in-down': 'fadeInDown 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards',
-                'pop-in': 'popIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) forwards',
+                'pop-in': `popIn 0.3s ${EASE_OUT_EXPO} forwards`,
                 'draw': 'draw 1.5s ease-in-out forwards',
                 'float': 'float 6s ease-in-out infinite',
                 'blob': 'blob 10s infinite',
@@ -91,7 +93,7 @@ export default {
                 }
             },
             transitionTimingFunction: {
-                'spring': 'cubic-bezier(0.16, 1, 0.3, 1)',
+                'spring': EASE_OUT_EXPO,
             }
         },
     },

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -91,7 +91,7 @@ export default {
                 }
             },
             transitionTimingFunction: {
-                'spring': 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+                'spring': 'cubic-bezier(0.16, 1, 0.3, 1)',
             }
         },
     },


### PR DESCRIPTION
Closes #463

## Summary

- Substitui `animate-bounce` em 4 elementos (Features hover, Hero arrow, Hero scroll pill, Problem cursor) por `animate-float` ou `animate-pulse`
- Substitui `cubic-bezier(0.34,1.56,0.64,1)` no modal de Solution por `cubic-bezier(0.16,1,0.3,1)` (ease-out-expo)
- Atualiza o token global `ease-spring` em `tailwind.config.mjs` para a mesma curva suave (beneficia também BackToTop, Highlights, SearchForm)

## Test plan

- [ ] Abrir `/beto-carrero` e verificar que a seta "Comece aqui!" flutua suavemente (não quica)
- [ ] Verificar que o pill de scroll entre Hero e Problem pulsa suavemente
- [ ] Verificar que o cursor flutuante em Problem usa float
- [ ] Abrir o modal em Solution e confirmar que a entrada é ease-out sem elástico
- [ ] Hover no card "Mais Diversão" em Features — ícone deve pulsar, não quicar
- [ ] `pnpm build` sem erros ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)