### PR TITLE
fix(design): reduce heading font weight from black/extrabold to semibold

### DIFF
--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -36,7 +36,7 @@ const Blog: React.FC = memo(() => {
                     <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border-2 border-brand-dark bg-brand-yellow text-brand-dark font-black text-xs uppercase tracking-widest shadow-[4px_4px_0px_#0f172a] transform -rotate-2 mb-4">
                         <BookOpen className="w-4 h-4" /> Diário de Bordo
                     </div>
-                    <h2 className="text-4xl md:text-5xl font-black text-brand-dark mb-4">
+                    <h2 className="text-4xl md:text-5xl font-semibold text-brand-dark mb-4">
                         Histórias & <span className="text-brand-cyan border-b-8 border-brand-cyan/20 px-1 inline-block">Dicas</span>
                     </h2>
                     <p className="text-gray-500 font-medium text-lg max-w-2xl mx-auto">
@@ -83,7 +83,7 @@ const Blog: React.FC = memo(() => {
                                         </span>
                                         <span className="flex items-center gap-1"><Calendar className="w-4 h-4" /> {formatDate(featuredPost.date)}</span>
                                     </div>
-                                    <h3 className="text-3xl md:text-4xl font-black text-brand-dark mb-4 leading-tight group-hover:text-brand-cyan transition-colors">
+                                    <h3 className="text-3xl md:text-4xl font-semibold text-brand-dark mb-4 leading-tight group-hover:text-brand-cyan transition-colors">
                                         {featuredPost.title}
                                     </h3>
                                     <p className="text-gray-600 text-lg mb-6 leading-relaxed">

--- a/components/CallToAction.tsx
+++ b/components/CallToAction.tsx
@@ -52,7 +52,7 @@ const CallToActionComponent: React.FC = () => {
                         {formState === 'closed' && (
                             <>
                                 <div className="mb-8">
-                                    <h2 className="text-4xl md:text-5xl font-black text-brand-dark mb-4 leading-tight">
+                                    <h2 className="text-4xl md:text-5xl font-semibold text-brand-dark mb-4 leading-tight">
                                         Próxima parada: <br />
                                         <span className="text-brand-vibrant">aquele lugar que você sempre adiou.</span>
                                     </h2>

--- a/components/Categories.tsx
+++ b/components/Categories.tsx
@@ -54,7 +54,7 @@ const Categories = memo(() => {
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border-2 border-brand-dark bg-white text-brand-dark font-black text-xs uppercase tracking-widest shadow-[4px_4px_0px_#0f172a] mb-4">
               <TrendingUp className="w-4 h-4" /> Em Alta
             </div>
-            <h2 className="text-4xl md:text-5xl font-black text-brand-dark">
+            <h2 className="text-4xl md:text-5xl font-semibold text-brand-dark">
               Todo mundo <br className="md:hidden" /> quer ir pra cá 👇
             </h2>
           </div>
@@ -94,7 +94,7 @@ const Categories = memo(() => {
 
               {/* Caption (Handwritten feel) */}
               <div className="text-center">
-                <h3 className="text-2xl font-black text-gray-800 mb-1 font-sans tracking-tight">{item.title}</h3>
+                <h3 className="text-2xl font-semibold text-gray-800 mb-1 font-sans tracking-tight">{item.title}</h3>
                 <p className="text-gray-500 font-medium font-serif italic">{item.subtitle}</p>
               </div>
 

--- a/components/Destinations.tsx
+++ b/components/Destinations.tsx
@@ -530,7 +530,7 @@ const Destinations: React.FC = memo(() => {
                         <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-dashed border-brand-dark bg-yellow-100 text-brand-dark font-black text-xs uppercase tracking-widest shadow-sm transform -rotate-1 mb-4">
                             <Compass className="w-4 h-4" /> Mapa Mundi
                         </div>
-                        <h2 className="text-4xl font-black text-brand-dark">Escolha seu <span className="text-brand-cyan relative inline-block">Pin 📍<svg className="absolute w-full h-3 -bottom-1 left-0 text-brand-cyan opacity-40" viewBox="0 0 100 10" preserveAspectRatio="none"><path d="M0 5 Q 50 10 100 5" stroke="currentColor" strokeWidth="4" fill="none" /></svg></span></h2>
+                        <h2 className="text-4xl font-semibold text-brand-dark">Escolha seu <span className="text-brand-cyan relative inline-block">Pin 📍<svg className="absolute w-full h-3 -bottom-1 left-0 text-brand-cyan opacity-40" viewBox="0 0 100 10" preserveAspectRatio="none"><path d="M0 5 Q 50 10 100 5" stroke="currentColor" strokeWidth="4" fill="none" /></svg></span></h2>
                     </div>
 
                     {/* Filter Pills - Sticker Style */}
@@ -639,7 +639,7 @@ const Destinations: React.FC = memo(() => {
 
                             <div className="px-2 pb-6">
                                 <div className="flex justify-between items-center mb-2">
-                                    <h3 className="text-2xl font-black text-gray-800">{dest.city}</h3>
+                                    <h3 className="text-2xl font-semibold text-gray-800">{dest.city}</h3>
                                     <div className="flex items-center gap-1 text-yellow-500 font-bold text-sm bg-yellow-50 px-2 py-1 rounded-full border border-yellow-100">
                                         <Star className="w-3 h-3 fill-current" /> {dest.rating}
                                     </div>
@@ -681,7 +681,7 @@ const Destinations: React.FC = memo(() => {
                             />
                             <div className="absolute bottom-0 left-0 w-full h-32 bg-gradient-to-t from-black/60 to-transparent"></div>
                             <div className="absolute bottom-6 left-6 text-white">
-                                <h2 className="text-4xl font-black mb-1 drop-shadow-md">{selectedDestination.city}</h2>
+                                <h2 className="text-4xl font-semibold mb-1 drop-shadow-md">{selectedDestination.city}</h2>
                                 <div className="flex items-center gap-2 font-medium opacity-90 drop-shadow-sm">
                                     <MapPin className="w-4 h-4" /> {selectedDestination.country}
                                 </div>

--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -212,7 +212,7 @@ const FAQ = memo(() => {
                     <div className="inline-block bg-brand-vibrant text-white px-4 py-1.5 rounded-full font-black text-xs uppercase tracking-widest mb-4 shadow-sm transform -rotate-1">
                         Tire suas dúvidas
                     </div>
-                    <h2 className="text-4xl md:text-5xl font-black text-brand-dark tracking-tight mb-4">
+                    <h2 className="text-4xl md:text-5xl font-semibold text-brand-dark tracking-tight mb-4">
                         Tá na cabeça?<br />
                         <span className="text-brand-cyan">
                             A gente responde.

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -142,7 +142,7 @@ const Hero: React.FC = memo(() => {
 
           {/* SEO H1 - Optimized with visible keywords for search engines */}
           <h1
-            className={`font-sans font-extrabold text-white mb-6 leading-[0.9] tracking-tight drop-shadow-lg transition-all duration-500
+            className={`font-sans font-semibold text-white mb-6 leading-[0.9] tracking-tight drop-shadow-lg transition-all duration-500
                 ${validCityForTitle ? 'text-4xl sm:text-5xl md:text-7xl' : 'text-5xl sm:text-6xl md:text-8xl'}
                 `}
           >

--- a/components/Highlights.tsx
+++ b/components/Highlights.tsx
@@ -158,7 +158,7 @@ const Highlights = memo(() => {
                                     <Sparkle className="w-4 h-4" weight="fill" /> O Jeito Anhangá
                                 </span>
                             </div>
-                            <h2 className="text-4xl md:text-5xl font-black text-brand-dark leading-tight mb-6">
+                            <h2 className="text-4xl md:text-5xl font-semibold text-brand-dark leading-tight mb-6">
                                 Não existe roteiro certo <br />
                                 <span className="text-anhanga-blue">
                                     para o viajante errado.
@@ -204,7 +204,7 @@ const Highlights = memo(() => {
                                         </m.div>
 
                                         {/* Content */}
-                                        <h3 className="text-xl font-extrabold text-gray-900 mb-3 leading-tight group-hover:text-brand-cyan transition-colors duration-300">
+                                        <h3 className="text-xl font-semibold text-gray-900 mb-3 leading-tight group-hover:text-brand-cyan transition-colors duration-300">
                                             {item.title}
                                         </h3>
                                         <p className="text-gray-500 font-medium leading-relaxed text-sm md:text-base">

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -90,7 +90,7 @@ const HowItWorks = memo(() => {
                 <span className="absolute -inset-1 block -skew-y-2 bg-brand-yellow rounded-lg" aria-hidden="true"></span>
                 <span className="relative text-brand-dark font-black text-sm uppercase tracking-widest px-2 py-1">Sem Complicação</span>
             </div>
-            <h2 className="text-4xl md:text-6xl font-extrabold text-brand-dark mt-6 mb-6 leading-tight">
+            <h2 className="text-4xl md:text-6xl font-semibold text-brand-dark mt-6 mb-6 leading-tight">
                 Como a mágica <br className="md:hidden"/> acontece?
             </h2>
             <p className="text-xl text-gray-600 font-medium font-sans">

--- a/components/LandingFAQ.tsx
+++ b/components/LandingFAQ.tsx
@@ -63,7 +63,7 @@ export const LandingFAQ: React.FC<LandingFAQProps> = ({
         <section className="py-20 bg-white">
             <div className="container mx-auto px-6 max-w-4xl">
                 <div className="text-center mb-12">
-                    <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">
+                    <h2 className="text-3xl md:text-4xl font-semibold text-brand-dark mb-4">
                         {title}
                     </h2>
                     <p className="text-lg text-gray-500">

--- a/components/blog/BlogPostContent.tsx
+++ b/components/blog/BlogPostContent.tsx
@@ -93,7 +93,7 @@ export const BlogPostContent: React.FC<BlogPostContentProps> = ({ post, canonica
             </div>
 
             <div className="mt-12 lg:hidden border-t border-gray-100 pt-10">
-                <h3 className="font-black text-2xl text-brand-dark mb-6 flex items-center gap-2">
+                <h3 className="font-semibold text-2xl text-brand-dark mb-6 flex items-center gap-2">
                     <span className="w-1.5 h-6 bg-brand-vibrant rounded-full"></span>
                     Leia Também
                 </h3>

--- a/components/blog/BlogPostFinalCTA.tsx
+++ b/components/blog/BlogPostFinalCTA.tsx
@@ -10,7 +10,7 @@ export const BlogPostFinalCTA: React.FC<BlogPostFinalCTAProps> = ({ post }) => {
     return (
         <div className="mt-24 bg-brand-dark rounded-[3rem] p-10 md:p-16 text-center shadow-2xl relative overflow-hidden">
             <div className="absolute top-0 right-0 w-64 h-64 bg-brand-cyan/10 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2"></div>
-            <h2 className="text-3xl md:text-5xl font-black text-white mb-6 relative z-10">
+            <h2 className="text-3xl md:text-5xl font-semibold text-white mb-6 relative z-10">
                 Gostou do conteúdo? <br />
                 <span className="text-brand-cyan">Sua viagem começa aqui.</span>
             </h2>

--- a/components/blog/BlogPostHero.tsx
+++ b/components/blog/BlogPostHero.tsx
@@ -39,7 +39,7 @@ export const BlogPostHero: React.FC<BlogPostHeroProps> = ({ post, authorName }) 
                             </span>
                         </div>
 
-                        <h1 className="text-2xl sm:text-3xl md:text-5xl lg:text-6xl font-black text-white mb-6 leading-[1.05] tracking-tight drop-shadow-lg md:mb-8">
+                        <h1 className="text-2xl sm:text-3xl md:text-5xl lg:text-6xl font-semibold text-white mb-6 leading-[1.05] tracking-tight drop-shadow-lg md:mb-8">
                             {post.title}
                         </h1>
 

--- a/components/blog/BlogPostSidebar.tsx
+++ b/components/blog/BlogPostSidebar.tsx
@@ -49,7 +49,7 @@ export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, author
             </div>
 
             <div className="bg-white p-2 rounded-3xl hidden lg:block">
-                <h3 className="font-black text-xl text-gray-800 mb-6 pl-2 flex items-center gap-2">
+                <h3 className="font-semibold text-xl text-gray-800 mb-6 pl-2 flex items-center gap-2">
                     <span className="w-1.5 h-6 bg-brand-vibrant rounded-full"></span>
                     Leia Também
                 </h3>

--- a/components/ui/SectionHeader.tsx
+++ b/components/ui/SectionHeader.tsx
@@ -31,7 +31,7 @@ export const SectionHeader: React.FC<SectionHeaderProps> = ({
                     {badge}
                 </Badge>
             )}
-            <h2 className="text-4xl font-black text-anhanga-dark leading-tight">
+            <h2 className="text-4xl font-semibold text-anhanga-dark leading-tight">
                 {title}
             </h2>
             {subtitle && (

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -69,7 +69,7 @@ const About: React.FC = () => {
               <Sparkles className="w-4 h-4 text-brand-cyan" /> Nossa Essência
             </span>
           </div>
-          <h1 className="text-5xl md:text-6xl font-black text-brand-dark mb-6 leading-tight">
+          <h1 className="text-5xl md:text-6xl font-semibold text-brand-dark mb-6 leading-tight">
             Viagens com alma, <br />
             <span className="text-brand-cyan">
               design e zero estresse.
@@ -132,7 +132,7 @@ const About: React.FC = () => {
               variants={fadeUp}
               custom={2}
             >
-              <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-6">Nossa História</h2>
+              <h2 className="text-3xl md:text-4xl font-semibold text-brand-dark mb-6">Nossa História</h2>
               <div className="space-y-4 text-gray-600 font-medium leading-relaxed text-lg">
                 <p>
                   A Anhangá Viagens nasceu em São Paulo com um propósito claro: resgatar o prazer de planejar uma viagem sem as dores de cabeça da burocracia digital e dos roteiros engessados.
@@ -158,7 +158,7 @@ const About: React.FC = () => {
             variants={fadeUp}
             custom={0}
           >
-            <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Por que viajar com a Anhangá?</h2>
+            <h2 className="text-3xl md:text-4xl font-semibold text-brand-dark mb-4">Por que viajar com a Anhangá?</h2>
             <p className="text-gray-500 font-medium">O que nos torna diferentes no mercado de turismo.</p>
           </m.div>
 
@@ -195,7 +195,7 @@ const About: React.FC = () => {
                 <div className={`w-14 h-14 rounded-2xl ${item.color} flex items-center justify-center mb-6`}>
                   <item.icon className="w-8 h-8" />
                 </div>
-                <h3 className="text-xl font-black text-brand-dark mb-4">{item.title}</h3>
+                <h3 className="text-xl font-semibold text-brand-dark mb-4">{item.title}</h3>
                 <p className="text-gray-500 font-medium leading-relaxed">{item.desc}</p>
               </m.div>
             ))}
@@ -212,7 +212,7 @@ const About: React.FC = () => {
               <div className="inline-flex items-center gap-2 px-4 py-1 bg-white/10 rounded-full text-brand-cyan text-sm font-bold mb-6">
                 <Award className="w-4 h-4" /> Credibilidade & Confiança
               </div>
-              <h2 className="text-3xl md:text-4xl font-black mb-6">Agência Certificada</h2>
+              <h2 className="text-3xl md:text-4xl font-semibold mb-6">Agência Certificada</h2>
               <p className="text-gray-300 text-lg font-medium leading-relaxed mb-8">
                 Sua segurança é nossa prioridade. A Anhangá Viagens é uma empresa devidamente registrada nos órgãos competentes, garantindo total conformidade legal para suas férias.
               </p>
@@ -276,7 +276,7 @@ const About: React.FC = () => {
           variants={fadeUp}
         >
           <div className="bg-brand-cyan/5 rounded-[3rem] p-12 md:p-20 border-2 border-dashed border-brand-cyan/20">
-            <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-6">Pronto para sua próxima história?</h2>
+            <h2 className="text-3xl md:text-4xl font-semibold text-brand-dark mb-6">Pronto para sua próxima história?</h2>
             <p className="text-gray-600 text-lg font-medium mb-10 max-w-xl mx-auto">
               Seja para um festival épico ou um refúgio relaxante, nós desenhamos a viagem perfeita para você.
             </p>

--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -50,7 +50,7 @@ const BlogList: React.FC = () => {
                     <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border-2 border-brand-dark bg-brand-yellow text-brand-dark font-black text-xs uppercase tracking-widest shadow-[4px_4px_0px_#0f172a] transform -rotate-1 mb-4">
                         <BookOpen className="w-4 h-4" /> Todos os Artigos
                     </div>
-                    <h1 className="text-3xl md:text-5xl lg:text-6xl font-black text-brand-dark mb-6">
+                    <h1 className="text-3xl md:text-5xl lg:text-6xl font-semibold text-brand-dark mb-6">
                         Diário de <span className="text-brand-cyan">Bordo</span>
                     </h1>
                     <p className="text-lg md:text-xl text-gray-500 font-medium mb-6">
@@ -143,7 +143,7 @@ const BlogList: React.FC = () => {
 
                 {/* Final CTA Section */}
                 <div className="mt-24 bg-brand-cyan/10 rounded-[3rem] p-10 md:p-16 text-center border-2 border-brand-cyan/20">
-                    <h2 className="text-3xl md:text-5xl font-black text-brand-dark mb-6">
+                    <h2 className="text-3xl md:text-5xl font-semibold text-brand-dark mb-6">
                         Pronto para transformar essas dicas em <span className="text-brand-cyan">Realidade?</span>
                     </h2>
                     <p className="text-xl text-gray-600 mb-10 max-w-2xl mx-auto">

--- a/pages/BlogPost.tsx
+++ b/pages/BlogPost.tsx
@@ -62,7 +62,7 @@ const BlogPost: React.FC = () => {
     if (!post) {
         return (
             <div className="min-h-screen flex flex-col items-center justify-center bg-[#fffdf5]">
-                <h2 className="text-4xl font-black text-brand-dark mb-4 text-center px-6">Ops! Artigo não encontrado.</h2>
+                <h2 className="text-4xl font-semibold text-brand-dark mb-4 text-center px-6">Ops! Artigo não encontrado.</h2>
                 <a href={getBlogHomeUrl()} className="text-brand-cyan font-bold hover:underline flex items-center gap-2">
                     <ArrowLeft className="w-4 h-4" /> Voltar para o Blog
                 </a>

--- a/pages/BlogRedirect.tsx
+++ b/pages/BlogRedirect.tsx
@@ -23,7 +23,7 @@ const BlogRedirect: React.FC = () => {
       />
       <main className="min-h-screen bg-[#fffdf5] pt-32 pb-24 px-6">
         <div className="max-w-2xl mx-auto text-center">
-          <h1 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Redirecionando para o Blog</h1>
+          <h1 className="text-3xl md:text-4xl font-semibold text-brand-dark mb-4">Redirecionando para o Blog</h1>
           <p className="text-gray-600 mb-6">
             O blog agora está em um novo endereço.
           </p>

--- a/pages/NotFound.tsx
+++ b/pages/NotFound.tsx
@@ -33,7 +33,7 @@ const NotFound: React.FC = () => {
             <Compass className="w-12 h-12 text-brand-cyan" />
           </div>
 
-          <h1 className="text-5xl md:text-7xl font-black text-brand-dark mb-6 leading-tight">
+          <h1 className="text-5xl md:text-7xl font-semibold text-brand-dark mb-6 leading-tight">
             Ops! Essa página <br />
             <span className="text-brand-cyan">pegou outro rumo.</span>
           </h1>

--- a/pages/SiteMap.tsx
+++ b/pages/SiteMap.tsx
@@ -35,10 +35,10 @@ const SiteMap: React.FC = () => {
       />
       <main className="min-h-screen bg-[#fffdf5] pt-32 pb-24">
         <section className="container mx-auto px-6 max-w-4xl">
-          <h1 className="text-4xl md:text-5xl font-black text-brand-dark mb-6">Mapa do Site</h1>
+          <h1 className="text-4xl md:text-5xl font-semibold text-brand-dark mb-6">Mapa do Site</h1>
           <p className="text-gray-600 mb-10">Acesse rapidamente as principais áreas do site.</p>
 
-          <h2 className="text-2xl font-extrabold text-brand-dark mb-4">Páginas Principais</h2>
+          <h2 className="text-2xl font-semibold text-brand-dark mb-4">Páginas Principais</h2>
           <ul className="space-y-3 mb-10">
             {coreLinks.map((link) => (
               <li key={link.to}>
@@ -49,7 +49,7 @@ const SiteMap: React.FC = () => {
             ))}
           </ul>
 
-          <h2 className="text-2xl font-extrabold text-brand-dark mb-4">Blog</h2>
+          <h2 className="text-2xl font-semibold text-brand-dark mb-4">Blog</h2>
           <ul className="space-y-3">
             {getAllPosts().map((post) => (
               <li key={post.slug}>

--- a/pages/landings/BetoCarreroLanding.tsx
+++ b/pages/landings/BetoCarreroLanding.tsx
@@ -71,14 +71,14 @@ const BetoCarreroLanding: React.FC = () => {
       <LandingFAQ items={BETO_FAQ_ITEMS} />
       <section className="bg-[#fffdf5] border-t border-brand-cyan/10 py-14">
         <div className="container mx-auto px-6 max-w-5xl">
-          <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Pacote Beto Carrero para viajar com tranquilidade</h2>
+          <h2 className="text-3xl md:text-4xl font-semibold text-brand-dark mb-4">Pacote Beto Carrero para viajar com tranquilidade</h2>
           <p className="text-gray-700 text-lg leading-relaxed mb-5">
             Nosso <strong>pacote Beto Carrero</strong> é desenhado para quem quer curtir o parque sem dor de cabeça com reservas, horários e deslocamentos.
           </p>
           <p className="text-gray-700 text-lg leading-relaxed mb-5">
             Você recebe planejamento completo com opções de hotel, logística e ingressos, além de orientação prática para aproveitar melhor cada dia de viagem em família.
           </p>
-          <h3 className="text-xl md:text-2xl font-extrabold text-brand-dark mb-3">O que pode entrar no seu pacote</h3>
+          <h3 className="text-xl md:text-2xl font-semibold text-brand-dark mb-3">O que pode entrar no seu pacote</h3>
           <ul className="list-disc list-inside text-gray-700 space-y-1 mb-6">
             <li>Hospedagem com localização estratégica</li>
             <li>Ingressos para o parque e upgrades opcionais</li>

--- a/pages/landings/BrazilPromotionDayLanding.tsx
+++ b/pages/landings/BrazilPromotionDayLanding.tsx
@@ -339,7 +339,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                     <Sparkle className="w-4 h-4" weight="fill" /> O Jeito Anhangá
                                 </span>
                             </div>
-                            <h2 className="text-4xl md:text-5xl font-black text-brand-dark leading-tight">
+                            <h2 className="text-4xl md:text-5xl font-semibold text-brand-dark leading-tight">
                                 Não existe roteiro certo <br />
                                 <span className="text-brand-cyan">
                                     para o viajante errado.
@@ -382,7 +382,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                             <Icon className={`w-8 h-8 ${item.iconColor}`} weight="fill" />
                                         </m.div>
 
-                                        <h3 className="text-xl font-extrabold text-gray-900 mb-3 leading-tight group-hover:text-brand-cyan transition-colors duration-300">
+                                        <h3 className="text-xl font-semibold text-gray-900 mb-3 leading-tight group-hover:text-brand-cyan transition-colors duration-300">
                                             {item.title}
                                         </h3>
                                         <p className="text-gray-500 font-medium leading-relaxed text-sm">
@@ -419,7 +419,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                     <AirplaneTilt className="w-4 h-4" weight="fill" />
                                     Atendimento imediato
                                 </p>
-                                <h2 className="text-4xl md:text-5xl font-black text-white leading-tight">
+                                <h2 className="text-4xl md:text-5xl font-semibold text-white leading-tight">
                                     Veio pelo QR Code? <br />
                                     <span className="text-brand-cyan">Bora conversar.</span>
                                 </h2>
@@ -464,7 +464,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                     </span>
                                 </div>
 
-                                <h2 className="text-4xl md:text-5xl font-black text-brand-dark leading-tight mb-6">
+                                <h2 className="text-4xl md:text-5xl font-semibold text-brand-dark leading-tight mb-6">
                                     Prefere que a gente <br />
                                     <span className="text-brand-cyan">
                                         entre em contato?
@@ -541,7 +541,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                         >
                                             <CheckCircle className="w-16 h-16 text-emerald-500 mb-4" weight="fill" />
                                         </m.div>
-                                        <h3 className="text-2xl font-black text-brand-dark mb-3">
+                                        <h3 className="text-2xl font-semibold text-brand-dark mb-3">
                                             Mensagem recebida! 🎉
                                         </h3>
                                         <p className="text-gray-500 max-w-xs leading-relaxed mb-8">

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -136,7 +136,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
           <p className="text-sm font-semibold text-anhanga-blue mb-4 tracking-wide uppercase">
             Consultoria de viagem · São Paulo
           </p>
-          <h1 className="text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1] font-serif">
+          <h1 className="text-4xl md:text-6xl font-semibold text-anhanga-dark mb-6 leading-[1.1] font-serif">
             Planeje uma viagem sob medida sem depender de pacote pronto
           </h1>
           <p className="text-xl text-gray-600 mb-10 leading-relaxed max-w-2xl">
@@ -159,7 +159,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       {/* Por que consultoria? */}
       <section className="py-20 bg-white">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-3 font-serif">
             Por que consultoria?
           </h2>
           <p className="text-gray-600 text-lg mb-12">
@@ -184,7 +184,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                     className={`w-5 h-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`}
                   />
                 </div>
-                <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
+                <h3 className={`text-xl font-semibold mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
                   {title}
                 </h3>
                 <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-gray-600 leading-relaxed'}>
@@ -201,7 +201,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
         <div className="max-w-5xl mx-auto px-6">
           <div className="md:grid md:grid-cols-2 md:gap-16 items-start">
             <div>
-              <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-8 font-serif">
+              <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-8 font-serif">
                 Para quem é
               </h2>
               <ul className="space-y-4">
@@ -228,7 +228,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       {/* Como funciona */}
       <section className="py-20 bg-white">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-12 font-serif">
             Como funciona
           </h2>
           <div className="space-y-0">
@@ -241,7 +241,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                   <span className="text-sm font-black text-anhanga-blue">{step}</span>
                 </div>
                 <div>
-                  <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
+                  <h3 className="text-xl font-semibold text-anhanga-dark mb-2">{title}</h3>
                   <p className="text-gray-600 leading-relaxed max-w-xl">{desc}</p>
                 </div>
               </div>
@@ -253,7 +253,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       {/* Sobre a Anhangá */}
       <section className="py-20 bg-[#fffdf5]">
         <div className="max-w-4xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-6 font-serif">
             Sobre a Anhangá Viagens
           </h2>
           <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mx-auto">
@@ -277,7 +277,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       {/* CTA Final */}
       <section className="py-20 bg-anhanga-blue">
         <div className="max-w-3xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-5xl font-black text-white mb-6 font-serif">
+          <h2 className="text-3xl md:text-5xl font-semibold text-white mb-6 font-serif">
             Pronto para planejar sua viagem?
           </h2>
           <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
@@ -299,7 +299,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       {/* Outros serviços */}
       <section className="py-16 bg-[#fffdf5]">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
+          <h2 className="text-2xl font-semibold text-anhanga-dark mb-8">Outros serviços</h2>
           <div className="grid md:grid-cols-3 gap-4">
             <Link
               to="/viagens-para-executivos"

--- a/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
+++ b/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
@@ -144,7 +144,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
           <p className="text-sm font-semibold text-anhanga-blue mb-4 tracking-wide uppercase">
             Cruzeiros no Brasil · Curadoria consultiva
           </p>
-          <h1 className="text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1] font-serif">
+          <h1 className="text-4xl md:text-6xl font-semibold text-anhanga-dark mb-6 leading-[1.1] font-serif">
             Escolha o cruzeiro certo no Brasil antes de fechar
           </h1>
           <p className="text-xl text-gray-600 mb-10 leading-relaxed max-w-2xl">
@@ -167,7 +167,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
       {/* O que analisamos juntos — posição 2: informação mais diferenciadora */}
       <section className="py-20 bg-white">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-4 font-serif">
             O que analisamos juntos
           </h2>
           <p className="text-gray-600 text-lg mb-10">
@@ -187,7 +187,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
       {/* Por que curadoria? */}
       <section className="py-20 bg-anhanga-light">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-3 font-serif">
             Por que curadoria?
           </h2>
           <p className="text-gray-600 text-lg mb-12">
@@ -212,7 +212,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
                     className={`w-5 h-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`}
                   />
                 </div>
-                <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
+                <h3 className={`text-xl font-semibold mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
                   {title}
                 </h3>
                 <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-gray-600 leading-relaxed'}>
@@ -227,13 +227,13 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
       {/* Para quem é */}
       <section className="py-20 bg-white">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-12 font-serif">
             Para quem é
           </h2>
           <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-5">
             {FOR_WHO.map(({ title, desc }) => (
               <div key={title} className="bg-anhanga-light rounded-2xl p-6">
-                <h3 className="font-black text-anhanga-dark mb-2">{title}</h3>
+                <h3 className="font-semibold text-anhanga-dark mb-2">{title}</h3>
                 <p className="text-gray-600 text-sm leading-relaxed">{desc}</p>
               </div>
             ))}
@@ -244,7 +244,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
       {/* Como funciona */}
       <section className="py-20 bg-anhanga-light">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-12 font-serif">
             Como funciona
           </h2>
           <div className="space-y-0">
@@ -257,7 +257,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
                   <span className="text-sm font-black text-anhanga-blue">{step}</span>
                 </div>
                 <div>
-                  <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
+                  <h3 className="text-xl font-semibold text-anhanga-dark mb-2">{title}</h3>
                   <p className="text-gray-600 leading-relaxed max-w-xl">{desc}</p>
                 </div>
               </div>
@@ -269,7 +269,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
       {/* Sobre a Anhangá */}
       <section className="py-20 bg-white">
         <div className="max-w-4xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-6 font-serif">
             Sobre a Anhangá Viagens
           </h2>
           <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mx-auto">
@@ -293,7 +293,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
       {/* CTA Final */}
       <section className="py-20 bg-anhanga-blue">
         <div className="max-w-3xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-5xl font-black text-white mb-6 font-serif">
+          <h2 className="text-3xl md:text-5xl font-semibold text-white mb-6 font-serif">
             Descubra o cruzeiro certo para você.
           </h2>
           <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
@@ -315,7 +315,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
       {/* Outros serviços */}
       <section className="py-16 bg-anhanga-light">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
+          <h2 className="text-2xl font-semibold text-anhanga-dark mb-8">Outros serviços</h2>
           <div className="grid md:grid-cols-3 gap-4">
             <Link
               to="/consultoria-de-viagem"

--- a/pages/landings/LollapaloozaLanding.tsx
+++ b/pages/landings/LollapaloozaLanding.tsx
@@ -73,7 +73,7 @@ const LollapaloozaLanding: React.FC = () => {
       <LandingFAQ items={LOLLAPALOOZA_FAQ_ITEMS} />
       <section className="bg-[#fffdf5] border-t border-brand-cyan/10 py-14">
         <div className="container mx-auto px-6 max-w-5xl">
-          <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">2026 encerrou forte. 2027 já está no radar.</h2>
+          <h2 className="text-3xl md:text-4xl font-semibold text-brand-dark mb-4">2026 encerrou forte. 2027 já está no radar.</h2>
           <p className="text-gray-700 text-lg leading-relaxed mb-5">
             A página do <strong>Lollapalooza Brasil</strong> continua no ar porque a campanha 2026 foi um sucesso e segue relevante para quem pesquisa logística, hotel e planejamento de festival em São Paulo. Agora, o foco é transformar essa procura em prioridade para a próxima edição.
           </p>
@@ -84,7 +84,7 @@ const LollapaloozaLanding: React.FC = () => {
             </a>{' '}
             com foco em atendimento consultivo e <strong>viagens personalizadas</strong> — do planejamento inicial ao suporte no destino.
           </p>
-          <h3 className="text-xl md:text-2xl font-extrabold text-brand-dark mb-3">O que segue valendo para quem quer ir ao festival</h3>
+          <h3 className="text-xl md:text-2xl font-semibold text-brand-dark mb-3">O que segue valendo para quem quer ir ao festival</h3>
           <ul className="list-disc list-inside text-gray-700 space-y-1 mb-6">
             <li>Hospedagem próxima a rotas de acesso ao festival</li>
             <li>Transporte com melhor custo-benefício (Linha 9 – Esmeralda ou Lolla Express)</li>

--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -133,7 +133,7 @@ const MelhorIdadeLanding: React.FC = () => {
               <div className="w-16 h-16 bg-brand-cyan/10 rounded-2xl flex items-center justify-center text-brand-cyan mb-6">
                 <ShieldCheck className="w-8 h-8" />
               </div>
-              <h3 className="text-2xl font-black text-brand-dark">Segurança em 1º lugar</h3>
+              <h3 className="text-2xl font-semibold text-brand-dark">Segurança em 1º lugar</h3>
               <p className="text-gray-500 font-medium leading-relaxed">
                 Hotéis com acessibilidade, seguro-viagem premium e suporte 24h para você viajar com tranquilidade total.
               </p>
@@ -142,7 +142,7 @@ const MelhorIdadeLanding: React.FC = () => {
               <div className="w-16 h-16 bg-orange-100 rounded-2xl flex items-center justify-center text-orange-600 mb-6">
                 <Coffee className="w-8 h-8" />
               </div>
-              <h3 className="text-2xl font-black text-brand-dark">Ritmo Desacelerado</h3>
+              <h3 className="text-2xl font-semibold text-brand-dark">Ritmo Desacelerado</h3>
               <p className="text-gray-500 font-medium leading-relaxed">
                 Nada de correrias. Roteiros desenhados para respeitar o seu tempo, com pausas estratégicas e menos deslocamentos.
               </p>
@@ -151,7 +151,7 @@ const MelhorIdadeLanding: React.FC = () => {
               <div className="w-16 h-16 bg-brand-vibrant/10 rounded-2xl flex items-center justify-center text-brand-vibrant mb-6">
                 <Sparkles className="w-8 h-8" />
               </div>
-              <h3 className="text-2xl font-black text-brand-dark">Curadoria Personalizada</h3>
+              <h3 className="text-2xl font-semibold text-brand-dark">Curadoria Personalizada</h3>
               <p className="text-gray-500 font-medium leading-relaxed">
                 Experiências gastronômicas, culturais e de lazer selecionadas a dedo para viajantes exigentes e experientes.
               </p>
@@ -163,19 +163,19 @@ const MelhorIdadeLanding: React.FC = () => {
       {/* CONTENT RICH SECTION FOR GEO */}
       <section className="py-24 bg-[#fffdf5]">
         <div className="container mx-auto px-6 max-w-4xl">
-          <h2 className="text-3xl md:text-5xl font-black text-brand-dark mb-12 text-center">Por que planejar sua viagem 50+ com a Anhangá?</h2>
+          <h2 className="text-3xl md:text-5xl font-semibold text-brand-dark mb-12 text-center">Por que planejar sua viagem 50+ com a Anhangá?</h2>
           
           <div className="prose prose-lg prose-brand max-w-none text-gray-700 font-medium leading-[1.8]">
             <p>
               Viajar na maturidade exige um olhar diferente. Não se trata apenas de escolher um destino, mas de garantir que cada etapa da jornada seja fluida e prazerosa. Na <strong>Anhangá Viagens</strong>, somos especialistas em transformar o planejamento em um processo leve e transparente.
             </p>
             
-            <h3 className="text-2xl font-black text-brand-dark mt-12 mb-6">Infraestrutura e Acessibilidade</h3>
+            <h3 className="text-2xl font-semibold text-brand-dark mt-12 mb-6">Infraestrutura e Acessibilidade</h3>
             <p>
               Selecionamos hotéis que oferecem não apenas luxo, mas <strong>acessibilidade real</strong>. Elevadores, poucas escadas, banheiros adaptados e localização central para evitar longas caminhadas desnecessárias. Nosso foco é sua autonomia e bem-estar.
             </p>
 
-            <h3 className="text-2xl font-black text-brand-dark mt-12 mb-6">Atendimento Consultivo e Humano</h3>
+            <h3 className="text-2xl font-semibold text-brand-dark mt-12 mb-6">Atendimento Consultivo e Humano</h3>
             <p>
               Ao contrário das grandes agências de massa, aqui você fala com pessoas que entendem suas necessidades. Ajustamos o roteiro conforme seu condicionamento físico e interesses, seja visitando museus na Europa ou relaxando em um resort no Nordeste.
             </p>
@@ -198,7 +198,7 @@ const MelhorIdadeLanding: React.FC = () => {
       <section className="py-24 container mx-auto px-6 text-center">
         <div className="bg-brand-dark text-white rounded-[3rem] p-12 md:p-24 relative overflow-hidden">
           <div className="absolute top-0 right-0 w-64 h-64 bg-brand-cyan/20 blur-[100px] rounded-full"></div>
-          <h2 className="text-4xl md:text-6xl font-black mb-8 relative z-10">Sua próxima aventura <br className="hidden md:block" /> começa agora.</h2>
+          <h2 className="text-4xl md:text-6xl font-semibold mb-8 relative z-10">Sua próxima aventura <br className="hidden md:block" /> começa agora.</h2>
           <p className="text-xl text-gray-300 mb-12 max-w-2xl mx-auto relative z-10">
             Fale conosco hoje mesmo e receba uma proposta exclusiva para sua viagem. Segurança, conforto e exclusividade em um só lugar.
           </p>

--- a/pages/landings/OrlandoLanding.tsx
+++ b/pages/landings/OrlandoLanding.tsx
@@ -76,14 +76,14 @@ const OrlandoLanding: React.FC = () => {
       <LandingFAQ items={ORLANDO_FAQ_ITEMS} />
       <section className="bg-[#fffdf5] border-t border-brand-cyan/10 py-14">
         <div className="container mx-auto px-6 max-w-5xl">
-          <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Pacote para Orlando sem improviso</h2>
+          <h2 className="text-3xl md:text-4xl font-semibold text-brand-dark mb-4">Pacote para Orlando sem improviso</h2>
           <p className="text-gray-700 text-lg leading-relaxed mb-5">
             Se você busca <strong>pacotes para Orlando</strong> com planejamento profissional, a Anhangá estrutura sua viagem com foco em custo-benefício, logística e experiência.
           </p>
           <p className="text-gray-700 text-lg leading-relaxed mb-5">
             Definimos roteiro de parques, hospedagem por região, estratégia de ingressos e suporte antes e durante a viagem para você evitar erros comuns e aproveitar melhor cada dia de viagem.
           </p>
-          <h3 className="text-xl md:text-2xl font-extrabold text-brand-dark mb-3">O que você pode incluir no pacote</h3>
+          <h3 className="text-xl md:text-2xl font-semibold text-brand-dark mb-3">O que você pode incluir no pacote</h3>
           <ul className="list-disc list-inside text-gray-700 space-y-1 mb-6">
             <li>Aéreo e hotel com perfil ideal para sua viagem</li>
             <li>Ingressos Disney e Universal com orientação de uso</li>

--- a/pages/landings/ViagensParaExecutivosLanding.tsx
+++ b/pages/landings/ViagensParaExecutivosLanding.tsx
@@ -135,7 +135,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
           <p className="text-sm font-semibold text-anhanga-yellow mb-8 tracking-widest uppercase">
             Atendimento consultivo premium
           </p>
-          <h1 className="text-4xl md:text-6xl font-black text-white mb-6 leading-[1.1] font-serif">
+          <h1 className="text-4xl md:text-6xl font-semibold text-white mb-6 leading-[1.1] font-serif">
             Sua viagem planejada com precisão, conforto e atendimento humano
           </h1>
           <p className="text-xl text-gray-300 mb-10 leading-relaxed max-w-2xl">
@@ -158,7 +158,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       {/* Para quem é */}
       <section className="py-20 bg-white">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-4 font-serif">
             Para quem é
           </h2>
           <p className="text-gray-600 text-lg mb-10">
@@ -183,7 +183,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       {/* O que a gente resolve */}
       <section className="py-20 bg-[#fffdf5]">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-12 font-serif">
             O que a gente resolve
           </h2>
           <div className="grid md:grid-cols-3 gap-6">
@@ -201,7 +201,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
                     className={`w-5 h-5 ${variant === 'filled' ? 'text-anhanga-yellow' : 'text-anhanga-blue'}`}
                   />
                 </div>
-                <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
+                <h3 className={`text-xl font-semibold mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
                   {title}
                 </h3>
                 <p className={variant === 'filled' ? 'text-gray-400 leading-relaxed' : 'text-gray-600 leading-relaxed'}>
@@ -216,7 +216,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       {/* Como funciona */}
       <section className="py-20 bg-white">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-12 font-serif">
             Como funciona
           </h2>
           <div className="space-y-0">
@@ -229,7 +229,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
                   <span className="text-sm font-black text-anhanga-blue">{step}</span>
                 </div>
                 <div>
-                  <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
+                  <h3 className="text-xl font-semibold text-anhanga-dark mb-2">{title}</h3>
                   <p className="text-gray-600 leading-relaxed max-w-xl">{desc}</p>
                 </div>
               </div>
@@ -241,7 +241,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       {/* Sobre a Anhangá */}
       <section className="py-20 bg-[#fffdf5]">
         <div className="max-w-4xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
+          <h2 className="text-3xl md:text-4xl font-semibold text-anhanga-dark mb-6 font-serif">
             Sobre a Anhangá Viagens
           </h2>
           <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mb-10">
@@ -265,7 +265,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       {/* CTA Final */}
       <section className="py-20 bg-anhanga-blue">
         <div className="max-w-3xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-5xl font-black text-white mb-6 font-serif">
+          <h2 className="text-3xl md:text-5xl font-semibold text-white mb-6 font-serif">
             Você merece uma viagem sem erro.
           </h2>
           <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
@@ -287,7 +287,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       {/* Outros serviços */}
       <section className="py-16 bg-[#fffdf5]">
         <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
+          <h2 className="text-2xl font-semibold text-anhanga-dark mb-8">Outros serviços</h2>
           <div className="grid md:grid-cols-3 gap-4">
             <Link
               to="/consultoria-de-viagem"


### PR DESCRIPTION
## Summary

- Substitui `font-black` (900) e `font-extrabold` (800) por `font-semibold` (600) em todos os elementos `<h1>`, `<h2>` e `<h3>` do site
- 28 arquivos alterados, 80 ocorrências convertidas
- Preserva `font-black`/`font-extrabold` em elementos não-heading (labels, badges, botões, spans decorativos) onde o impacto visual é intencional
- **Excluído do escopo:** `components/landings/lollapalooza/` e `components/landings/beto-carrero/` — identidade visual dessas landings depende do peso tipográfico
- **Excluído do escopo:** `AIChat.tsx` e `ContactModal.tsx` — headings pequenos onde a justificativa de legibilidade em display sizes não se aplica

## Test plan

- [x] `pnpm typecheck` — zero erros
- [x] `pnpm build` — SSR prerender completo sem erros
- [ ] Verificar visualmente heros e seções de destaque após deploy (nota da issue: algumas seções podem precisar ajuste de `font-size`)

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)