### PR TITLE
refactor(design): replace w-N h-N with size-N shorthand

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -351,14 +351,14 @@ const AIChat: React.FC = memo(() => {
                     bg-brand-vibrant text-white
                     shadow-[0_8px_30px_rgba(255,107,53,0.3)] hover:shadow-[0_8px_30px_rgba(255,107,53,0.5)] hover:-translate-y-1
                     transition-all duration-300
-                    w-16 h-16 rounded-2xl sm:w-auto sm:h-auto sm:px-6 sm:py-3.5 sm:rounded-full
+                    size-16 rounded-2xl sm:w-auto sm:h-auto sm:px-6 sm:py-3.5 sm:rounded-full
                     focus:outline-none focus:ring-4 focus:ring-brand-vibrant/30
                     ${isOrlandoPage ? 'orlando-chat-glow' : ''}`}
         aria-label="Abrir assistente virtual"
       >
         <div className="relative flex items-center justify-center">
-          <ChatCircleDots className="w-7 h-7" weight="fill" />
-          <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full animate-pulse border-2 border-brand-vibrant"></span>
+          <ChatCircleDots className="size-7" weight="fill" />
+          <span className="absolute -top-1 -right-1 size-3 bg-red-500 rounded-full animate-pulse border-2 border-brand-vibrant"></span>
         </div>
 
         <div className="text-left hidden sm:flex sm:flex-col">
@@ -388,17 +388,17 @@ const AIChat: React.FC = memo(() => {
         {/* Header - Scrapbook Softness */}
         <div className="bg-white/80 backdrop-blur-md px-6 py-5 border-b border-gray-100 flex justify-between items-center shrink-0 z-10">
           <div className="flex gap-4 items-center">
-            <div className="w-12 h-12 bg-gray-50 rounded-[1.25rem] flex items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
-              <Sparkle className="w-6 h-6 text-brand-vibrant" weight="fill" />
+            <div className="size-12 bg-gray-50 rounded-[1.25rem] flex items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+              <Sparkle className="size-6 text-brand-vibrant" weight="fill" />
             </div>
             <div>
               <h2 className="font-extrabold text-lg text-brand-dark tracking-tight leading-none">
                 Hub Anhangá
               </h2>
               <div className="flex items-center gap-1.5 mt-1 opacity-80">
-                <span className="relative flex h-2 w-2">
+                <span className="relative flex size-2">
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
-                  <span className="relative inline-flex rounded-full h-2 w-2 bg-green-400"></span>
+                  <span className="relative inline-flex rounded-full size-2 bg-green-400"></span>
                 </span>
                 <span className="text-xs font-bold text-gray-500 uppercase tracking-widest">
                   Assistente Online
@@ -411,7 +411,7 @@ const AIChat: React.FC = memo(() => {
             className="text-gray-400 hover:text-gray-700 bg-gray-50 hover:bg-gray-100 rounded-full p-2.5 transition-colors focus:outline-none"
             aria-label="Fechar gaveta"
           >
-            <X className="w-5 h-5" weight="bold" />
+            <X className="size-5" weight="bold" />
           </button>
         </div>
 
@@ -427,11 +427,11 @@ const AIChat: React.FC = memo(() => {
               <div key={msg.id} className={`relative flex flex-col gap-2 ${msg.role === 'user' ? 'items-end' : 'items-start'} z-10`}>
                 <div className={`flex items-end gap-3 max-w-[90%] ${msg.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}>
                   {/* Avatar */}
-                  <div className={`w-9 h-9 flex items-center justify-center shrink-0 rounded-full shadow-sm ${msg.role === 'user'
+                  <div className={`size-9 flex items-center justify-center shrink-0 rounded-full shadow-sm ${msg.role === 'user'
                     ? 'bg-brand-dark text-white'
                     : 'bg-white text-brand-vibrant border border-gray-100'
                     }`}>
-                    {msg.role === 'user' ? <User className="w-4 h-4" weight="fill" /> : <Robot className="w-5 h-5" weight="fill" />}
+                    {msg.role === 'user' ? <User className="size-4" weight="fill" /> : <Robot className="size-5" weight="fill" />}
                   </div>
 
                   {/* Bubble */}
@@ -492,11 +492,11 @@ const AIChat: React.FC = memo(() => {
 
           {isLoading && (
             <div data-testid="chat-typing-indicator" className="flex items-end gap-3 z-10 relative">
-              <div className="w-9 h-9 bg-white rounded-full border border-gray-100 text-brand-vibrant flex items-center justify-center shadow-sm">
-                <Robot className="w-5 h-5" weight="fill" />
+              <div className="size-9 bg-white rounded-full border border-gray-100 text-brand-vibrant flex items-center justify-center shadow-sm">
+                <Robot className="size-5" weight="fill" />
               </div>
               <div className="bg-white px-4 py-3 border border-gray-100 rounded-2xl rounded-bl-sm shadow-sm flex items-center gap-2.5">
-                <CircleNotch className="w-4 h-4 animate-spin text-brand-vibrant" weight="bold" />
+                <CircleNotch className="size-4 animate-spin text-brand-vibrant" weight="bold" />
                 <span className="text-xs font-medium text-gray-400">Anhangá digitando...</span>
               </div>
             </div>
@@ -524,7 +524,7 @@ const AIChat: React.FC = memo(() => {
               className="absolute right-2 bottom-2 p-2.5 bg-brand-vibrant text-white rounded-[10px] shadow-sm hover:bg-brand-blue hover:shadow-md transition-all disabled:opacity-0 disabled:scale-75 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-vibrant/50"
               aria-label="Enviar mensagem"
             >
-              <PaperPlaneTilt className="w-4 h-4 ml-0.5" weight="fill" />
+              <PaperPlaneTilt className="size-4 ml-0.5" weight="fill" />
             </button>
           </div>
           <p className="text-center text-[10px] text-gray-400 mt-2">

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -27,14 +27,14 @@ const Blog: React.FC = memo(() => {
     return (
         <section id="blog" className="py-24 bg-white relative overflow-hidden dynamic-blog-content">
             {/* Background Decorations */}
-            <div className="absolute top-0 right-0 w-96 h-96 bg-brand-cyan/5 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2"></div>
+            <div className="absolute top-0 right-0 size-96 bg-brand-cyan/5 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2"></div>
             <div className="absolute bottom-0 left-0 w-full h-24 bg-[#fffdf5] skew-y-2 translate-y-12"></div>
 
             <div className="container mx-auto px-6 relative z-10">
                 {/* Header Section */}
                 <div className="text-center mb-16">
                     <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border-2 border-brand-dark bg-brand-yellow text-brand-dark font-black text-xs uppercase tracking-widest shadow-[4px_4px_0px_#0f172a] transform -rotate-2 mb-4">
-                        <BookOpen className="w-4 h-4" /> Diário de Bordo
+                        <BookOpen className="size-4" /> Diário de Bordo
                     </div>
                     <h2 className="text-4xl md:text-5xl font-black text-brand-dark mb-4">
                         Histórias & <span className="text-brand-cyan border-b-8 border-brand-cyan/20 px-1 inline-block">Dicas</span>
@@ -81,7 +81,7 @@ const Blog: React.FC = memo(() => {
                                         <span className={`px-3 py-1 rounded-full border ${getCategoryColor(featuredPost.category)}`}>
                                             {featuredPost.category}
                                         </span>
-                                        <span className="flex items-center gap-1"><Calendar className="w-4 h-4" /> {formatDate(featuredPost.date)}</span>
+                                        <span className="flex items-center gap-1"><Calendar className="size-4" /> {formatDate(featuredPost.date)}</span>
                                     </div>
                                     <h3 className="text-3xl md:text-4xl font-black text-brand-dark mb-4 leading-tight group-hover:text-brand-cyan transition-colors">
                                         {featuredPost.title}
@@ -91,7 +91,7 @@ const Blog: React.FC = memo(() => {
                                     </p>
                                     <div className="flex items-center justify-between border-t border-gray-200 pt-6">
                                         <div className="flex items-center gap-2">
-                                            <div className="w-10 h-10 rounded-full bg-brand-dark flex items-center justify-center text-white text-base font-black shrink-0">
+                                            <div className="size-10 rounded-full bg-brand-dark flex items-center justify-center text-white text-base font-black shrink-0">
                                                 {(AUTHORS[featuredPost.author]?.name ?? featuredPost.author).charAt(0).toUpperCase()}
                                             </div>
                                             <div className="flex flex-col">
@@ -100,7 +100,7 @@ const Blog: React.FC = memo(() => {
                                             </div>
                                         </div>
                                         <span className="flex items-center gap-2 text-brand-cyan font-black uppercase tracking-wide group-hover:gap-4 transition-all">
-                                            Ler Agora <ArrowRight className="w-5 h-5" />
+                                            Ler Agora <ArrowRight className="size-5" />
                                         </span>
                                     </div>
                                 </div>
@@ -155,13 +155,13 @@ const Blog: React.FC = memo(() => {
 
                                 <div className="pt-4 border-t border-dashed border-gray-100 flex items-center justify-between">
                                     <span className="text-xs font-bold text-gray-400 flex items-center gap-2">
-                                        <div className="w-5 h-5 rounded-full bg-brand-dark flex items-center justify-center text-white text-[10px] font-black shrink-0">
+                                        <div className="size-5 rounded-full bg-brand-dark flex items-center justify-center text-white text-[10px] font-black shrink-0">
                                             {(AUTHORS[post.author]?.name ?? post.author).charAt(0).toUpperCase()}
                                         </div>
                                         {AUTHORS[post.author]?.name ?? post.author}
                                     </span>
-                                    <span className="w-8 h-8 rounded-full flex items-center justify-center transition-colors bg-gray-100 text-gray-400 group-hover:bg-brand-cyan group-hover:text-white">
-                                        <ArrowRight className="w-4 h-4" />
+                                    <span className="size-8 rounded-full flex items-center justify-center transition-colors bg-gray-100 text-gray-400 group-hover:bg-brand-cyan group-hover:text-white">
+                                        <ArrowRight className="size-4" />
                                     </span>
                                 </div>
                             </div>
@@ -172,9 +172,9 @@ const Blog: React.FC = memo(() => {
                 {/* View More Button */}
                 <div className="mt-16 text-center">
                     <a href={getBlogHomeUrl()} className="inline-flex items-center gap-2 px-8 py-4 bg-white border-2 border-gray-200 text-gray-600 rounded-full font-bold hover:border-brand-cyan hover:text-brand-cyan transition-all shadow-sm hover:shadow-md group">
-                        <Sparkles className="w-4 h-4 text-brand-yellow fill-brand-yellow" />
+                        <Sparkles className="size-4 text-brand-yellow fill-brand-yellow" />
                         Ver Todos os Artigos
-                        <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+                        <ArrowRight className="size-4 group-hover:translate-x-1 transition-transform" />
                     </a>
                 </div>
             </div>

--- a/components/CallToAction.tsx
+++ b/components/CallToAction.tsx
@@ -43,7 +43,7 @@ const CallToActionComponent: React.FC = () => {
                         {/* Header Strip */}
                         <div className="flex justify-between items-center mb-8 border-b-2 border-dashed border-gray-100 pb-4">
                             <div className="flex items-center gap-2 text-brand-cyan font-black tracking-widest text-sm uppercase" title="Estilo Boarding Pass">
-                                <AirplaneTilt className="w-5 h-5" weight="fill" /> Anhangá Airlines
+                                <AirplaneTilt className="size-5" weight="fill" /> Anhangá Airlines
                                 <span className="text-[10px] opacity-40 ml-1 hidden lg:inline">(Boarding Pass)</span>
                             </div>
                             <div className="text-gray-400 font-bold text-xs uppercase">First Class Experience</div>
@@ -141,7 +141,7 @@ const CallToActionComponent: React.FC = () => {
                                         type="checkbox"
                                         checked={fields.emailOptIn}
                                         onChange={(event) => setField('emailOptIn', event.target.checked)}
-                                        className="mt-0.5 w-4 h-4 rounded border-2 border-brand-vibrant accent-brand-vibrant cursor-pointer flex-shrink-0"
+                                        className="mt-0.5 size-4 rounded border-2 border-brand-vibrant accent-brand-vibrant cursor-pointer flex-shrink-0"
                                     />
                                     <label htmlFor="cta-optIn" className="text-xs text-blue-700 leading-relaxed cursor-pointer">
                                         Quero receber novidades por e-mail.{' '}
@@ -162,9 +162,9 @@ const CallToActionComponent: React.FC = () => {
                                         className="w-full sm:flex-1 flex items-center justify-center gap-2 bg-[#25D366] text-white text-sm font-bold px-4 py-2.5 rounded-xl hover:bg-[#1fba59] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                                     >
                                         {isSubmitting ? (
-                                            <SpinnerGap className="w-4 h-4 animate-spin" weight="bold" />
+                                            <SpinnerGap className="size-4 animate-spin" weight="bold" />
                                         ) : (
-                                            <WhatsappLogo className="w-4 h-4" weight="fill" />
+                                            <WhatsappLogo className="size-4" weight="fill" />
                                         )}
                                         Chamar no WhatsApp
                                     </button>
@@ -183,16 +183,16 @@ const CallToActionComponent: React.FC = () => {
                         {formState === 'submitted' && (
                             <div className="flex flex-col gap-3" role="status" aria-live="polite">
                                 <p className="flex items-center gap-2 text-green-600 text-sm font-bold">
-                                    <CheckCircle className="w-5 h-5" weight="fill" />
+                                    <CheckCircle className="size-5" weight="fill" />
                                     Recebemos! Nossa equipe entra em contato em breve.
                                 </p>
                             </div>
                         )}
 
                         {/* Top "Hole" for perforation illusion */}
-                        <div className="hidden md:block absolute -right-4 top-[-1.5rem] w-8 h-8 bg-brand-light rounded-full z-20"></div>
+                        <div className="hidden md:block absolute -right-4 top-[-1.5rem] size-8 bg-brand-light rounded-full z-20"></div>
                         {/* Bottom "Hole" for perforation illusion */}
-                        <div className="hidden md:block absolute -right-4 bottom-[-1.5rem] w-8 h-8 bg-brand-light rounded-full z-20"></div>
+                        <div className="hidden md:block absolute -right-4 bottom-[-1.5rem] size-8 bg-brand-light rounded-full z-20"></div>
                     </div>
 
                     {/* --- DIVIDER (Perforation) --- */}
@@ -201,8 +201,8 @@ const CallToActionComponent: React.FC = () => {
                         <div className="w-full h-[2px] md:w-[2px] md:h-[90%] border-t-2 md:border-t-0 md:border-l-2 border-dashed border-gray-300"></div>
 
                         {/* Mobile Holes (Left/Right) */}
-                        <div className="md:hidden absolute -left-4 top-1/2 -translate-y-1/2 w-8 h-8 bg-brand-light rounded-full z-20"></div>
-                        <div className="md:hidden absolute -right-4 top-1/2 -translate-y-1/2 w-8 h-8 bg-brand-light rounded-full z-20"></div>
+                        <div className="md:hidden absolute -left-4 top-1/2 -translate-y-1/2 size-8 bg-brand-light rounded-full z-20"></div>
+                        <div className="md:hidden absolute -right-4 top-1/2 -translate-y-1/2 size-8 bg-brand-light rounded-full z-20"></div>
                     </div>
 
                     {/* --- RIGHT SIDE: Stub / Details --- */}
@@ -211,7 +211,7 @@ const CallToActionComponent: React.FC = () => {
                         {/* Stub Header */}
                         <div className="flex justify-between items-center mb-5 opacity-60">
                             <span className="text-[10px] font-bold tracking-widest uppercase">Anhangá Air</span>
-                            <AirplaneTilt className="w-3 h-3" weight="fill" />
+                            <AirplaneTilt className="size-3" weight="fill" />
                         </div>
 
                         {/* Passenger Name */}
@@ -303,14 +303,14 @@ const CallToActionComponent: React.FC = () => {
                                     <span className="font-mono text-[9px] font-bold tracking-[0.3em] text-gray-400 uppercase">
                                         ETKT 29384910239
                                     </span>
-                                    <DeviceMobile className="w-3 h-3 text-gray-300" weight="fill" />
+                                    <DeviceMobile className="size-3 text-gray-300" weight="fill" />
                                 </div>
                             </div>
                         </div>
 
                         {/* Decorative Stamp Watermark */}
                         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 opacity-[0.03] rotate-[-30deg] pointer-events-none">
-                            <AirplaneTilt className="w-32 h-32 text-brand-dark" weight="fill" />
+                            <AirplaneTilt className="size-32 text-brand-dark" weight="fill" />
                         </div>
                     </div>
 

--- a/components/Categories.tsx
+++ b/components/Categories.tsx
@@ -52,7 +52,7 @@ const Categories = memo(() => {
         <div className="flex flex-col md:flex-row justify-between items-end mb-16 gap-4">
           <div>
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border-2 border-brand-dark bg-white text-brand-dark font-black text-xs uppercase tracking-widest shadow-[4px_4px_0px_#0f172a] mb-4">
-              <TrendingUp className="w-4 h-4" /> Em Alta
+              <TrendingUp className="size-4" /> Em Alta
             </div>
             <h2 className="text-4xl md:text-5xl font-black text-brand-dark">
               Todo mundo <br className="md:hidden" /> quer ir pra cá 👇
@@ -101,7 +101,7 @@ const Categories = memo(() => {
               {/* Sticker Decor */}
               <div className="absolute -bottom-4 -right-4 opacity-0 group-hover:opacity-100 transition-all duration-300 transform scale-0 group-hover:scale-110">
                 <div className="bg-brand-yellow text-brand-dark rounded-full p-3 shadow-lg border-2 border-white">
-                  <ArrowRight className="w-6 h-6 -rotate-45" />
+                  <ArrowRight className="size-6 -rotate-45" />
                 </div>
               </div>
             </Link>

--- a/components/ChatLeadForm.tsx
+++ b/components/ChatLeadForm.tsx
@@ -236,7 +236,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
   return (
     <div className="bg-white rounded-2xl border border-brand-blue/10 shadow-[0_8px_30px_rgb(0,0,0,0.08)] w-full overflow-hidden transform transition-all hover:shadow-[0_8px_30px_rgb(0,0,0,0.12)] hover:-translate-y-1">
       <div className="bg-gradient-to-r from-brand-vibrant/10 to-transparent p-3 flex items-center gap-2 border-b border-gray-100">
-        <CheckCircle2 className="w-5 h-5 text-green-500" />
+        <CheckCircle2 className="size-5 text-green-500" />
         <span className="text-sm font-bold tracking-wide text-brand-dark uppercase">
           Link Gerado
         </span>
@@ -311,9 +311,9 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
                   type="checkbox"
                   checked={acceptedLGPD}
                   onChange={(e) => setAcceptedLGPD(e.target.checked)}
-                  className="peer h-4 w-4 cursor-pointer appearance-none rounded border border-gray-300 bg-white checked:bg-brand-vibrant checked:border-brand-vibrant transition-all focus:ring-2 focus:ring-brand-vibrant/20"
+                  className="peer size-4 cursor-pointer appearance-none rounded border border-gray-300 bg-white checked:bg-brand-vibrant checked:border-brand-vibrant transition-all focus:ring-2 focus:ring-brand-vibrant/20"
                 />
-                <CheckCircle2 className="absolute h-3 w-3 text-white opacity-0 peer-checked:opacity-100 left-0.5 pointer-events-none transition-opacity" />
+                <CheckCircle2 className="absolute size-3 text-white opacity-0 peer-checked:opacity-100 left-0.5 pointer-events-none transition-opacity" />
               </div>
               <span className="text-xs text-gray-500 leading-tight">
                 Aceito receber comunicações e autorizo o tratamento dos meus dados conforme a <a href="https://www.anhanga.tur.br/politica-privacidade/" target="_blank" rel="noopener noreferrer" className="underline hover:text-brand-vibrant">Política de Privacidade</a>.
@@ -342,13 +342,13 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
         >
           {isSubmittingLead || isLocallySubmitting ? (
             <>
-              <Loader2 className="w-5 h-5 animate-spin" />
+              <Loader2 className="size-5 animate-spin" />
               <span>Salvando...</span>
             </>
           ) : (
             <>
               <span>Salvar e abrir WhatsApp</span>
-              <ExternalLink className="w-4 h-4 group-hover:scale-110 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-transform" />
+              <ExternalLink className="size-4 group-hover:scale-110 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-transform" />
             </>
           )}
         </button>

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -124,7 +124,7 @@ const ContactModal: React.FC = () => {
                         className="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan"
                         aria-label="Fechar"
                     >
-                        <X className="h-5 w-5" weight="bold" />
+                        <X className="size-5" weight="bold" />
                     </button>
                 </div>
 
@@ -135,7 +135,7 @@ const ContactModal: React.FC = () => {
                             role="status"
                             aria-live="polite"
                         >
-                            <CheckCircle className="h-14 w-14 text-green-600" weight="fill" />
+                            <CheckCircle className="size-14 text-green-600" weight="fill" />
                             <p className="font-bold text-gray-800">Recebemos seu contato!</p>
                             <p className="text-sm text-gray-500">
                                 Nossa equipe entra em contato em breve pelo WhatsApp.
@@ -229,7 +229,7 @@ const ContactModal: React.FC = () => {
                                 type="checkbox"
                                 checked={fields.emailOptIn}
                                 onChange={(event) => setField('emailOptIn', event.target.checked)}
-                                className="mt-0.5 h-4 w-4 flex-shrink-0 cursor-pointer rounded border-2 border-brand-vibrant accent-brand-vibrant"
+                                className="mt-0.5 size-4 flex-shrink-0 cursor-pointer rounded border-2 border-brand-vibrant accent-brand-vibrant"
                             />
                             <label htmlFor="contact-optIn" className="cursor-pointer text-xs leading-relaxed text-blue-700">
                                 Quero receber novidades e ofertas de viagem por e-mail.{' '}

--- a/components/Destinations.tsx
+++ b/components/Destinations.tsx
@@ -528,7 +528,7 @@ const Destinations: React.FC = memo(() => {
                 <div className="flex flex-col md:flex-row justify-between items-end mb-12">
                     <div>
                         <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-dashed border-brand-dark bg-yellow-100 text-brand-dark font-black text-xs uppercase tracking-widest shadow-sm transform -rotate-1 mb-4">
-                            <Compass className="w-4 h-4" /> Mapa Mundi
+                            <Compass className="size-4" /> Mapa Mundi
                         </div>
                         <h2 className="text-4xl font-black text-brand-dark">Escolha seu <span className="text-brand-cyan relative inline-block">Pin 📍<svg className="absolute w-full h-3 -bottom-1 left-0 text-brand-cyan opacity-40" viewBox="0 0 100 10" preserveAspectRatio="none"><path d="M0 5 Q 50 10 100 5" stroke="currentColor" strokeWidth="4" fill="none" /></svg></span></h2>
                     </div>
@@ -580,23 +580,23 @@ const Destinations: React.FC = memo(() => {
                         <div className="absolute bottom-6 right-6 flex flex-col gap-2 z-[400]">
                             <button
                                 onClick={() => handleZoom('in')}
-                                className="w-10 h-10 bg-white border-2 border-gray-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all text-gray-700 font-black"
+                                className="size-10 bg-white border-2 border-gray-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all text-gray-700 font-black"
                                 aria-label="Aumentar zoom no mapa"
                             >
-                                <Plus className="w-5 h-5" />
+                                <Plus className="size-5" />
                             </button>
                             <button
                                 onClick={() => handleZoom('out')}
-                                className="w-10 h-10 bg-white border-2 border-gray-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all text-gray-700 font-black"
+                                className="size-10 bg-white border-2 border-gray-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all text-gray-700 font-black"
                                 aria-label="Diminuir zoom no mapa"
                             >
-                                <Minus className="w-5 h-5" />
+                                <Minus className="size-5" />
                             </button>
                         </div>
 
                         {/* "Note" Sticker */}
                         <div className="hidden md:block absolute top-8 left-8 bg-yellow-100 p-4 rounded-sm shadow-md transform -rotate-3 z-[400] max-w-[150px] border border-yellow-200">
-                            <div className="w-3 h-3 rounded-full bg-red-400 mx-auto -mt-6 mb-2 shadow-sm border border-red-500"></div>
+                            <div className="size-3 rounded-full bg-red-400 mx-auto -mt-6 mb-2 shadow-sm border border-red-500"></div>
                             <p className="font-serif italic text-gray-700 text-sm leading-tight text-center">
                                 "O mundo é um livro e quem não viaja lê apenas uma página."
                                 <span className="block not-italic text-gray-400 text-xs mt-1">— Santo Agostinho</span>
@@ -641,13 +641,13 @@ const Destinations: React.FC = memo(() => {
                                 <div className="flex justify-between items-center mb-2">
                                     <h3 className="text-2xl font-black text-gray-800">{dest.city}</h3>
                                     <div className="flex items-center gap-1 text-yellow-500 font-bold text-sm bg-yellow-50 px-2 py-1 rounded-full border border-yellow-100">
-                                        <Star className="w-3 h-3 fill-current" /> {dest.rating}
+                                        <Star className="size-3 fill-current" /> {dest.rating}
                                     </div>
                                 </div>
                                 <p className="text-gray-500 text-sm font-medium mb-4">{dest.description}</p>
 
                                 <div className="flex items-center gap-2 text-brand-cyan font-bold text-sm uppercase tracking-wide group-hover:gap-3 transition-all">
-                                    Saiba Mais <ArrowRight className="w-4 h-4" />
+                                    Saiba Mais <ArrowRight className="size-4" />
                                 </div>
                             </div>
                         </div>
@@ -668,7 +668,7 @@ const Destinations: React.FC = memo(() => {
                             className="absolute top-4 right-4 z-30 bg-white border-2 border-gray-100 p-2 rounded-full shadow-md hover:scale-110 transition-transform text-gray-800"
                             aria-label="Fechar detalhes do destino"
                         >
-                            <X className="w-5 h-5" />
+                            <X className="size-5" />
                         </button>
 
                         <div className="w-full md:w-1/2 h-64 md:h-auto relative bg-gray-100">
@@ -683,7 +683,7 @@ const Destinations: React.FC = memo(() => {
                             <div className="absolute bottom-6 left-6 text-white">
                                 <h2 className="text-4xl font-black mb-1 drop-shadow-md">{selectedDestination.city}</h2>
                                 <div className="flex items-center gap-2 font-medium opacity-90 drop-shadow-sm">
-                                    <MapPin className="w-4 h-4" /> {selectedDestination.country}
+                                    <MapPin className="size-4" /> {selectedDestination.country}
                                 </div>
                             </div>
                         </div>
@@ -692,7 +692,7 @@ const Destinations: React.FC = memo(() => {
                             <p className="text-gray-600 mb-8 text-lg leading-relaxed font-medium font-serif italic">"{selectedDestination.details}"</p>
 
                             <h4 className="font-black text-gray-900 mb-4 flex items-center gap-2">
-                                <Star className="w-5 h-5 text-yellow-400 fill-current" /> Atrações Imperdíveis
+                                <Star className="size-5 text-yellow-400 fill-current" /> Atrações Imperdíveis
                             </h4>
                             <div className="flex flex-wrap gap-3 mb-8">
                                 {selectedDestination.activities.map((act) => (
@@ -718,7 +718,7 @@ const Destinations: React.FC = memo(() => {
                                         onClick={() => setSelectedDestination(null)}
                                         className="w-full bg-white border-2 border-brand-dark text-brand-dark py-4 rounded-xl font-black text-lg hover:bg-gray-50 transition-all shadow-[4px_4px_0px_#0f172a] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2"
                                     >
-                                        Ver detalhes do pacote <ArrowRight className="w-5 h-5" />
+                                        Ver detalhes do pacote <ArrowRight className="size-5" />
                                     </Link>
                                 )}
                                 <button

--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -35,7 +35,7 @@ const FAQItem = memo(({ question, answer, idx }: FAQItemProps) => {
             >
                 <div className="flex items-center gap-3">
                     {/* Semantic icon visual aid (optional but nice) */}
-                    <span className="hidden md:flex items-center justify-center w-8 h-8 rounded-full bg-brand-light text-brand-cyan text-xs font-bold">
+                    <span className="hidden md:flex items-center justify-center size-8 rounded-full bg-brand-light text-brand-cyan text-xs font-bold">
                         {idx + 1}
                     </span>
                     <h3
@@ -45,11 +45,11 @@ const FAQItem = memo(({ question, answer, idx }: FAQItemProps) => {
                     </h3>
                 </div>
 
-                <div className={`w-10 h-10 rounded-xl flex items-center justify-center transition-all duration-300 ${isOpen
+                <div className={`size-10 rounded-xl flex items-center justify-center transition-all duration-300 ${isOpen
                     ? 'bg-brand-cyan text-white rotate-180'
                     : 'bg-white text-gray-400 group-hover:text-brand-cyan'
                     }`}>
-                    {isOpen ? <CaretUp className="w-6 h-6" weight="bold" /> : <CaretDown className="w-6 h-6" weight="bold" />}
+                    {isOpen ? <CaretUp className="size-6" weight="bold" /> : <CaretDown className="size-6" weight="bold" />}
                 </div>
             </button>
             <div
@@ -99,11 +99,11 @@ const FAQS = [
                     Você recebe uma proposta com todos os custos listados:
                 </p>
                 <ul className="space-y-2 mb-4">
-                    <li className="flex items-center gap-2"><AirplaneTilt className="w-4 h-4 text-brand-cyan" weight="fill" /> Passagens aéreas (consultamos o melhor preço do dia)</li>
-                    <li className="flex items-center gap-2"><Buildings className="w-4 h-4 text-brand-cyan" weight="fill" /> Hospedagem (você escolhe o nível de conforto)</li>
-                    <li className="flex items-center gap-2"><Ticket className="w-4 h-4 text-brand-cyan" weight="fill" /> Entradas em atrações</li>
-                    <li className="flex items-center gap-2"><MapPin className="w-4 h-4 text-brand-cyan" weight="fill" /> Transporte terrestre</li>
-                    <li className="flex items-center gap-2"><Sparkle className="w-4 h-4 text-brand-cyan" weight="fill" /> Refeições recomendadas (opcionais)</li>
+                    <li className="flex items-center gap-2"><AirplaneTilt className="size-4 text-brand-cyan" weight="fill" /> Passagens aéreas (consultamos o melhor preço do dia)</li>
+                    <li className="flex items-center gap-2"><Buildings className="size-4 text-brand-cyan" weight="fill" /> Hospedagem (você escolhe o nível de conforto)</li>
+                    <li className="flex items-center gap-2"><Ticket className="size-4 text-brand-cyan" weight="fill" /> Entradas em atrações</li>
+                    <li className="flex items-center gap-2"><MapPin className="size-4 text-brand-cyan" weight="fill" /> Transporte terrestre</li>
+                    <li className="flex items-center gap-2"><Sparkle className="size-4 text-brand-cyan" weight="fill" /> Refeições recomendadas (opcionais)</li>
                 </ul>
                 <p className="font-bold text-brand-dark">Só avançamos após sua aprovação. Sem surpresas!</p>
             </div>
@@ -205,7 +205,7 @@ const FAQ = memo(() => {
             style={{ backgroundColor: '#fffdf5' }}
         >
             {/* Decorative blob for background interest */}
-            <div className="absolute top-0 right-0 w-[500px] h-[500px] bg-yellow-100/40 rounded-full blur-3xl pointer-events-none -z-10 translate-x-1/3 -translate-y-1/3"></div>
+            <div className="absolute top-0 right-0 size-[500px] bg-yellow-100/40 rounded-full blur-3xl pointer-events-none -z-10 translate-x-1/3 -translate-y-1/3"></div>
 
             <div className="container mx-auto px-6 max-w-4xl">
                 <div className="text-center mb-16">
@@ -233,7 +233,7 @@ const FAQ = memo(() => {
                 <div className="mt-16 flex justify-center">
                     <div className="bg-white/80 backdrop-blur-sm border border-brand-cyan/20 rounded-3xl p-6 flex flex-col md:flex-row items-center gap-5 max-w-lg shadow-[0_8px_30px_rgba(14,165,233,0.1)] hover:shadow-[0_8px_30px_rgba(14,165,233,0.2)] transition-shadow cursor-default">
                         <div className="bg-brand-light p-4 rounded-full">
-                            <Sparkle className="w-8 h-8 text-brand-cyan animate-pulse" weight="fill" />
+                            <Sparkle className="size-8 text-brand-cyan animate-pulse" weight="fill" />
                         </div>
                         <div className="text-center md:text-left">
                             <h4 className="font-bold text-brand-dark text-xl mb-1">Ainda tem dúvidas?</h4>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -67,15 +67,15 @@ const Footer: React.FC = () => {
                         <h4 className="font-bold text-white mb-6 uppercase tracking-wider text-xs">Fale Conosco</h4>
                         <ul className="space-y-4 font-medium text-sm">
                             <li className="flex items-center gap-3">
-                                <Phone className="w-5 h-5 text-brand-cyan" weight="fill" />
+                                <Phone className="size-5 text-brand-cyan" weight="fill" />
                                 <a href="tel:+551152833309" className="hover:text-brand-yellow transition-colors">(11) 5283-3309</a>
                             </li>
                             <li className="flex items-center gap-3">
-                                <Envelope className="w-5 h-5 text-brand-cyan" weight="fill" />
+                                <Envelope className="size-5 text-brand-cyan" weight="fill" />
                                 <a href="mailto:contato@anhanga.tur.br" className="hover:text-brand-yellow transition-colors">contato@anhanga.tur.br</a>
                             </li>
                             <li className="flex items-start gap-3">
-                                <MapPin className="w-5 h-5 text-brand-cyan shrink-0 mt-1" weight="fill" />
+                                <MapPin className="size-5 text-brand-cyan shrink-0 mt-1" weight="fill" />
                                 <span className="leading-snug">Av. Dom Pedro I, 773<br />Vila Monumento, São Paulo-SP</span>
                             </li>
                         </ul>
@@ -92,7 +92,7 @@ const Footer: React.FC = () => {
                             className="p-2 bg-white/5 rounded-full hover:bg-brand-vibrant hover:text-white transition-colors"
                             aria-label="Siga a Anhangá Viagens no Instagram"
                         >
-                            <InstagramLogo className="w-5 h-5" weight="fill" />
+                            <InstagramLogo className="size-5" weight="fill" />
                         </a>
                         <a
                             href="https://facebook.com/profile.php?id=61585422494271"
@@ -101,13 +101,13 @@ const Footer: React.FC = () => {
                             className="p-2 bg-white/5 rounded-full hover:bg-brand-vibrant hover:text-white transition-colors"
                             aria-label="Siga a Anhangá Viagens no Facebook"
                         >
-                            <FacebookLogo className="w-5 h-5" weight="fill" />
+                            <FacebookLogo className="size-5" weight="fill" />
                         </a>
                     </div>
 
                     <div className="flex flex-col md:items-end gap-2 text-center md:text-right order-1 md:order-2">
                         <div className="text-xs text-gray-500 font-medium flex items-center justify-center md:justify-end gap-1">
-                            Feito com <Heart className="w-3 h-3 text-red-500" weight="fill" aria-hidden="true" /> pela <img src={ANHANGA_TECH_LOGO_URL} alt="Anhangá.tech" width="80" height="16" loading="lazy" className="h-4 w-auto inline-block mx-1 align-sub" />
+                            Feito com <Heart className="size-3 text-red-500" weight="fill" aria-hidden="true" /> pela <img src={ANHANGA_TECH_LOGO_URL} alt="Anhangá.tech" width="80" height="16" loading="lazy" className="h-4 w-auto inline-block mx-1 align-sub" />
                             {runtimeMetadata ? ` • ${runtimeMetadata.currentYear}` : null}
                         </div>
                         <div className="text-[10px] text-gray-600 font-medium flex flex-wrap justify-center md:justify-end gap-x-2">

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -96,7 +96,7 @@ const Header: React.FC = () => {
               onClick={handleContactClick}
               className={`btn-whatsapp btn-specialist rounded-full font-medium text-sm transition-all duration-500 flex items-center gap-2 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-vibrant ${ctaPaddingClass} ${buttonClass}`}
             >
-              <Phone className="w-4 h-4" weight="fill" />
+              <Phone className="size-4" weight="fill" />
               Fale Conosco
             </a>
           </div>
@@ -108,7 +108,7 @@ const Header: React.FC = () => {
             aria-expanded={isMobileMenuOpen}
             aria-controls="mobile-menu"
           >
-            {isMobileMenuOpen ? <X className="w-6 h-6" weight="bold" /> : <List className="w-6 h-6" weight="bold" />}
+            {isMobileMenuOpen ? <X className="size-6" weight="bold" /> : <List className="size-6" weight="bold" />}
           </button>
         </div>
       </div>

--- a/components/Header/HeaderNavigation.tsx
+++ b/components/Header/HeaderNavigation.tsx
@@ -44,7 +44,7 @@ export function DesktopNavigation({
             <>
               <button className={`flex items-center gap-1 cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus:underline decoration-2 underline-offset-4 ${navTextClass}`}>
                 {link.name}
-                <CaretDown className="w-4 h-4 transition-transform duration-300 group-hover:rotate-180" weight="bold" />
+                <CaretDown className="size-4 transition-transform duration-300 group-hover:rotate-180" weight="bold" />
               </button>
 
               <div className="absolute top-full z-10 w-48 translate-y-2 pt-4 opacity-0 invisible transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100 group-hover:visible focus-within:translate-y-0 focus-within:opacity-100 focus-within:visible">

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -237,7 +237,7 @@ const Hero: React.FC = memo(() => {
                 className="flex items-center gap-2 text-white/90 font-bold text-sm bg-white/10 px-4 py-2 rounded-full backdrop-blur-md border border-white/10 hover:bg-white/20 transition-all duration-300 cursor-default"
                 whileHover={{ scale: 1.05, transition: { type: 'spring', stiffness: 400, damping: 15 } }}
               >
-                <feat.icon className="w-4 h-4 text-yellow-300" />
+                <feat.icon className="size-4 text-yellow-300" />
                 {feat.text}
               </m.div>
             ))}

--- a/components/Highlights.tsx
+++ b/components/Highlights.tsx
@@ -136,7 +136,7 @@ const Highlights = memo(() => {
                                 }}
                                 className="flex items-center justify-center gap-3 w-full bg-brand-dark text-white px-6 py-4 rounded-xl font-bold transition-all duration-300 ease-spring shadow-[4px_4px_0px_#94a3b8] hover:shadow-[2px_2px_0px_#94a3b8] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none"
                             >
-                                <ShieldCheck className="w-5 h-5" weight="fill" />
+                                <ShieldCheck className="size-5" weight="fill" />
                                 <span>Falar com Especialista</span>
                             </button>
                         </div>
@@ -155,7 +155,7 @@ const Highlights = memo(() => {
                             <div className="inline-block relative mb-4">
                                 <span className="absolute inset-0 bg-anhanga-blue/10 transform -skew-x-12 rounded-lg"></span>
                                 <span className="relative px-3 py-1 text-anhanga-blue font-black uppercase tracking-widest text-sm flex items-center gap-2">
-                                    <Sparkle className="w-4 h-4" weight="fill" /> O Jeito Anhangá
+                                    <Sparkle className="size-4" weight="fill" /> O Jeito Anhangá
                                 </span>
                             </div>
                             <h2 className="text-4xl md:text-5xl font-black text-brand-dark leading-tight mb-6">
@@ -197,10 +197,10 @@ const Highlights = memo(() => {
 
                                         {/* Icon Badge */}
                                         <m.div
-                                            className={`w-16 h-16 rounded-2xl ${item.bg} border-2 ${item.accent} flex items-center justify-center mb-6 shadow-sm`}
+                                            className={`size-16 rounded-2xl ${item.bg} border-2 ${item.accent} flex items-center justify-center mb-6 shadow-sm`}
                                             whileHover={{ scale: 1.1, rotate: 6, transition: { type: 'spring', stiffness: 400, damping: 15 } }}
                                         >
-                                            <Icon className={`w-8 h-8 ${item.iconColor}`} weight="fill" />
+                                            <Icon className={`size-8 ${item.iconColor}`} weight="fill" />
                                         </m.div>
 
                                         {/* Content */}
@@ -213,7 +213,7 @@ const Highlights = memo(() => {
 
                                         {/* Corner Arrow */}
                                         <div className="absolute bottom-6 right-6 opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-x-4 group-hover:translate-x-0">
-                                            <ArrowRight className={`w-5 h-5 ${item.iconColor}`} />
+                                            <ArrowRight className={`size-5 ${item.iconColor}`} />
                                         </div>
                                     </m.div>
                                 );

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -15,18 +15,18 @@ import { openContactModal } from '../utils/contactForm';
 const STEPS = [
   {
     id: 1,
-    icon: <ChatCircleDots className="w-8 h-8 text-white" weight="fill" />,
+    icon: <ChatCircleDots className="size-8 text-white" weight="fill" />,
     title: "Oie! Vamos conversar?",
     desc: "Nada de formulários chatos. A gente bate um papo no WhatsApp para entender seus sonhos e quanto você quer investir.",
     color: "bg-brand-yellow",
     lightColor: "bg-yellow-50",
     borderColor: "border-yellow-200",
     rotate: "-rotate-2",
-    sticker: <Heart className="w-20 h-20 text-yellow-400 drop-shadow-md" weight="fill" />
+    sticker: <Heart className="size-20 text-yellow-400 drop-shadow-md" weight="fill" />
   },
   {
     id: 2,
-    icon: <PaintBrushBroad className="w-8 h-8 text-white" weight="fill" />,
+    icon: <PaintBrushBroad className="size-8 text-white" weight="fill" />,
     title: "Desenhando o Sonho",
     desc: "Nossos especialistas criam um roteiro dia-a-dia só seu. Ajustamos cada detalhe até você dizer: 'É isso!'",
     color: "bg-brand-cyan",
@@ -34,15 +34,15 @@ const STEPS = [
     borderColor: "border-sky-200",
     rotate: "rotate-3",
     sticker: (
-      <div className="relative w-24 h-24 drop-shadow-md" aria-hidden="true">
-        <Star className="absolute inset-0 w-24 h-24 text-sky-200" weight="fill" />
-        <Star className="absolute inset-0 w-24 h-24 text-sky-400" weight="regular" />
+      <div className="relative size-24 drop-shadow-md" aria-hidden="true">
+        <Star className="absolute inset-0 size-24 text-sky-200" weight="fill" />
+        <Star className="absolute inset-0 size-24 text-sky-400" weight="regular" />
       </div>
     )
   },
   {
     id: 3,
-    icon: <CreditCard className="w-8 h-8 text-white" weight="fill" />,
+    icon: <CreditCard className="size-8 text-white" weight="fill" />,
     title: "Burocracia? Deixa com a gente",
     desc: "Aprovado? Ótimo! Nós emitimos voos, hotéis e passeios. Parcelamos tudo e você recebe os vouchers organizadinhos.",
     color: "bg-emerald-500",
@@ -53,7 +53,7 @@ const STEPS = [
   },
   {
     id: 4,
-    icon: <AirplaneTilt className="w-8 h-8 text-white" weight="fill" />,
+    icon: <AirplaneTilt className="size-8 text-white" weight="fill" />,
     title: "Fui! Partiu Viajar",
     desc: "Agora é só fazer as malas! E se precisar de algo lá longe? Nosso time fica de plantão 24h por você.",
     color: "bg-green-500",
@@ -136,7 +136,7 @@ const HowItWorks = memo(() => {
                                 
                                 {/* Header: Icon + Number */}
                                 <div className="flex justify-between items-start mb-6">
-                                    <div className={`w-16 h-16 rounded-2xl ${step.color} shadow-lg flex items-center justify-center transform -rotate-6 group-hover:rotate-0 transition-transform duration-300`}>
+                                    <div className={`size-16 rounded-2xl ${step.color} shadow-lg flex items-center justify-center transform -rotate-6 group-hover:rotate-0 transition-transform duration-300`}>
                                         {step.icon}
                                     </div>
                                     <span className="font-black text-6xl text-gray-100 select-none absolute top-4 right-6 z-0">
@@ -179,10 +179,10 @@ const HowItWorks = memo(() => {
                     }}
                     className="relative z-10 flex items-center gap-4 bg-white text-brand-dark px-10 py-6 rounded-full font-black text-xl shadow-[0_20px_50px_rgba(8,_112,_184,_0.15)] hover:shadow-[0_20px_50px_rgba(8,_112,_184,_0.25)] transform transition-all hover:scale-105 active:scale-95 border-4 border-transparent hover:border-brand-yellow text-left"
                 >
-                    <Sparkle className="w-6 h-6 text-brand-yellow" weight="fill" />
+                    <Sparkle className="size-6 text-brand-yellow" weight="fill" />
                     <span>Quero meu roteiro agora!</span>
-                    <div className="w-10 h-10 bg-brand-dark rounded-full flex items-center justify-center text-white">
-                        <ArrowRight className="w-5 h-5" weight="bold" />
+                    <div className="size-10 bg-brand-dark rounded-full flex items-center justify-center text-white">
+                        <ArrowRight className="size-5" weight="bold" />
                     </div>
                 </button>
             </div>

--- a/components/LandingFAQ.tsx
+++ b/components/LandingFAQ.tsx
@@ -26,10 +26,10 @@ const FAQItemComponent = memo(({ question, answer, isOpen, idx, onToggle }: FAQI
                 <h3 className="text-xl font-bold text-brand-dark group-hover:text-brand-cyan transition-colors pr-8">
                     {question}
                 </h3>
-                <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-all duration-300 ${
+                <div className={`flex-shrink-0 size-8 rounded-full flex items-center justify-center transition-all duration-300 ${
                     isOpen ? 'bg-brand-cyan text-white rotate-180' : 'bg-brand-light text-brand-cyan'
                 }`}>
-                    {isOpen ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}
+                    {isOpen ? <ChevronUp className="size-5" /> : <ChevronDown className="size-5" />}
                 </div>
             </button>
             <div

--- a/components/SearchForm.tsx
+++ b/components/SearchForm.tsx
@@ -165,7 +165,7 @@ const DestinationField = memo(({
       ref={destRef}
     >
       <label htmlFor="destination-input" className="block text-[10px] font-black text-gray-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-focus-within:text-brand-cyan transition-colors">
-        <MapPin className="w-3 h-3" /> Para onde?
+        <MapPin className="size-3" /> Para onde?
       </label>
       <div className="relative flex items-center">
         <input
@@ -198,7 +198,7 @@ const DestinationField = memo(({
             className="absolute right-0 p-1 text-gray-400 hover:text-brand-vibrant transition-colors rounded-full focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-brand-vibrant"
             aria-label="Limpar destino"
           >
-            <X className="w-4 h-4" />
+            <X className="size-4" />
           </button>
         )}
       </div>
@@ -217,7 +217,7 @@ const DestinationField = memo(({
                   index === activeSuggestionIndex ? 'bg-brand-light text-brand-cyan' : 'hover:bg-brand-light text-gray-700'
                 }`}
               >
-                <MapPin className={`w-4 h-4 shrink-0 ${index === activeSuggestionIndex ? 'text-brand-cyan' : 'text-brand-cyan/50'}`} />
+                <MapPin className={`size-4 shrink-0 ${index === activeSuggestionIndex ? 'text-brand-cyan' : 'text-brand-cyan/50'}`} />
                 <span className="truncate">{dest.label}</span>
               </li>
             ))}
@@ -273,13 +273,13 @@ const DateField = memo(({
       data-testid="dates-filter-btn"
     >
       <span className="block text-[10px] font-black text-gray-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
-        <Calendar className="w-3 h-3" /> Quando?
+        <Calendar className="size-3" /> Quando?
       </span>
       <div className="flex items-center justify-between">
         <span className={`text-lg md:text-xl font-bold truncate transition-colors ${startDate ? "text-gray-800" : "text-gray-300"}`}>
           {startDate ? `${formatDateDisplay(startDate)} - ${endDate ? formatDateDisplay(endDate) : '...'}` : "Definir datas"}
         </span>
-        <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform duration-300 ${showCalendar ? 'rotate-180' : ''}`} />
+        <ChevronDown className={`size-4 text-gray-400 transition-transform duration-300 ${showCalendar ? 'rotate-180' : ''}`} />
       </div>
     </button>
 
@@ -293,11 +293,11 @@ const DateField = memo(({
             className={`p-1 rounded-full transition-colors ${canGoToPreviousMonth ? 'hover:bg-gray-100 text-gray-600' : 'text-gray-300 cursor-not-allowed'}`}
             aria-label="Mês anterior"
           >
-            <ChevronLeft className="w-5 h-5" />
+            <ChevronLeft className="size-5" />
           </button>
           <span className="font-bold text-gray-800">{MONTH_NAMES[currentMonth.getMonth()]} {currentMonth.getFullYear()}</span>
           <button type="button" onClick={() => onChangeMonth(1)} className="p-1 hover:bg-gray-100 rounded-full text-gray-600 transition-colors" aria-label="Próximo mês">
-            <ChevronRight className="w-5 h-5" />
+            <ChevronRight className="size-5" />
           </button>
         </div>
         <div className="grid grid-cols-7 mb-2 text-center text-xs font-bold text-gray-400">
@@ -318,7 +318,7 @@ const DateField = memo(({
                 onClick={() => onDateClick(date)}
                 disabled={past}
                 aria-disabled={past}
-                className={`h-9 w-9 mx-auto flex items-center justify-center text-sm rounded-full transition-all duration-200 border-2
+                className={`size-9 mx-auto flex items-center justify-center text-sm rounded-full transition-all duration-200 border-2
                   ${past ? 'border-transparent text-gray-300 cursor-not-allowed' : selected ? 'bg-brand-cyan border-brand-cyan text-white font-bold scale-110' : inRange ? 'bg-brand-light border-transparent text-brand-cyan font-bold' : 'border-transparent text-gray-600 hover:bg-gray-100'}`}
               >
                 {date.getDate()}
@@ -369,11 +369,11 @@ const GuestsField = memo(({
       data-testid="guests-filter-btn"
     >
       <span className="block text-[10px] font-black text-gray-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
-        <User className="w-3 h-3" /> Quem vai?
+        <User className="size-3" /> Quem vai?
       </span>
       <div className="flex items-center justify-between">
         <span className="text-lg md:text-xl font-bold text-gray-800 truncate transition-colors">{guestSummary}</span>
-        <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform duration-300 ${showGuestDropdown ? 'rotate-180' : ''}`} />
+        <ChevronDown className={`size-4 text-gray-400 transition-transform duration-300 ${showGuestDropdown ? 'rotate-180' : ''}`} />
       </div>
     </button>
 
@@ -386,19 +386,19 @@ const GuestsField = memo(({
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onAdultsChange(Math.max(1, adults - 1)); }}
               disabled={adults <= 1}
-              className="w-8 h-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              className="size-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all disabled:opacity-40 disabled:cursor-not-allowed"
               aria-label="Remover um adulto"
             >
-              <Minus className="w-4 h-4" />
+              <Minus className="size-4" />
             </button>
             <span className="font-bold w-8 text-center text-gray-900" aria-live="polite">{adults}</span>
             <button
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onAdultsChange(adults + 1); }}
-              className="w-8 h-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all"
+              className="size-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all"
               aria-label="Adicionar um adulto"
             >
-              <Plus className="w-4 h-4" />
+              <Plus className="size-4" />
             </button>
           </div>
         </div>
@@ -409,19 +409,19 @@ const GuestsField = memo(({
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onChildCountChange('remove'); }}
               disabled={children <= 0}
-              className="w-8 h-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              className="size-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all disabled:opacity-40 disabled:cursor-not-allowed"
               aria-label="Remover uma criança"
             >
-              <Minus className="w-4 h-4" />
+              <Minus className="size-4" />
             </button>
             <span className="font-bold w-8 text-center text-gray-900" aria-live="polite">{children}</span>
             <button
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onChildCountChange('add'); }}
-              className="w-8 h-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all"
+              className="size-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all"
               aria-label="Adicionar uma criança"
             >
-              <Plus className="w-4 h-4" />
+              <Plus className="size-4" />
             </button>
           </div>
         </div>
@@ -481,18 +481,18 @@ const TripTypeField = memo(({
       data-testid="trip-type-filter-btn"
     >
       <span className="block text-[10px] font-black text-gray-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
-        <Briefcase className="w-3 h-3" /> Tipo de Viagem
+        <Briefcase className="size-3" /> Tipo de Viagem
       </span>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 overflow-hidden">
           {selectedTripObj && (
-            <selectedTripObj.icon className={`w-5 h-5 ${selectedTripObj.color}`} />
+            <selectedTripObj.icon className={`size-5 ${selectedTripObj.color}`} />
           )}
           <span className={`text-lg md:text-lg font-bold truncate transition-colors ${tripType ? "text-gray-800" : "text-gray-300"}`}>
             {tripType || "Lazer, Lua de Mel..."}
           </span>
         </div>
-        <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform duration-300 ${showTripTypeDropdown ? 'rotate-180' : ''}`} />
+        <ChevronDown className={`size-4 text-gray-400 transition-transform duration-300 ${showTripTypeDropdown ? 'rotate-180' : ''}`} />
       </div>
     </button>
 
@@ -508,7 +508,7 @@ const TripTypeField = memo(({
                 ${tripType === type.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-gray-50 hover:border-gray-100'}`}
             >
               <div className={`p-2 rounded-xl ${type.bg} ${type.color}`}>
-                <type.icon className="w-5 h-5" />
+                <type.icon className="size-5" />
               </div>
               <span className={`font-bold text-base ${tripType === type.label ? 'text-brand-dark' : 'text-gray-600'}`}>
                 {type.label}
@@ -549,7 +549,7 @@ const BudgetField = memo(({
       data-testid="budget-filter-btn"
     >
       <span className="block text-[10px] font-black text-gray-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
-        <Wallet className="w-3 h-3" /> Orçamento Aprox.
+        <Wallet className="size-3" /> Orçamento Aprox.
       </span>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 overflow-hidden">
@@ -562,7 +562,7 @@ const BudgetField = memo(({
             {budget || "Definir padrão"}
           </span>
         </div>
-        <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform duration-300 ${showBudgetDropdown ? 'rotate-180' : ''}`} />
+        <ChevronDown className={`size-4 text-gray-400 transition-transform duration-300 ${showBudgetDropdown ? 'rotate-180' : ''}`} />
       </div>
     </button>
 
@@ -577,7 +577,7 @@ const BudgetField = memo(({
               ${budget === option.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-gray-50 hover:border-gray-100'}`}
           >
             <div className={`p-2 rounded-xl bg-gray-100 text-gray-600 ${budget === option.label ? 'bg-brand-vibrant text-white' : ''}`}>
-              <option.icon className="w-5 h-5" />
+              <option.icon className="size-5" />
             </div>
             <div className="text-left">
               <div className="flex items-center gap-2">
@@ -626,12 +626,12 @@ const SearchButton = memo(({ isSearchLoading, validationError }: SearchButtonPro
     >
       {isSearchLoading ? (
         <>
-          <Loader2 className="w-6 h-6 animate-spin" />
+          <Loader2 className="size-6 animate-spin" />
           <span className="font-black text-lg">Planejando...</span>
         </>
       ) : (
         <>
-          <Search className="w-6 h-6 group-hover:rotate-12 transition-transform duration-300 ease-spring" strokeWidth={2.5} />
+          <Search className="size-6 group-hover:rotate-12 transition-transform duration-300 ease-spring" strokeWidth={2.5} />
           <span className="font-black text-lg">Planejar Viagem</span>
         </>
       )}
@@ -968,8 +968,8 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
       </div>
 
       <div className="w-full h-[2px] border-t-2 border-dashed border-gray-200 relative my-1">
-        <div className="absolute left-[-16px] top-[-8px] w-4 h-4 bg-brand-light rounded-full"></div>
-        <div className="absolute right-[-16px] top-[-8px] w-4 h-4 bg-brand-light rounded-full"></div>
+        <div className="absolute left-[-16px] top-[-8px] size-4 bg-brand-light rounded-full"></div>
+        <div className="absolute right-[-16px] top-[-8px] size-4 bg-brand-light rounded-full"></div>
       </div>
 
       <div className="flex flex-col md:flex-row items-stretch w-full divide-y md:divide-y-0 md:divide-x divide-gray-100">

--- a/components/SocialShare.tsx
+++ b/components/SocialShare.tsx
@@ -69,7 +69,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                     title="Compartilhar"
                     aria-label="Compartilhar"
                 >
-                    <Share2 className="w-4 h-4" />
+                    <Share2 className="size-4" />
                 </button>
                 <button
                     onClick={(e) => {
@@ -82,7 +82,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                     title={copied ? "Link copiado!" : "Copiar link"}
                     aria-label={copied ? "Link copiado com sucesso" : "Copiar link"}
                 >
-                    {copied ? <Check className="w-4 h-4" /> : <LinkIcon className="w-4 h-4" />}
+                    {copied ? <Check className="size-4" /> : <LinkIcon className="size-4" />}
                 </button>
             </div>
         );
@@ -96,7 +96,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                 onMouseEnter={prefetchHaptics}
                 className="flex items-center gap-2 px-5 py-2.5 bg-brand-cyan text-white font-bold rounded-xl hover:bg-brand-cyanDark transition-all shadow-[0_4px_0px_#0369a1] active:shadow-none active:translate-y-1 lg:hidden"
             >
-                <Share2 className="w-5 h-5" /> Compartilhar
+                <Share2 className="size-5" /> Compartilhar
             </button>
 
             {/* Social Buttons */}
@@ -115,7 +115,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                             .catch(() => {});
                     }}
                 >
-                    <MessageCircle className="w-5 h-5 fill-current" />
+                    <MessageCircle className="size-5 fill-current" />
                 </a>
                 <a
                     href={links.facebook}
@@ -131,7 +131,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                             .catch(() => {});
                     }}
                 >
-                    <Facebook className="w-5 h-5 fill-current" />
+                    <Facebook className="size-5 fill-current" />
                 </a>
                 <a
                     href={links.linkedin}
@@ -147,7 +147,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                             .catch(() => {});
                     }}
                 >
-                    <Linkedin className="w-5 h-5 fill-current" />
+                    <Linkedin className="size-5 fill-current" />
                 </a>
 
                 {/* Native Share (secondary on desktop) */}
@@ -158,7 +158,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                     title="Mais opções de compartilhamento"
                     aria-label="Mais opções de compartilhamento"
                 >
-                    <Share2 className="w-5 h-5" />
+                    <Share2 className="size-5" />
                 </button>
 
                 {/* Copy Link button */}
@@ -169,7 +169,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                     title={copied ? "Link copiado!" : "Copiar link"}
                     aria-label={copied ? "Link copiado com sucesso" : "Copiar link"}
                 >
-                    {copied ? <Check className="w-5 h-5" /> : <LinkIcon className="w-5 h-5" />}
+                    {copied ? <Check className="size-5" /> : <LinkIcon className="size-5" />}
                 </button>
             </div>
         </div>

--- a/components/Testimonials.tsx
+++ b/components/Testimonials.tsx
@@ -40,7 +40,7 @@ const Testimonials: React.FC = memo(() => {
             <div className="container mx-auto px-6 relative z-10">
                 <SectionHeader
                     badge="Love Notes"
-                    badgeIcon={<MessageSquareHeart className="w-4 h-4 text-red-500 fill-red-500" />}
+                    badgeIcon={<MessageSquareHeart className="size-4 text-red-500 fill-red-500" />}
                     title="Mural do Amor ❤️"
                     subtitle="Depoimentos reais de quem viajou com a gente"
                     className="mb-16"
@@ -82,11 +82,11 @@ const Testimonials: React.FC = memo(() => {
                                     transition-transform duration-500 hover:rotate-0 hover:scale-[1.01]
                                 `}>
                                             {/* Pin Graphic */}
-                                            <div className="absolute -top-6 left-1/2 -translate-x-1/2 w-4 h-4 rounded-full bg-red-400 shadow-sm z-20 border border-red-600"></div>
+                                            <div className="absolute -top-6 left-1/2 -translate-x-1/2 size-4 rounded-full bg-red-400 shadow-sm z-20 border border-red-600"></div>
 
                                             {/* Animated Avatar Sticker */}
                                             <div className="relative shrink-0">
-                                                <div className="w-32 h-32 rounded-full border-4 border-white shadow-lg overflow-hidden bg-white animate-float">
+                                                <div className="size-32 rounded-full border-4 border-white shadow-lg overflow-hidden bg-white animate-float">
                                                     <LazyImage
                                                         src={testimonial.image}
                                                         alt={testimonial.name}
@@ -102,7 +102,7 @@ const Testimonials: React.FC = memo(() => {
 
                                             {/* Text */}
                                             <div className="text-center md:text-left">
-                                                <Quote className="w-10 h-10 text-brand-cyan/20 mx-auto md:mx-0 mb-4 fill-current" />
+                                                <Quote className="size-10 text-brand-cyan/20 mx-auto md:mx-0 mb-4 fill-current" />
                                                 <p itemProp="reviewBody" className="text-xl md:text-2xl font-bold text-gray-700 leading-snug mb-6 font-serif italic">
                                                     "{testimonial.text}"
                                                 </p>
@@ -127,8 +127,8 @@ const Testimonials: React.FC = memo(() => {
 
                     {/* Controls */}
                     <div className="flex justify-center gap-4 mt-8">
-                        <button onClick={prevSlide} className="w-12 h-12 bg-white border-2 border-white/50 rounded-full flex items-center justify-center shadow-md hover:scale-110 transition-transform text-brand-cyan hover:bg-brand-cyan hover:text-white z-20">
-                            <ChevronLeft className="w-6 h-6" />
+                        <button onClick={prevSlide} className="size-12 bg-white border-2 border-white/50 rounded-full flex items-center justify-center shadow-md hover:scale-110 transition-transform text-brand-cyan hover:bg-brand-cyan hover:text-white z-20">
+                            <ChevronLeft className="size-6" />
                         </button>
                         <div className="flex gap-2 items-center z-20">
                             {TESTIMONIALS.map((t, i) => (
@@ -140,8 +140,8 @@ const Testimonials: React.FC = memo(() => {
                                 />
                             ))}
                         </div>
-                        <button onClick={nextSlide} className="w-12 h-12 bg-white border-2 border-white/50 rounded-full flex items-center justify-center shadow-md hover:scale-110 transition-transform text-brand-cyan hover:bg-brand-cyan hover:text-white z-20">
-                            <ChevronRight className="w-6 h-6" />
+                        <button onClick={nextSlide} className="size-12 bg-white border-2 border-white/50 rounded-full flex items-center justify-center shadow-md hover:scale-110 transition-transform text-brand-cyan hover:bg-brand-cyan hover:text-white z-20">
+                            <ChevronRight className="size-6" />
                         </button>
                     </div>
 

--- a/components/blog/BlogPostContent.tsx
+++ b/components/blog/BlogPostContent.tsx
@@ -39,7 +39,7 @@ export const BlogPostContent: React.FC<BlogPostContentProps> = ({ post, canonica
                 <div className="mb-8 p-6 bg-yellow-50 border-2 border-brand-yellow text-brand-dark rounded-2xl font-serif italic text-base md:text-lg">
                     <div className="flex gap-3">
                         <div className="shrink-0 mt-1">
-                            <svg className="w-5 h-5 text-brand-yellow" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                            <svg className="size-5 text-brand-yellow" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                                 <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
                             </svg>
                         </div>
@@ -113,7 +113,7 @@ export const BlogPostContent: React.FC<BlogPostContentProps> = ({ post, canonica
                                     {related.title}
                                 </h5>
                                 <div className="flex items-center gap-3 text-xs text-gray-400 font-bold">
-                                    <span className="flex items-center gap-1"><Clock className="w-3 h-3" /> {related.readingTime}</span>
+                                    <span className="flex items-center gap-1"><Clock className="size-3" /> {related.readingTime}</span>
                                     <span>•</span>
                                     <span>{formatDate(related.date)}</span>
                                 </div>

--- a/components/blog/BlogPostFinalCTA.tsx
+++ b/components/blog/BlogPostFinalCTA.tsx
@@ -9,7 +9,7 @@ interface BlogPostFinalCTAProps {
 export const BlogPostFinalCTA: React.FC<BlogPostFinalCTAProps> = ({ post }) => {
     return (
         <div className="mt-24 bg-brand-dark rounded-[3rem] p-10 md:p-16 text-center shadow-2xl relative overflow-hidden">
-            <div className="absolute top-0 right-0 w-64 h-64 bg-brand-cyan/10 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2"></div>
+            <div className="absolute top-0 right-0 size-64 bg-brand-cyan/10 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2"></div>
             <h2 className="text-3xl md:text-5xl font-black text-white mb-6 relative z-10">
                 Gostou do conteúdo? <br />
                 <span className="text-brand-cyan">Sua viagem começa aqui.</span>

--- a/components/blog/BlogPostHero.tsx
+++ b/components/blog/BlogPostHero.tsx
@@ -29,12 +29,12 @@ export const BlogPostHero: React.FC<BlogPostHeroProps> = ({ post, authorName }) 
             <div className="absolute inset-0 flex items-end pb-14 pt-36 md:pb-16 md:pt-40 lg:pb-20 lg:pt-44">
                 <div className="container mx-auto px-6">
                     <a href="https://www.anhanga.tur.br/" className="inline-flex items-center gap-2 text-white/80 hover:text-white mb-8 font-bold uppercase tracking-wider text-xs transition-colors backdrop-blur-sm bg-white/10 px-4 py-2 rounded-full w-fit hover:bg-white/20 border border-white/20">
-                        <ArrowLeft className="w-4 h-4" /> Voltar para o Blog
+                        <ArrowLeft className="size-4" /> Voltar para o Blog
                     </a>
                     <div className="max-w-3xl">
                         <div className="flex items-center gap-3 mb-6">
                             <span className={`inline-flex items-center gap-2 px-4 py-2 rounded-xl border-2 ${getCategoryColor(post.category)} shadow-[4px_4px_0px_rgba(0,0,0,0.3)] font-black text-xs uppercase tracking-widest transform -rotate-1`}>
-                                <Tag className="w-3 h-3 fill-current opacity-50" />
+                                <Tag className="size-3 fill-current opacity-50" />
                                 {post.category}
                             </span>
                         </div>
@@ -46,19 +46,19 @@ export const BlogPostHero: React.FC<BlogPostHeroProps> = ({ post, authorName }) 
                         <div className="flex flex-wrap items-center gap-4 border-t border-white/20 pt-4 font-medium text-white/90 md:gap-6 md:pt-6">
                             <div className="flex items-center gap-2">
                                 <div className="p-1.5 bg-white/10 rounded-lg backdrop-blur-md">
-                                    <User className="w-4 h-4" />
+                                    <User className="size-4" />
                                 </div>
                                 <span>Por <span className="font-bold text-white border-b-2 border-brand-yellow/50">{authorName}</span></span>
                             </div>
                             <div className="flex items-center gap-2">
                                 <div className="p-1.5 bg-white/10 rounded-lg backdrop-blur-md">
-                                    <Calendar className="w-4 h-4" />
+                                    <Calendar className="size-4" />
                                 </div>
                                 <span>{formatDate(post.date)}</span>
                             </div>
                             <div className="flex items-center gap-2">
                                 <div className="p-1.5 bg-white/10 rounded-lg backdrop-blur-md">
-                                    <Clock className="w-4 h-4" />
+                                    <Clock className="size-4" />
                                 </div>
                                 <span>{post.readingTime}</span>
                             </div>

--- a/components/blog/BlogPostSidebar.tsx
+++ b/components/blog/BlogPostSidebar.tsx
@@ -21,8 +21,8 @@ export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, author
     return (
         <div className="sticky top-32 space-y-8">
             <div className="bg-white rounded-3xl p-8 border-2 border-gray-100 text-center relative overflow-hidden shadow-lg group hover:border-brand-yellow/30 transition-colors">
-                <div className="absolute top-0 right-0 w-32 h-32 bg-brand-yellow/10 rounded-bl-full -mr-10 -mt-10 transition-all group-hover:scale-110"></div>
-                <div className="w-28 h-28 bg-gray-200 rounded-full mx-auto mb-6 overflow-hidden border-[6px] border-white shadow-xl relative z-10">
+                <div className="absolute top-0 right-0 size-32 bg-brand-yellow/10 rounded-bl-full -mr-10 -mt-10 transition-all group-hover:scale-110"></div>
+                <div className="size-28 bg-gray-200 rounded-full mx-auto mb-6 overflow-hidden border-[6px] border-white shadow-xl relative z-10">
                     {author?.image ? (
                         <img src={author.image} alt={author.name} width="112" height="112" loading="lazy" className="w-full h-full object-cover" />
                     ) : (
@@ -56,7 +56,7 @@ export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, author
                 <div className="space-y-4">
                     {relatedPosts.map(related => (
                         <a href={getBlogPostUrl(related.slug)} key={related.slug} className="group flex gap-5 items-center bg-white p-4 rounded-2xl hover:bg-white hover:shadow-xl transition-all border border-transparent hover:border-gray-100 duration-300">
-                            <div className="w-24 h-24 rounded-2xl overflow-hidden shrink-0 border border-gray-100 shadow-sm relative">
+                            <div className="size-24 rounded-2xl overflow-hidden shrink-0 border border-gray-100 shadow-sm relative">
                                 <img src={optimizeRemoteImageUrl(related.image, 200, 200)} alt={related.title} width="200" height="200" loading="lazy" className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700" />
                             </div>
                             <div className="flex flex-col h-full justify-center">
@@ -69,7 +69,7 @@ export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, author
                                     {related.title}
                                 </h5>
                                 <span className="text-xs text-gray-400 font-bold flex items-center gap-1">
-                                    <Clock className="w-3 h-3" /> {related.readingTime}
+                                    <Clock className="size-3" /> {related.readingTime}
                                 </span>
                             </div>
                         </a>

--- a/components/landings/beto-carrero/Attractions.tsx
+++ b/components/landings/beto-carrero/Attractions.tsx
@@ -70,8 +70,8 @@ const Attractions: React.FC = () => {
       </div>
 
       {/* Background Scribbles */}
-      <div className="absolute top-1/4 right-0 w-64 h-64 bg-fun-yellow/20 rounded-full blur-3xl -z-10"></div>
-      <div className="absolute bottom-1/4 left-0 w-64 h-64 bg-fun-pink/10 rounded-full blur-3xl -z-10"></div>
+      <div className="absolute top-1/4 right-0 size-64 bg-fun-yellow/20 rounded-full blur-3xl -z-10"></div>
+      <div className="absolute bottom-1/4 left-0 size-64 bg-fun-pink/10 rounded-full blur-3xl -z-10"></div>
 
       <div className="container mx-auto px-4">
         <SectionTitle

--- a/components/landings/beto-carrero/Button.tsx
+++ b/components/landings/beto-carrero/Button.tsx
@@ -75,7 +75,7 @@ const Button: React.FC<ButtonProps> = ({
         aria-label={computedAriaLabel}
         data-tracking={dataTracking}
       >
-        {icon && <MessageCircle className="w-6 h-6 mr-2" />}
+        {icon && <MessageCircle className="size-6 mr-2" />}
         {text}
       </button>
 
@@ -83,7 +83,7 @@ const Button: React.FC<ButtonProps> = ({
         <div className={`absolute left-1/2 transform -translate-x-1/2 w-max max-w-[200px] md:max-w-xs transition-all duration-200 opacity-0 group-hover:opacity-100 pointer-events-none z-50 ${positionStyles} ${animationStyles}`}>
           <div className="bg-fun-dark text-white text-sm font-bold py-2 px-3 rounded-xl shadow-lg border-2 border-white text-center relative">
             {tooltip}
-            <div className={`absolute left-1/2 transform -translate-x-1/2 w-3 h-3 bg-fun-dark rotate-45 ${arrowStyles}`}></div>
+            <div className={`absolute left-1/2 transform -translate-x-1/2 size-3 bg-fun-dark rotate-45 ${arrowStyles}`}></div>
           </div>
         </div>
       )}

--- a/components/landings/beto-carrero/FAQ.tsx
+++ b/components/landings/beto-carrero/FAQ.tsx
@@ -22,12 +22,12 @@ const FAQ: React.FC = () => {
     <section className="py-24 bg-fun-yellow relative overflow-hidden">
       
       {/* Background Decor */}
-      <div className="absolute top-20 left-10 w-32 h-32 bg-white/20 rounded-full blur-3xl"></div>
-      <div className="absolute bottom-20 right-10 w-40 h-40 bg-fun-pink/10 rounded-full blur-3xl"></div>
+      <div className="absolute top-20 left-10 size-32 bg-white/20 rounded-full blur-3xl"></div>
+      <div className="absolute bottom-20 right-10 size-40 bg-fun-pink/10 rounded-full blur-3xl"></div>
       
       {/* Floating Question Marks */}
-      <HelpCircle className="absolute top-10 right-[10%] text-fun-dark/10 w-24 h-24 -rotate-12 animate-pulse" />
-      <HelpCircle className="absolute bottom-10 left-[5%] text-fun-dark/10 w-16 h-16 rotate-12" />
+      <HelpCircle className="absolute top-10 right-[10%] text-fun-dark/10 size-24 -rotate-12 animate-pulse" />
+      <HelpCircle className="absolute bottom-10 left-[5%] text-fun-dark/10 size-16 rotate-12" />
 
       <div className="container mx-auto px-4 max-w-4xl relative z-10">
         
@@ -54,7 +54,7 @@ const FAQ: React.FC = () => {
                       <span className={`font-sans font-bold text-lg md:text-xl pr-4 leading-tight ${isOpen ? 'text-fun-blue' : 'text-fun-dark'}`}>
                         {item.question}
                       </span>
-                      <div className={`flex-shrink-0 w-8 h-8 rounded-full border-2 border-fun-dark flex items-center justify-center transition-all duration-300 ${isOpen ? 'bg-fun-blue text-white rotate-180' : 'bg-white text-fun-dark'}`}>
+                      <div className={`flex-shrink-0 size-8 rounded-full border-2 border-fun-dark flex items-center justify-center transition-all duration-300 ${isOpen ? 'bg-fun-blue text-white rotate-180' : 'bg-white text-fun-dark'}`}>
                         <ChevronDown size={20} strokeWidth={3} />
                       </div>
                     </button>

--- a/components/landings/beto-carrero/Features.tsx
+++ b/components/landings/beto-carrero/Features.tsx
@@ -79,7 +79,7 @@ const Features: React.FC = () => {
                   )}
 
                   {/* Icon Badge - Highlighted & Larger */}
-                  <div className={`w-24 h-24 rounded-2xl border-4 border-fun-dark flex items-center justify-center mb-8 shadow-hard transition-all duration-300 group-hover:shadow-hard-hover group-hover:scale-110 ${feature.color} relative z-10`}>
+                  <div className={`size-24 rounded-2xl border-4 border-fun-dark flex items-center justify-center mb-8 shadow-hard transition-all duration-300 group-hover:shadow-hard-hover group-hover:scale-110 ${feature.color} relative z-10`}>
                     {feature.icon}
                   </div>
 

--- a/components/landings/beto-carrero/Hero.tsx
+++ b/components/landings/beto-carrero/Hero.tsx
@@ -14,8 +14,8 @@ const Hero: React.FC = () => {
       </div>
 
       {/* --- Background Doodles (Abstract Shapes) --- */}
-      <div className="absolute top-10 left-0 size-24 md:w-40 md:h-40 bg-white/30 rounded-full blur-2xl animate-pulse"></div>
-      <div className="absolute bottom-1/4 right-0 size-32 md:w-64 md:h-64 bg-fun-pink/10 rounded-full blur-3xl"></div>
+      <div className="absolute top-10 left-0 size-24 md:size-40 bg-white/30 rounded-full blur-2xl animate-pulse"></div>
+      <div className="absolute bottom-1/4 right-0 size-32 md:size-64 bg-fun-pink/10 rounded-full blur-3xl"></div>
 
       <div className="container mx-auto px-4 grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-4 items-center relative z-20 mb-12 md:mb-0">
 
@@ -92,7 +92,7 @@ const Hero: React.FC = () => {
             <div className="absolute -top-6 -right-4 sm:-right-10 md:-right-4 lg:-right-12 xl:-right-16 bg-white p-2 sm:p-3 lg:p-5 rounded-xl border-2 border-fun-dark shadow-hard transform rotate-12 z-20 animate-[float_4s_ease-in-out_infinite] scale-95 sm:scale-100 md:scale-90 lg:scale-110">
               <div className="flex items-center gap-2 sm:gap-3 lg:gap-4">
                 <div className="bg-blue-100 p-1.5 sm:p-2 lg:p-3 rounded-lg text-fun-blue border-2 border-fun-dark">
-                  <Plane size={20} className="sm:w-6 sm:h-6 lg:w-8 lg:h-8" />
+                  <Plane size={20} className="sm:size-6 lg:size-8" />
                 </div>
                 <div>
                   <div className="text-[10px] sm:text-xs lg:text-sm font-bold text-gray-400 leading-none mb-1">Voo Confirmado</div>
@@ -104,25 +104,25 @@ const Hero: React.FC = () => {
             {/* 3. Floating Sticker: Park Ticket (Bottom Left) */}
             <div className="absolute bottom-16 -left-4 sm:bottom-20 sm:-left-12 md:-left-4 md:bottom-24 lg:bottom-8 lg:-left-16 xl:bottom-24 xl:-left-20 bg-fun-pink text-white p-3 sm:p-4 lg:p-4 xl:p-6 px-4 sm:px-6 lg:px-6 xl:px-8 rounded-xl border-2 border-fun-dark shadow-hard transform -rotate-12 z-30 animate-[float_5s_ease-in-out_infinite_1s] scale-90 sm:scale-100 md:scale-85 lg:scale-75 xl:scale-110">
               <div className="flex items-center gap-2 lg:gap-3">
-                <Ticket size={20} className="sm:w-6 sm:h-6 lg:w-8 lg:h-8" />
+                <Ticket size={20} className="sm:size-6 lg:size-8" />
                 <span className="font-sans font-bold text-sm sm:text-lg lg:text-2xl">Ingresso VIP</span>
               </div>
               {/* Perforation line */}
-              <div className="absolute -right-1 top-1/2 -translate-y-1/2 size-3 lg:w-4 lg:h-4 bg-fun-yellow rounded-full border-2 border-fun-dark"></div>
-              <div className="absolute -left-1 top-1/2 -translate-y-1/2 size-3 lg:w-4 lg:h-4 bg-fun-yellow rounded-full border-2 border-fun-dark"></div>
+              <div className="absolute -right-1 top-1/2 -translate-y-1/2 size-3 lg:size-4 bg-fun-yellow rounded-full border-2 border-fun-dark"></div>
+              <div className="absolute -left-1 top-1/2 -translate-y-1/2 size-3 lg:size-4 bg-fun-yellow rounded-full border-2 border-fun-dark"></div>
             </div>
 
             {/* 4. Floating Sticker: 5 Stars (Bottom Right) */}
             <div className="absolute -bottom-8 -right-2 md:-bottom-6 md:-right-6 lg:-bottom-2 lg:right-8 xl:right-4 xl:-bottom-8 bg-fun-green p-2 sm:p-3 lg:p-2 xl:p-4 rounded-full border-2 border-fun-dark shadow-hard z-20 transform rotate-6 hover:scale-110 transition-transform scale-90 sm:scale-100 lg:scale-75 xl:scale-110">
               <div className="flex gap-1 text-white">
                 {[...Array(5)].map((_, i) => (
-                  <Star key={`star-${i}`} size={14} className="sm:w-4 sm:h-4 lg:w-6 lg:h-6" fill="currentColor" />
+                  <Star key={`star-${i}`} size={14} className="sm:size-4 lg:size-6" fill="currentColor" />
                 ))}
               </div>
             </div>
 
             {/* 5. Decorative Sparkles */}
-            <Sparkles className="absolute -top-10 left-0 lg:-left-10 text-white size-10 sm:w-12 sm:h-12 lg:w-20 lg:h-20 animate-pulse z-0" strokeWidth={1} />
+            <Sparkles className="absolute -top-10 left-0 lg:-left-10 text-white size-10 sm:size-12 lg:size-20 animate-pulse z-0" strokeWidth={1} />
           </div>
 
         </div>

--- a/components/landings/beto-carrero/Hero.tsx
+++ b/components/landings/beto-carrero/Hero.tsx
@@ -14,8 +14,8 @@ const Hero: React.FC = () => {
       </div>
 
       {/* --- Background Doodles (Abstract Shapes) --- */}
-      <div className="absolute top-10 left-0 w-24 h-24 md:w-40 md:h-40 bg-white/30 rounded-full blur-2xl animate-pulse"></div>
-      <div className="absolute bottom-1/4 right-0 w-32 h-32 md:w-64 md:h-64 bg-fun-pink/10 rounded-full blur-3xl"></div>
+      <div className="absolute top-10 left-0 size-24 md:w-40 md:h-40 bg-white/30 rounded-full blur-2xl animate-pulse"></div>
+      <div className="absolute bottom-1/4 right-0 size-32 md:w-64 md:h-64 bg-fun-pink/10 rounded-full blur-3xl"></div>
 
       <div className="container mx-auto px-4 grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-4 items-center relative z-20 mb-12 md:mb-0">
 
@@ -108,8 +108,8 @@ const Hero: React.FC = () => {
                 <span className="font-sans font-bold text-sm sm:text-lg lg:text-2xl">Ingresso VIP</span>
               </div>
               {/* Perforation line */}
-              <div className="absolute -right-1 top-1/2 -translate-y-1/2 w-3 h-3 lg:w-4 lg:h-4 bg-fun-yellow rounded-full border-2 border-fun-dark"></div>
-              <div className="absolute -left-1 top-1/2 -translate-y-1/2 w-3 h-3 lg:w-4 lg:h-4 bg-fun-yellow rounded-full border-2 border-fun-dark"></div>
+              <div className="absolute -right-1 top-1/2 -translate-y-1/2 size-3 lg:w-4 lg:h-4 bg-fun-yellow rounded-full border-2 border-fun-dark"></div>
+              <div className="absolute -left-1 top-1/2 -translate-y-1/2 size-3 lg:w-4 lg:h-4 bg-fun-yellow rounded-full border-2 border-fun-dark"></div>
             </div>
 
             {/* 4. Floating Sticker: 5 Stars (Bottom Right) */}
@@ -122,7 +122,7 @@ const Hero: React.FC = () => {
             </div>
 
             {/* 5. Decorative Sparkles */}
-            <Sparkles className="absolute -top-10 left-0 lg:-left-10 text-white w-10 h-10 sm:w-12 sm:h-12 lg:w-20 lg:h-20 animate-pulse z-0" strokeWidth={1} />
+            <Sparkles className="absolute -top-10 left-0 lg:-left-10 text-white size-10 sm:w-12 sm:h-12 lg:w-20 lg:h-20 animate-pulse z-0" strokeWidth={1} />
           </div>
 
         </div>
@@ -151,7 +151,7 @@ const Hero: React.FC = () => {
           <span className="font-sans font-bold text-fun-dark text-sm md:text-lg whitespace-nowrap">
             O pesadelo de planejar
           </span>
-          <div className="bg-fun-pink text-white rounded-full w-8 h-8 flex items-center justify-center border-2 border-fun-dark group-hover:bg-fun-dark transition-colors">
+          <div className="bg-fun-pink text-white rounded-full size-8 flex items-center justify-center border-2 border-fun-dark group-hover:bg-fun-dark transition-colors">
             <ArrowDown size={18} strokeWidth={3} />
           </div>
         </div>

--- a/components/landings/beto-carrero/Problem.tsx
+++ b/components/landings/beto-carrero/Problem.tsx
@@ -24,23 +24,23 @@ const Problem: React.FC = () => {
                <div className="lg:col-span-6 relative h-[450px] md:h-[550px] lg:h-[600px] flex items-center justify-center w-full md:max-w-2xl md:mx-auto lg:max-w-none">
 
                   {/* Decorative Background Blob */}
-                  <div className="absolute w-80 h-80 md:w-[450px] md:h-[450px] lg:w-[500px] lg:h-[500px] bg-fun-pink/10 rounded-full blur-3xl"></div>
+                  <div className="absolute size-80 md:w-[450px] md:h-[450px] lg:w-[500px] lg:h-[500px] bg-fun-pink/10 rounded-full blur-3xl"></div>
 
                   {/* Element 1: The Browser Window (Base) */}
                   {/* Tablet Adjustment: Centered using translate-x logic and adjusted width */}
                   <div className="absolute top-10 left-0 md:left-1/2 md:-translate-x-1/2 lg:left-0 lg:translate-x-0 w-full md:w-[480px] lg:w-[32rem] bg-white border-2 border-fun-dark rounded-xl shadow-hard z-10 transform -rotate-3 transition-transform hover:rotate-0 duration-300">
                      {/* Browser Header */}
                      <div className="bg-gray-100 border-b-2 border-fun-dark p-2 lg:p-3 flex items-center gap-2 rounded-t-lg">
-                        <div className="w-3 h-3 lg:w-4 lg:h-4 rounded-full bg-red-400 border border-fun-dark"></div>
-                        <div className="w-3 h-3 lg:w-4 lg:h-4 rounded-full bg-yellow-400 border border-fun-dark"></div>
-                        <div className="w-3 h-3 lg:w-4 lg:h-4 rounded-full bg-green-400 border border-fun-dark"></div>
+                        <div className="size-3 lg:w-4 lg:h-4 rounded-full bg-red-400 border border-fun-dark"></div>
+                        <div className="size-3 lg:w-4 lg:h-4 rounded-full bg-yellow-400 border border-fun-dark"></div>
+                        <div className="size-3 lg:w-4 lg:h-4 rounded-full bg-green-400 border border-fun-dark"></div>
                         <div className="flex-grow bg-white border border-gray-300 h-5 lg:h-7 rounded-md text-[10px] lg:text-xs flex items-center px-2 text-gray-400 overflow-hidden">
                            betocarrero-hoteis-baratos-socorro.com...
                         </div>
                      </div>
                      {/* Browser Body */}
                      <div className="p-6 md:p-8 lg:p-10 flex flex-col items-center text-center">
-                        <Search className="text-fun-blue w-10 h-10 lg:w-16 lg:h-16 mb-2 animate-pulse" />
+                        <Search className="text-fun-blue size-10 lg:w-16 lg:h-16 mb-2 animate-pulse" />
                         <h3 className="font-sans font-bold text-xl md:text-2xl lg:text-3xl text-fun-dark">157 abas abertas</h3>
                         <p className="text-sm md:text-base lg:text-lg text-slate-500 mt-2 leading-tight">
                            Comparando preços, lendo reviews antigos e ficando cada vez mais confuso.
@@ -52,7 +52,7 @@ const Problem: React.FC = () => {
                   {/* Tablet Adjustment: Increased width (md:w-72), padding (md:p-6), and text sizes */}
                   <div className="absolute bottom-20 right-0 md:right-[2%] lg:-right-4 bg-fun-yellow p-4 md:p-6 lg:p-6 rounded-xl border-2 border-fun-dark shadow-hard z-20 transform rotate-6 w-56 md:w-72 lg:w-80 hover:scale-105 transition-transform">
                      <div className="flex items-start gap-3 lg:gap-4">
-                        <AlertTriangle className="text-fun-dark w-6 h-6 md:w-8 md:h-8 lg:w-10 lg:h-10 flex-shrink-0" />
+                        <AlertTriangle className="text-fun-dark size-6 md:w-8 md:h-8 lg:w-10 lg:h-10 flex-shrink-0" />
                         <div>
                            <h3 className="font-bold text-sm md:text-lg lg:text-xl leading-tight mb-1">Preço mudou!</h3>
                            <p className="text-xs md:text-sm lg:text-base text-fun-dark/80">A passagem aumentou enquanto você pensava.</p>
@@ -63,15 +63,15 @@ const Problem: React.FC = () => {
                   {/* Element 3: Low Battery (Floating Left) */}
                   {/* Tablet Adjustment: Increased padding (md:p-4 md:px-8), icon size, and font size */}
                   <div className="absolute bottom-10 left-4 md:left-[5%] lg:left-4 bg-white p-3 px-5 md:p-4 md:px-8 lg:p-5 lg:px-8 rounded-full border-2 border-fun-dark shadow-hard z-30 transform -rotate-12 flex items-center gap-2 md:gap-3 lg:gap-3">
-                     <BatteryLow className="text-fun-pink w-5 h-5 md:w-7 md:h-7 lg:w-8 lg:h-8" />
+                     <BatteryLow className="text-fun-pink size-5 md:w-7 md:h-7 lg:w-8 lg:h-8" />
                      <span className="font-bold text-sm md:text-lg lg:text-xl text-slate-600">Exaustão Mental</span>
                   </div>
 
                   {/* Floating Cursor */}
-                  <MousePointer2 className="absolute top-1/2 right-1/4 md:right-[20%] text-fun-dark w-8 h-8 lg:w-12 lg:h-12 fill-white stroke-[1.5px] z-40 animate-float" />
+                  <MousePointer2 className="absolute top-1/2 right-1/4 md:right-[20%] text-fun-dark size-8 lg:w-12 lg:h-12 fill-white stroke-[1.5px] z-40 animate-float" />
 
                   {/* Floating Question Marks */}
-                  <HelpCircle className="absolute top-0 right-10 md:right-[15%] lg:right-0 text-gray-300 w-12 h-12 lg:w-20 lg:h-20 transform rotate-12" />
+                  <HelpCircle className="absolute top-0 right-10 md:right-[15%] lg:right-0 text-gray-300 size-12 lg:w-20 lg:h-20 transform rotate-12" />
                </div>
 
 
@@ -82,7 +82,7 @@ const Problem: React.FC = () => {
                   {/* Problem Card 1 */}
                   <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 transform rotate-1 h-full">
                      <div className="flex gap-5 lg:gap-8 items-start h-full">
-                        <div className="flex-shrink-0 w-14 h-14 lg:w-20 lg:h-20 rounded-xl bg-red-100 flex items-center justify-center text-fun-pink border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
+                        <div className="flex-shrink-0 size-14 lg:w-20 lg:h-20 rounded-xl bg-red-100 flex items-center justify-center text-fun-pink border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
                            <HelpCircle size={28} className="lg:w-10 lg:h-10" strokeWidth={2.5} />
                         </div>
                         <div>
@@ -100,7 +100,7 @@ const Problem: React.FC = () => {
                   {/* Problem Card 2 */}
                   <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 transform -rotate-1 h-full">
                      <div className="flex gap-5 lg:gap-8 items-start h-full">
-                        <div className="flex-shrink-0 w-14 h-14 lg:w-20 lg:h-20 rounded-xl bg-fun-yellow flex items-center justify-center text-fun-dark border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
+                        <div className="flex-shrink-0 size-14 lg:w-20 lg:h-20 rounded-xl bg-fun-yellow flex items-center justify-center text-fun-dark border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
                            <X size={28} className="lg:w-10 lg:h-10" strokeWidth={2.5} />
                         </div>
                         <div>
@@ -115,7 +115,7 @@ const Problem: React.FC = () => {
                   {/* Problem Card 3 - Spans 2 columns on tablet to center it */}
                   <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 transform rotate-1 md:col-span-2 lg:col-span-1 md:w-3/4 md:mx-auto lg:w-full">
                      <div className="flex gap-5 lg:gap-8 items-start h-full">
-                        <div className="flex-shrink-0 w-14 h-14 lg:w-20 lg:h-20 rounded-xl bg-blue-100 flex items-center justify-center text-fun-blue border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
+                        <div className="flex-shrink-0 size-14 lg:w-20 lg:h-20 rounded-xl bg-blue-100 flex items-center justify-center text-fun-blue border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
                            <AlertTriangle size={28} className="lg:w-10 lg:h-10" strokeWidth={2.5} />
                         </div>
                         <div>

--- a/components/landings/beto-carrero/Problem.tsx
+++ b/components/landings/beto-carrero/Problem.tsx
@@ -24,23 +24,23 @@ const Problem: React.FC = () => {
                <div className="lg:col-span-6 relative h-[450px] md:h-[550px] lg:h-[600px] flex items-center justify-center w-full md:max-w-2xl md:mx-auto lg:max-w-none">
 
                   {/* Decorative Background Blob */}
-                  <div className="absolute size-80 md:w-[450px] md:h-[450px] lg:w-[500px] lg:h-[500px] bg-fun-pink/10 rounded-full blur-3xl"></div>
+                  <div className="absolute size-80 md:size-[450px] lg:size-[500px] bg-fun-pink/10 rounded-full blur-3xl"></div>
 
                   {/* Element 1: The Browser Window (Base) */}
                   {/* Tablet Adjustment: Centered using translate-x logic and adjusted width */}
                   <div className="absolute top-10 left-0 md:left-1/2 md:-translate-x-1/2 lg:left-0 lg:translate-x-0 w-full md:w-[480px] lg:w-[32rem] bg-white border-2 border-fun-dark rounded-xl shadow-hard z-10 transform -rotate-3 transition-transform hover:rotate-0 duration-300">
                      {/* Browser Header */}
                      <div className="bg-gray-100 border-b-2 border-fun-dark p-2 lg:p-3 flex items-center gap-2 rounded-t-lg">
-                        <div className="size-3 lg:w-4 lg:h-4 rounded-full bg-red-400 border border-fun-dark"></div>
-                        <div className="size-3 lg:w-4 lg:h-4 rounded-full bg-yellow-400 border border-fun-dark"></div>
-                        <div className="size-3 lg:w-4 lg:h-4 rounded-full bg-green-400 border border-fun-dark"></div>
+                        <div className="size-3 lg:size-4 rounded-full bg-red-400 border border-fun-dark"></div>
+                        <div className="size-3 lg:size-4 rounded-full bg-yellow-400 border border-fun-dark"></div>
+                        <div className="size-3 lg:size-4 rounded-full bg-green-400 border border-fun-dark"></div>
                         <div className="flex-grow bg-white border border-gray-300 h-5 lg:h-7 rounded-md text-[10px] lg:text-xs flex items-center px-2 text-gray-400 overflow-hidden">
                            betocarrero-hoteis-baratos-socorro.com...
                         </div>
                      </div>
                      {/* Browser Body */}
                      <div className="p-6 md:p-8 lg:p-10 flex flex-col items-center text-center">
-                        <Search className="text-fun-blue size-10 lg:w-16 lg:h-16 mb-2 animate-pulse" />
+                        <Search className="text-fun-blue size-10 lg:size-16 mb-2 animate-pulse" />
                         <h3 className="font-sans font-bold text-xl md:text-2xl lg:text-3xl text-fun-dark">157 abas abertas</h3>
                         <p className="text-sm md:text-base lg:text-lg text-slate-500 mt-2 leading-tight">
                            Comparando preços, lendo reviews antigos e ficando cada vez mais confuso.
@@ -52,7 +52,7 @@ const Problem: React.FC = () => {
                   {/* Tablet Adjustment: Increased width (md:w-72), padding (md:p-6), and text sizes */}
                   <div className="absolute bottom-20 right-0 md:right-[2%] lg:-right-4 bg-fun-yellow p-4 md:p-6 lg:p-6 rounded-xl border-2 border-fun-dark shadow-hard z-20 transform rotate-6 w-56 md:w-72 lg:w-80 hover:scale-105 transition-transform">
                      <div className="flex items-start gap-3 lg:gap-4">
-                        <AlertTriangle className="text-fun-dark size-6 md:w-8 md:h-8 lg:w-10 lg:h-10 flex-shrink-0" />
+                        <AlertTriangle className="text-fun-dark size-6 md:size-8 lg:size-10 flex-shrink-0" />
                         <div>
                            <h3 className="font-bold text-sm md:text-lg lg:text-xl leading-tight mb-1">Preço mudou!</h3>
                            <p className="text-xs md:text-sm lg:text-base text-fun-dark/80">A passagem aumentou enquanto você pensava.</p>
@@ -63,15 +63,15 @@ const Problem: React.FC = () => {
                   {/* Element 3: Low Battery (Floating Left) */}
                   {/* Tablet Adjustment: Increased padding (md:p-4 md:px-8), icon size, and font size */}
                   <div className="absolute bottom-10 left-4 md:left-[5%] lg:left-4 bg-white p-3 px-5 md:p-4 md:px-8 lg:p-5 lg:px-8 rounded-full border-2 border-fun-dark shadow-hard z-30 transform -rotate-12 flex items-center gap-2 md:gap-3 lg:gap-3">
-                     <BatteryLow className="text-fun-pink size-5 md:w-7 md:h-7 lg:w-8 lg:h-8" />
+                     <BatteryLow className="text-fun-pink size-5 md:size-7 lg:size-8" />
                      <span className="font-bold text-sm md:text-lg lg:text-xl text-slate-600">Exaustão Mental</span>
                   </div>
 
                   {/* Floating Cursor */}
-                  <MousePointer2 className="absolute top-1/2 right-1/4 md:right-[20%] text-fun-dark size-8 lg:w-12 lg:h-12 fill-white stroke-[1.5px] z-40 animate-float" />
+                  <MousePointer2 className="absolute top-1/2 right-1/4 md:right-[20%] text-fun-dark size-8 lg:size-12 fill-white stroke-[1.5px] z-40 animate-float" />
 
                   {/* Floating Question Marks */}
-                  <HelpCircle className="absolute top-0 right-10 md:right-[15%] lg:right-0 text-gray-300 size-12 lg:w-20 lg:h-20 transform rotate-12" />
+                  <HelpCircle className="absolute top-0 right-10 md:right-[15%] lg:right-0 text-gray-300 size-12 lg:size-20 transform rotate-12" />
                </div>
 
 
@@ -82,8 +82,8 @@ const Problem: React.FC = () => {
                   {/* Problem Card 1 */}
                   <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 transform rotate-1 h-full">
                      <div className="flex gap-5 lg:gap-8 items-start h-full">
-                        <div className="flex-shrink-0 size-14 lg:w-20 lg:h-20 rounded-xl bg-red-100 flex items-center justify-center text-fun-pink border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
-                           <HelpCircle size={28} className="lg:w-10 lg:h-10" strokeWidth={2.5} />
+                        <div className="flex-shrink-0 size-14 lg:size-20 rounded-xl bg-red-100 flex items-center justify-center text-fun-pink border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
+                           <HelpCircle size={28} className="lg:size-10" strokeWidth={2.5} />
                         </div>
                         <div>
                            <h3 className="font-sans font-extrabold text-xl md:text-2xl lg:text-3xl mb-2 text-fun-dark">Insegurança na escolha</h3>
@@ -100,8 +100,8 @@ const Problem: React.FC = () => {
                   {/* Problem Card 2 */}
                   <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 transform -rotate-1 h-full">
                      <div className="flex gap-5 lg:gap-8 items-start h-full">
-                        <div className="flex-shrink-0 size-14 lg:w-20 lg:h-20 rounded-xl bg-fun-yellow flex items-center justify-center text-fun-dark border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
-                           <X size={28} className="lg:w-10 lg:h-10" strokeWidth={2.5} />
+                        <div className="flex-shrink-0 size-14 lg:size-20 rounded-xl bg-fun-yellow flex items-center justify-center text-fun-dark border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
+                           <X size={28} className="lg:size-10" strokeWidth={2.5} />
                         </div>
                         <div>
                            <h3 className="font-sans font-extrabold text-xl md:text-2xl lg:text-3xl mb-2 text-fun-dark">Logística Complicada</h3>
@@ -115,8 +115,8 @@ const Problem: React.FC = () => {
                   {/* Problem Card 3 - Spans 2 columns on tablet to center it */}
                   <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 transform rotate-1 md:col-span-2 lg:col-span-1 md:w-3/4 md:mx-auto lg:w-full">
                      <div className="flex gap-5 lg:gap-8 items-start h-full">
-                        <div className="flex-shrink-0 size-14 lg:w-20 lg:h-20 rounded-xl bg-blue-100 flex items-center justify-center text-fun-blue border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
-                           <AlertTriangle size={28} className="lg:w-10 lg:h-10" strokeWidth={2.5} />
+                        <div className="flex-shrink-0 size-14 lg:size-20 rounded-xl bg-blue-100 flex items-center justify-center text-fun-blue border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
+                           <AlertTriangle size={28} className="lg:size-10" strokeWidth={2.5} />
                         </div>
                         <div>
                            <h3 className="font-sans font-extrabold text-xl md:text-2xl lg:text-3xl mb-2 text-fun-dark">Surpresas no Pagamento</h3>

--- a/components/landings/beto-carrero/Solution.tsx
+++ b/components/landings/beto-carrero/Solution.tsx
@@ -72,8 +72,8 @@ const Solution: React.FC = () => {
                         {/* Left Side: Content */}
                         <div className="p-3 pl-4 lg:p-6 lg:pl-8 flex-grow flex items-center gap-4 lg:gap-6">
                            {/* Redesigned Icon: Blue Circle Token */}
-                           <div className="size-14 lg:w-20 lg:h-20 bg-fun-blue rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-6 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
-                              <Plane className="size-6 lg:w-9 lg:h-9" strokeWidth={2.5} />
+                           <div className="size-14 lg:size-20 bg-fun-blue rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-6 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
+                              <Plane className="size-6 lg:size-9" strokeWidth={2.5} />
                            </div>
                            <div>
                               <h3 className="font-sans font-bold text-lg lg:text-2xl text-fun-dark">Passagem Aérea</h3>
@@ -87,8 +87,8 @@ const Solution: React.FC = () => {
                         </div>
                         {/* Right Side: Stamp */}
                         <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
-                           <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:w-10 lg:h-10 rounded-full flex items-center justify-center transform rotate-12 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
-                              <Check className="size-[18px] lg:w-6 lg:h-6" strokeWidth={3} />
+                           <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform rotate-12 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
+                              <Check className="size-[18px] lg:size-6" strokeWidth={3} />
                            </div>
                         </div>
                      </div>
@@ -97,8 +97,8 @@ const Solution: React.FC = () => {
                      <div className="group bg-white rounded-xl border-2 border-fun-dark shadow-hard transform rotate-1 hover:rotate-0 transition-transform duration-300 flex overflow-hidden ml-0 md:ml-12 lg:ml-12 w-full max-w-sm lg:max-w-md">
                         <div className="p-3 pl-4 lg:p-6 lg:pl-8 flex-grow flex items-center gap-4 lg:gap-6">
                            {/* Redesigned Icon: Yellow Circle Token */}
-                           <div className="size-14 lg:w-20 lg:h-20 bg-fun-yellow rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-fun-dark transform rotate-3 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
-                              <BedDouble className="size-6 lg:w-9 lg:h-9" strokeWidth={2.5} />
+                           <div className="size-14 lg:size-20 bg-fun-yellow rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-fun-dark transform rotate-3 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
+                              <BedDouble className="size-6 lg:size-9" strokeWidth={2.5} />
                            </div>
                            <div>
                               <h3 className="font-sans font-bold text-lg lg:text-2xl text-fun-dark">Hotel Top</h3>
@@ -110,8 +110,8 @@ const Solution: React.FC = () => {
                            <div className="absolute -bottom-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
                         </div>
                         <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
-                           <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:w-10 lg:h-10 rounded-full flex items-center justify-center transform -rotate-6 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
-                              <Check className="size-[18px] lg:w-6 lg:h-6" strokeWidth={3} />
+                           <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform -rotate-6 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
+                              <Check className="size-[18px] lg:size-6" strokeWidth={3} />
                            </div>
                         </div>
                      </div>
@@ -132,8 +132,8 @@ const Solution: React.FC = () => {
                      >
                         <div className="p-3 pl-4 lg:p-6 lg:pl-8 flex-grow flex items-center gap-4 lg:gap-6">
                            {/* Redesigned Icon: Pink Circle Token */}
-                           <div className="size-14 lg:w-20 lg:h-20 bg-fun-pink rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-3 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
-                              <Ticket className="size-6 lg:w-9 lg:h-9" strokeWidth={2.5} />
+                           <div className="size-14 lg:size-20 bg-fun-pink rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-3 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
+                              <Ticket className="size-6 lg:size-9" strokeWidth={2.5} />
                            </div>
                            <div>
                               <h3 className="font-sans font-bold text-lg lg:text-2xl text-fun-dark">Ingresso Oficial</h3>
@@ -145,8 +145,8 @@ const Solution: React.FC = () => {
                            <div className="absolute -bottom-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
                         </div>
                         <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
-                           <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:w-10 lg:h-10 rounded-full flex items-center justify-center transform rotate-3 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
-                              <Check className="size-[18px] lg:w-6 lg:h-6" strokeWidth={3} />
+                           <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform rotate-3 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
+                              <Check className="size-[18px] lg:size-6" strokeWidth={3} />
                            </div>
                         </div>
                      </div>

--- a/components/landings/beto-carrero/Solution.tsx
+++ b/components/landings/beto-carrero/Solution.tsx
@@ -72,8 +72,8 @@ const Solution: React.FC = () => {
                         {/* Left Side: Content */}
                         <div className="p-3 pl-4 lg:p-6 lg:pl-8 flex-grow flex items-center gap-4 lg:gap-6">
                            {/* Redesigned Icon: Blue Circle Token */}
-                           <div className="w-14 h-14 lg:w-20 lg:h-20 bg-fun-blue rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-6 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
-                              <Plane className="w-6 h-6 lg:w-9 lg:h-9" strokeWidth={2.5} />
+                           <div className="size-14 lg:w-20 lg:h-20 bg-fun-blue rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-6 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
+                              <Plane className="size-6 lg:w-9 lg:h-9" strokeWidth={2.5} />
                            </div>
                            <div>
                               <h3 className="font-sans font-bold text-lg lg:text-2xl text-fun-dark">Passagem Aérea</h3>
@@ -82,13 +82,13 @@ const Solution: React.FC = () => {
                         </div>
                         {/* Divider Line */}
                         <div className="w-0 border-l-2 border-dashed border-gray-300 relative my-2">
-                           <div className="absolute -top-3 -left-1.5 w-3 h-3 bg-fun-blue rounded-full"></div>
-                           <div className="absolute -bottom-3 -left-1.5 w-3 h-3 bg-fun-blue rounded-full"></div>
+                           <div className="absolute -top-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
+                           <div className="absolute -bottom-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
                         </div>
                         {/* Right Side: Stamp */}
                         <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
-                           <div className="bg-green-100 text-green-600 border-2 border-green-500 w-8 h-8 lg:w-10 lg:h-10 rounded-full flex items-center justify-center transform rotate-12 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
-                              <Check className="w-[18px] h-[18px] lg:w-6 lg:h-6" strokeWidth={3} />
+                           <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:w-10 lg:h-10 rounded-full flex items-center justify-center transform rotate-12 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
+                              <Check className="size-[18px] lg:w-6 lg:h-6" strokeWidth={3} />
                            </div>
                         </div>
                      </div>
@@ -97,8 +97,8 @@ const Solution: React.FC = () => {
                      <div className="group bg-white rounded-xl border-2 border-fun-dark shadow-hard transform rotate-1 hover:rotate-0 transition-transform duration-300 flex overflow-hidden ml-0 md:ml-12 lg:ml-12 w-full max-w-sm lg:max-w-md">
                         <div className="p-3 pl-4 lg:p-6 lg:pl-8 flex-grow flex items-center gap-4 lg:gap-6">
                            {/* Redesigned Icon: Yellow Circle Token */}
-                           <div className="w-14 h-14 lg:w-20 lg:h-20 bg-fun-yellow rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-fun-dark transform rotate-3 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
-                              <BedDouble className="w-6 h-6 lg:w-9 lg:h-9" strokeWidth={2.5} />
+                           <div className="size-14 lg:w-20 lg:h-20 bg-fun-yellow rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-fun-dark transform rotate-3 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
+                              <BedDouble className="size-6 lg:w-9 lg:h-9" strokeWidth={2.5} />
                            </div>
                            <div>
                               <h3 className="font-sans font-bold text-lg lg:text-2xl text-fun-dark">Hotel Top</h3>
@@ -106,12 +106,12 @@ const Solution: React.FC = () => {
                            </div>
                         </div>
                         <div className="w-0 border-l-2 border-dashed border-gray-300 relative my-2">
-                           <div className="absolute -top-3 -left-1.5 w-3 h-3 bg-fun-blue rounded-full"></div>
-                           <div className="absolute -bottom-3 -left-1.5 w-3 h-3 bg-fun-blue rounded-full"></div>
+                           <div className="absolute -top-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
+                           <div className="absolute -bottom-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
                         </div>
                         <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
-                           <div className="bg-green-100 text-green-600 border-2 border-green-500 w-8 h-8 lg:w-10 lg:h-10 rounded-full flex items-center justify-center transform -rotate-6 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
-                              <Check className="w-[18px] h-[18px] lg:w-6 lg:h-6" strokeWidth={3} />
+                           <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:w-10 lg:h-10 rounded-full flex items-center justify-center transform -rotate-6 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
+                              <Check className="size-[18px] lg:w-6 lg:h-6" strokeWidth={3} />
                            </div>
                         </div>
                      </div>
@@ -132,8 +132,8 @@ const Solution: React.FC = () => {
                      >
                         <div className="p-3 pl-4 lg:p-6 lg:pl-8 flex-grow flex items-center gap-4 lg:gap-6">
                            {/* Redesigned Icon: Pink Circle Token */}
-                           <div className="w-14 h-14 lg:w-20 lg:h-20 bg-fun-pink rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-3 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
-                              <Ticket className="w-6 h-6 lg:w-9 lg:h-9" strokeWidth={2.5} />
+                           <div className="size-14 lg:w-20 lg:h-20 bg-fun-pink rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-3 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
+                              <Ticket className="size-6 lg:w-9 lg:h-9" strokeWidth={2.5} />
                            </div>
                            <div>
                               <h3 className="font-sans font-bold text-lg lg:text-2xl text-fun-dark">Ingresso Oficial</h3>
@@ -141,12 +141,12 @@ const Solution: React.FC = () => {
                            </div>
                         </div>
                         <div className="w-0 border-l-2 border-dashed border-gray-300 relative my-2">
-                           <div className="absolute -top-3 -left-1.5 w-3 h-3 bg-fun-blue rounded-full"></div>
-                           <div className="absolute -bottom-3 -left-1.5 w-3 h-3 bg-fun-blue rounded-full"></div>
+                           <div className="absolute -top-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
+                           <div className="absolute -bottom-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
                         </div>
                         <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
-                           <div className="bg-green-100 text-green-600 border-2 border-green-500 w-8 h-8 lg:w-10 lg:h-10 rounded-full flex items-center justify-center transform rotate-3 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
-                              <Check className="w-[18px] h-[18px] lg:w-6 lg:h-6" strokeWidth={3} />
+                           <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:w-10 lg:h-10 rounded-full flex items-center justify-center transform rotate-3 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
+                              <Check className="size-[18px] lg:w-6 lg:h-6" strokeWidth={3} />
                            </div>
                         </div>
                      </div>
@@ -199,8 +199,8 @@ const Solution: React.FC = () => {
                <div className="lg:w-1/2 relative flex justify-center mt-12 lg:mt-0">
 
                   {/* Decorative Elements behind phone */}
-                  <div className="absolute top-10 right-0 w-32 h-32 bg-fun-yellow rounded-full border-2 border-fun-dark mix-blend-multiply opacity-80 animate-pulse"></div>
-                  <div className="absolute bottom-10 left-10 w-20 h-20 bg-fun-pink rounded-full border-2 border-fun-dark mix-blend-multiply opacity-80"></div>
+                  <div className="absolute top-10 right-0 size-32 bg-fun-yellow rounded-full border-2 border-fun-dark mix-blend-multiply opacity-80 animate-pulse"></div>
+                  <div className="absolute bottom-10 left-10 size-20 bg-fun-pink rounded-full border-2 border-fun-dark mix-blend-multiply opacity-80"></div>
 
                   {/* The Phone */}
                   <div className="bg-white p-3 rounded-[3rem] border-4 border-fun-dark shadow-hard-lg max-w-sm w-full relative z-10 transform rotate-2 transition-transform hover:rotate-0 duration-500">
@@ -210,13 +210,13 @@ const Solution: React.FC = () => {
 
                         {/* Header */}
                         <div className="bg-fun-green p-4 pt-8 flex items-center gap-3 border-b-2 border-fun-dark">
-                           <div className="w-10 h-10 bg-white rounded-full flex items-center justify-center border-2 border-fun-dark">
+                           <div className="size-10 bg-white rounded-full flex items-center justify-center border-2 border-fun-dark">
                               <span className="font-bold text-fun-green text-lg">A</span>
                            </div>
                            <div>
                               <p className="font-bold text-white text-sm leading-tight">Anhangá Viagens</p>
                               <p className="text-green-100 text-xs flex items-center gap-1">
-                                 <span className="w-2 h-2 bg-green-300 rounded-full animate-pulse"></span> Online agora
+                                 <span className="size-2 bg-green-300 rounded-full animate-pulse"></span> Online agora
                               </p>
                            </div>
                         </div>
@@ -258,7 +258,7 @@ const Solution: React.FC = () => {
                         {/* Footer Input */}
                         <div className="p-3 bg-white border-t border-gray-200 flex items-center gap-2">
                            <div className="w-full h-10 bg-gray-100 rounded-full border border-gray-300"></div>
-                           <div className="w-10 h-10 bg-fun-blue rounded-full flex items-center justify-center text-white">
+                           <div className="size-10 bg-fun-blue rounded-full flex items-center justify-center text-white">
                               <Send size={18} />
                            </div>
                         </div>
@@ -319,9 +319,9 @@ const Solution: React.FC = () => {
 
                      {/* Item 1: Floripa */}
                      <div className="group bg-white p-5 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 flex items-center gap-5 cursor-default relative overflow-hidden">
-                        <div className="absolute right-0 top-0 w-16 h-16 bg-fun-yellow/20 rounded-bl-full z-0"></div>
+                        <div className="absolute right-0 top-0 size-16 bg-fun-yellow/20 rounded-bl-full z-0"></div>
 
-                        <div className="w-16 h-16 bg-fun-yellow border-2 border-fun-dark rounded-full flex items-center justify-center shadow-sm shrink-0 z-10 group-hover:rotate-12 transition-transform duration-300">
+                        <div className="size-16 bg-fun-yellow border-2 border-fun-dark rounded-full flex items-center justify-center shadow-sm shrink-0 z-10 group-hover:rotate-12 transition-transform duration-300">
                            <Sun size={32} className="text-fun-dark" strokeWidth={2.5} />
                         </div>
                         <div className="z-10">
@@ -332,9 +332,9 @@ const Solution: React.FC = () => {
 
                      {/* Item 2: Bombinhas */}
                      <div className="group bg-white p-5 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 flex items-center gap-5 cursor-default relative overflow-hidden">
-                        <div className="absolute right-0 top-0 w-16 h-16 bg-fun-green/20 rounded-bl-full z-0"></div>
+                        <div className="absolute right-0 top-0 size-16 bg-fun-green/20 rounded-bl-full z-0"></div>
 
-                        <div className="w-16 h-16 bg-fun-green border-2 border-fun-dark rounded-full flex items-center justify-center shadow-sm shrink-0 z-10 group-hover:-rotate-12 transition-transform duration-300">
+                        <div className="size-16 bg-fun-green border-2 border-fun-dark rounded-full flex items-center justify-center shadow-sm shrink-0 z-10 group-hover:-rotate-12 transition-transform duration-300">
                            <Fish size={32} className="text-white" strokeWidth={2.5} />
                         </div>
                         <div className="z-10">
@@ -345,9 +345,9 @@ const Solution: React.FC = () => {
 
                      {/* Item 3: Balneário */}
                      <div className="group bg-white p-5 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 flex items-center gap-5 cursor-default relative overflow-hidden">
-                        <div className="absolute right-0 top-0 w-16 h-16 bg-fun-blue/20 rounded-bl-full z-0"></div>
+                        <div className="absolute right-0 top-0 size-16 bg-fun-blue/20 rounded-bl-full z-0"></div>
 
-                        <div className="w-16 h-16 bg-fun-blue border-2 border-fun-dark rounded-full flex items-center justify-center shadow-sm shrink-0 z-10 group-hover:rotate-6 transition-transform duration-300">
+                        <div className="size-16 bg-fun-blue border-2 border-fun-dark rounded-full flex items-center justify-center shadow-sm shrink-0 z-10 group-hover:rotate-6 transition-transform duration-300">
                            <Building2 size={32} className="text-white" strokeWidth={2.5} />
                         </div>
                         <div className="z-10">

--- a/components/landings/beto-carrero/Testimonials.tsx
+++ b/components/landings/beto-carrero/Testimonials.tsx
@@ -62,7 +62,7 @@ const Testimonials: React.FC = () => {
                  <div className={`absolute -top-4 left-1/2 -translate-x-1/2 w-32 h-10 ${tapeColors[idx % 3]} backdrop-blur-sm shadow-sm transform -rotate-1 border-l-2 border-r-2 border-white/20 z-20`}></div>
 
                  {/* Giant Quote Icon Background */}
-                 <Quote className="absolute top-8 left-6 text-gray-100 w-24 h-24 rotate-12 z-0 pointer-events-none" />
+                 <Quote className="absolute top-8 left-6 text-gray-100 size-24 rotate-12 z-0 pointer-events-none" />
 
                  {/* Stars */}
                  <div className="flex gap-1 mb-6 text-fun-yellow relative z-10">
@@ -77,7 +77,7 @@ const Testimonials: React.FC = () => {
                  {/* Author & Verification */}
                  <div className="flex items-center gap-4 border-t-2 border-dashed border-gray-200 pt-6 mt-auto relative z-10">
                    <div className="relative">
-                      <img src={t.avatar} alt={t.name} width="56" height="56" loading="lazy" className="w-14 h-14 rounded-full border-2 border-fun-dark shadow-sm" />
+                      <img src={t.avatar} alt={t.name} width="56" height="56" loading="lazy" className="size-14 rounded-full border-2 border-fun-dark shadow-sm" />
                       <div className="absolute -bottom-1 -right-1 bg-fun-blue text-white rounded-full p-0.5 border border-white">
                         <CheckCircle2 size={12} strokeWidth={4} />
                       </div>

--- a/components/landings/lollapalooza/LineupSection.tsx
+++ b/components/landings/lollapalooza/LineupSection.tsx
@@ -118,7 +118,7 @@ const LineupSection: React.FC = () => {
           <div className="flex justify-center items-center -space-x-4 mb-8" aria-hidden="true">
             {headliners.slice(0, 5).map((artist) => (
               <div key={artist.name} className="relative z-0 hover:z-10 transition-all duration-300 transform hover:scale-110 hover:-translate-y-2 group">
-                <div className="size-16 md:w-24 md:h-24 rounded-full border-4 border-black group-hover:border-anhanga-yellow overflow-hidden relative shadow-lg">
+                <div className="size-16 md:size-24 rounded-full border-4 border-black group-hover:border-anhanga-yellow overflow-hidden relative shadow-lg">
                   <img
                     src={getArtistImageUrl(artist.image, 96, 96)}
                     alt={`Foto de ${artist.name}`}
@@ -133,7 +133,7 @@ const LineupSection: React.FC = () => {
                 </div>
               </div>
             ))}
-            <div className="relative z-0 size-16 md:w-24 md:h-24 rounded-full border-4 border-black bg-anhanga-yellow flex flex-col items-center justify-center text-anhanga-darkBlue shadow-lg transform hover:scale-105 transition-transform">
+            <div className="relative z-0 size-16 md:size-24 rounded-full border-4 border-black bg-anhanga-yellow flex flex-col items-center justify-center text-anhanga-darkBlue shadow-lg transform hover:scale-105 transition-transform">
               <span className="font-black text-lg md:text-2xl leading-none">+50</span>
               <span className="text-[10px] font-bold uppercase tracking-wider">Stars</span>
             </div>

--- a/components/landings/lollapalooza/LineupSection.tsx
+++ b/components/landings/lollapalooza/LineupSection.tsx
@@ -108,8 +108,8 @@ const LineupSection: React.FC = () => {
   return (
     <section id="lineup" className="py-20 bg-gray-950 text-white relative overflow-hidden" aria-labelledby="lineup-heading" ref={elementRef}>
       {/* Decorative blobs */}
-      <div className="absolute top-0 right-0 w-64 h-64 bg-anhanga-blue opacity-20 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2" aria-hidden="true"></div>
-      <div className="absolute bottom-0 left-0 w-96 h-96 bg-anhanga-yellow opacity-10 rounded-full blur-3xl translate-y-1/2 -translate-x-1/2" aria-hidden="true"></div>
+      <div className="absolute top-0 right-0 size-64 bg-anhanga-blue opacity-20 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2" aria-hidden="true"></div>
+      <div className="absolute bottom-0 left-0 size-96 bg-anhanga-yellow opacity-10 rounded-full blur-3xl translate-y-1/2 -translate-x-1/2" aria-hidden="true"></div>
 
       <div className="container mx-auto px-4 relative z-10">
         {/* Headline Section */}
@@ -118,7 +118,7 @@ const LineupSection: React.FC = () => {
           <div className="flex justify-center items-center -space-x-4 mb-8" aria-hidden="true">
             {headliners.slice(0, 5).map((artist) => (
               <div key={artist.name} className="relative z-0 hover:z-10 transition-all duration-300 transform hover:scale-110 hover:-translate-y-2 group">
-                <div className="w-16 h-16 md:w-24 md:h-24 rounded-full border-4 border-black group-hover:border-anhanga-yellow overflow-hidden relative shadow-lg">
+                <div className="size-16 md:w-24 md:h-24 rounded-full border-4 border-black group-hover:border-anhanga-yellow overflow-hidden relative shadow-lg">
                   <img
                     src={getArtistImageUrl(artist.image, 96, 96)}
                     alt={`Foto de ${artist.name}`}
@@ -133,7 +133,7 @@ const LineupSection: React.FC = () => {
                 </div>
               </div>
             ))}
-            <div className="relative z-0 w-16 h-16 md:w-24 md:h-24 rounded-full border-4 border-black bg-anhanga-yellow flex flex-col items-center justify-center text-anhanga-darkBlue shadow-lg transform hover:scale-105 transition-transform">
+            <div className="relative z-0 size-16 md:w-24 md:h-24 rounded-full border-4 border-black bg-anhanga-yellow flex flex-col items-center justify-center text-anhanga-darkBlue shadow-lg transform hover:scale-105 transition-transform">
               <span className="font-black text-lg md:text-2xl leading-none">+50</span>
               <span className="text-[10px] font-bold uppercase tracking-wider">Stars</span>
             </div>
@@ -206,7 +206,7 @@ const LineupSection: React.FC = () => {
                 <div className="mb-6 space-y-4">
                   {day.main.map((act) => (
                     <div key={act.name} className="flex items-center gap-4 group/artist">
-                      <div className="w-12 h-12 rounded-full overflow-hidden border-2 border-gray-700 group-hover/artist:border-anhanga-yellow transition-colors shrink-0 bg-gray-800">
+                      <div className="size-12 rounded-full overflow-hidden border-2 border-gray-700 group-hover/artist:border-anhanga-yellow transition-colors shrink-0 bg-gray-800">
                         <img
                           src={getArtistImageUrl(act.image, 100, 100)}
                           alt={act.name}
@@ -248,7 +248,7 @@ const LineupSection: React.FC = () => {
               <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 {['Chegada tranquila ao Autódromo', 'Descanso em hotel 4 estrelas', 'Suporte local para imprevistos', 'After-parties sugeridas'].map((item) => (
                   <li key={item} className="flex items-center gap-3 text-base text-gray-200">
-                    <span className="flex-shrink-0 w-5 h-5 rounded-full bg-anhanga-blue flex items-center justify-center text-xs font-bold" aria-hidden="true">✓</span>
+                    <span className="flex-shrink-0 size-5 rounded-full bg-anhanga-blue flex items-center justify-center text-xs font-bold" aria-hidden="true">✓</span>
                     {item}
                   </li>
                 ))}

--- a/components/landings/lollapalooza/PackageFeatures.tsx
+++ b/components/landings/lollapalooza/PackageFeatures.tsx
@@ -66,8 +66,8 @@ const PackageFeatures: React.FC = () => {
     <section id="pacote" className="bg-gray-950 py-20 relative overflow-hidden" ref={elementRef}>
       {/* Abstract Background Elements */}
       <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
-        <div className="absolute top-[-10%] left-[-10%] w-[50%] h-[50%] bg-anhanga-blue rounded-full blur-[120px] opacity-20"></div>
-        <div className="absolute bottom-[-10%] right-[-10%] w-[50%] h-[50%] bg-anhanga-yellow rounded-full blur-[120px] opacity-10"></div>
+        <div className="absolute top-[-10%] left-[-10%] size-[50%] bg-anhanga-blue rounded-full blur-[120px] opacity-20"></div>
+        <div className="absolute bottom-[-10%] right-[-10%] size-[50%] bg-anhanga-yellow rounded-full blur-[120px] opacity-10"></div>
       </div>
 
       <div className="container mx-auto px-4 relative z-10">

--- a/components/landings/lollapalooza/VenueMap.tsx
+++ b/components/landings/lollapalooza/VenueMap.tsx
@@ -296,7 +296,7 @@ const VenueMap: React.FC = () => {
                     <div className="relative z-10 p-3 flex items-center justify-between">
                       <div className="flex items-center gap-3">
                         <div
-                          className="w-8 h-8 rounded-full flex items-center justify-center shadow-sm transition-colors shrink-0"
+                          className="size-8 rounded-full flex items-center justify-center shadow-sm transition-colors shrink-0"
                           style={{
                             backgroundColor: activeIndex === idx ? '#0056D2' : style.bgColor,
                             color: activeIndex === idx ? 'white' : style.iconColor

--- a/components/landings/lollapalooza/WaitlistSection.tsx
+++ b/components/landings/lollapalooza/WaitlistSection.tsx
@@ -134,8 +134,8 @@ const WaitlistSection: React.FC = () => {
             className="relative lg:mt-0 mt-12"
           >
             {/* Geometric Accent Decoration */}
-            <div className="absolute -top-6 -left-6 w-24 h-24 border-t-2 border-l-2 border-anhanga-yellow z-0 opacity-50" />
-            <div className="absolute -bottom-6 -right-6 w-24 h-24 border-b-2 border-r-2 border-anhanga-blue z-0 opacity-50" />
+            <div className="absolute -top-6 -left-6 size-24 border-t-2 border-l-2 border-anhanga-yellow z-0 opacity-50" />
+            <div className="absolute -bottom-6 -right-6 size-24 border-b-2 border-r-2 border-anhanga-blue z-0 opacity-50" />
 
             <div className="relative z-10 flex flex-col bg-anhanga-darkBlue/50 backdrop-blur-xl border border-white/10 ring-1 ring-white/5 p-8 md:p-10">
               <div className="mb-10 text-center lg:text-left">
@@ -192,7 +192,7 @@ const WaitlistSection: React.FC = () => {
                       onChange={(event) => setAcceptedLgpd(event.target.checked)}
                       className="peer sr-only"
                     />
-                    <div className="h-5 w-5 border-2 border-white/20 peer-checked:border-anhanga-yellow peer-checked:bg-anhanga-yellow transition-all duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-anhanga-yellow peer-focus-visible:outline-offset-2" />
+                    <div className="size-5 border-2 border-white/20 peer-checked:border-anhanga-yellow peer-checked:bg-anhanga-yellow transition-all duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-anhanga-yellow peer-focus-visible:outline-offset-2" />
                     <CheckCircle2 size={12} className="absolute text-black opacity-0 peer-checked:opacity-100 transition-opacity" />
                   </div>
                   <span className="text-xs text-gray-400 leading-snug group-hover:text-gray-300 transition-colors">

--- a/components/landings/lollapalooza/WhyUs.tsx
+++ b/components/landings/lollapalooza/WhyUs.tsx
@@ -51,7 +51,7 @@ const WhyUs: React.FC = () => {
               ].map((item) => (
                 <div key={item.title} className="flex gap-4 group">
                   <div className="flex-shrink-0 mt-1">
-                    <div className={`w-12 h-12 ${item.color === 'yellow' ? 'bg-yellow-100 text-anhanga-darkBlue group-hover:bg-anhanga-yellow' : item.color === 'blue' ? 'bg-blue-100 text-anhanga-blue group-hover:bg-anhanga-blue group-hover:text-white' : 'bg-green-100 text-green-600 group-hover:bg-green-500 group-hover:text-white'} transition-colors duration-300 rounded-full flex items-center justify-center`}>
+                    <div className={`size-12 ${item.color === 'yellow' ? 'bg-yellow-100 text-anhanga-darkBlue group-hover:bg-anhanga-yellow' : item.color === 'blue' ? 'bg-blue-100 text-anhanga-blue group-hover:bg-anhanga-blue group-hover:text-white' : 'bg-green-100 text-green-600 group-hover:bg-green-500 group-hover:text-white'} transition-colors duration-300 rounded-full flex items-center justify-center`}>
                       <item.Icon size={24} aria-hidden="true" />
                     </div>
                   </div>

--- a/components/ui/BackToTop.tsx
+++ b/components/ui/BackToTop.tsx
@@ -51,7 +51,7 @@ const BackToTop: React.FC = () => {
         ${isVisible ? 'opacity-100 translate-y-0 pointer-events-auto' : 'opacity-0 translate-y-4 pointer-events-none'}
       `}
     >
-      <CaretUp className="w-6 h-6" weight="bold" />
+      <CaretUp className="size-6" weight="bold" />
     </button>
   );
 };

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -62,7 +62,7 @@ export const Button: React.FC<ButtonProps> = ({
         >
             {isLoading ? (
                 <>
-                    <CircleNotch className="w-4 h-4 animate-spin" weight="bold" aria-hidden="true" />
+                    <CircleNotch className="size-4 animate-spin" weight="bold" aria-hidden="true" />
                     {children}
                 </>
             ) : (

--- a/components/ui/LazyImage.tsx
+++ b/components/ui/LazyImage.tsx
@@ -74,7 +74,7 @@ export const LazyImage = React.memo<LazyImageProps>(({
         >
             {!isLoaded && (
                 <div className={`absolute inset-0 flex items-center justify-center z-10 ${placeholderClassName}`}>
-                    <ImageIcon className="w-8 h-8 text-gray-400 opacity-40" />
+                    <ImageIcon className="size-8 text-gray-400 opacity-40" />
                 </div>
             )}
             {isVisible && (

--- a/components/ui/PassportStamp.tsx
+++ b/components/ui/PassportStamp.tsx
@@ -41,7 +41,7 @@ export const PassportStamp: React.FC<PassportStampProps> = ({
         }
       `}} />
 
-            <div className="relative w-24 h-24 md:w-28 md:h-28 shrink-0">
+            <div className="relative size-24 md:w-28 md:h-28 shrink-0">
                 {/* Outer distressed ring */}
                 <div className="absolute inset-0 rounded-full border-[3px] border-brand-vibrant border-dashed opacity-80" style={{ clipPath: 'polygon(0% 0%, 100% 0%, 100% 90%, 80% 100%, 0% 100%)' }}></div>
                 <div className="absolute inset-1 rounded-full border-[2px] border-brand-vibrant opacity-60"></div>

--- a/components/ui/PassportStamp.tsx
+++ b/components/ui/PassportStamp.tsx
@@ -41,7 +41,7 @@ export const PassportStamp: React.FC<PassportStampProps> = ({
         }
       `}} />
 
-            <div className="relative size-24 md:w-28 md:h-28 shrink-0">
+            <div className="relative size-24 md:size-28 shrink-0">
                 {/* Outer distressed ring */}
                 <div className="absolute inset-0 rounded-full border-[3px] border-brand-vibrant border-dashed opacity-80" style={{ clipPath: 'polygon(0% 0%, 100% 0%, 100% 90%, 80% 100%, 0% 100%)' }}></div>
                 <div className="absolute inset-1 rounded-full border-[2px] border-brand-vibrant opacity-60"></div>

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -66,7 +66,7 @@ const About: React.FC = () => {
           <div className="inline-block relative mb-6">
             <span className="absolute inset-0 bg-brand-cyan/20 transform -skew-x-12 rounded-lg"></span>
             <span className="relative px-4 py-1 text-brand-dark font-black uppercase tracking-widest text-sm flex items-center gap-2">
-              <Sparkles className="w-4 h-4 text-brand-cyan" /> Nossa Essência
+              <Sparkles className="size-4 text-brand-cyan" /> Nossa Essência
             </span>
           </div>
           <h1 className="text-5xl md:text-6xl font-black text-brand-dark mb-6 leading-tight">
@@ -85,7 +85,7 @@ const About: React.FC = () => {
               data-tracking="hero-about"
             >
               Solicitar Orçamento
-              <Sparkles className="w-5 h-5" />
+              <Sparkles className="size-5" />
             </button>
           </div>
         </m.section>
@@ -102,7 +102,7 @@ const About: React.FC = () => {
               custom={1}
             >
               <div className="relative">
-                <div className="absolute -top-4 -left-4 w-24 h-24 bg-brand-yellow/30 rounded-full blur-2xl z-0"></div>
+                <div className="absolute -top-4 -left-4 size-24 bg-brand-yellow/30 rounded-full blur-2xl z-0"></div>
                 <div className="relative rounded-3xl overflow-hidden border-8 border-white shadow-2xl rotate-2 hover:rotate-0 transition-transform duration-500">
                   <LazyImage
                     src="images/about/equipe-anhanga.jpg"
@@ -112,8 +112,8 @@ const About: React.FC = () => {
                 </div>
                 <div className="absolute -bottom-6 -right-6 bg-white p-6 rounded-2xl shadow-xl border border-gray-100 hidden md:block">
                   <div className="flex items-center gap-4">
-                    <div className="w-12 h-12 bg-brand-cyan/10 rounded-full flex items-center justify-center text-brand-cyan">
-                      <Heart className="w-6 h-6 fill-current" />
+                    <div className="size-12 bg-brand-cyan/10 rounded-full flex items-center justify-center text-brand-cyan">
+                      <Heart className="size-6 fill-current" />
                     </div>
                     <div>
                       <p className="text-xs font-bold text-gray-400 uppercase tracking-wider">Paixão por</p>
@@ -192,8 +192,8 @@ const About: React.FC = () => {
                 variants={fadeUp}
                 custom={i + 1}
               >
-                <div className={`w-14 h-14 rounded-2xl ${item.color} flex items-center justify-center mb-6`}>
-                  <item.icon className="w-8 h-8" />
+                <div className={`size-14 rounded-2xl ${item.color} flex items-center justify-center mb-6`}>
+                  <item.icon className="size-8" />
                 </div>
                 <h3 className="text-xl font-black text-brand-dark mb-4">{item.title}</h3>
                 <p className="text-gray-500 font-medium leading-relaxed">{item.desc}</p>
@@ -204,13 +204,13 @@ const About: React.FC = () => {
 
         {/* TRUST & COMPLIANCE SECTION */}
         <section id="certificacoes" className="bg-brand-dark rounded-[3rem] p-12 md:p-20 text-white overflow-hidden relative">
-          <div className="absolute top-0 right-0 w-64 h-64 bg-brand-vibrant/20 blur-[100px] rounded-full"></div>
-          <div className="absolute bottom-0 left-0 w-64 h-64 bg-brand-cyan/10 blur-[100px] rounded-full"></div>
+          <div className="absolute top-0 right-0 size-64 bg-brand-vibrant/20 blur-[100px] rounded-full"></div>
+          <div className="absolute bottom-0 left-0 size-64 bg-brand-cyan/10 blur-[100px] rounded-full"></div>
 
           <div className="relative z-10 flex flex-col lg:flex-row gap-16 items-center">
             <div className="w-full lg:w-1/2">
               <div className="inline-flex items-center gap-2 px-4 py-1 bg-white/10 rounded-full text-brand-cyan text-sm font-bold mb-6">
-                <Award className="w-4 h-4" /> Credibilidade & Confiança
+                <Award className="size-4" /> Credibilidade & Confiança
               </div>
               <h2 className="text-3xl md:text-4xl font-black mb-6">Agência Certificada</h2>
               <p className="text-gray-300 text-lg font-medium leading-relaxed mb-8">
@@ -219,8 +219,8 @@ const About: React.FC = () => {
 
               <ul className="space-y-6">
                 <li className="flex items-start gap-4">
-                  <div className="w-6 h-6 rounded-full bg-brand-cyan/20 flex items-center justify-center shrink-0 mt-1">
-                    <div className="w-2 h-2 rounded-full bg-brand-cyan"></div>
+                  <div className="size-6 rounded-full bg-brand-cyan/20 flex items-center justify-center shrink-0 mt-1">
+                    <div className="size-2 rounded-full bg-brand-cyan"></div>
                   </div>
                   <div>
                     <p className="font-bold text-lg leading-none mb-1">Cadastur Oficial</p>
@@ -228,8 +228,8 @@ const About: React.FC = () => {
                   </div>
                 </li>
                 <li className="flex items-start gap-4">
-                  <div className="w-6 h-6 rounded-full bg-brand-cyan/20 flex items-center justify-center shrink-0 mt-1">
-                    <div className="w-2 h-2 rounded-full bg-brand-cyan"></div>
+                  <div className="size-6 rounded-full bg-brand-cyan/20 flex items-center justify-center shrink-0 mt-1">
+                    <div className="size-2 rounded-full bg-brand-cyan"></div>
                   </div>
                   <div>
                     <p className="font-bold text-lg leading-none mb-1">Sede Própria em São Paulo</p>
@@ -241,13 +241,13 @@ const About: React.FC = () => {
 
             <div className="w-full lg:w-1/2 grid grid-cols-2 gap-4">
               <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
-                <Award className="w-12 h-12 text-brand-cyan mb-4" />
+                <Award className="size-12 text-brand-cyan mb-4" />
                 <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Membro Oficial</p>
                 <p className="font-black text-xl">Beto Carrero World</p>
                 <p className="text-xs text-brand-cyan mt-1">Agente Credenciado</p>
               </div>
               <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
-                <Coffee className="w-12 h-12 text-brand-yellow mb-4" />
+                <Coffee className="size-12 text-brand-yellow mb-4" />
                 <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Localizada em</p>
                 <p className="font-black text-xl">São Paulo - SP</p>
                 <p className="text-xs text-brand-yellow mt-1">Atendimento Presencial</p>
@@ -286,7 +286,7 @@ const About: React.FC = () => {
               data-tracking="footer-about"
             >
               Começar Planejamento
-              <Sparkles className="w-5 h-5" />
+              <Sparkles className="size-5" />
             </button>
           </div>
         </m.section>

--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -48,7 +48,7 @@ const BlogList: React.FC = () => {
                 {/* Header */}
                 <div className="text-center mb-16 max-w-3xl mx-auto">
                     <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border-2 border-brand-dark bg-brand-yellow text-brand-dark font-black text-xs uppercase tracking-widest shadow-[4px_4px_0px_#0f172a] transform -rotate-1 mb-4">
-                        <BookOpen className="w-4 h-4" /> Todos os Artigos
+                        <BookOpen className="size-4" /> Todos os Artigos
                     </div>
                     <h1 className="text-3xl md:text-5xl lg:text-6xl font-black text-brand-dark mb-6">
                         Diário de <span className="text-brand-cyan">Bordo</span>
@@ -68,7 +68,7 @@ const BlogList: React.FC = () => {
                             onChange={(e) => setSearchTerm(e.target.value)}
                             className="w-full px-6 py-4 rounded-full border-2 border-gray-200 focus:border-brand-cyan focus:outline-none shadow-sm pl-12 text-gray-700 font-medium transition-all"
                         />
-                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5" />
+                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 size-5" />
                     </div>
                 </div>
 
@@ -125,10 +125,10 @@ const BlogList: React.FC = () => {
 
                                     <div className="pt-4 border-t border-dashed border-gray-100 flex items-center justify-between">
                                         <span className="text-xs font-bold text-gray-400 flex items-center gap-1">
-                                            <User className="w-3 h-3" /> {AUTHORS[post.author]?.name ?? post.author}
+                                            <User className="size-3" /> {AUTHORS[post.author]?.name ?? post.author}
                                         </span>
-                                        <span className="w-10 h-10 rounded-full flex items-center justify-center transition-colors bg-gray-100 text-gray-400 group-hover:bg-brand-cyan group-hover:text-white">
-                                            <ArrowRight className="w-5 h-5" />
+                                        <span className="size-10 rounded-full flex items-center justify-center transition-colors bg-gray-100 text-gray-400 group-hover:bg-brand-cyan group-hover:text-white">
+                                            <ArrowRight className="size-5" />
                                         </span>
                                     </div>
                                 </div>

--- a/pages/BlogPost.tsx
+++ b/pages/BlogPost.tsx
@@ -64,7 +64,7 @@ const BlogPost: React.FC = () => {
             <div className="min-h-screen flex flex-col items-center justify-center bg-[#fffdf5]">
                 <h2 className="text-4xl font-black text-brand-dark mb-4 text-center px-6">Ops! Artigo não encontrado.</h2>
                 <a href={getBlogHomeUrl()} className="text-brand-cyan font-bold hover:underline flex items-center gap-2">
-                    <ArrowLeft className="w-4 h-4" /> Voltar para o Blog
+                    <ArrowLeft className="size-4" /> Voltar para o Blog
                 </a>
             </div>
         );

--- a/pages/NotFound.tsx
+++ b/pages/NotFound.tsx
@@ -25,12 +25,12 @@ const NotFound: React.FC = () => {
 
       <section data-testid="not-found-section" className="min-h-[70vh] flex items-center justify-center pt-48 pb-20 px-6 bg-brand-light relative overflow-hidden">
         {/* Background Decorations */}
-        <div className="absolute top-20 left-10 w-64 h-64 bg-brand-cyan/5 rounded-full blur-3xl animate-blob"></div>
-        <div className="absolute bottom-20 right-10 w-80 h-80 bg-brand-yellow/5 rounded-full blur-3xl animate-blob" style={{ animationDelay: '2s' }}></div>
+        <div className="absolute top-20 left-10 size-64 bg-brand-cyan/5 rounded-full blur-3xl animate-blob"></div>
+        <div className="absolute bottom-20 right-10 size-80 bg-brand-yellow/5 rounded-full blur-3xl animate-blob" style={{ animationDelay: '2s' }}></div>
 
         <div className="container mx-auto max-w-4xl text-center relative z-10">
-          <div className="inline-flex items-center justify-center w-24 h-24 rounded-full bg-white shadow-xl mb-8 animate-float">
-            <Compass className="w-12 h-12 text-brand-cyan" />
+          <div className="inline-flex items-center justify-center size-24 rounded-full bg-white shadow-xl mb-8 animate-float">
+            <Compass className="size-12 text-brand-cyan" />
           </div>
 
           <h1 className="text-5xl md:text-7xl font-black text-brand-dark mb-6 leading-tight">
@@ -47,8 +47,8 @@ const NotFound: React.FC = () => {
               href={`${SITE_URL}/`}
               className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition-all duration-300 group"
             >
-              <div className="w-12 h-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
-                <HomeIcon className="w-6 h-6" />
+              <div className="size-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
+                <HomeIcon className="size-6" />
               </div>
               <div className="text-left">
                 <p className="font-bold text-brand-dark">Página Inicial</p>
@@ -60,8 +60,8 @@ const NotFound: React.FC = () => {
               href={getBlogHomeUrl()}
               className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition-all duration-300 group"
             >
-              <div className="w-12 h-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
-                <BookOpen className="w-6 h-6" />
+              <div className="size-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
+                <BookOpen className="size-6" />
               </div>
               <div className="text-left">
                 <p className="font-bold text-brand-dark">Blog de Viagens</p>
@@ -73,8 +73,8 @@ const NotFound: React.FC = () => {
               href={`${SITE_URL}/orlando/`}
               className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition-all duration-300 group"
             >
-              <div className="w-12 h-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
-                <MapPin className="w-6 h-6" />
+              <div className="size-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
+                <MapPin className="size-6" />
               </div>
               <div className="text-left">
                 <p className="font-bold text-brand-dark">Orlando</p>
@@ -88,8 +88,8 @@ const NotFound: React.FC = () => {
                 href={`${SITE_URL}/beto-carrero/`}
                 className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition-all duration-300 group"
               >
-                <div className="w-12 h-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
-                  <MapPin className="w-6 h-6" />
+                <div className="size-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
+                  <MapPin className="size-6" />
                 </div>
                 <div className="text-left">
                   <p className="font-bold text-brand-dark">Beto Carrero</p>
@@ -101,8 +101,8 @@ const NotFound: React.FC = () => {
                 href={`${SITE_URL}/lollapalooza/`}
                 className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition-all duration-300 group"
               >
-                <div className="w-12 h-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
-                  <MapPin className="w-6 h-6" />
+                <div className="size-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
+                  <MapPin className="size-6" />
                 </div>
                 <div className="text-left">
                   <p className="font-bold text-brand-dark">Lollapalooza</p>
@@ -116,7 +116,7 @@ const NotFound: React.FC = () => {
             href={`${SITE_URL}/`}
             className="inline-flex items-center gap-2 text-brand-cyan font-bold hover:gap-4 transition-all duration-300"
           >
-            <ArrowLeft className="w-5 h-5" />
+            <ArrowLeft className="size-5" />
             Voltar para a Home
           </a>
         </div>

--- a/pages/landings/BrazilPromotionDayLanding.tsx
+++ b/pages/landings/BrazilPromotionDayLanding.tsx
@@ -170,7 +170,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                             data-contact-intent
                             data-tracking="header-brazil-promotion-day"
                         >
-                            <WhatsappLogo className="w-4 h-4" weight="fill" />
+                            <WhatsappLogo className="size-4" weight="fill" />
                             Falar no WhatsApp
                         </button>
                     </div>
@@ -192,11 +192,11 @@ const BrazilPromotionDayLanding: React.FC = () => {
                     {/* Decorative blobs */}
                     <div
                         aria-hidden="true"
-                        className="absolute top-0 right-0 w-[500px] h-[500px] rounded-full bg-blue-500/20 blur-3xl animate-blob"
+                        className="absolute top-0 right-0 size-[500px] rounded-full bg-blue-500/20 blur-3xl animate-blob"
                     />
                     <div
                         aria-hidden="true"
-                        className="absolute bottom-0 left-0 w-96 h-96 rounded-full bg-brand-yellow/10 blur-3xl animate-blob"
+                        className="absolute bottom-0 left-0 size-96 rounded-full bg-brand-yellow/10 blur-3xl animate-blob"
                         style={{ animationDelay: '4s' }}
                     />
 
@@ -213,7 +213,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                             >
                                 <span className="absolute inset-0 bg-brand-yellow/30 transform -skew-x-12 rounded-lg" />
                                 <span className="relative px-4 py-1.5 text-white font-black uppercase tracking-widest text-xs flex items-center gap-2">
-                                    <AirplaneTilt className="w-4 h-4" weight="fill" />
+                                    <AirplaneTilt className="size-4" weight="fill" />
                                     Brazil Promotion Day 2026
                                 </span>
                             </m.div>
@@ -256,7 +256,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                     data-contact-intent
                                     data-tracking="hero-brazil-promotion-day"
                                 >
-                                    <WhatsappLogo className="w-6 h-6" weight="fill" />
+                                    <WhatsappLogo className="size-6" weight="fill" />
                                     Falar com a gente agora
                                 </button>
                                 <a
@@ -264,7 +264,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                     className="btn-specialist flex items-center justify-center gap-2 border-2 border-white/40 text-white px-8 py-4 rounded-2xl font-bold text-lg hover:border-white hover:bg-white/10 transition-all duration-200"
                                 >
                                     Prefiro ser contatado
-                                    <ArrowRight className="w-5 h-5" />
+                                    <ArrowRight className="size-5" />
                                 </a>
                             </m.div>
 
@@ -336,7 +336,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                             <div className="inline-block relative mb-4">
                                 <span className="absolute inset-0 bg-blue-100 transform -skew-x-12 rounded-lg" />
                                 <span className="relative px-3 py-1 text-blue-600 font-black uppercase tracking-widest text-sm flex items-center gap-2">
-                                    <Sparkle className="w-4 h-4" weight="fill" /> O Jeito Anhangá
+                                    <Sparkle className="size-4" weight="fill" /> O Jeito Anhangá
                                 </span>
                             </div>
                             <h2 className="text-4xl md:text-5xl font-black text-brand-dark leading-tight">
@@ -376,10 +376,10 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                         <div className="absolute -top-3 left-1/2 -translate-x-1/2 w-24 h-6 bg-yellow-50/90 backdrop-blur-sm border-l-2 border-r-2 border-white/40 rotate-1 shadow-sm z-20 opacity-90" />
 
                                         <m.div
-                                            className={`w-16 h-16 rounded-2xl ${item.bg} border-2 ${item.accent} flex items-center justify-center mb-6 shadow-sm`}
+                                            className={`size-16 rounded-2xl ${item.bg} border-2 ${item.accent} flex items-center justify-center mb-6 shadow-sm`}
                                             whileHover={{ scale: 1.1, rotate: 6, transition: { type: 'spring', stiffness: 400, damping: 15 } }}
                                         >
-                                            <Icon className={`w-8 h-8 ${item.iconColor}`} weight="fill" />
+                                            <Icon className={`size-8 ${item.iconColor}`} weight="fill" />
                                         </m.div>
 
                                         <h3 className="text-xl font-extrabold text-gray-900 mb-3 leading-tight group-hover:text-brand-cyan transition-colors duration-300">
@@ -390,7 +390,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                         </p>
 
                                         <div className="absolute bottom-6 right-6 opacity-0 group-hover:opacity-100 transition-all duration-300 translate-x-4 group-hover:translate-x-0">
-                                            <ArrowRight className={`w-5 h-5 ${item.iconColor}`} />
+                                            <ArrowRight className={`size-5 ${item.iconColor}`} />
                                         </div>
                                     </m.div>
                                 );
@@ -416,7 +416,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                         <div className="max-w-5xl mx-auto flex flex-col md:flex-row items-center justify-between gap-8 bg-white/5 rounded-[2rem] p-10 border border-white/10">
                             <div>
                                 <p className="text-brand-yellow font-bold uppercase tracking-widest text-xs mb-3 flex items-center gap-2">
-                                    <AirplaneTilt className="w-4 h-4" weight="fill" />
+                                    <AirplaneTilt className="size-4" weight="fill" />
                                     Atendimento imediato
                                 </p>
                                 <h2 className="text-4xl md:text-5xl font-black text-white leading-tight">
@@ -431,7 +431,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                 data-contact-intent
                                 data-tracking="whatsapp-band-brazil-promotion-day"
                             >
-                                <WhatsappLogo className="w-6 h-6" weight="fill" />
+                                <WhatsappLogo className="size-6" weight="fill" />
                                 Abrir WhatsApp
                             </button>
                         </div>
@@ -460,7 +460,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                 <div className="inline-block relative mb-4">
                                     <span className="absolute inset-0 bg-emerald-100 transform -skew-x-12 rounded-lg" />
                                     <span className="relative px-3 py-1 text-emerald-600 font-black uppercase tracking-widest text-sm flex items-center gap-2">
-                                        <Sparkle className="w-4 h-4" weight="fill" /> Fale com a gente
+                                        <Sparkle className="size-4" weight="fill" /> Fale com a gente
                                     </span>
                                 </div>
 
@@ -482,8 +482,8 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                         { icon: MapPin, label: 'Av. Dom Pedro I, 773 — Vila Monumento, SP', href: null },
                                     ].map(({ icon: Icon, label, href }) => (
                                         <li key={label} className="flex items-start gap-4">
-                                            <div className="w-10 h-10 rounded-xl bg-blue-100 border-2 border-blue-200 flex items-center justify-center shrink-0 mt-0.5">
-                                                <Icon className="w-5 h-5 text-blue-600" weight="fill" />
+                                            <div className="size-10 rounded-xl bg-blue-100 border-2 border-blue-200 flex items-center justify-center shrink-0 mt-0.5">
+                                                <Icon className="size-5 text-blue-600" weight="fill" />
                                             </div>
                                             {href ? (
                                                 <a href={href} className="font-semibold text-gray-700 hover:text-brand-cyan transition-colors duration-150 pt-1.5">
@@ -512,11 +512,11 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                                 href={href}
                                                 target="_blank"
                                                 rel="noopener noreferrer"
-                                                className="w-11 h-11 rounded-xl bg-white border-2 border-gray-200 flex items-center justify-center text-gray-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-[4px_4px_0px_#fbbf24] hover:-translate-y-1 transition-all duration-200"
+                                                className="size-11 rounded-xl bg-white border-2 border-gray-200 flex items-center justify-center text-gray-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-[4px_4px_0px_#fbbf24] hover:-translate-y-1 transition-all duration-200"
                                                 aria-label={label}
                                                 {...(contact ? { 'data-contact-intent': true, 'data-tracking': 'social-whatsapp-brazil-promotion-day' } : {})}
                                             >
-                                                <Icon className="w-5 h-5" weight="fill" />
+                                                <Icon className="size-5" weight="fill" />
                                             </a>
                                         ))}
                                     </div>
@@ -539,7 +539,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                             animate={{ scale: 1, opacity: 1 }}
                                             transition={{ type: 'spring', stiffness: 400, damping: 20 }}
                                         >
-                                            <CheckCircle className="w-16 h-16 text-emerald-500 mb-4" weight="fill" />
+                                            <CheckCircle className="size-16 text-emerald-500 mb-4" weight="fill" />
                                         </m.div>
                                         <h3 className="text-2xl font-black text-brand-dark mb-3">
                                             Mensagem recebida! 🎉
@@ -555,7 +555,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                             data-contact-intent
                                             data-tracking="success-brazil-promotion-day"
                                         >
-                                            <WhatsappLogo className="w-4 h-4" weight="fill" />
+                                            <WhatsappLogo className="size-4" weight="fill" />
                                             Ou fale agora no WhatsApp →
                                         </a>
                                     </div>
@@ -564,7 +564,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                         {/* Form header strip */}
                                         <div className="flex justify-between items-center px-8 py-5 border-b-2 border-dashed border-gray-100">
                                             <span className="text-brand-cyan font-black tracking-widest text-sm uppercase flex items-center gap-2">
-                                                <AirplaneTilt className="w-4 h-4" weight="fill" /> Formulário de Contato
+                                                <AirplaneTilt className="size-4" weight="fill" /> Formulário de Contato
                                             </span>
                                             <span className="text-gray-400 font-bold text-xs uppercase">Brazil Promotion Day</span>
                                         </div>
@@ -664,12 +664,12 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                             >
                                                 {isSubmitting ? (
                                                     <>
-                                                        <SpinnerGap className="w-5 h-5 animate-spin" weight="bold" />
+                                                        <SpinnerGap className="size-5 animate-spin" weight="bold" />
                                                         Enviando…
                                                     </>
                                                 ) : (
                                                     <>
-                                                        <PaperPlaneTilt className="w-5 h-5" weight="fill" />
+                                                        <PaperPlaneTilt className="size-5" weight="fill" />
                                                         Quero ser contatado
                                                     </>
                                                 )}

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -111,9 +111,9 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             className="inline-flex items-center gap-2 group"
             aria-label="Voltar para o site principal da Anhangá Viagens"
           >
-            <ArrowLeft className="w-4 h-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
-            <span className="w-7 h-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
-              <img src="/favicon.svg" alt="" aria-hidden="true" className="w-4 h-4" />
+            <ArrowLeft className="size-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
+            <span className="size-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
+              <img src="/favicon.svg" alt="" aria-hidden="true" className="size-4" />
             </span>
             <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
               Anhangá Viagens
@@ -150,7 +150,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             data-tracking="hero-consultoria-viagem"
           >
             Falar com um consultor
-            <ArrowRight className="w-5 h-5" />
+            <ArrowRight className="size-5" />
           </button>
           <p className="mt-4 text-sm text-gray-600">Sem taxa de consultoria. Gratuito.</p>
         </div>
@@ -176,12 +176,12 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                 }`}
               >
                 <div
-                  className={`w-11 h-11 rounded-xl flex items-center justify-center mb-5 ${
+                  className={`size-11 rounded-xl flex items-center justify-center mb-5 ${
                     variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
                   }`}
                 >
                   <Icon
-                    className={`w-5 h-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`}
+                    className={`size-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`}
                   />
                 </div>
                 <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
@@ -207,7 +207,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               <ul className="space-y-4">
                 {FOR_WHO.map(item => (
                   <li key={item} className="flex items-start gap-3">
-                    <CheckCircle className="w-5 h-5 text-anhanga-blue flex-shrink-0 mt-0.5" aria-hidden="true" />
+                    <CheckCircle className="size-5 text-anhanga-blue flex-shrink-0 mt-0.5" aria-hidden="true" />
                     <span className="text-gray-700 leading-snug">{item}</span>
                   </li>
                 ))}
@@ -237,7 +237,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                 key={step}
                 className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-gray-100' : ''}`}
               >
-                <div className="flex-shrink-0 w-12 h-12 rounded-full bg-anhanga-blue/10 flex items-center justify-center">
+                <div className="flex-shrink-0 size-12 rounded-full bg-anhanga-blue/10 flex items-center justify-center">
                   <span className="text-sm font-black text-anhanga-blue">{step}</span>
                 </div>
                 <div>
@@ -291,7 +291,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             data-tracking="footer-consultoria-viagem"
           >
             Falar com um consultor
-            <ArrowRight className="w-6 h-6" />
+            <ArrowRight className="size-6" />
           </button>
         </div>
       </section>

--- a/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
+++ b/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
@@ -119,9 +119,9 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
             className="inline-flex items-center gap-2 group"
             aria-label="Voltar para o site principal da Anhangá Viagens"
           >
-            <ArrowLeft className="w-4 h-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
-            <span className="w-7 h-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
-              <img src="/favicon.svg" alt="" aria-hidden="true" className="w-4 h-4" />
+            <ArrowLeft className="size-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
+            <span className="size-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
+              <img src="/favicon.svg" alt="" aria-hidden="true" className="size-4" />
             </span>
             <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
               Anhangá Viagens
@@ -158,7 +158,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
             data-tracking="hero-cruzeiros-brasil"
           >
             Falar com um especialista
-            <ArrowRight className="w-5 h-5" />
+            <ArrowRight className="size-5" />
           </button>
           <p className="mt-4 text-sm text-gray-600">Sem taxa de curadoria. Gratuito.</p>
         </div>
@@ -176,7 +176,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
           <div className="grid sm:grid-cols-2 gap-4">
             {WHAT_WE_ANALYZE.map(item => (
               <div key={item} className="flex items-start gap-3 p-4 rounded-xl bg-anhanga-light">
-                <CheckCircle className="w-5 h-5 text-anhanga-blue flex-shrink-0 mt-0.5" aria-hidden="true" />
+                <CheckCircle className="size-5 text-anhanga-blue flex-shrink-0 mt-0.5" aria-hidden="true" />
                 <span className="text-gray-700">{item}</span>
               </div>
             ))}
@@ -204,12 +204,12 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
                 }`}
               >
                 <div
-                  className={`w-11 h-11 rounded-xl flex items-center justify-center mb-5 ${
+                  className={`size-11 rounded-xl flex items-center justify-center mb-5 ${
                     variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
                   }`}
                 >
                   <Icon
-                    className={`w-5 h-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`}
+                    className={`size-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`}
                   />
                 </div>
                 <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
@@ -253,7 +253,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
                 key={step}
                 className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-anhanga-blue/10' : ''}`}
               >
-                <div className="flex-shrink-0 w-12 h-12 rounded-full bg-white flex items-center justify-center shadow-sm">
+                <div className="flex-shrink-0 size-12 rounded-full bg-white flex items-center justify-center shadow-sm">
                   <span className="text-sm font-black text-anhanga-blue">{step}</span>
                 </div>
                 <div>
@@ -307,7 +307,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
             data-tracking="footer-cruzeiros-brasil"
           >
             Falar com um especialista
-            <ArrowRight className="w-6 h-6" />
+            <ArrowRight className="size-6" />
           </button>
         </div>
       </section>

--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -57,8 +57,8 @@ const MelhorIdadeLanding: React.FC = () => {
       <div className="bg-white/80 backdrop-blur-md py-4 border-b border-gray-100 sticky top-0 z-[60]">
         <div className="container mx-auto px-6 flex justify-between items-center">
           <Link to="/" className="text-sm font-bold text-brand-dark hover:text-brand-cyan transition-colors flex items-center gap-2">
-            <span className="w-8 h-8 bg-brand-cyan/10 rounded-lg flex items-center justify-center">
-              <img src="/favicon.svg" alt="Anhangá" className="w-5 h-5" />
+            <span className="size-8 bg-brand-cyan/10 rounded-lg flex items-center justify-center">
+              <img src="/favicon.svg" alt="Anhangá" className="size-5" />
             </span>
             Anhangá Viagens
           </Link>
@@ -81,7 +81,7 @@ const MelhorIdadeLanding: React.FC = () => {
               animate={{ opacity: 1, y: 0 }}
               className="inline-flex items-center gap-2 bg-brand-cyan/10 text-brand-cyan px-4 py-1 rounded-full text-sm font-bold mb-6"
             >
-              <Heart className="w-4 h-4 fill-current" /> Viagens com Propósito
+              <Heart className="size-4 fill-current" /> Viagens com Propósito
             </m.div>
             <m.h1 
               initial={{ opacity: 0, y: 20 }}
@@ -114,7 +114,7 @@ const MelhorIdadeLanding: React.FC = () => {
                 data-tracking="hero-melhor-idade"
               >
                 Solicitar Orçamento
-                <Sparkles className="w-5 h-5" />
+                <Sparkles className="size-5" />
               </button>
             </m.div>
           </div>
@@ -122,7 +122,7 @@ const MelhorIdadeLanding: React.FC = () => {
         
         {/* Background Decals */}
         <div className="absolute top-0 right-0 w-1/3 h-full bg-gradient-to-l from-brand-cyan/5 to-transparent pointer-events-none"></div>
-        <div className="absolute -bottom-24 -right-24 w-96 h-96 bg-brand-yellow/10 rounded-full blur-[100px] pointer-events-none"></div>
+        <div className="absolute -bottom-24 -right-24 size-96 bg-brand-yellow/10 rounded-full blur-[100px] pointer-events-none"></div>
       </section>
 
       {/* PILARES SECTION */}
@@ -130,8 +130,8 @@ const MelhorIdadeLanding: React.FC = () => {
         <div className="container mx-auto px-6">
           <div className="grid md:grid-cols-3 gap-12">
             <div className="space-y-4">
-              <div className="w-16 h-16 bg-brand-cyan/10 rounded-2xl flex items-center justify-center text-brand-cyan mb-6">
-                <ShieldCheck className="w-8 h-8" />
+              <div className="size-16 bg-brand-cyan/10 rounded-2xl flex items-center justify-center text-brand-cyan mb-6">
+                <ShieldCheck className="size-8" />
               </div>
               <h3 className="text-2xl font-black text-brand-dark">Segurança em 1º lugar</h3>
               <p className="text-gray-500 font-medium leading-relaxed">
@@ -139,8 +139,8 @@ const MelhorIdadeLanding: React.FC = () => {
               </p>
             </div>
             <div className="space-y-4">
-              <div className="w-16 h-16 bg-orange-100 rounded-2xl flex items-center justify-center text-orange-600 mb-6">
-                <Coffee className="w-8 h-8" />
+              <div className="size-16 bg-orange-100 rounded-2xl flex items-center justify-center text-orange-600 mb-6">
+                <Coffee className="size-8" />
               </div>
               <h3 className="text-2xl font-black text-brand-dark">Ritmo Desacelerado</h3>
               <p className="text-gray-500 font-medium leading-relaxed">
@@ -148,8 +148,8 @@ const MelhorIdadeLanding: React.FC = () => {
               </p>
             </div>
             <div className="space-y-4">
-              <div className="w-16 h-16 bg-brand-vibrant/10 rounded-2xl flex items-center justify-center text-brand-vibrant mb-6">
-                <Sparkles className="w-8 h-8" />
+              <div className="size-16 bg-brand-vibrant/10 rounded-2xl flex items-center justify-center text-brand-vibrant mb-6">
+                <Sparkles className="size-8" />
               </div>
               <h3 className="text-2xl font-black text-brand-dark">Curadoria Personalizada</h3>
               <p className="text-gray-500 font-medium leading-relaxed">
@@ -197,7 +197,7 @@ const MelhorIdadeLanding: React.FC = () => {
       {/* FINAL CTA */}
       <section className="py-24 container mx-auto px-6 text-center">
         <div className="bg-brand-dark text-white rounded-[3rem] p-12 md:p-24 relative overflow-hidden">
-          <div className="absolute top-0 right-0 w-64 h-64 bg-brand-cyan/20 blur-[100px] rounded-full"></div>
+          <div className="absolute top-0 right-0 size-64 bg-brand-cyan/20 blur-[100px] rounded-full"></div>
           <h2 className="text-4xl md:text-6xl font-black mb-8 relative z-10">Sua próxima aventura <br className="hidden md:block" /> começa agora.</h2>
           <p className="text-xl text-gray-300 mb-12 max-w-2xl mx-auto relative z-10">
             Fale conosco hoje mesmo e receba uma proposta exclusiva para sua viagem. Segurança, conforto e exclusividade em um só lugar.

--- a/pages/landings/ViagensParaExecutivosLanding.tsx
+++ b/pages/landings/ViagensParaExecutivosLanding.tsx
@@ -110,9 +110,9 @@ const ViagensParaExecutivosLanding: React.FC = () => {
             className="inline-flex items-center gap-2 group"
             aria-label="Voltar para o site principal da Anhangá Viagens"
           >
-            <ArrowLeft className="w-4 h-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
-            <span className="w-7 h-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
-              <img src="/favicon.svg" alt="" aria-hidden="true" className="w-4 h-4" />
+            <ArrowLeft className="size-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
+            <span className="size-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
+              <img src="/favicon.svg" alt="" aria-hidden="true" className="size-4" />
             </span>
             <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
               Anhangá Viagens
@@ -149,7 +149,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
             data-tracking="hero-viagens-executivos"
           >
             Falar com um consultor
-            <ArrowRight className="w-5 h-5" />
+            <ArrowRight className="size-5" />
           </button>
           <p className="mt-4 text-sm text-gray-400">Consultor fixo do início ao fim.</p>
         </div>
@@ -193,12 +193,12 @@ const ViagensParaExecutivosLanding: React.FC = () => {
                 className={`p-8 rounded-2xl ${variant === 'filled' ? 'bg-anhanga-dark text-white' : 'bg-white'}`}
               >
                 <div
-                  className={`w-11 h-11 rounded-xl flex items-center justify-center mb-5 ${
+                  className={`size-11 rounded-xl flex items-center justify-center mb-5 ${
                     variant === 'filled' ? 'bg-anhanga-yellow/20' : 'bg-anhanga-blue/10'
                   }`}
                 >
                   <Icon
-                    className={`w-5 h-5 ${variant === 'filled' ? 'text-anhanga-yellow' : 'text-anhanga-blue'}`}
+                    className={`size-5 ${variant === 'filled' ? 'text-anhanga-yellow' : 'text-anhanga-blue'}`}
                   />
                 </div>
                 <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
@@ -225,7 +225,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
                 key={step}
                 className={`flex gap-8 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-gray-100' : ''}`}
               >
-                <div className="flex-shrink-0 w-12 h-12 rounded-full bg-anhanga-blue/10 flex items-center justify-center">
+                <div className="flex-shrink-0 size-12 rounded-full bg-anhanga-blue/10 flex items-center justify-center">
                   <span className="text-sm font-black text-anhanga-blue">{step}</span>
                 </div>
                 <div>
@@ -279,7 +279,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
             data-tracking="footer-viagens-executivos"
           >
             Falar com um consultor
-            <ArrowRight className="w-6 h-6" />
+            <ArrowRight className="size-6" />
           </button>
         </div>
       </section>


### PR DESCRIPTION
## Summary

- Collapse 328 redundant `w-N h-N` / `h-N w-N` pairs into Tailwind `size-N` shorthand across 48 files
- Covers both numeric (`w-4 h-4` → `size-4`) and arbitrary value (`w-[18px] h-[18px]` → `size-[18px]`) variants
- Zero visual or behavioral change — pure class-name simplification

Closes #477

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test:regression` — 261/261 tests pass
- [x] Visual spot-check on key pages (Home, AIChat, landings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)