### PR TITLE
ref(design): Replace default Tailwind palette (gray/slate) with zinc tokens (#476)

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -49,7 +49,7 @@ const FormattedText = memo(({ text }: { text: string }) => {
 
         const content = parts.map((part, i) => {
           if (part.startsWith('**') && part.endsWith('**')) {
-            return <strong key={`part-${i}`} className="font-bold text-gray-900">{part.slice(2, -2)}</strong>;
+            return <strong key={`part-${i}`} className="font-bold text-zinc-900">{part.slice(2, -2)}</strong>;
           }
           return part;
         });
@@ -58,12 +58,12 @@ const FormattedText = memo(({ text }: { text: string }) => {
           return (
             <div key={`para-${idx}`} className="flex items-start gap-2 ml-1">
               <span className="shrink-0 mt-1.5 w-1.5 h-1.5 bg-brand-vibrant rounded-full opacity-70"></span>
-              <span className="leading-relaxed text-gray-700">{content}</span>
+              <span className="leading-relaxed text-zinc-700">{content}</span>
             </div>
           );
         }
 
-        return <p key={`para-${idx}`} className="leading-relaxed text-gray-700">{content}</p>;
+        return <p key={`para-${idx}`} className="leading-relaxed text-zinc-700">{content}</p>;
       })}
     </div>
   );
@@ -386,9 +386,9 @@ const AIChat: React.FC = memo(() => {
         aria-label="Assistente Virtual Anhangá"
       >
         {/* Header - Scrapbook Softness */}
-        <div className="bg-white/80 backdrop-blur-md px-6 py-5 border-b border-gray-100 flex justify-between items-center shrink-0 z-10">
+        <div className="bg-white/80 backdrop-blur-md px-6 py-5 border-b border-zinc-100 flex justify-between items-center shrink-0 z-10">
           <div className="flex gap-4 items-center">
-            <div className="size-12 bg-gray-50 rounded-[1.25rem] flex items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+            <div className="size-12 bg-zinc-50 rounded-[1.25rem] flex items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
               <Sparkle className="size-6 text-brand-vibrant" weight="fill" />
             </div>
             <div>
@@ -400,7 +400,7 @@ const AIChat: React.FC = memo(() => {
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
                   <span className="relative inline-flex rounded-full size-2 bg-green-400"></span>
                 </span>
-                <span className="text-xs font-bold text-gray-500 uppercase tracking-widest">
+                <span className="text-xs font-bold text-zinc-500 uppercase tracking-widest">
                   Assistente Online
                 </span>
               </div>
@@ -408,7 +408,7 @@ const AIChat: React.FC = memo(() => {
           </div>
           <button
             onClick={() => closeChatDrawer()}
-            className="text-gray-400 hover:text-gray-700 bg-gray-50 hover:bg-gray-100 rounded-full p-2.5 transition-colors focus:outline-none"
+            className="text-zinc-400 hover:text-zinc-700 bg-zinc-50 hover:bg-zinc-100 rounded-full p-2.5 transition-colors focus:outline-none"
             aria-label="Fechar gaveta"
           >
             <X className="size-5" weight="bold" />
@@ -429,7 +429,7 @@ const AIChat: React.FC = memo(() => {
                   {/* Avatar */}
                   <div className={`size-9 flex items-center justify-center shrink-0 rounded-full shadow-sm ${msg.role === 'user'
                     ? 'bg-brand-dark text-white'
-                    : 'bg-white text-brand-vibrant border border-gray-100'
+                    : 'bg-white text-brand-vibrant border border-zinc-100'
                     }`}>
                     {msg.role === 'user' ? <User className="size-4" weight="fill" /> : <Robot className="size-5" weight="fill" />}
                   </div>
@@ -457,10 +457,10 @@ const AIChat: React.FC = memo(() => {
                       data-testid={msg.role === 'user' ? 'chat-user-message' : undefined}
                       className={`p-4 text-sm shadow-sm ${msg.role === 'user'
                       ? 'bg-brand-vibrant text-white rounded-2xl rounded-br-sm'
-                      : 'bg-white text-gray-800 border border-gray-100 rounded-2xl rounded-bl-sm'
+                      : 'bg-white text-zinc-800 border border-zinc-100 rounded-2xl rounded-bl-sm'
                       }`}>
                       {msg.role === 'model' ? (
-                        <div className="prose prose-sm max-w-none prose-p:text-gray-700 prose-p:leading-relaxed prose-strong:text-gray-900 prose-strong:font-bold prose-ul:text-gray-700">
+                        <div className="prose prose-sm max-w-none prose-p:text-zinc-700 prose-p:leading-relaxed prose-strong:text-zinc-900 prose-strong:font-bold prose-ul:text-zinc-700">
                           <ReactMarkdown>{msg.text}</ReactMarkdown>
                         </div>
                       ) : (
@@ -479,7 +479,7 @@ const AIChat: React.FC = memo(() => {
                       <button
                         key={chipIdx}
                         onClick={() => submitMessage(chip)}
-                        className="text-[12px] font-semibold text-gray-600 bg-white border border-gray-200 px-4 py-2 rounded-xl shadow-sm hover:shadow hover:border-brand-vibrant/30 hover:text-brand-vibrant hover:-translate-y-0.5 transition-all text-left"
+                        className="text-[12px] font-semibold text-zinc-600 bg-white border border-zinc-200 px-4 py-2 rounded-xl shadow-sm hover:shadow hover:border-brand-vibrant/30 hover:text-brand-vibrant hover:-translate-y-0.5 transition-all text-left"
                       >
                         {chip}
                       </button>
@@ -492,12 +492,12 @@ const AIChat: React.FC = memo(() => {
 
           {isLoading && (
             <div data-testid="chat-typing-indicator" className="flex items-end gap-3 z-10 relative">
-              <div className="size-9 bg-white rounded-full border border-gray-100 text-brand-vibrant flex items-center justify-center shadow-sm">
+              <div className="size-9 bg-white rounded-full border border-zinc-100 text-brand-vibrant flex items-center justify-center shadow-sm">
                 <Robot className="size-5" weight="fill" />
               </div>
-              <div className="bg-white px-4 py-3 border border-gray-100 rounded-2xl rounded-bl-sm shadow-sm flex items-center gap-2.5">
+              <div className="bg-white px-4 py-3 border border-zinc-100 rounded-2xl rounded-bl-sm shadow-sm flex items-center gap-2.5">
                 <CircleNotch className="w-4 h-4 animate-spin text-brand-vibrant" weight="bold" />
-                <span className="text-xs font-medium text-gray-400">Anhangá digitando…</span>
+                <span className="text-xs font-medium text-zinc-400">Anhangá digitando…</span>
               </div>
             </div>
           )}
@@ -505,8 +505,8 @@ const AIChat: React.FC = memo(() => {
         </div>
 
         {/* Input Area */}
-        <div className="p-4 sm:p-5 bg-white border-t border-gray-100 shrink-0 z-10 shadow-[0_-4px_20px_rgba(0,0,0,0.02)]">
-          <div className="relative flex items-end bg-slate-50 border border-gray-200 rounded-2xl focus-within:border-brand-vibrant/40 focus-within:bg-white focus-within:ring-4 focus-within:ring-brand-vibrant/10 transition-all">
+        <div className="p-4 sm:p-5 bg-white border-t border-zinc-100 shrink-0 z-10 shadow-[0_-4px_20px_rgba(0,0,0,0.02)]">
+          <div className="relative flex items-end bg-zinc-50 border border-zinc-200 rounded-2xl focus-within:border-brand-vibrant/40 focus-within:bg-white focus-within:ring-4 focus-within:ring-brand-vibrant/10 transition-all">
             <label htmlFor="chat-textarea" className="sr-only">Sua mensagem</label>
             <textarea
               id="chat-textarea"
@@ -516,7 +516,7 @@ const AIChat: React.FC = memo(() => {
               onKeyDown={handleKeyDown}
               placeholder="Digite sua dúvida aqui..."
               rows={1}
-              className="flex-1 max-h-[120px] pl-4 pr-[50px] py-4 bg-transparent outline-none text-sm text-gray-700 font-medium placeholder-gray-400 resize-none overflow-y-auto w-full leading-snug"
+              className="flex-1 max-h-[120px] pl-4 pr-[50px] py-4 bg-transparent outline-none text-sm text-zinc-700 font-medium placeholder-zinc-400 resize-none overflow-y-auto w-full leading-snug"
             />
             <button
               onClick={() => submitMessage(input)}
@@ -527,7 +527,7 @@ const AIChat: React.FC = memo(() => {
               <PaperPlaneTilt className="size-4 ml-0.5" weight="fill" />
             </button>
           </div>
-          <p className="text-center text-[10px] text-gray-400 mt-2">
+          <p className="text-center text-[10px] text-zinc-400 mt-2">
             Nossa IA pode cometer erros. Confirme os dados no WhatsApp.
           </p>
         </div>

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -39,7 +39,7 @@ const Blog: React.FC = memo(() => {
                     <h2 className="text-4xl md:text-5xl font-black text-brand-dark mb-4">
                         Histórias & <span className="text-brand-cyan border-b-8 border-brand-cyan/20 px-1 inline-block">Dicas</span>
                     </h2>
-                    <p className="text-gray-500 font-medium text-lg max-w-2xl mx-auto">
+                    <p className="text-zinc-500 font-medium text-lg max-w-2xl mx-auto">
                         Inspiração real para sua próxima aventura. Sem filtros, só verdades.
                     </p>
                 </div>
@@ -48,7 +48,7 @@ const Blog: React.FC = memo(() => {
                 {featuredPost && (
                     <div className="mb-16 cursor-pointer relative">
                         <a href={getBlogPostUrl(featuredPost.slug)} className="group">
-                            <div className="bg-[#fffdf5] rounded-[2.5rem] p-6 md:p-8 border-4 border-gray-100 shadow-[0_20px_40px_-10px_rgba(0,0,0,0.1)] flex flex-col md:flex-row gap-8 items-center transition-transform duration-300 hover:scale-[1.01]">
+                            <div className="bg-[#fffdf5] rounded-[2.5rem] p-6 md:p-8 border-4 border-zinc-100 shadow-[0_20px_40px_-10px_rgba(0,0,0,0.1)] flex flex-col md:flex-row gap-8 items-center transition-transform duration-300 hover:scale-[1.01]">
 
                                 {/* Featured Image */}
                                 <div className="w-full md:w-1/2 relative">
@@ -77,7 +77,7 @@ const Blog: React.FC = memo(() => {
 
                                 {/* Featured Content */}
                                 <div className="w-full md:w-1/2 md:pr-8">
-                                    <div className="flex items-center gap-3 mb-4 text-sm font-bold text-gray-400">
+                                    <div className="flex items-center gap-3 mb-4 text-sm font-bold text-zinc-400">
                                         <span className={`px-3 py-1 rounded-full border ${getCategoryColor(featuredPost.category)}`}>
                                             {featuredPost.category}
                                         </span>
@@ -86,16 +86,16 @@ const Blog: React.FC = memo(() => {
                                     <h3 className="text-3xl md:text-4xl font-black text-brand-dark mb-4 leading-tight group-hover:text-brand-cyan transition-colors">
                                         {featuredPost.title}
                                     </h3>
-                                    <p className="text-gray-600 text-lg mb-6 leading-relaxed">
+                                    <p className="text-zinc-600 text-lg mb-6 leading-relaxed">
                                         {featuredPost.excerpt}
                                     </p>
-                                    <div className="flex items-center justify-between border-t border-gray-200 pt-6">
+                                    <div className="flex items-center justify-between border-t border-zinc-200 pt-6">
                                         <div className="flex items-center gap-2">
                                             <div className="size-10 rounded-full bg-brand-dark flex items-center justify-center text-white text-base font-black shrink-0">
                                                 {(AUTHORS[featuredPost.author]?.name ?? featuredPost.author).charAt(0).toUpperCase()}
                                             </div>
                                             <div className="flex flex-col">
-                                                <span className="text-xs font-bold text-gray-400 uppercase">Escrito por</span>
+                                                <span className="text-xs font-bold text-zinc-400 uppercase">Escrito por</span>
                                                 <span className="text-sm font-black text-brand-dark">{AUTHORS[featuredPost.author]?.name ?? featuredPost.author}</span>
                                             </div>
                                         </div>
@@ -115,10 +115,10 @@ const Blog: React.FC = memo(() => {
                         <a
                             href={getBlogPostUrl(post.slug)}
                             key={post.slug}
-                            className="group bg-white rounded-3xl p-4 shadow-[0_10px_20px_-5px_rgba(0,0,0,0.05)] border border-gray-100 transform transition-all duration-300 hover:-translate-y-2 hover:shadow-xl flex flex-col h-full"
+                            className="group bg-white rounded-3xl p-4 shadow-[0_10px_20px_-5px_rgba(0,0,0,0.05)] border border-zinc-100 transform transition-all duration-300 hover:-translate-y-2 hover:shadow-xl flex flex-col h-full"
                         >
                             {/* Image Area — aspect ratio alternado para quebrar ritmo uniforme */}
-                            <div className={`relative ${index % 2 === 0 ? 'aspect-[4/3]' : 'aspect-video'} rounded-2xl overflow-hidden mb-5 bg-gray-100`}>
+                            <div className={`relative ${index % 2 === 0 ? 'aspect-[4/3]' : 'aspect-video'} rounded-2xl overflow-hidden mb-5 bg-zinc-100`}>
                                 <LazyImage
                                     src={post.image}
                                     alt={post.title}
@@ -126,7 +126,7 @@ const Blog: React.FC = memo(() => {
                                     height={480}
                                     className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                                 />
-                                <div className="absolute top-3 right-3 bg-white/90 backdrop-blur rounded-lg px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-gray-800 shadow-sm">
+                                <div className="absolute top-3 right-3 bg-white/90 backdrop-blur rounded-lg px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-zinc-800 shadow-sm">
                                     {formatDate(post.date)}
                                 </div>
                                 <div className="absolute bottom-3 right-3 z-30">
@@ -146,21 +146,21 @@ const Blog: React.FC = memo(() => {
                                         {post.category}
                                     </span>
                                 </div>
-                                <h4 className="text-xl font-extrabold text-gray-800 mb-3 leading-snug group-hover:text-brand-cyan transition-colors">
+                                <h4 className="text-xl font-extrabold text-zinc-800 mb-3 leading-snug group-hover:text-brand-cyan transition-colors">
                                     {post.title}
                                 </h4>
-                                <p className="text-sm text-gray-500 font-medium leading-relaxed mb-6 flex-1 line-clamp-3">
+                                <p className="text-sm text-zinc-500 font-medium leading-relaxed mb-6 flex-1 line-clamp-3">
                                     {post.excerpt}
                                 </p>
 
-                                <div className="pt-4 border-t border-dashed border-gray-100 flex items-center justify-between">
-                                    <span className="text-xs font-bold text-gray-400 flex items-center gap-2">
+                                <div className="pt-4 border-t border-dashed border-zinc-100 flex items-center justify-between">
+                                    <span className="text-xs font-bold text-zinc-400 flex items-center gap-2">
                                         <div className="size-5 rounded-full bg-brand-dark flex items-center justify-center text-white text-[10px] font-black shrink-0">
                                             {(AUTHORS[post.author]?.name ?? post.author).charAt(0).toUpperCase()}
                                         </div>
                                         {AUTHORS[post.author]?.name ?? post.author}
                                     </span>
-                                    <span className="size-8 rounded-full flex items-center justify-center transition-colors bg-gray-100 text-gray-400 group-hover:bg-brand-cyan group-hover:text-white">
+                                    <span className="size-8 rounded-full flex items-center justify-center transition-colors bg-zinc-100 text-zinc-400 group-hover:bg-brand-cyan group-hover:text-white">
                                         <ArrowRight className="size-4" />
                                     </span>
                                 </div>
@@ -171,7 +171,7 @@ const Blog: React.FC = memo(() => {
 
                 {/* View More Button */}
                 <div className="mt-16 text-center">
-                    <a href={getBlogHomeUrl()} className="inline-flex items-center gap-2 px-8 py-4 bg-white border-2 border-gray-200 text-gray-600 rounded-full font-bold hover:border-brand-cyan hover:text-brand-cyan transition-all shadow-sm hover:shadow-md group">
+                    <a href={getBlogHomeUrl()} className="inline-flex items-center gap-2 px-8 py-4 bg-white border-2 border-zinc-200 text-zinc-600 rounded-full font-bold hover:border-brand-cyan hover:text-brand-cyan transition-all shadow-sm hover:shadow-md group">
                         <Sparkles className="size-4 text-brand-yellow fill-brand-yellow" />
                         Ver Todos os Artigos
                         <ArrowRight className="size-4 group-hover:translate-x-1 transition-transform" />

--- a/components/CallToAction.tsx
+++ b/components/CallToAction.tsx
@@ -41,12 +41,12 @@ const CallToActionComponent: React.FC = () => {
                     <div className="w-full md:w-[70%] p-8 md:p-12 relative flex flex-col justify-between">
 
                         {/* Header Strip */}
-                        <div className="flex justify-between items-center mb-8 border-b-2 border-dashed border-gray-100 pb-4">
+                        <div className="flex justify-between items-center mb-8 border-b-2 border-dashed border-zinc-100 pb-4">
                             <div className="flex items-center gap-2 text-brand-cyan font-black tracking-widest text-sm uppercase" title="Estilo Boarding Pass">
                                 <AirplaneTilt className="size-5" weight="fill" /> Anhangá Airlines
                                 <span className="text-[10px] opacity-40 ml-1 hidden lg:inline">(Boarding Pass)</span>
                             </div>
-                            <div className="text-gray-400 font-bold text-xs uppercase">First Class Experience</div>
+                            <div className="text-zinc-400 font-bold text-xs uppercase">First Class Experience</div>
                         </div>
 
                         {formState === 'closed' && (
@@ -56,7 +56,7 @@ const CallToActionComponent: React.FC = () => {
                                         Próxima parada: <br />
                                         <span className="text-brand-vibrant">aquele lugar que você sempre adiou.</span>
                                     </h2>
-                                    <p className="text-gray-500 font-medium text-lg max-w-md">
+                                    <p className="text-zinc-500 font-medium text-lg max-w-md">
                                         Orçamento gratuito. Roteiro feito do zero, só pra você.
                                     </p>
                                 </div>
@@ -80,7 +80,7 @@ const CallToActionComponent: React.FC = () => {
                                 className="flex flex-col gap-3 w-full"
                                 noValidate
                             >
-                                <p className="text-xs font-black text-gray-500 uppercase tracking-widest mb-1">
+                                <p className="text-xs font-black text-zinc-500 uppercase tracking-widest mb-1">
                                     Seus dados para contato
                                 </p>
 
@@ -94,7 +94,7 @@ const CallToActionComponent: React.FC = () => {
                                             value={fields.firstName}
                                             onChange={(event) => setField('firstName', event.target.value)}
                                             required
-                                            className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-gray-400"
+                                            className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400"
                                         />
                                     </div>
                                     <div className="flex-1">
@@ -105,7 +105,7 @@ const CallToActionComponent: React.FC = () => {
                                             placeholder="Sobrenome"
                                             value={fields.lastName}
                                             onChange={(event) => setField('lastName', event.target.value)}
-                                            className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-gray-400"
+                                            className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400"
                                         />
                                     </div>
                                 </div>
@@ -119,7 +119,7 @@ const CallToActionComponent: React.FC = () => {
                                         value={fields.whatsapp}
                                         onChange={(event) => setField('whatsapp', event.target.value)}
                                         required
-                                        className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-gray-400"
+                                        className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400"
                                     />
                                 </div>
 
@@ -131,7 +131,7 @@ const CallToActionComponent: React.FC = () => {
                                         placeholder="E-mail (opcional)"
                                         value={fields.email}
                                         onChange={(event) => setField('email', event.target.value)}
-                                        className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-gray-400"
+                                        className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400"
                                     />
                                 </div>
 
@@ -198,7 +198,7 @@ const CallToActionComponent: React.FC = () => {
                     {/* --- DIVIDER (Perforation) --- */}
                     <div className="relative w-full h-8 md:w-8 md:h-auto flex items-center justify-center">
                         {/* The Dashed Line */}
-                        <div className="w-full h-[2px] md:w-[2px] md:h-[90%] border-t-2 md:border-t-0 md:border-l-2 border-dashed border-gray-300"></div>
+                        <div className="w-full h-[2px] md:w-[2px] md:h-[90%] border-t-2 md:border-t-0 md:border-l-2 border-dashed border-zinc-300"></div>
 
                         {/* Mobile Holes (Left/Right) */}
                         <div className="md:hidden absolute -left-4 top-1/2 -translate-y-1/2 size-8 bg-brand-light rounded-full z-20"></div>
@@ -206,7 +206,7 @@ const CallToActionComponent: React.FC = () => {
                     </div>
 
                     {/* --- RIGHT SIDE: Stub / Details --- */}
-                    <div className="w-full md:w-[30%] bg-gray-50 p-6 flex flex-col relative">
+                    <div className="w-full md:w-[30%] bg-zinc-50 p-6 flex flex-col relative">
 
                         {/* Stub Header */}
                         <div className="flex justify-between items-center mb-5 opacity-60">
@@ -216,44 +216,44 @@ const CallToActionComponent: React.FC = () => {
 
                         {/* Passenger Name */}
                         <div className="mb-4">
-                            <span className="block text-[9px] uppercase font-bold text-gray-400 tracking-wider mb-0.5">Passenger Name</span>
+                            <span className="block text-[9px] uppercase font-bold text-zinc-400 tracking-wider mb-0.5">Passenger Name</span>
                             <span className="block text-lg font-black text-brand-dark truncate">VOCÊ / VIP</span>
                         </div>
 
                         {/* Flight Details Grid */}
-                        <div className="grid grid-cols-2 gap-y-3 gap-x-2 mb-4 border-b-2 border-dashed border-gray-200 pb-4">
+                        <div className="grid grid-cols-2 gap-y-3 gap-x-2 mb-4 border-b-2 border-dashed border-zinc-200 pb-4">
                             <div>
-                                <span className="block text-[9px] uppercase font-bold text-gray-400 tracking-wider">Flight</span>
-                                <span className="block text-sm font-bold font-mono text-gray-800">ANH 777</span>
+                                <span className="block text-[9px] uppercase font-bold text-zinc-400 tracking-wider">Flight</span>
+                                <span className="block text-sm font-bold font-mono text-zinc-800">ANH 777</span>
                             </div>
                             <div>
-                                <span className="block text-[9px] uppercase font-bold text-gray-400 tracking-wider">Date</span>
-                                <span className="block text-sm font-bold font-mono text-gray-800">HOJE</span>
+                                <span className="block text-[9px] uppercase font-bold text-zinc-400 tracking-wider">Date</span>
+                                <span className="block text-sm font-bold font-mono text-zinc-800">HOJE</span>
                             </div>
                             <div>
-                                <span className="block text-[9px] uppercase font-bold text-gray-400 tracking-wider">From</span>
-                                <span className="block text-base font-black text-gray-800">GRU</span>
+                                <span className="block text-[9px] uppercase font-bold text-zinc-400 tracking-wider">From</span>
+                                <span className="block text-base font-black text-zinc-800">GRU</span>
                             </div>
                             <div>
-                                <span className="block text-[9px] uppercase font-bold text-gray-400 tracking-wider">To</span>
+                                <span className="block text-[9px] uppercase font-bold text-zinc-400 tracking-wider">To</span>
                                 <span className="block text-base font-black text-brand-vibrant">MUNDO</span>
                             </div>
                         </div>
 
                         {/* Critical Boarding Info (Boxed) */}
-                        <div className="bg-white rounded-xl border-2 border-gray-100 p-2 flex justify-between items-center shadow-sm mb-4">
+                        <div className="bg-white rounded-xl border-2 border-zinc-100 p-2 flex justify-between items-center shadow-sm mb-4">
                             <div className="text-center flex-1">
-                                <span className="block text-[8px] font-bold text-gray-400 uppercase tracking-wider">Gate</span>
+                                <span className="block text-[8px] font-bold text-zinc-400 uppercase tracking-wider">Gate</span>
                                 <span className="block text-xl font-black text-brand-dark">01</span>
                             </div>
-                            <div className="w-[1px] h-8 bg-gray-100"></div>
+                            <div className="w-[1px] h-8 bg-zinc-100"></div>
                             <div className="text-center flex-1">
-                                <span className="block text-[8px] font-bold text-gray-400 uppercase tracking-wider">Seat</span>
+                                <span className="block text-[8px] font-bold text-zinc-400 uppercase tracking-wider">Seat</span>
                                 <span className="block text-xl font-black text-brand-dark">1A</span>
                             </div>
-                            <div className="w-[1px] h-8 bg-gray-100"></div>
+                            <div className="w-[1px] h-8 bg-zinc-100"></div>
                             <div className="text-center flex-1">
-                                <span className="block text-[8px] font-bold text-gray-400 uppercase tracking-wider">Zone</span>
+                                <span className="block text-[8px] font-bold text-zinc-400 uppercase tracking-wider">Zone</span>
                                 <span className="block text-xl font-black text-brand-dark">1</span>
                             </div>
                         </div>
@@ -262,23 +262,23 @@ const CallToActionComponent: React.FC = () => {
                         <div className="mt-auto">
                             <div className="flex justify-between items-end mb-2">
                                 <div>
-                                    <span className="block text-[9px] uppercase font-bold text-gray-400 tracking-wider">Boarding</span>
+                                    <span className="block text-[9px] uppercase font-bold text-zinc-400 tracking-wider">Boarding</span>
                                     <span className="block text-sm font-black text-red-500">AGORA</span>
                                 </div>
                                 <div className="text-right">
-                                    <span className="block text-[9px] uppercase font-bold text-gray-400 tracking-wider">SEQ</span>
-                                    <span className="block text-sm font-mono font-bold text-gray-600">001</span>
+                                    <span className="block text-[9px] uppercase font-bold text-zinc-400 tracking-wider">SEQ</span>
+                                    <span className="block text-sm font-mono font-bold text-zinc-600">001</span>
                                 </div>
                             </div>
 
                             {/* High Fidelity Barcode */}
-                            <div className="pt-2 border-t border-gray-200">
+                            <div className="pt-2 border-t border-zinc-200">
                                 {/* Barcode Lines */}
                                 <div className="flex justify-center items-stretch h-12 w-full overflow-hidden select-none bg-transparent gap-[1px]">
                                     {[4, 2, 1, 1, 3, 1, 2, 1, 4, 1, 1, 2, 3, 1, 2, 1, 3, 1, 1, 2, 1, 2, 1, 3, 1, 1, 2, 1, 4, 1, 2].map((w, i) => (
                                         <div
                                             key={`bar-start-${i}`}
-                                            className="bg-gray-950"
+                                            className="bg-zinc-950"
                                             style={{
                                                 width: `${w * 2}px`, // Thicker bars
                                                 flexShrink: 0
@@ -289,7 +289,7 @@ const CallToActionComponent: React.FC = () => {
                                     {[2, 1, 3, 1, 1, 2, 4, 1, 2, 1, 3, 1, 1, 2].map((w, i) => (
                                         <div
                                             key={`bar-end-${i}`}
-                                            className="bg-gray-950"
+                                            className="bg-zinc-950"
                                             style={{
                                                 width: `${w * 2}px`,
                                                 flexShrink: 0
@@ -300,10 +300,10 @@ const CallToActionComponent: React.FC = () => {
 
                                 {/* Ticket Number & Icons */}
                                 <div className="flex justify-between items-center mt-1">
-                                    <span className="font-mono text-[9px] font-bold tracking-[0.3em] text-gray-400 uppercase">
+                                    <span className="font-mono text-[9px] font-bold tracking-[0.3em] text-zinc-400 uppercase">
                                         ETKT 29384910239
                                     </span>
-                                    <DeviceMobile className="size-3 text-gray-300" weight="fill" />
+                                    <DeviceMobile className="size-3 text-zinc-300" weight="fill" />
                                 </div>
                             </div>
                         </div>

--- a/components/Categories.tsx
+++ b/components/Categories.tsx
@@ -76,7 +76,7 @@ const Categories = memo(() => {
               <div className="absolute -top-3 left-1/2 -translate-x-1/2 w-32 h-8 bg-white/30 backdrop-blur-sm border-l border-r border-white/60 rotate-1 shadow-sm z-20"></div>
 
               {/* Image Area */}
-              <div className="aspect-square w-full overflow-hidden bg-gray-100 mb-6 relative">
+              <div className="aspect-square w-full overflow-hidden bg-zinc-100 mb-6 relative">
                 <LazyImage
                   src={item.image}
                   width={600}
@@ -94,8 +94,8 @@ const Categories = memo(() => {
 
               {/* Caption (Handwritten feel) */}
               <div className="text-center">
-                <h3 className="text-2xl font-black text-gray-800 mb-1 font-sans tracking-tight">{item.title}</h3>
-                <p className="text-gray-500 font-medium font-serif italic">{item.subtitle}</p>
+                <h3 className="text-2xl font-black text-zinc-800 mb-1 font-sans tracking-tight">{item.title}</h3>
+                <p className="text-zinc-500 font-medium font-serif italic">{item.subtitle}</p>
               </div>
 
               {/* Sticker Decor */}

--- a/components/ChatLeadForm.tsx
+++ b/components/ChatLeadForm.tsx
@@ -152,7 +152,7 @@ function TextField({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className={`w-full bg-white border ${error ? 'border-red-500' : 'border-gray-200'} rounded-xl px-4 py-3 text-sm text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-vibrant/30 focus:border-brand-vibrant transition-all shadow-sm`}
+        className={`w-full bg-white border ${error ? 'border-red-500' : 'border-zinc-200'} rounded-xl px-4 py-3 text-sm text-zinc-700 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-brand-vibrant/30 focus:border-brand-vibrant transition-all shadow-sm`}
       />
       {error && <span className="text-[10px] text-red-500 font-bold ml-1 uppercase">{error}</span>}
     </div>
@@ -235,14 +235,14 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
 
   return (
     <div className="bg-white rounded-2xl border border-brand-blue/10 shadow-[0_8px_30px_rgb(0,0,0,0.08)] w-full overflow-hidden transform transition-all hover:shadow-[0_8px_30px_rgb(0,0,0,0.12)] hover:-translate-y-1">
-      <div className="bg-gradient-to-r from-brand-vibrant/10 to-transparent p-3 flex items-center gap-2 border-b border-gray-100">
+      <div className="bg-gradient-to-r from-brand-vibrant/10 to-transparent p-3 flex items-center gap-2 border-b border-zinc-100">
         <CheckCircle2 className="size-5 text-green-500" />
         <span className="text-sm font-bold tracking-wide text-brand-dark uppercase">
           Link Gerado
         </span>
       </div>
-      <div className="p-5 bg-gradient-to-br from-white to-slate-50/50">
-        <p className="text-sm text-gray-600 mb-5 font-medium leading-relaxed">
+      <div className="p-5 bg-gradient-to-br from-white to-zinc-50/50">
+        <p className="text-sm text-zinc-600 mb-5 font-medium leading-relaxed">
           Sua solicitação para <strong className="font-bold text-brand-vibrant relative px-1"><span className="absolute inset-0 bg-brand-yellow/20 -skew-x-6 rounded"></span><span className="relative">{destination}</span></strong> está pronta. Finalize seus dados:
         </p>
 
@@ -285,7 +285,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
                 id="lead-country-code"
                 value={countryCode}
                 onChange={(e) => setCountryCode(e.target.value)}
-                className="w-[112px] shrink-0 bg-white border border-gray-200 rounded-xl p-3 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-brand-vibrant/30 focus:border-brand-vibrant transition-all shadow-sm"
+                className="w-[112px] shrink-0 bg-white border border-zinc-200 rounded-xl p-3 text-sm text-zinc-700 focus:outline-none focus:ring-2 focus:ring-brand-vibrant/30 focus:border-brand-vibrant transition-all shadow-sm"
               >
                 <option value="+55">+55 BR</option>
                 <option value="+1">+1 US/CA</option>
@@ -311,11 +311,11 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
                   type="checkbox"
                   checked={acceptedLGPD}
                   onChange={(e) => setAcceptedLGPD(e.target.checked)}
-                  className="peer size-4 cursor-pointer appearance-none rounded border border-gray-300 bg-white checked:bg-brand-vibrant checked:border-brand-vibrant transition-all focus:ring-2 focus:ring-brand-vibrant/20"
+                  className="peer size-4 cursor-pointer appearance-none rounded border border-zinc-300 bg-white checked:bg-brand-vibrant checked:border-brand-vibrant transition-all focus:ring-2 focus:ring-brand-vibrant/20"
                 />
                 <CheckCircle2 className="absolute size-3 text-white opacity-0 peer-checked:opacity-100 left-0.5 pointer-events-none transition-opacity" />
               </div>
-              <span className="text-xs text-gray-500 leading-tight">
+              <span className="text-xs text-zinc-500 leading-tight">
                 Aceito receber comunicações e autorizo o tratamento dos meus dados conforme a <a href="https://www.anhanga.tur.br/politica-privacidade/" target="_blank" rel="noopener noreferrer" className="underline hover:text-brand-vibrant">Política de Privacidade</a>.
               </span>
             </label>

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -121,7 +121,7 @@ const ContactModal: React.FC = () => {
                     <button
                         type="button"
                         onClick={close}
-                        className="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                        className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan"
                         aria-label="Fechar"
                     >
                         <X className="size-5" weight="bold" />
@@ -136,8 +136,8 @@ const ContactModal: React.FC = () => {
                             aria-live="polite"
                         >
                             <CheckCircle className="size-14 text-green-600" weight="fill" />
-                            <p className="font-bold text-gray-800">Recebemos seu contato!</p>
-                            <p className="text-sm text-gray-500">
+                            <p className="font-bold text-zinc-800">Recebemos seu contato!</p>
+                            <p className="text-sm text-zinc-500">
                                 Nossa equipe entra em contato em breve pelo WhatsApp.
                             </p>
                         </div>
@@ -161,7 +161,7 @@ const ContactModal: React.FC = () => {
                     >
                         <div className="flex gap-3">
                             <div className="flex-1">
-                                <label htmlFor="contact-firstName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-gray-500">
+                                <label htmlFor="contact-firstName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
                                     Nome *
                                 </label>
                                 <input
@@ -172,12 +172,12 @@ const ContactModal: React.FC = () => {
                                     value={fields.firstName}
                                     onChange={(event) => setField('firstName', event.target.value)}
                                     required
-                                    className="w-full rounded-xl border-2 border-gray-200 px-3 py-2.5 text-sm font-medium text-gray-800 outline-none transition-colors placeholder-gray-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                                    className="w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
                                     placeholder="ex: Maria"
                                 />
                             </div>
                             <div className="flex-1">
-                                <label htmlFor="contact-lastName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-gray-500">
+                                <label htmlFor="contact-lastName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
                                     Sobrenome
                                 </label>
                                 <input
@@ -186,14 +186,14 @@ const ContactModal: React.FC = () => {
                                     autoComplete="family-name"
                                     value={fields.lastName}
                                     onChange={(event) => setField('lastName', event.target.value)}
-                                    className="w-full rounded-xl border-2 border-gray-200 px-3 py-2.5 text-sm font-medium text-gray-800 outline-none transition-colors placeholder-gray-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                                    className="w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
                                     placeholder="ex: Silva"
                                 />
                             </div>
                         </div>
 
                         <div>
-                            <label htmlFor="contact-whatsapp" className="mb-1 block text-xs font-bold uppercase tracking-wider text-gray-500">
+                            <label htmlFor="contact-whatsapp" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
                                 WhatsApp *
                             </label>
                             <input
@@ -203,13 +203,13 @@ const ContactModal: React.FC = () => {
                                 value={fields.whatsapp}
                                 onChange={(event) => setField('whatsapp', event.target.value)}
                                 required
-                                className="w-full rounded-xl border-2 border-gray-200 px-3 py-2.5 text-sm font-medium text-gray-800 outline-none transition-colors placeholder-gray-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                                className="w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
                                 placeholder="+55 (11) 9 0000-0000"
                             />
                         </div>
 
                         <div>
-                            <label htmlFor="contact-email" className="mb-1 block text-xs font-bold uppercase tracking-wider text-gray-500">
+                            <label htmlFor="contact-email" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
                                 E-mail
                             </label>
                             <input
@@ -218,7 +218,7 @@ const ContactModal: React.FC = () => {
                                 autoComplete="email"
                                 value={fields.email}
                                 onChange={(event) => setField('email', event.target.value)}
-                                className="w-full rounded-xl border-2 border-gray-200 px-3 py-2.5 text-sm font-medium text-gray-800 outline-none transition-colors placeholder-gray-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                                className="w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
                                 placeholder="seu@email.com (opcional)"
                             />
                         </div>

--- a/components/Destinations.tsx
+++ b/components/Destinations.tsx
@@ -541,7 +541,7 @@ const Destinations: React.FC = memo(() => {
                                 onClick={() => setActiveFilter(filter)}
                                 className={`px-5 py-2 rounded-lg text-sm font-bold border-2 transition-all whitespace-nowrap flex-shrink-0 shadow-[3px_3px_0px_rgba(0,0,0,0.1)] active:shadow-none active:translate-x-[2px] active:translate-y-[2px] ${activeFilter === filter
                                     ? 'bg-brand-dark text-white border-brand-dark transform -rotate-1'
-                                    : 'bg-white text-gray-600 border-gray-100 hover:border-brand-vibrant hover:text-brand-vibrant'
+                                    : 'bg-white text-zinc-600 border-zinc-100 hover:border-brand-vibrant hover:text-brand-vibrant'
                                     }`}
                             >
                                 {filter}
@@ -561,7 +561,7 @@ const Destinations: React.FC = memo(() => {
                         <div className="absolute -top-3 right-10 w-24 h-8 bg-yellow-400/80 rotate-[10deg] z-30 backdrop-blur-sm shadow-sm opacity-90 border-l border-r border-white/30"></div>
 
                         {/* Map Inner Border & Content */}
-                        <div className="w-full h-full border-2 border-gray-100 overflow-hidden relative bg-[#FAFAFA]">
+                        <div className="w-full h-full border-2 border-zinc-100 overflow-hidden relative bg-[#FAFAFA]">
                             {/* Paper Texture Overlay */}
                             <div className="absolute inset-0 z-[5] pointer-events-none opacity-[0.15] mix-blend-multiply" style={noiseTextureStyle}></div>
 
@@ -571,7 +571,7 @@ const Destinations: React.FC = memo(() => {
                             <div ref={mapRef} className="w-full h-full z-0" />
 
                             {/* Mobile Hint */}
-                            <div className="md:hidden absolute bottom-4 left-1/2 -translate-x-1/2 bg-white/90 backdrop-blur-sm px-4 py-2 rounded-full text-[10px] font-bold text-gray-500 pointer-events-none z-[400] shadow-md border border-gray-200">
+                            <div className="md:hidden absolute bottom-4 left-1/2 -translate-x-1/2 bg-white/90 backdrop-blur-sm px-4 py-2 rounded-full text-[10px] font-bold text-zinc-500 pointer-events-none z-[400] shadow-md border border-zinc-200">
                                 Use dois dedos para mover
                             </div>
                         </div>
@@ -580,14 +580,14 @@ const Destinations: React.FC = memo(() => {
                         <div className="absolute bottom-6 right-6 flex flex-col gap-2 z-[400]">
                             <button
                                 onClick={() => handleZoom('in')}
-                                className="size-10 bg-white border-2 border-gray-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all text-gray-700 font-black"
+                                className="size-10 bg-white border-2 border-zinc-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all text-zinc-700 font-black"
                                 aria-label="Aumentar zoom no mapa"
                             >
                                 <Plus className="size-5" />
                             </button>
                             <button
                                 onClick={() => handleZoom('out')}
-                                className="size-10 bg-white border-2 border-gray-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all text-gray-700 font-black"
+                                className="size-10 bg-white border-2 border-zinc-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all text-zinc-700 font-black"
                                 aria-label="Diminuir zoom no mapa"
                             >
                                 <Minus className="size-5" />
@@ -597,9 +597,9 @@ const Destinations: React.FC = memo(() => {
                         {/* "Note" Sticker */}
                         <div className="hidden md:block absolute top-8 left-8 bg-yellow-100 p-4 rounded-sm shadow-md transform -rotate-3 z-[400] max-w-[150px] border border-yellow-200">
                             <div className="size-3 rounded-full bg-red-400 mx-auto -mt-6 mb-2 shadow-sm border border-red-500"></div>
-                            <p className="font-serif italic text-gray-700 text-sm leading-tight text-center">
+                            <p className="font-serif italic text-zinc-700 text-sm leading-tight text-center">
                                 "O mundo é um livro e quem não viaja lê apenas uma página."
-                                <span className="block not-italic text-gray-400 text-xs mt-1">(Santo Agostinho)</span>
+                                <span className="block not-italic text-zinc-400 text-xs mt-1">(Santo Agostinho)</span>
                             </p>
                         </div>
                     </div>
@@ -613,7 +613,7 @@ const Destinations: React.FC = memo(() => {
                             tabIndex={0}
                             role="button"
                             aria-label={`Ver detalhes de ${dest.city}, ${dest.country}`}
-                            className="group bg-white rounded-[2rem] border-2 border-gray-100 p-4 pb-0 shadow-[6px_6px_0px_rgba(0,0,0,0.05)] hover:shadow-[10px_10px_0px_rgba(0,0,0,0.08)] hover:-translate-y-2 transition-all cursor-pointer flex flex-col focus:outline-none focus-visible:ring-4 focus-visible:ring-brand-cyan"
+                            className="group bg-white rounded-[2rem] border-2 border-zinc-100 p-4 pb-0 shadow-[6px_6px_0px_rgba(0,0,0,0.05)] hover:shadow-[10px_10px_0px_rgba(0,0,0,0.08)] hover:-translate-y-2 transition-all cursor-pointer flex flex-col focus:outline-none focus-visible:ring-4 focus-visible:ring-brand-cyan"
                             onClick={() => setSelectedDestination(dest)}
                             onKeyDown={(e) => {
                                 if (e.key === 'Enter' || e.key === ' ') {
@@ -622,7 +622,7 @@ const Destinations: React.FC = memo(() => {
                                 }
                             }}
                         >
-                            <div className="relative h-56 rounded-[1.5rem] overflow-hidden mb-4 border border-gray-100">
+                            <div className="relative h-56 rounded-[1.5rem] overflow-hidden mb-4 border border-zinc-100">
                                 <LazyImage
                                     src={dest.image}
                                     alt={`${dest.city}, ${dest.country} — pacote de viagem personalizado Anhangá Viagens`}
@@ -632,19 +632,19 @@ const Destinations: React.FC = memo(() => {
                                 />
 
                                 {/* Price Tag Sticker */}
-                                <div className="absolute top-4 right-4 bg-white text-brand-dark font-black px-3 py-1 rounded-md shadow-[3px_3px_0px_rgba(0,0,0,0.2)] text-sm rotate-3 group-hover:rotate-6 transition-transform border border-gray-100">
+                                <div className="absolute top-4 right-4 bg-white text-brand-dark font-black px-3 py-1 rounded-md shadow-[3px_3px_0px_rgba(0,0,0,0.2)] text-sm rotate-3 group-hover:rotate-6 transition-transform border border-zinc-100">
                                     A partir de {dest.price}
                                 </div>
                             </div>
 
                             <div className="px-2 pb-6">
                                 <div className="flex justify-between items-center mb-2">
-                                    <h3 className="text-2xl font-black text-gray-800">{dest.city}</h3>
+                                    <h3 className="text-2xl font-black text-zinc-800">{dest.city}</h3>
                                     <div className="flex items-center gap-1 text-yellow-500 font-bold text-sm bg-yellow-50 px-2 py-1 rounded-full border border-yellow-100">
                                         <Star className="size-3 fill-current" /> {dest.rating}
                                     </div>
                                 </div>
-                                <p className="text-gray-500 text-sm font-medium mb-4">{dest.description}</p>
+                                <p className="text-zinc-500 text-sm font-medium mb-4">{dest.description}</p>
 
                                 <div className="flex items-center gap-2 text-brand-cyan font-bold text-sm uppercase tracking-wide group-hover:gap-3 transition-all">
                                     Saiba Mais <ArrowRight className="size-4" />
@@ -657,7 +657,7 @@ const Destinations: React.FC = memo(() => {
 
             {/* Modal - Scrapbook Page Style */}
             {selectedDestination && (
-                <div role="button" tabIndex={0} aria-label="Fechar destino" className="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-sm" onClick={() => setSelectedDestination(null)} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSelectedDestination(null); }}>
+                <div role="button" tabIndex={0} aria-label="Fechar destino" className="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-zinc-900/60 backdrop-blur-sm" onClick={() => setSelectedDestination(null)} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSelectedDestination(null); }}>
                     <div role="presentation" className="bg-[#fffdf5] w-full max-w-4xl rounded-[2.5rem] shadow-2xl overflow-hidden relative flex flex-col md:flex-row max-h-[90vh] border-8 border-white transform rotate-1" onClick={e => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
 
                         {/* Washi Tape Decor */}
@@ -665,13 +665,13 @@ const Destinations: React.FC = memo(() => {
 
                         <button
                             onClick={() => setSelectedDestination(null)}
-                            className="absolute top-4 right-4 z-30 bg-white border-2 border-gray-100 p-2 rounded-full shadow-md hover:scale-110 transition-transform text-gray-800"
+                            className="absolute top-4 right-4 z-30 bg-white border-2 border-zinc-100 p-2 rounded-full shadow-md hover:scale-110 transition-transform text-zinc-800"
                             aria-label="Fechar detalhes do destino"
                         >
                             <X className="size-5" />
                         </button>
 
-                        <div className="w-full md:w-1/2 h-64 md:h-auto relative bg-gray-100">
+                        <div className="w-full md:w-1/2 h-64 md:h-auto relative bg-zinc-100">
                             <LazyImage
                                 src={selectedDestination.image}
                                 alt={selectedDestination.city}
@@ -689,21 +689,21 @@ const Destinations: React.FC = memo(() => {
                         </div>
 
                         <div className="w-full md:w-1/2 p-8 md:p-10 overflow-y-auto" style={noiseTextureStyle}>
-                            <p className="text-gray-600 mb-8 text-lg leading-relaxed font-medium font-serif italic">"{selectedDestination.details}"</p>
+                            <p className="text-zinc-600 mb-8 text-lg leading-relaxed font-medium font-serif italic">"{selectedDestination.details}"</p>
 
-                            <h4 className="font-black text-gray-900 mb-4 flex items-center gap-2">
+                            <h4 className="font-black text-zinc-900 mb-4 flex items-center gap-2">
                                 <Star className="size-5 text-yellow-400 fill-current" /> Atrações Imperdíveis
                             </h4>
                             <div className="flex flex-wrap gap-3 mb-8">
                                 {selectedDestination.activities.map((act) => (
-                                    <span key={act} className="bg-white border-2 border-gray-100 px-4 py-2 rounded-xl text-sm text-gray-700 font-bold shadow-sm transform hover:-rotate-1 transition-transform cursor-default">
+                                    <span key={act} className="bg-white border-2 border-zinc-100 px-4 py-2 rounded-xl text-sm text-zinc-700 font-bold shadow-sm transform hover:-rotate-1 transition-transform cursor-default">
                                         {act}
                                     </span>
                                 ))}
                             </div>
 
-                            <div className="mb-8 p-4 bg-white/50 rounded-2xl border border-gray-100">
-                                <p className="text-sm font-bold text-gray-400 uppercase tracking-widest mb-3">Compartilhar destino</p>
+                            <div className="mb-8 p-4 bg-white/50 rounded-2xl border border-zinc-100">
+                                <p className="text-sm font-bold text-zinc-400 uppercase tracking-widest mb-3">Compartilhar destino</p>
                                 <SocialShare
                                     url={`https://www.anhanga.tur.br/#destinos`}
                                     title={`Confira esse destino na Anhangá Viagens: ${selectedDestination.city}`}
@@ -716,7 +716,7 @@ const Destinations: React.FC = memo(() => {
                                     <Link
                                         to={selectedDestination.landingPage}
                                         onClick={() => setSelectedDestination(null)}
-                                        className="w-full bg-white border-2 border-brand-dark text-brand-dark py-4 rounded-xl font-black text-lg hover:bg-gray-50 transition-all shadow-[4px_4px_0px_#0f172a] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2"
+                                        className="w-full bg-white border-2 border-brand-dark text-brand-dark py-4 rounded-xl font-black text-lg hover:bg-zinc-50 transition-all shadow-[4px_4px_0px_#0f172a] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2"
                                     >
                                         Ver detalhes do pacote <ArrowRight className="size-5" />
                                     </Link>

--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -47,7 +47,7 @@ const FAQItem = memo(({ question, answer, idx }: FAQItemProps) => {
 
                 <div className={`size-10 rounded-xl flex items-center justify-center transition-all duration-300 ${isOpen
                     ? 'bg-brand-cyan text-white rotate-180'
-                    : 'bg-white text-gray-400 group-hover:text-brand-cyan'
+                    : 'bg-white text-zinc-400 group-hover:text-brand-cyan'
                     }`}>
                     {isOpen ? <CaretUp className="size-6" weight="bold" /> : <CaretDown className="size-6" weight="bold" />}
                 </div>
@@ -55,7 +55,7 @@ const FAQItem = memo(({ question, answer, idx }: FAQItemProps) => {
             <div
                 className={`overflow-hidden transition-all duration-500 ease-in-out ${isOpen ? 'max-h-[800px] opacity-100' : 'max-h-0 opacity-0'}`}
             >
-                <div className="px-6 pb-8 pt-4 text-gray-700 font-medium leading-relaxed text-lg bg-white/40">
+                <div className="px-6 pb-8 pt-4 text-zinc-700 font-medium leading-relaxed text-lg bg-white/40">
                     {/* The answer content is injected here */}
                     {answer}
                 </div>
@@ -218,7 +218,7 @@ const FAQ = memo(() => {
                             A gente responde.
                         </span>
                     </h2>
-                    <p className="text-lg text-gray-500 max-w-2xl mx-auto">
+                    <p className="text-lg text-zinc-500 max-w-2xl mx-auto">
                         As perguntas que chegam mais no nosso WhatsApp, com resposta de verdade.
                     </p>
                 </div>
@@ -237,7 +237,7 @@ const FAQ = memo(() => {
                         </div>
                         <div className="text-center md:text-left">
                             <h4 className="font-bold text-brand-dark text-xl mb-1">Ainda tem dúvidas?</h4>
-                            <p className="text-gray-600">
+                            <p className="text-zinc-600">
                                 Nossa <span className="font-bold text-brand-cyan">IA Especialista</span> está pronta para ajudar.
                                 Chame no chat aqui no canto! 👉
                             </p>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -17,7 +17,7 @@ const Footer: React.FC = () => {
     const runtimeMetadata = useFooterRuntimeMetadata();
 
     return (
-        <footer className="relative bg-brand-dark text-gray-300 pt-32 pb-32 md:pb-24 font-sans overflow-hidden">
+        <footer className="relative bg-brand-dark text-zinc-300 pt-32 pb-32 md:pb-24 font-sans overflow-hidden">
 
             {/* Wavy Top Border */}
             <div className="absolute top-0 left-0 w-full overflow-hidden leading-none">
@@ -40,7 +40,7 @@ const Footer: React.FC = () => {
                                 className="h-32 w-auto object-contain"
                             />
                         </div>
-                        <p className="text-gray-400 leading-relaxed max-w-sm font-medium">
+                        <p className="text-zinc-400 leading-relaxed max-w-sm font-medium">
                             Roteiros feitos do zero. Sem pacote pronto, sem estresse. <br />
                             Só a sua viagem.
                         </p>
@@ -106,18 +106,18 @@ const Footer: React.FC = () => {
                     </div>
 
                     <div className="flex flex-col md:items-end gap-2 text-center md:text-right order-1 md:order-2">
-                        <div className="text-xs text-gray-500 font-medium flex items-center justify-center md:justify-end gap-1">
+                        <div className="text-xs text-zinc-500 font-medium flex items-center justify-center md:justify-end gap-1">
                             Feito com <Heart className="size-3 text-red-500" weight="fill" aria-hidden="true" /> pela <img src={ANHANGA_TECH_LOGO_URL} alt="Anhangá.tech" width="80" height="16" loading="lazy" className="h-4 w-auto inline-block mx-1 align-sub" />
                             {runtimeMetadata ? ` • ${runtimeMetadata.currentYear}` : null}
                         </div>
-                        <div className="text-[10px] text-gray-600 font-medium flex flex-wrap justify-center md:justify-end gap-x-2">
-                            <span>ANHANGA TURISMO LTDA • CNPJ/Cadastur: <a href="https://cadastur.turismo.gov.br/" target="_blank" rel="noopener noreferrer" className="hover:text-brand-yellow transition-colors underline decoration-gray-600 underline-offset-2">37.036.732/0001-41</a></span>
+                        <div className="text-[10px] text-zinc-600 font-medium flex flex-wrap justify-center md:justify-end gap-x-2">
+                            <span>ANHANGA TURISMO LTDA • CNPJ/Cadastur: <a href="https://cadastur.turismo.gov.br/" target="_blank" rel="noopener noreferrer" className="hover:text-brand-yellow transition-colors underline decoration-zinc-600 underline-offset-2">37.036.732/0001-41</a></span>
                             <span className="hidden md:inline">•</span>
-                            <a href="https://www.abav.com.br/" target="_blank" rel="noopener noreferrer" className="hover:text-brand-yellow transition-colors underline decoration-gray-600 underline-offset-2">Membro ABAV</a>
+                            <a href="https://www.abav.com.br/" target="_blank" rel="noopener noreferrer" className="hover:text-brand-yellow transition-colors underline decoration-zinc-600 underline-offset-2">Membro ABAV</a>
                             <span className="hidden md:inline">•</span>
-                            <a href="https://www.gov.br/turismo/pt-br" target="_blank" rel="noopener noreferrer" className="hover:text-brand-yellow transition-colors underline decoration-gray-600 underline-offset-2">Ministério do Turismo</a>
+                            <a href="https://www.gov.br/turismo/pt-br" target="_blank" rel="noopener noreferrer" className="hover:text-brand-yellow transition-colors underline decoration-zinc-600 underline-offset-2">Ministério do Turismo</a>
                         </div>
-                        <div className="text-[10px] text-gray-700 font-bold uppercase tracking-widest mt-2">
+                        <div className="text-[10px] text-zinc-700 font-bold uppercase tracking-widest mt-2">
                             Conteúdo da equipe Anhangá Viagens
                             {runtimeMetadata ? ` • Última atualização: ${runtimeMetadata.lastUpdatedLabel}` : null}
                         </div>

--- a/components/Header/HeaderNavigation.tsx
+++ b/components/Header/HeaderNavigation.tsx
@@ -48,7 +48,7 @@ export function DesktopNavigation({
               </button>
 
               <div className="absolute top-full z-10 w-48 translate-y-2 pt-4 opacity-0 invisible transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100 group-hover:visible focus-within:translate-y-0 focus-within:opacity-100 focus-within:visible">
-                <div className="rounded-md border border-gray-100 bg-white py-2 shadow-lg">
+                <div className="rounded-md border border-zinc-100 bg-white py-2 shadow-lg">
                   {link.subLinks.map((subLink) => {
                     const href = isPageLink(subLink.href)
                       ? `${SITE_URL}${subLink.href}`
@@ -63,7 +63,7 @@ export function DesktopNavigation({
                             onNavClick(event, subLink.href);
                           }
                         }}
-                        className="block px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-100"
+                        className="block px-4 py-2 text-sm text-zinc-700 transition-colors hover:bg-zinc-100"
                       >
                         {subLink.name}
                       </a>
@@ -112,7 +112,7 @@ export function MobileNavigationMenu({
     <div
       id="mobile-menu"
       hidden={!isOpen}
-      className="md:hidden absolute top-full left-0 w-full bg-white shadow-lg py-4 px-6 flex flex-col gap-4 border-t border-gray-100 text-gray-800 animate-fade-in-down"
+      className="md:hidden absolute top-full left-0 w-full bg-white shadow-lg py-4 px-6 flex flex-col gap-4 border-t border-zinc-100 text-zinc-800 animate-fade-in-down"
     >
       {NAV_LINKS.map((link) => {
         if (link.subLinks) {
@@ -125,7 +125,7 @@ export function MobileNavigationMenu({
               <a
                 key={subLink.name}
                 href={href}
-                className="text-gray-700 font-medium py-2 border-b border-gray-50 focus:text-brand-vibrant focus:outline-none"
+                className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:text-brand-vibrant focus:outline-none"
                 onClick={(event) => {
                   if (!isPageLink(subLink.href) && isHome) {
                     onNavClick(event, subLink.href);
@@ -144,7 +144,7 @@ export function MobileNavigationMenu({
           <a
             key={link.name}
             href={buildSectionHref(link.href!, isHome)}
-            className="text-gray-700 font-medium py-2 border-b border-gray-50 focus:text-brand-vibrant focus:outline-none"
+            className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:text-brand-vibrant focus:outline-none"
             onClick={(event) => {
               if (isHome) {
                 onNavClick(event, link.href!);
@@ -160,7 +160,7 @@ export function MobileNavigationMenu({
 
       <a
         href={getBlogHomeUrl()}
-        className="text-gray-700 font-medium py-2 border-b border-gray-50 focus:text-brand-vibrant focus:outline-none"
+        className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:text-brand-vibrant focus:outline-none"
         onClick={onCloseMenu}
       >
         Blog de Viagens

--- a/components/Header/useHeaderStyles.ts
+++ b/components/Header/useHeaderStyles.ts
@@ -30,13 +30,13 @@ export function useHeaderStyles(isScrolled: boolean, isInternalPage: boolean): H
         ctaPaddingClass: isInternalPage ? 'px-4 py-2' : 'px-5 py-2.5',
 
         navTextClass: useSolidHeader
-            ? 'text-gray-600 hover:text-brand-vibrant'
+            ? 'text-zinc-600 hover:text-brand-vibrant'
             : 'text-white/90 hover:text-white',
 
         buttonClass: useSolidHeader
             ? 'bg-brand-vibrant hover:bg-brand-blue text-white'
             : 'bg-white/20 hover:bg-white/30 backdrop-blur-sm text-white border border-white/30',
 
-        mobileToggleClass: useSolidHeader ? 'text-gray-700' : 'text-white',
+        mobileToggleClass: useSolidHeader ? 'text-zinc-700' : 'text-white',
     };
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -199,7 +199,7 @@ const Hero: React.FC = memo(() => {
                   value={mobileDestination}
                   onChange={(e) => setMobileDestination(e.target.value)}
                   placeholder="Para onde você quer ir?"
-                  className="flex-1 outline-none text-gray-800 font-semibold placeholder-gray-400 bg-transparent text-base"
+                  className="flex-1 outline-none text-zinc-800 font-semibold placeholder-zinc-400 bg-transparent text-base"
                   autoComplete="off"
                   data-testid="destination-input-mobile"
                 />

--- a/components/Highlights.tsx
+++ b/components/Highlights.tsx
@@ -117,16 +117,16 @@ const Highlights = memo(() => {
                                     height={600}
                                     className="w-full object-cover aspect-[4/3]"
                                 />
-                                <div className="absolute bottom-4 right-4 bg-white/90 backdrop-blur-md px-4 py-1 rounded-full text-xs font-bold text-gray-700 shadow-sm transition-transform duration-300 group-hover:scale-110">
+                                <div className="absolute bottom-4 right-4 bg-white/90 backdrop-blur-md px-4 py-1 rounded-full text-xs font-bold text-zinc-700 shadow-sm transition-transform duration-300 group-hover:scale-110">
                                     📍 Caribe? Talvez.
                                 </div>
                             </m.div>
                         </div>
 
-                        <div className="bg-white p-8 rounded-[2rem] border-2 border-gray-100 shadow-[8px_8px_0px_rgba(0,0,0,0.05)] text-center lg:text-left">
+                        <div className="bg-white p-8 rounded-[2rem] border-2 border-zinc-100 shadow-[8px_8px_0px_rgba(0,0,0,0.05)] text-center lg:text-left">
                             {/* Changed h4 to p to maintain correct heading hierarchy and avoid SEO audit findings. */}
-                            <p className="font-black text-2xl text-gray-900 mb-2">Viaje Leve! 🎈</p>
-                            <p className="text-gray-500 text-lg mb-6 leading-relaxed">
+                            <p className="font-black text-2xl text-zinc-900 mb-2">Viaje Leve! 🎈</p>
+                            <p className="text-zinc-500 text-lg mb-6 leading-relaxed">
                                 Comece a planejar agora e receba um roteiro prévio sem compromisso.
                             </p>
                             <button
@@ -164,7 +164,7 @@ const Highlights = memo(() => {
                                     para o viajante errado.
                                 </span>
                             </h2>
-                            <p className="text-gray-600 text-lg md:text-xl font-medium leading-relaxed mb-8">
+                            <p className="text-zinc-600 text-lg md:text-xl font-medium leading-relaxed mb-8">
                                 A <strong>Anhangá</strong> é uma agência de viagens em São Paulo. Não trabalhamos com pacote pronto. Ouvimos o que você quer, pesquisamos o que faz sentido pra você e montamos cada detalhe do roteiro. Do primeiro voo ao último café da manhã, você não está sozinho.
                             </p>
                         </m.div>
@@ -204,10 +204,10 @@ const Highlights = memo(() => {
                                         </m.div>
 
                                         {/* Content */}
-                                        <h3 className="text-xl font-extrabold text-gray-900 mb-3 leading-tight group-hover:text-brand-cyan transition-colors duration-300">
+                                        <h3 className="text-xl font-extrabold text-zinc-900 mb-3 leading-tight group-hover:text-brand-cyan transition-colors duration-300">
                                             {item.title}
                                         </h3>
-                                        <p className="text-gray-500 font-medium leading-relaxed text-sm md:text-base">
+                                        <p className="text-zinc-500 font-medium leading-relaxed text-sm md:text-base">
                                             {item.description}
                                         </p>
 

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -93,7 +93,7 @@ const HowItWorks = memo(() => {
             <h2 className="text-4xl md:text-6xl font-extrabold text-brand-dark mt-6 mb-6 leading-tight">
                 Como a mágica <br className="md:hidden"/> acontece?
             </h2>
-            <p className="text-xl text-gray-600 font-medium font-sans">
+            <p className="text-xl text-zinc-600 font-medium font-sans">
                 Planejar viagem não precisa ser chato. <br className="hidden md:block"/>
                 Aqui vai funcionar assim: você fala, a gente afia o lápis e monta tudo.
             </p>
@@ -117,7 +117,7 @@ const HowItWorks = memo(() => {
             </div>
 
             {/* Mobile Vertical Line */}
-            <div className="md:hidden absolute top-4 bottom-4 left-8 w-1 bg-gray-200 border-l-2 border-dashed border-gray-300 z-0"></div>
+            <div className="md:hidden absolute top-4 bottom-4 left-8 w-1 bg-zinc-200 border-l-2 border-dashed border-zinc-300 z-0"></div>
 
             <div className="flex flex-col gap-12 md:gap-0">
                 {STEPS.map((step, idx) => {
@@ -139,15 +139,15 @@ const HowItWorks = memo(() => {
                                     <div className={`size-16 rounded-2xl ${step.color} shadow-lg flex items-center justify-center transform -rotate-6 group-hover:rotate-0 transition-transform duration-300`}>
                                         {step.icon}
                                     </div>
-                                    <span className="font-black text-6xl text-gray-100 select-none absolute top-4 right-6 z-0">
+                                    <span className="font-black text-6xl text-zinc-100 select-none absolute top-4 right-6 z-0">
                                         0{step.id}
                                     </span>
                                 </div>
 
                                 {/* Content */}
                                 <div className="relative z-10">
-                                    <h3 className="text-2xl font-bold text-gray-800 mb-3">{step.title}</h3>
-                                    <p className="text-gray-600 leading-relaxed font-medium">
+                                    <h3 className="text-2xl font-bold text-zinc-800 mb-3">{step.title}</h3>
+                                    <p className="text-zinc-600 leading-relaxed font-medium">
                                         {step.desc}
                                     </p>
                                 </div>
@@ -186,7 +186,7 @@ const HowItWorks = memo(() => {
                     </div>
                 </button>
             </div>
-            <p className="mt-6 text-gray-400 font-medium text-sm">
+            <p className="mt-6 text-zinc-400 font-medium text-sm">
                 (Prometemos: Zero estresse, 100% diversão)
             </p>
         </div>

--- a/components/LandingFAQ.tsx
+++ b/components/LandingFAQ.tsx
@@ -37,7 +37,7 @@ const FAQItemComponent = memo(({ question, answer, isOpen, idx, onToggle }: FAQI
                     isOpen ? 'max-h-[500px] opacity-100 pb-8' : 'max-h-0 opacity-0'
                 }`}
             >
-                <div className="text-gray-600 text-lg leading-relaxed">
+                <div className="text-zinc-600 text-lg leading-relaxed">
                     {typeof answer === 'string' ? <p>{answer}</p> : answer}
                 </div>
             </div>
@@ -66,7 +66,7 @@ export const LandingFAQ: React.FC<LandingFAQProps> = ({
                     <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">
                         {title}
                     </h2>
-                    <p className="text-lg text-gray-500">
+                    <p className="text-lg text-zinc-500">
                         {subtitle}
                     </p>
                 </div>

--- a/components/SearchForm.tsx
+++ b/components/SearchForm.tsx
@@ -161,10 +161,10 @@ const DestinationField = memo(({
 
   return (
     <div
-      className="w-full md:flex-[1.5] p-3 md:p-6 relative group text-left cursor-text hover:bg-gray-50/80 transition-all duration-300 rounded-t-[2rem] md:rounded-tl-[2rem] md:rounded-tr-none"
+      className="w-full md:flex-[1.5] p-3 md:p-6 relative group text-left cursor-text hover:bg-zinc-50/80 transition-all duration-300 rounded-t-[2rem] md:rounded-tl-[2rem] md:rounded-tr-none"
       ref={destRef}
     >
-      <label htmlFor="destination-input" className="block text-[10px] font-black text-gray-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-focus-within:text-brand-cyan transition-colors">
+      <label htmlFor="destination-input" className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-focus-within:text-brand-cyan transition-colors">
         <MapPin className="size-3" /> Para onde?
       </label>
       <div className="relative flex items-center">
@@ -178,7 +178,7 @@ const DestinationField = memo(({
           onFocus={onFocus}
           onKeyDown={onKeyDown}
           placeholder="Ex: Orlando, Paris, Brasil..."
-          className="w-full outline-none text-gray-800 font-bold placeholder-gray-300 bg-transparent text-lg md:text-xl truncate transition-colors pr-8"
+          className="w-full outline-none text-zinc-800 font-bold placeholder-zinc-300 bg-transparent text-lg md:text-xl truncate transition-colors pr-8"
           autoComplete="off"
           role="combobox"
           aria-autocomplete="list"
@@ -195,7 +195,7 @@ const DestinationField = memo(({
               e.stopPropagation();
               onClear();
             }}
-            className="absolute right-0 p-1 text-gray-400 hover:text-brand-vibrant transition-colors rounded-full focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-brand-vibrant"
+            className="absolute right-0 p-1 text-zinc-400 hover:text-brand-vibrant transition-colors rounded-full focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-brand-vibrant"
             aria-label="Limpar destino"
           >
             <X className="size-4" />
@@ -203,7 +203,7 @@ const DestinationField = memo(({
         )}
       </div>
       {showDestSuggestions && hasSuggestions && (
-        <div className="absolute top-full left-0 w-full bg-white rounded-2xl shadow-xl border-2 border-gray-100 mt-4 overflow-hidden z-[60] animate-pop-in origin-top">
+        <div className="absolute top-full left-0 w-full bg-white rounded-2xl shadow-xl border-2 border-zinc-100 mt-4 overflow-hidden z-[60] animate-pop-in origin-top">
           <ul id="destination-results" role="listbox" className="max-h-60 overflow-y-auto custom-scrollbar">
             {filteredDestinations.map((dest, index) => (
               <li
@@ -213,8 +213,8 @@ const DestinationField = memo(({
                 aria-selected={index === activeSuggestionIndex}
                 onClick={() => onSelect(dest)}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onSelect(dest); }}
-                className={`px-6 py-3 cursor-pointer text-left text-sm font-medium border-b border-gray-50 last:border-0 flex items-center gap-2 transition-colors ${
-                  index === activeSuggestionIndex ? 'bg-brand-light text-brand-cyan' : 'hover:bg-brand-light text-gray-700'
+                className={`px-6 py-3 cursor-pointer text-left text-sm font-medium border-b border-zinc-50 last:border-0 flex items-center gap-2 transition-colors ${
+                  index === activeSuggestionIndex ? 'bg-brand-light text-brand-cyan' : 'hover:bg-brand-light text-zinc-700'
                 }`}
               >
                 <MapPin className={`size-4 shrink-0 ${index === activeSuggestionIndex ? 'text-brand-cyan' : 'text-brand-cyan/50'}`} />
@@ -225,8 +225,8 @@ const DestinationField = memo(({
         </div>
       )}
       {shouldShowEmptyState && (
-        <div className="absolute top-full left-0 w-full bg-white rounded-2xl shadow-xl border-2 border-gray-100 mt-4 p-4 z-[60] animate-pop-in origin-top">
-          <p className="text-gray-400 text-sm font-medium text-center">Nenhum destino encontrado. Tente outra cidade ou país.</p>
+        <div className="absolute top-full left-0 w-full bg-white rounded-2xl shadow-xl border-2 border-zinc-100 mt-4 p-4 z-[60] animate-pop-in origin-top">
+          <p className="text-zinc-400 text-sm font-medium text-center">Nenhum destino encontrado. Tente outra cidade ou país.</p>
         </div>
       )}
     </div>
@@ -267,40 +267,40 @@ const DateField = memo(({
     <button
       type="button"
       onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-gray-50/80 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
       aria-expanded={showCalendar}
       aria-haspopup="grid"
       data-testid="dates-filter-btn"
     >
-      <span className="block text-[10px] font-black text-gray-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
+      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
         <Calendar className="size-3" /> Quando?
       </span>
       <div className="flex items-center justify-between">
-        <span className={`text-lg md:text-xl font-bold truncate transition-colors ${startDate ? "text-gray-800" : "text-gray-300"}`}>
+        <span className={`text-lg md:text-xl font-bold truncate transition-colors ${startDate ? "text-zinc-800" : "text-zinc-300"}`}>
           {startDate ? `${formatDateDisplay(startDate)} - ${endDate ? formatDateDisplay(endDate) : '...'}` : "Definir datas"}
         </span>
-        <ChevronDown className={`size-4 text-gray-400 transition-transform duration-300 ${showCalendar ? 'rotate-180' : ''}`} />
+        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${showCalendar ? 'rotate-180' : ''}`} />
       </div>
     </button>
 
     {showCalendar && (
-      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 md:left-auto md:right-0 bg-white rounded-3xl shadow-2xl border-2 border-gray-100 mt-4 p-6 z-[60] w-full md:w-80 cursor-default animate-pop-in origin-top">
+      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 md:left-auto md:right-0 bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-4 p-6 z-[60] w-full md:w-80 cursor-default animate-pop-in origin-top">
         <div className="flex items-center justify-between mb-4">
           <button
             type="button"
             onClick={() => onChangeMonth(-1)}
             disabled={!canGoToPreviousMonth}
-            className={`p-1 rounded-full transition-colors ${canGoToPreviousMonth ? 'hover:bg-gray-100 text-gray-600' : 'text-gray-300 cursor-not-allowed'}`}
+            className={`p-1 rounded-full transition-colors ${canGoToPreviousMonth ? 'hover:bg-zinc-100 text-zinc-600' : 'text-zinc-300 cursor-not-allowed'}`}
             aria-label="Mês anterior"
           >
             <ChevronLeft className="size-5" />
           </button>
-          <span className="font-bold text-gray-800">{MONTH_NAMES[currentMonth.getMonth()]} {currentMonth.getFullYear()}</span>
-          <button type="button" onClick={() => onChangeMonth(1)} className="p-1 hover:bg-gray-100 rounded-full text-gray-600 transition-colors" aria-label="Próximo mês">
+          <span className="font-bold text-zinc-800">{MONTH_NAMES[currentMonth.getMonth()]} {currentMonth.getFullYear()}</span>
+          <button type="button" onClick={() => onChangeMonth(1)} className="p-1 hover:bg-zinc-100 rounded-full text-zinc-600 transition-colors" aria-label="Próximo mês">
             <ChevronRight className="size-5" />
           </button>
         </div>
-        <div className="grid grid-cols-7 mb-2 text-center text-xs font-bold text-gray-400">
+        <div className="grid grid-cols-7 mb-2 text-center text-xs font-bold text-zinc-400">
           {WEEK_DAYS.map((day) => <div key={day}>{day}</div>)}
         </div>
         <div className="grid grid-cols-7 gap-y-1">
@@ -319,7 +319,7 @@ const DateField = memo(({
                 disabled={past}
                 aria-disabled={past}
                 className={`size-9 mx-auto flex items-center justify-center text-sm rounded-full transition-all duration-200 border-2
-                  ${past ? 'border-transparent text-gray-300 cursor-not-allowed' : selected ? 'bg-brand-cyan border-brand-cyan text-white font-bold scale-110' : inRange ? 'bg-brand-light border-transparent text-brand-cyan font-bold' : 'border-transparent text-gray-600 hover:bg-gray-100'}`}
+                  ${past ? 'border-transparent text-zinc-300 cursor-not-allowed' : selected ? 'bg-brand-cyan border-brand-cyan text-white font-bold scale-110' : inRange ? 'bg-brand-light border-transparent text-brand-cyan font-bold' : 'border-transparent text-zinc-600 hover:bg-zinc-100'}`}
               >
                 {date.getDate()}
               </button>
@@ -363,39 +363,39 @@ const GuestsField = memo(({
     <button
       type="button"
       onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-gray-50/80 transition-all duration-300 md:rounded-tr-[2rem] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition-all duration-300 md:rounded-tr-[2rem] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
       aria-expanded={showGuestDropdown}
       aria-haspopup="true"
       data-testid="guests-filter-btn"
     >
-      <span className="block text-[10px] font-black text-gray-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
+      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
         <User className="size-3" /> Quem vai?
       </span>
       <div className="flex items-center justify-between">
-        <span className="text-lg md:text-xl font-bold text-gray-800 truncate transition-colors">{guestSummary}</span>
-        <ChevronDown className={`size-4 text-gray-400 transition-transform duration-300 ${showGuestDropdown ? 'rotate-180' : ''}`} />
+        <span className="text-lg md:text-xl font-bold text-zinc-800 truncate transition-colors">{guestSummary}</span>
+        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${showGuestDropdown ? 'rotate-180' : ''}`} />
       </div>
     </button>
 
     {showGuestDropdown && (
-      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 md:left-auto md:right-0 bg-white rounded-3xl shadow-2xl border-2 border-gray-100 mt-4 p-6 z-[60] w-full md:w-72 cursor-default animate-pop-in origin-top">
+      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 md:left-auto md:right-0 bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-4 p-6 z-[60] w-full md:w-72 cursor-default animate-pop-in origin-top">
         <div className="flex justify-between items-center mb-4">
-          <p className="font-bold text-gray-800">Adultos</p>
+          <p className="font-bold text-zinc-800">Adultos</p>
           <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onAdultsChange(Math.max(1, adults - 1)); }}
               disabled={adults <= 1}
-              className="size-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition-all disabled:opacity-40 disabled:cursor-not-allowed"
               aria-label="Remover um adulto"
             >
               <Minus className="size-4" />
             </button>
-            <span className="font-bold w-8 text-center text-gray-900" aria-live="polite">{adults}</span>
+            <span className="font-bold w-8 text-center text-zinc-900" aria-live="polite">{adults}</span>
             <button
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onAdultsChange(adults + 1); }}
-              className="size-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all"
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition-all"
               aria-label="Adicionar um adulto"
             >
               <Plus className="size-4" />
@@ -403,22 +403,22 @@ const GuestsField = memo(({
           </div>
         </div>
         <div className="flex justify-between items-center mb-4">
-          <p className="font-bold text-gray-800">Crianças</p>
+          <p className="font-bold text-zinc-800">Crianças</p>
           <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onChildCountChange('remove'); }}
               disabled={children <= 0}
-              className="size-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition-all disabled:opacity-40 disabled:cursor-not-allowed"
               aria-label="Remover uma criança"
             >
               <Minus className="size-4" />
             </button>
-            <span className="font-bold w-8 text-center text-gray-900" aria-live="polite">{children}</span>
+            <span className="font-bold w-8 text-center text-zinc-900" aria-live="polite">{children}</span>
             <button
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onChildCountChange('add'); }}
-              className="size-8 rounded-full border-2 border-gray-200 flex items-center justify-center text-gray-600 hover:border-brand-cyan hover:text-brand-cyan transition-all"
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition-all"
               aria-label="Adicionar uma criança"
             >
               <Plus className="size-4" />
@@ -430,7 +430,7 @@ const GuestsField = memo(({
           <div className="mb-4 grid grid-cols-2 gap-2 max-h-32 overflow-y-auto pr-1 custom-scrollbar animate-fade-in-up">
             {childAges.map((age, index) => (
               <div key={`child-age-${index}`} className="flex flex-col">
-                <label htmlFor={`child-age-input-${index}`} className="text-[10px] text-gray-400 font-bold mb-1">Idade Criança {index + 1}</label>
+                <label htmlFor={`child-age-input-${index}`} className="text-[10px] text-zinc-400 font-bold mb-1">Idade Criança {index + 1}</label>
                 <input
                   id={`child-age-input-${index}`}
                   type="number"
@@ -439,7 +439,7 @@ const GuestsField = memo(({
                   value={age}
                   onClick={(event) => event.stopPropagation()}
                   onChange={(event) => onChildAgeChange(index, event.target.value)}
-                  className="w-full border-2 border-gray-100 rounded-lg px-2 py-1 text-sm font-bold text-gray-700 outline-none focus:border-brand-cyan transition-colors"
+                  className="w-full border-2 border-zinc-100 rounded-lg px-2 py-1 text-sm font-bold text-zinc-700 outline-none focus:border-brand-cyan transition-colors"
                   placeholder="Ex: 5"
                 />
               </div>
@@ -475,12 +475,12 @@ const TripTypeField = memo(({
     <button
       type="button"
       onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-gray-50/80 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
       aria-expanded={showTripTypeDropdown}
       aria-haspopup="true"
       data-testid="trip-type-filter-btn"
     >
-      <span className="block text-[10px] font-black text-gray-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
+      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
         <Briefcase className="size-3" /> Tipo de Viagem
       </span>
       <div className="flex items-center justify-between">
@@ -488,16 +488,16 @@ const TripTypeField = memo(({
           {selectedTripObj && (
             <selectedTripObj.icon className={`size-5 ${selectedTripObj.color}`} />
           )}
-          <span className={`text-lg md:text-lg font-bold truncate transition-colors ${tripType ? "text-gray-800" : "text-gray-300"}`}>
+          <span className={`text-lg md:text-lg font-bold truncate transition-colors ${tripType ? "text-zinc-800" : "text-zinc-300"}`}>
             {tripType || "Lazer, Lua de Mel..."}
           </span>
         </div>
-        <ChevronDown className={`size-4 text-gray-400 transition-transform duration-300 ${showTripTypeDropdown ? 'rotate-180' : ''}`} />
+        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${showTripTypeDropdown ? 'rotate-180' : ''}`} />
       </div>
     </button>
 
     {showTripTypeDropdown && (
-      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 w-full md:w-[400px] bg-white rounded-3xl shadow-2xl border-2 border-gray-100 mt-2 z-[60] animate-pop-in origin-top overflow-hidden p-4">
+      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 w-full md:w-[400px] bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-2 z-[60] animate-pop-in origin-top overflow-hidden p-4">
         <div className="grid grid-cols-2 gap-3">
           {TRIP_OPTIONS.map((type) => (
             <button
@@ -505,12 +505,12 @@ const TripTypeField = memo(({
               type="button"
               onClick={() => onSelect(type.label)}
               className={`flex flex-col items-start gap-2 p-3 rounded-2xl border-2 transition-all duration-200 text-left
-                ${tripType === type.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-gray-50 hover:border-gray-100'}`}
+                ${tripType === type.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-zinc-50 hover:border-zinc-100'}`}
             >
               <div className={`p-2 rounded-xl ${type.bg} ${type.color}`}>
                 <type.icon className="size-5" />
               </div>
-              <span className={`font-bold text-base ${tripType === type.label ? 'text-brand-dark' : 'text-gray-600'}`}>
+              <span className={`font-bold text-base ${tripType === type.label ? 'text-brand-dark' : 'text-zinc-600'}`}>
                 {type.label}
               </span>
             </button>
@@ -543,12 +543,12 @@ const BudgetField = memo(({
     <button
       type="button"
       onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-gray-50/80 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
       aria-expanded={showBudgetDropdown}
       aria-haspopup="true"
       data-testid="budget-filter-btn"
     >
-      <span className="block text-[10px] font-black text-gray-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
+      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
         <Wallet className="size-3" /> Orçamento Aprox.
       </span>
       <div className="flex items-center justify-between">
@@ -558,30 +558,30 @@ const BudgetField = memo(({
               {Array.from({ length: selectedBudgetObj.level }, (_, index) => <span key={`selected-budget-${index}`}>$</span>)}
             </div>
           )}
-          <span className={`text-lg md:text-lg font-bold truncate transition-colors ${budget ? "text-gray-800" : "text-gray-300"}`}>
+          <span className={`text-lg md:text-lg font-bold truncate transition-colors ${budget ? "text-zinc-800" : "text-zinc-300"}`}>
             {budget || "Definir padrão"}
           </span>
         </div>
-        <ChevronDown className={`size-4 text-gray-400 transition-transform duration-300 ${showBudgetDropdown ? 'rotate-180' : ''}`} />
+        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${showBudgetDropdown ? 'rotate-180' : ''}`} />
       </div>
     </button>
 
     {showBudgetDropdown && (
-      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 w-full md:w-[320px] bg-white rounded-3xl shadow-2xl border-2 border-gray-100 mt-2 z-[60] animate-pop-in origin-top overflow-hidden p-3">
+      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 w-full md:w-[320px] bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-2 z-[60] animate-pop-in origin-top overflow-hidden p-3">
         {BUDGET_TIERS.map((option) => (
           <button
             key={option.label}
             type="button"
             onClick={() => onSelect(option.label)}
             className={`w-full flex items-center gap-4 p-3 rounded-2xl border-2 transition-all duration-200 mb-2 last:mb-0
-              ${budget === option.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-gray-50 hover:border-gray-100'}`}
+              ${budget === option.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-zinc-50 hover:border-zinc-100'}`}
           >
-            <div className={`p-2 rounded-xl bg-gray-100 text-gray-600 ${budget === option.label ? 'bg-brand-vibrant text-white' : ''}`}>
+            <div className={`p-2 rounded-xl bg-zinc-100 text-zinc-600 ${budget === option.label ? 'bg-brand-vibrant text-white' : ''}`}>
               <option.icon className="size-5" />
             </div>
             <div className="text-left">
               <div className="flex items-center gap-2">
-                <span className={`font-bold text-base ${budget === option.label ? 'text-brand-dark' : 'text-gray-800'}`}>
+                <span className={`font-bold text-base ${budget === option.label ? 'text-brand-dark' : 'text-zinc-800'}`}>
                   {option.label}
                 </span>
                 <div className="flex text-[10px] font-black text-green-600 bg-green-50 px-1.5 rounded">
@@ -589,9 +589,9 @@ const BudgetField = memo(({
                 </div>
               </div>
               <div className="flex items-center gap-2 mt-1">
-                <span className="text-sm text-gray-400 font-medium">{option.desc}</span>
-                <span className="text-xs text-gray-500 font-semibold">•</span>
-                <span className="text-sm text-gray-600 font-semibold">{option.range}</span>
+                <span className="text-sm text-zinc-400 font-medium">{option.desc}</span>
+                <span className="text-xs text-zinc-500 font-semibold">•</span>
+                <span className="text-sm text-zinc-600 font-semibold">{option.range}</span>
               </div>
             </div>
           </button>
@@ -924,7 +924,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
         validationError ? 'ring-4 ring-red-500/20 border-red-500/20' : ''
       }`}
     >
-      <div className="flex flex-col md:flex-row items-center w-full divide-y md:divide-y-0 md:divide-x divide-gray-100">
+      <div className="flex flex-col md:flex-row items-center w-full divide-y md:divide-y-0 md:divide-x divide-zinc-100">
         <DestinationField
           destRef={destRef}
           inputRef={destinationInputRef}
@@ -967,12 +967,12 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
         />
       </div>
 
-      <div className="w-full h-[2px] border-t-2 border-dashed border-gray-200 relative my-1">
+      <div className="w-full h-[2px] border-t-2 border-dashed border-zinc-200 relative my-1">
         <div className="absolute left-[-16px] top-[-8px] size-4 bg-brand-light rounded-full"></div>
         <div className="absolute right-[-16px] top-[-8px] size-4 bg-brand-light rounded-full"></div>
       </div>
 
-      <div className="flex flex-col md:flex-row items-stretch w-full divide-y md:divide-y-0 md:divide-x divide-gray-100">
+      <div className="flex flex-col md:flex-row items-stretch w-full divide-y md:divide-y-0 md:divide-x divide-zinc-100">
         <TripTypeField
           tripTypeRef={tripTypeRef}
           showTripTypeDropdown={showTripTypeDropdown}

--- a/components/SocialShare.tsx
+++ b/components/SocialShare.tsx
@@ -65,7 +65,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                         handleNativeShare();
                     }}
                     onMouseEnter={prefetchHaptics}
-                    className="p-2 bg-white/80 hover:bg-brand-cyan hover:text-white text-gray-600 rounded-full transition-all shadow-sm border border-gray-100"
+                    className="p-2 bg-white/80 hover:bg-brand-cyan hover:text-white text-zinc-600 rounded-full transition-all shadow-sm border border-zinc-100"
                     title="Compartilhar"
                     aria-label="Compartilhar"
                 >
@@ -78,7 +78,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                         handleCopy();
                     }}
                     onMouseEnter={prefetchHaptics}
-                    className={`p-2 rounded-full transition-all shadow-sm border ${copied ? 'bg-green-700 text-white border-green-800' : 'bg-white/80 text-gray-600 border-gray-100 hover:bg-gray-100'}`}
+                    className={`p-2 rounded-full transition-all shadow-sm border ${copied ? 'bg-green-700 text-white border-green-800' : 'bg-white/80 text-zinc-600 border-zinc-100 hover:bg-zinc-100'}`}
                     role={copied ? "status" : undefined}
                     title={copied ? "Link copiado!" : "Copiar link"}
                     aria-label={copied ? "Link copiado com sucesso" : "Copiar link"}
@@ -155,7 +155,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                 <button
                     onClick={handleNativeShare}
                     onMouseEnter={prefetchHaptics}
-                    className="hidden lg:flex p-2.5 bg-gray-100 text-gray-600 rounded-xl hover:bg-gray-200 transition-all shadow-sm"
+                    className="hidden lg:flex p-2.5 bg-zinc-100 text-zinc-600 rounded-xl hover:bg-zinc-200 transition-all shadow-sm"
                     title="Mais opções de compartilhamento"
                     aria-label="Mais opções de compartilhamento"
                 >
@@ -166,7 +166,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                 <button
                     onClick={handleCopy}
                     onMouseEnter={prefetchHaptics}
-                    className={`p-2.5 rounded-xl transition-all shadow-sm border ${copied ? 'bg-green-700 text-white border-green-800' : 'bg-gray-100 text-gray-600 border-transparent hover:bg-gray-200'}`}
+                    className={`p-2.5 rounded-xl transition-all shadow-sm border ${copied ? 'bg-green-700 text-white border-green-800' : 'bg-zinc-100 text-zinc-600 border-transparent hover:bg-zinc-200'}`}
                     role={copied ? "status" : undefined}
                     title={copied ? "Link copiado!" : "Copiar link"}
                     aria-label={copied ? "Link copiado com sucesso" : "Copiar link"}

--- a/components/Testimonials.tsx
+++ b/components/Testimonials.tsx
@@ -103,7 +103,7 @@ const Testimonials: React.FC = memo(() => {
                                             {/* Text */}
                                             <div className="text-center md:text-left">
                                                 <Quote className="size-10 text-brand-cyan/20 mx-auto md:mx-0 mb-4 fill-current" />
-                                                <p itemProp="reviewBody" className="text-xl md:text-2xl font-bold text-gray-700 leading-snug mb-6 font-serif italic">
+                                                <p itemProp="reviewBody" className="text-xl md:text-2xl font-bold text-zinc-700 leading-snug mb-6 font-serif italic">
                                                     "{testimonial.text}"
                                                 </p>
                                                 <div>

--- a/components/blog/BlogPostContent.tsx
+++ b/components/blog/BlogPostContent.tsx
@@ -18,14 +18,14 @@ interface BlogPostContentProps {
 
 export const BlogPostContent: React.FC<BlogPostContentProps> = ({ post, canonicalUrl, MdxContent, relatedPosts }) => {
     return (
-        <div className="bg-white rounded-[2.5rem] p-8 md:p-14 shadow-xl border border-gray-100">
+        <div className="bg-white rounded-[2.5rem] p-8 md:p-14 shadow-xl border border-zinc-100">
 
-            <div className="mb-6 pb-4 border-b border-gray-100 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            <div className="mb-6 pb-4 border-b border-zinc-100 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
                 <div className="flex items-center gap-3">
                     <span className={`px-3 py-1 rounded-full text-xs font-black uppercase tracking-widest border ${getCategoryColor(post.category)}`}>
                         {post.category}
                     </span>
-                    <span className="text-xs font-bold text-gray-400 uppercase tracking-wider">{formatDate(post.date)}</span>
+                    <span className="text-xs font-bold text-zinc-400 uppercase tracking-wider">{formatDate(post.date)}</span>
                 </div>
                 <SocialShare
                     minimal
@@ -53,19 +53,19 @@ export const BlogPostContent: React.FC<BlogPostContentProps> = ({ post, canonica
                     <div className="
                         prose md:prose-lg max-w-none
                         prose-headings:font-sans prose-headings:font-black prose-headings:tracking-tight prose-headings:text-brand-dark
-                        prose-p:font-serif prose-p:text-gray-600 prose-p:leading-relaxed prose-p:mb-6
+                        prose-p:font-serif prose-p:text-zinc-600 prose-p:leading-relaxed prose-p:mb-6
                         prose-a:text-brand-cyan prose-a:font-bold prose-a:no-underline prose-a:border-b-2 prose-a:border-brand-cyan/30 hover:prose-a:border-brand-cyan hover:prose-a:text-brand-cyanDark hover:prose-a:bg-brand-cyan/5 prose-a:transition-all
                         prose-strong:text-brand-dark prose-strong:font-black
                         prose-ul:list-disc prose-ul:pl-6 prose-ul:marker:text-brand-yellow
-                        prose-li:font-serif prose-li:text-gray-600
+                        prose-li:font-serif prose-li:text-zinc-600
                         prose-blockquote:border-2 prose-blockquote:border-brand-yellow/40 prose-blockquote:bg-yellow-50 prose-blockquote:py-4 prose-blockquote:px-8 prose-blockquote:rounded-2xl prose-blockquote:not-italic prose-blockquote:font-serif prose-blockquote:text-brand-dark [&_blockquote_p]:text-brand-dark
                         first-letter:text-[3rem] first-letter:md:text-[4.5rem] first-letter:font-black first-letter:text-brand-dark first-letter:float-left first-letter:leading-none first-letter:mr-2 first-letter:mt-1
                     ">
                         <Suspense fallback={
                             <div className="animate-pulse space-y-4">
-                                <div className="h-4 bg-gray-200 rounded w-3/4" />
-                                <div className="h-4 bg-gray-200 rounded w-full" />
-                                <div className="h-4 bg-gray-200 rounded w-5/6" />
+                                <div className="h-4 bg-zinc-200 rounded w-3/4" />
+                                <div className="h-4 bg-zinc-200 rounded w-full" />
+                                <div className="h-4 bg-zinc-200 rounded w-5/6" />
                             </div>
                         }>
                             <MdxContent />
@@ -73,15 +73,15 @@ export const BlogPostContent: React.FC<BlogPostContentProps> = ({ post, canonica
                     </div>
                 </MDXProvider>
             ) : (
-                <div className="prose md:prose-lg max-w-none prose-p:font-serif prose-p:text-gray-600 prose-p:leading-relaxed">
+                <div className="prose md:prose-lg max-w-none prose-p:font-serif prose-p:text-zinc-600 prose-p:leading-relaxed">
                     <p>{post.excerpt}</p>
-                    <p className="text-gray-400 italic">Conteúdo completo em breve…</p>
+                    <p className="text-zinc-400 italic">Conteúdo completo em breve…</p>
                 </div>
             )}
 
             {post.showChatCTA && <ChatCTA destino={post.chatCTADestination} />}
 
-            <div className="mt-12 pt-8 border-t-2 border-dashed border-gray-200 flex flex-col sm:flex-row items-center justify-between gap-6">
+            <div className="mt-12 pt-8 border-t-2 border-dashed border-zinc-200 flex flex-col sm:flex-row items-center justify-between gap-6">
                 <div className="flex items-center gap-2">
                     <span className="font-bold text-brand-dark text-lg">Gostou? Espalhe a palavra:</span>
                 </div>
@@ -92,14 +92,14 @@ export const BlogPostContent: React.FC<BlogPostContentProps> = ({ post, canonica
                 />
             </div>
 
-            <div className="mt-12 lg:hidden border-t border-gray-100 pt-10">
+            <div className="mt-12 lg:hidden border-t border-zinc-100 pt-10">
                 <h3 className="font-black text-2xl text-brand-dark mb-6 flex items-center gap-2">
                     <span className="w-1.5 h-6 bg-brand-vibrant rounded-full"></span>
                     Leia Também
                 </h3>
                 <div className="grid sm:grid-cols-2 gap-6">
                     {relatedPosts.map(related => (
-                        <a href={getBlogPostUrl(related.slug)} key={`mobile-${related.slug}`} className="group flex flex-col bg-white rounded-2xl overflow-hidden border border-gray-100 shadow-sm hover:shadow-md transition-all">
+                        <a href={getBlogPostUrl(related.slug)} key={`mobile-${related.slug}`} className="group flex flex-col bg-white rounded-2xl overflow-hidden border border-zinc-100 shadow-sm hover:shadow-md transition-all">
                             <div className="aspect-video w-full overflow-hidden relative">
                                 <img src={optimizeRemoteImageUrl(related.image, 400, 225)} alt={related.title} width="400" height="225" loading="lazy" className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700" />
                                 <div className="absolute top-3 left-3">
@@ -109,10 +109,10 @@ export const BlogPostContent: React.FC<BlogPostContentProps> = ({ post, canonica
                                 </div>
                             </div>
                             <div className="p-4">
-                                <h5 className="font-bold text-gray-800 leading-tight group-hover:text-brand-cyan transition-colors text-base mb-2">
+                                <h5 className="font-bold text-zinc-800 leading-tight group-hover:text-brand-cyan transition-colors text-base mb-2">
                                     {related.title}
                                 </h5>
-                                <div className="flex items-center gap-3 text-xs text-gray-400 font-bold">
+                                <div className="flex items-center gap-3 text-xs text-zinc-400 font-bold">
                                     <span className="flex items-center gap-1"><Clock className="size-3" /> {related.readingTime}</span>
                                     <span>•</span>
                                     <span>{formatDate(related.date)}</span>

--- a/components/blog/BlogPostFinalCTA.tsx
+++ b/components/blog/BlogPostFinalCTA.tsx
@@ -14,7 +14,7 @@ export const BlogPostFinalCTA: React.FC<BlogPostFinalCTAProps> = ({ post }) => {
                 Gostou do conteúdo? <br />
                 <span className="text-brand-cyan">Sua viagem começa aqui.</span>
             </h2>
-            <p className="text-xl text-gray-300 mb-10 max-w-2xl mx-auto relative z-10">
+            <p className="text-xl text-zinc-300 mb-10 max-w-2xl mx-auto relative z-10">
                 Transformamos essas inspirações em um roteiro real e exclusivo para você.
             </p>
             <button

--- a/components/blog/BlogPostSidebar.tsx
+++ b/components/blog/BlogPostSidebar.tsx
@@ -20,9 +20,9 @@ interface BlogPostSidebarProps {
 export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, authorFallbackName, relatedPosts }) => {
     return (
         <div className="sticky top-32 space-y-8">
-            <div className="bg-white rounded-3xl p-8 border-2 border-gray-100 text-center relative overflow-hidden shadow-lg group hover:border-brand-yellow/30 transition-colors">
+            <div className="bg-white rounded-3xl p-8 border-2 border-zinc-100 text-center relative overflow-hidden shadow-lg group hover:border-brand-yellow/30 transition-colors">
                 <div className="absolute top-0 right-0 size-32 bg-brand-yellow/10 rounded-bl-full -mr-10 -mt-10 transition-all group-hover:scale-110"></div>
-                <div className="size-28 bg-gray-200 rounded-full mx-auto mb-6 overflow-hidden border-[6px] border-white shadow-xl relative z-10">
+                <div className="size-28 bg-zinc-200 rounded-full mx-auto mb-6 overflow-hidden border-[6px] border-white shadow-xl relative z-10">
                     {author?.image ? (
                         <img src={author.image} alt={author.name} width="112" height="112" loading="lazy" className="w-full h-full object-cover" />
                     ) : (
@@ -32,8 +32,8 @@ export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, author
                     )}
                 </div>
                 <h4 className="font-black text-2xl text-brand-dark mb-1">{author?.name || authorFallbackName}</h4>
-                <p className="text-xs font-bold text-gray-400 uppercase tracking-widest mb-6 bg-gray-50 inline-block px-3 py-1 rounded-full">{author?.role || 'Especialista em Viagens'}</p>
-                <p className="text-gray-600 font-serif italic text-base mb-8 leading-relaxed">
+                <p className="text-xs font-bold text-zinc-400 uppercase tracking-widest mb-6 bg-zinc-50 inline-block px-3 py-1 rounded-full">{author?.role || 'Especialista em Viagens'}</p>
+                <p className="text-zinc-600 font-serif italic text-base mb-8 leading-relaxed">
                     {author?.bio ? `"${author.bio}"` : '"Apaixonado por descobrir lugares novos e compartilhar dicas que não estão nos guias turísticos."'}
                 </p>
                 <button
@@ -49,14 +49,14 @@ export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, author
             </div>
 
             <div className="bg-white p-2 rounded-3xl hidden lg:block">
-                <h3 className="font-black text-xl text-gray-800 mb-6 pl-2 flex items-center gap-2">
+                <h3 className="font-black text-xl text-zinc-800 mb-6 pl-2 flex items-center gap-2">
                     <span className="w-1.5 h-6 bg-brand-vibrant rounded-full"></span>
                     Leia Também
                 </h3>
                 <div className="space-y-4">
                     {relatedPosts.map(related => (
-                        <a href={getBlogPostUrl(related.slug)} key={related.slug} className="group flex gap-5 items-center bg-white p-4 rounded-2xl hover:bg-white hover:shadow-xl transition-all border border-transparent hover:border-gray-100 duration-300">
-                            <div className="size-24 rounded-2xl overflow-hidden shrink-0 border border-gray-100 shadow-sm relative">
+                        <a href={getBlogPostUrl(related.slug)} key={related.slug} className="group flex gap-5 items-center bg-white p-4 rounded-2xl hover:bg-white hover:shadow-xl transition-all border border-transparent hover:border-zinc-100 duration-300">
+                            <div className="size-24 rounded-2xl overflow-hidden shrink-0 border border-zinc-100 shadow-sm relative">
                                 <img src={optimizeRemoteImageUrl(related.image, 200, 200)} alt={related.title} width="200" height="200" loading="lazy" className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700" />
                             </div>
                             <div className="flex flex-col h-full justify-center">
@@ -65,10 +65,10 @@ export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, author
                                         {related.category}
                                     </span>
                                 </div>
-                                <h5 className="font-bold text-gray-800 leading-tight group-hover:text-brand-cyan transition-colors text-base mb-2 font-sans">
+                                <h5 className="font-bold text-zinc-800 leading-tight group-hover:text-brand-cyan transition-colors text-base mb-2 font-sans">
                                     {related.title}
                                 </h5>
-                                <span className="text-xs text-gray-400 font-bold flex items-center gap-1">
+                                <span className="text-xs text-zinc-400 font-bold flex items-center gap-1">
                                     <Clock className="size-3" /> {related.readingTime}
                                 </span>
                             </div>

--- a/components/landings/beto-carrero/Attractions.tsx
+++ b/components/landings/beto-carrero/Attractions.tsx
@@ -110,7 +110,7 @@ const Attractions: React.FC = () => {
                 <h3 className="font-sans font-black text-3xl text-fun-dark mb-3 leading-[0.9]">
                   {item.name}
                 </h3>
-                <p className="font-sans text-slate-700 font-bold text-base leading-snug">
+                <p className="font-sans text-zinc-700 font-bold text-base leading-snug">
                   {item.description}
                 </p>
               </div>

--- a/components/landings/beto-carrero/BetoCarreroApp.tsx
+++ b/components/landings/beto-carrero/BetoCarreroApp.tsx
@@ -163,7 +163,7 @@ const App: React.FC = () => {
             {/* Mobile Menu Toggle */}
             <button
               onClick={toggleMobileMenu}
-              className="lg:hidden relative z-50 p-2 text-fun-dark hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus:ring-4 focus:ring-fun-blue"
+              className="lg:hidden relative z-50 p-2 text-fun-dark hover:bg-zinc-100 rounded-lg transition-colors focus:outline-none focus:ring-4 focus:ring-fun-blue"
               aria-label={mobileMenuOpen ? "Fechar menu" : "Abrir menu"}
             >
               {mobileMenuOpen ? <X size={32} strokeWidth={2.5} /> : <Menu size={32} strokeWidth={2.5} />}
@@ -177,7 +177,7 @@ const App: React.FC = () => {
                 key={link.name}
                 href={link.href}
                 onClick={handleLinkClick}
-                className="font-sans font-bold text-2xl text-fun-dark text-center py-2 border-b-2 border-dashed border-gray-200 active:text-fun-pink"
+                className="font-sans font-bold text-2xl text-fun-dark text-center py-2 border-b-2 border-dashed border-zinc-200 active:text-fun-pink"
               >
                 {link.name}
               </a>

--- a/components/landings/beto-carrero/FAQ.tsx
+++ b/components/landings/beto-carrero/FAQ.tsx
@@ -44,7 +44,7 @@ const FAQ: React.FC = () => {
                 return (
                   <div
                     key={item.question}
-                    className={`border-2 border-fun-dark rounded-2xl transition-all duration-300 overflow-hidden ${isOpen ? 'bg-blue-50 shadow-hard' : 'bg-white hover:bg-gray-50'}`}
+                    className={`border-2 border-fun-dark rounded-2xl transition-all duration-300 overflow-hidden ${isOpen ? 'bg-blue-50 shadow-hard' : 'bg-white hover:bg-zinc-50'}`}
                   >
                     <button 
                       onClick={() => toggleAccordion(idx)}
@@ -67,7 +67,7 @@ const FAQ: React.FC = () => {
                         <div className="px-6 md:px-8 pb-6 md:pb-8">
                            {/* Improved Text Formatting */}
                            <div className="pt-6 border-t-2 border-dashed border-fun-dark/20">
-                             <p className="text-slate-700 text-base md:text-lg font-medium leading-relaxed md:leading-8">
+                             <p className="text-zinc-700 text-base md:text-lg font-medium leading-relaxed md:leading-8">
                                {item.answer}
                              </p>
                            </div>
@@ -93,7 +93,7 @@ const FAQ: React.FC = () => {
                     Sua viagem começa no <span className="text-[#25D366]">WhatsApp</span>
                  </h3>
                  
-                 <p className="text-gray-300 text-lg mb-8 max-w-lg mx-auto">
+                 <p className="text-zinc-300 text-lg mb-8 max-w-lg mx-auto">
                     Não perca tempo em sites confusos. Diga a data e receba sua proposta completa hoje mesmo.
                  </p>
                  

--- a/components/landings/beto-carrero/Features.tsx
+++ b/components/landings/beto-carrero/Features.tsx
@@ -49,7 +49,7 @@ const Features: React.FC = () => {
               className="relative group perspective-1000"
             >
               {/* The Large Number Floating Behind */}
-              <div className="absolute -top-10 -left-2 text-[120px] font-sans font-black text-gray-100 select-none z-0 transition-all duration-300 group-hover:text-gray-200 group-hover:-translate-y-4 group-hover:scale-105">
+              <div className="absolute -top-10 -left-2 text-[120px] font-sans font-black text-zinc-100 select-none z-0 transition-all duration-300 group-hover:text-zinc-200 group-hover:-translate-y-4 group-hover:scale-105">
                 0{idx + 1}
               </div>
 
@@ -87,7 +87,7 @@ const Features: React.FC = () => {
                     {feature.title}
                   </h3>
                   
-                  <p className="font-sans text-xl text-slate-600 leading-relaxed">
+                  <p className="font-sans text-xl text-zinc-600 leading-relaxed">
                     {feature.description}
                   </p>
                 </div>

--- a/components/landings/beto-carrero/Hero.tsx
+++ b/components/landings/beto-carrero/Hero.tsx
@@ -74,7 +74,7 @@ const Hero: React.FC = () => {
               {/* Tape Effect */}
               <div className="absolute -top-4 lg:-top-6 left-1/2 -translate-x-1/2 w-20 md:w-24 lg:w-32 h-8 lg:h-12 bg-white/50 backdrop-blur-sm border-l-2 border-r-2 border-white/60 transform -rotate-2 shadow-sm z-20"></div>
 
-              <div className="bg-gray-200 border-2 border-fun-dark overflow-hidden rounded-sm relative w-full h-full">
+              <div className="bg-zinc-200 border-2 border-fun-dark overflow-hidden rounded-sm relative w-full h-full">
                 <img
                   src={optimizeRemoteImageUrl(`${PROD_ASSET_BASE}/grupo-em-frente-ao-castelo.jpg`, 1200)}
                   alt="Grupo em frente ao Castelo Beto Carrero"
@@ -95,7 +95,7 @@ const Hero: React.FC = () => {
                   <Plane size={20} className="sm:size-6 lg:size-8" />
                 </div>
                 <div>
-                  <div className="text-[10px] sm:text-xs lg:text-sm font-bold text-gray-400 leading-none mb-1">Voo Confirmado</div>
+                  <div className="text-[10px] sm:text-xs lg:text-sm font-bold text-zinc-400 leading-none mb-1">Voo Confirmado</div>
                   <div className="font-sans font-bold text-fun-dark text-sm sm:text-base lg:text-xl leading-none">GRU ➔ NVT</div>
                 </div>
               </div>

--- a/components/landings/beto-carrero/Problem.tsx
+++ b/components/landings/beto-carrero/Problem.tsx
@@ -7,7 +7,7 @@ const Problem: React.FC = () => {
       <section className="py-24 pt-32 md:pt-40 lg:pt-24 bg-fun-white relative overflow-hidden">
 
          {/* Background Decor: Confused Squiggle */}
-         <svg className="absolute top-20 left-0 w-full h-full text-gray-200 pointer-events-none -z-0" fill="none" viewBox="0 0 100 100" preserveAspectRatio="none">
+         <svg className="absolute top-20 left-0 w-full h-full text-zinc-200 pointer-events-none -z-0" fill="none" viewBox="0 0 100 100" preserveAspectRatio="none">
             <path d="M0,50 Q25,30 50,50 T100,50" stroke="currentColor" strokeWidth="0.5" strokeDasharray="5,5" />
          </svg>
 
@@ -30,11 +30,11 @@ const Problem: React.FC = () => {
                   {/* Tablet Adjustment: Centered using translate-x logic and adjusted width */}
                   <div className="absolute top-10 left-0 md:left-1/2 md:-translate-x-1/2 lg:left-0 lg:translate-x-0 w-full md:w-[480px] lg:w-[32rem] bg-white border-2 border-fun-dark rounded-xl shadow-hard z-10 transform -rotate-3 transition-transform hover:rotate-0 duration-300">
                      {/* Browser Header */}
-                     <div className="bg-gray-100 border-b-2 border-fun-dark p-2 lg:p-3 flex items-center gap-2 rounded-t-lg">
+                     <div className="bg-zinc-100 border-b-2 border-fun-dark p-2 lg:p-3 flex items-center gap-2 rounded-t-lg">
                         <div className="size-3 lg:size-4 rounded-full bg-red-400 border border-fun-dark"></div>
                         <div className="size-3 lg:size-4 rounded-full bg-yellow-400 border border-fun-dark"></div>
                         <div className="size-3 lg:size-4 rounded-full bg-green-400 border border-fun-dark"></div>
-                        <div className="flex-grow bg-white border border-gray-300 h-5 lg:h-7 rounded-md text-[10px] lg:text-xs flex items-center px-2 text-gray-400 overflow-hidden">
+                        <div className="flex-grow bg-white border border-zinc-300 h-5 lg:h-7 rounded-md text-[10px] lg:text-xs flex items-center px-2 text-zinc-400 overflow-hidden">
                            betocarrero-hoteis-baratos-socorro.com...
                         </div>
                      </div>
@@ -42,7 +42,7 @@ const Problem: React.FC = () => {
                      <div className="p-6 md:p-8 lg:p-10 flex flex-col items-center text-center">
                         <Search className="text-fun-blue size-10 lg:size-16 mb-2 animate-pulse" />
                         <h3 className="font-sans font-bold text-xl md:text-2xl lg:text-3xl text-fun-dark">157 abas abertas</h3>
-                        <p className="text-sm md:text-base lg:text-lg text-slate-500 mt-2 leading-tight">
+                        <p className="text-sm md:text-base lg:text-lg text-zinc-500 mt-2 leading-tight">
                            Comparando preços, lendo reviews antigos e ficando cada vez mais confuso.
                         </p>
                      </div>
@@ -64,14 +64,14 @@ const Problem: React.FC = () => {
                   {/* Tablet Adjustment: Increased padding (md:p-4 md:px-8), icon size, and font size */}
                   <div className="absolute bottom-10 left-4 md:left-[5%] lg:left-4 bg-white p-3 px-5 md:p-4 md:px-8 lg:p-5 lg:px-8 rounded-full border-2 border-fun-dark shadow-hard z-30 transform -rotate-12 flex items-center gap-2 md:gap-3 lg:gap-3">
                      <BatteryLow className="text-fun-pink size-5 md:size-7 lg:size-8" />
-                     <span className="font-bold text-sm md:text-lg lg:text-xl text-slate-600">Exaustão Mental</span>
+                     <span className="font-bold text-sm md:text-lg lg:text-xl text-zinc-600">Exaustão Mental</span>
                   </div>
 
                   {/* Floating Cursor */}
                   <MousePointer2 className="absolute top-1/2 right-1/4 md:right-[20%] text-fun-dark size-8 lg:size-12 fill-white stroke-[1.5px] z-40 animate-float" />
 
                   {/* Floating Question Marks */}
-                  <HelpCircle className="absolute top-0 right-10 md:right-[15%] lg:right-0 text-gray-300 size-12 lg:size-20 transform rotate-12" />
+                  <HelpCircle className="absolute top-0 right-10 md:right-[15%] lg:right-0 text-zinc-300 size-12 lg:size-20 transform rotate-12" />
                </div>
 
 
@@ -87,7 +87,7 @@ const Problem: React.FC = () => {
                         </div>
                         <div>
                            <h3 className="font-sans font-extrabold text-xl md:text-2xl lg:text-3xl mb-2 text-fun-dark">Insegurança na escolha</h3>
-                           <p className="text-slate-600 font-medium leading-relaxed text-sm md:text-base lg:text-lg">
+                           <p className="text-zinc-600 font-medium leading-relaxed text-sm md:text-base lg:text-lg">
                               "Será que esse hotel é limpo? Fica longe do parque? O transfer busca a gente?"
                            </p>
                            <span className="inline-block mt-3 lg:mt-4 bg-fun-pink text-white text-xs lg:text-sm font-bold px-3 py-1 lg:px-4 lg:py-2 rounded-full border-2 border-fun-dark transform -rotate-1 shadow-sm">
@@ -105,7 +105,7 @@ const Problem: React.FC = () => {
                         </div>
                         <div>
                            <h3 className="font-sans font-extrabold text-xl md:text-2xl lg:text-3xl mb-2 text-fun-dark">Logística Complicada</h3>
-                           <p className="text-slate-600 font-medium leading-relaxed text-sm md:text-base lg:text-lg">
+                           <p className="text-zinc-600 font-medium leading-relaxed text-sm md:text-base lg:text-lg">
                               Conciliar horário de voo, check-in do hotel e dias de parque sem perder tempo é um quebra-cabeça chato.
                            </p>
                         </div>
@@ -120,7 +120,7 @@ const Problem: React.FC = () => {
                         </div>
                         <div>
                            <h3 className="font-sans font-extrabold text-xl md:text-2xl lg:text-3xl mb-2 text-fun-dark">Surpresas no Pagamento</h3>
-                           <p className="text-slate-600 font-medium leading-relaxed text-sm md:text-base lg:text-lg">
+                           <p className="text-zinc-600 font-medium leading-relaxed text-sm md:text-base lg:text-lg">
                               Taxas escondidas, sites que travam na hora de pagar e parcelamentos com juros abusivos.
                            </p>
                         </div>

--- a/components/landings/beto-carrero/SectionTitle.tsx
+++ b/components/landings/beto-carrero/SectionTitle.tsx
@@ -14,7 +14,7 @@ const SectionTitle: React.FC<SectionTitleProps> = ({
   color = 'dark'
 }) => {
   const textColor = color === 'white' ? 'text-white' : 'text-fun-dark';
-  const subtitleColor = color === 'white' ? 'text-blue-100' : 'text-slate-600';
+  const subtitleColor = color === 'white' ? 'text-blue-100' : 'text-zinc-600';
 
   return (
     <div className={`mb-12 ${align === 'center' ? 'text-center' : 'text-left'}`}>

--- a/components/landings/beto-carrero/Solution.tsx
+++ b/components/landings/beto-carrero/Solution.tsx
@@ -77,16 +77,16 @@ const Solution: React.FC = () => {
                            </div>
                            <div>
                               <h3 className="font-sans font-bold text-lg lg:text-2xl text-fun-dark">Passagem Aérea</h3>
-                              <p className="text-slate-600 text-xs lg:text-sm font-bold">Horários que funcionam.</p>
+                              <p className="text-zinc-600 text-xs lg:text-sm font-bold">Horários que funcionam.</p>
                            </div>
                         </div>
                         {/* Divider Line */}
-                        <div className="w-0 border-l-2 border-dashed border-gray-300 relative my-2">
+                        <div className="w-0 border-l-2 border-dashed border-zinc-300 relative my-2">
                            <div className="absolute -top-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
                            <div className="absolute -bottom-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
                         </div>
                         {/* Right Side: Stamp */}
-                        <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
+                        <div className="w-16 lg:w-20 bg-zinc-50 flex items-center justify-center flex-shrink-0">
                            <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform rotate-12 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
                               <Check className="size-[18px] lg:size-6" strokeWidth={3} />
                            </div>
@@ -102,14 +102,14 @@ const Solution: React.FC = () => {
                            </div>
                            <div>
                               <h3 className="font-sans font-bold text-lg lg:text-2xl text-fun-dark">Hotel Top</h3>
-                              <p className="text-slate-600 text-xs lg:text-sm font-bold">Perto da diversão.</p>
+                              <p className="text-zinc-600 text-xs lg:text-sm font-bold">Perto da diversão.</p>
                            </div>
                         </div>
-                        <div className="w-0 border-l-2 border-dashed border-gray-300 relative my-2">
+                        <div className="w-0 border-l-2 border-dashed border-zinc-300 relative my-2">
                            <div className="absolute -top-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
                            <div className="absolute -bottom-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
                         </div>
-                        <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
+                        <div className="w-16 lg:w-20 bg-zinc-50 flex items-center justify-center flex-shrink-0">
                            <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform -rotate-6 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
                               <Check className="size-[18px] lg:size-6" strokeWidth={3} />
                            </div>
@@ -137,14 +137,14 @@ const Solution: React.FC = () => {
                            </div>
                            <div>
                               <h3 className="font-sans font-bold text-lg lg:text-2xl text-fun-dark">Ingresso Oficial</h3>
-                              <p className="text-slate-600 text-xs lg:text-sm font-bold">Direto na catraca.</p>
+                              <p className="text-zinc-600 text-xs lg:text-sm font-bold">Direto na catraca.</p>
                            </div>
                         </div>
-                        <div className="w-0 border-l-2 border-dashed border-gray-300 relative my-2">
+                        <div className="w-0 border-l-2 border-dashed border-zinc-300 relative my-2">
                            <div className="absolute -top-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
                            <div className="absolute -bottom-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
                         </div>
-                        <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
+                        <div className="w-16 lg:w-20 bg-zinc-50 flex items-center justify-center flex-shrink-0">
                            <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform rotate-3 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
                               <Check className="size-[18px] lg:size-6" strokeWidth={3} />
                            </div>
@@ -174,7 +174,7 @@ const Solution: React.FC = () => {
                         </div>
 
                         {/* Description */}
-                        <p className="text-lg font-bold text-slate-800 mb-4 leading-snug">
+                        <p className="text-lg font-bold text-zinc-800 mb-4 leading-snug">
                            Dá pra incluir praia no roteiro? <br />
                            <span className="text-fun-pink text-xl">Com certeza!</span>
                         </p>
@@ -206,7 +206,7 @@ const Solution: React.FC = () => {
                   <div className="bg-white p-3 rounded-[3rem] border-4 border-fun-dark shadow-hard-lg max-w-sm w-full relative z-10 transform rotate-2 transition-transform hover:rotate-0 duration-500">
 
                      {/* Screen */}
-                     <div className="bg-slate-50 rounded-[2.5rem] overflow-hidden border-2 border-gray-200 h-[500px] relative flex flex-col">
+                     <div className="bg-zinc-50 rounded-[2.5rem] overflow-hidden border-2 border-zinc-200 h-[500px] relative flex flex-col">
 
                         {/* Header */}
                         <div className="bg-fun-green p-4 pt-8 flex items-center gap-3 border-b-2 border-fun-dark">
@@ -228,9 +228,9 @@ const Solution: React.FC = () => {
 
                            {/* Msg 1 (User) */}
                            <div className="flex justify-end animate-[slideUp_0.5s_ease-out_forwards]">
-                              <div className="bg-white border-2 border-gray-200 text-slate-700 p-3 px-4 rounded-2xl rounded-tr-none shadow-sm max-w-[85%]">
+                              <div className="bg-white border-2 border-zinc-200 text-zinc-700 p-3 px-4 rounded-2xl rounded-tr-none shadow-sm max-w-[85%]">
                                  <p className="text-sm">Oi! Quero levar as crianças pro Beto Carrero em Julho. 🎢</p>
-                                 <span className="text-[10px] text-gray-400 block text-right mt-1">10:42</span>
+                                 <span className="text-[10px] text-zinc-400 block text-right mt-1">10:42</span>
                               </div>
                            </div>
 
@@ -249,15 +249,15 @@ const Solution: React.FC = () => {
 
                            {/* Msg 3 (User) */}
                            <div className="flex justify-end animate-[slideUp_0.6s_ease-out_1.5s_both]">
-                              <div className="bg-white border-2 border-gray-200 text-slate-700 p-3 px-4 rounded-2xl rounded-tr-none shadow-sm max-w-[85%]">
+                              <div className="bg-white border-2 border-zinc-200 text-zinc-700 p-3 px-4 rounded-2xl rounded-tr-none shadow-sm max-w-[85%]">
                                  <p className="text-sm">Perfeito! Vamos fechar. 😍</p>
                               </div>
                            </div>
                         </div>
 
                         {/* Footer Input */}
-                        <div className="p-3 bg-white border-t border-gray-200 flex items-center gap-2">
-                           <div className="w-full h-10 bg-gray-100 rounded-full border border-gray-300"></div>
+                        <div className="p-3 bg-white border-t border-zinc-200 flex items-center gap-2">
+                           <div className="w-full h-10 bg-zinc-100 rounded-full border border-zinc-300"></div>
                            <div className="size-10 bg-fun-blue rounded-full flex items-center justify-center text-white">
                               <Send size={18} />
                            </div>
@@ -311,7 +311,7 @@ const Solution: React.FC = () => {
                   {/* Header */}
                   <div className="text-center mb-8">
                      <h3 className="font-sans font-bold text-3xl md:text-4xl text-fun-dark mb-2">Destinos Extras</h3>
-                     <p className="text-slate-600 font-bold">Escolha um (ou todos) e peça no Zap!</p>
+                     <p className="text-zinc-600 font-bold">Escolha um (ou todos) e peça no Zap!</p>
                   </div>
 
                   {/* Destinations List */}
@@ -326,7 +326,7 @@ const Solution: React.FC = () => {
                         </div>
                         <div className="z-10">
                            <h4 className="font-sans font-bold text-2xl text-fun-dark mb-1">Florianópolis</h4>
-                           <p className="text-sm font-bold text-slate-500 leading-tight">42 praias, dunas de areia e gastronomia.</p>
+                           <p className="text-sm font-bold text-zinc-500 leading-tight">42 praias, dunas de areia e gastronomia.</p>
                         </div>
                      </div>
 
@@ -339,7 +339,7 @@ const Solution: React.FC = () => {
                         </div>
                         <div className="z-10">
                            <h4 className="font-sans font-bold text-2xl text-fun-dark mb-1">Bombinhas</h4>
-                           <p className="text-sm font-bold text-slate-500 leading-tight">Mergulho ecológico e águas cristalinas.</p>
+                           <p className="text-sm font-bold text-zinc-500 leading-tight">Mergulho ecológico e águas cristalinas.</p>
                         </div>
                      </div>
 
@@ -352,14 +352,14 @@ const Solution: React.FC = () => {
                         </div>
                         <div className="z-10">
                            <h4 className="font-sans font-bold text-2xl text-fun-dark mb-1">Balneário Camboriú</h4>
-                           <p className="text-sm font-bold text-slate-500 leading-tight">Roda gigante, aquário e vida noturna.</p>
+                           <p className="text-sm font-bold text-zinc-500 leading-tight">Roda gigante, aquário e vida noturna.</p>
                         </div>
                      </div>
 
                   </div>
 
                   {/* Footer CTA */}
-                  <div className="text-center mt-8 pt-6 border-t-2 border-dashed border-gray-300">
+                  <div className="text-center mt-8 pt-6 border-t-2 border-dashed border-zinc-300">
                      <Button
                         text="Montar Roteiro no Zap"
                         variant="secondary"

--- a/components/landings/beto-carrero/Testimonials.tsx
+++ b/components/landings/beto-carrero/Testimonials.tsx
@@ -62,7 +62,7 @@ const Testimonials: React.FC = () => {
                  <div className={`absolute -top-4 left-1/2 -translate-x-1/2 w-32 h-10 ${tapeColors[idx % 3]} backdrop-blur-sm shadow-sm transform -rotate-1 border-l-2 border-r-2 border-white/20 z-20`}></div>
 
                  {/* Giant Quote Icon Background */}
-                 <Quote className="absolute top-8 left-6 text-gray-100 size-24 rotate-12 z-0 pointer-events-none" />
+                 <Quote className="absolute top-8 left-6 text-zinc-100 size-24 rotate-12 z-0 pointer-events-none" />
 
                  {/* Stars */}
                  <div className="flex gap-1 mb-6 text-fun-yellow relative z-10">
@@ -75,7 +75,7 @@ const Testimonials: React.FC = () => {
                  </p>
 
                  {/* Author & Verification */}
-                 <div className="flex items-center gap-4 border-t-2 border-dashed border-gray-200 pt-6 mt-auto relative z-10">
+                 <div className="flex items-center gap-4 border-t-2 border-dashed border-zinc-200 pt-6 mt-auto relative z-10">
                    <div className="relative">
                       <img src={t.avatar} alt={t.name} width="56" height="56" loading="lazy" className="size-14 rounded-full border-2 border-fun-dark shadow-sm" />
                       <div className="absolute -bottom-1 -right-1 bg-fun-blue text-white rounded-full p-0.5 border border-white">

--- a/components/landings/lollapalooza/Button.tsx
+++ b/components/landings/lollapalooza/Button.tsx
@@ -26,7 +26,7 @@ const Button: React.FC<ButtonProps> = ({ text, className = '', variant = 'primar
 
   const variants = {
     primary: "bg-anhanga-yellow text-anhanga-darkBlue hover:bg-anhanga-yellowHover",
-    secondary: "bg-white text-anhanga-blue hover:bg-gray-100",
+    secondary: "bg-white text-anhanga-blue hover:bg-zinc-100",
     outline: "border-2 border-white text-white hover:bg-white hover:text-anhanga-blue"
   };
 

--- a/components/landings/lollapalooza/Footer.tsx
+++ b/components/landings/lollapalooza/Footer.tsx
@@ -7,7 +7,7 @@ const Footer: React.FC = () => {
   const runtimeMetadata = useFooterRuntimeMetadata();
 
   return (
-    <footer className="bg-gray-900 text-gray-400 py-12 border-t border-gray-800" role="contentinfo">
+    <footer className="bg-zinc-900 text-zinc-400 py-12 border-t border-zinc-800" role="contentinfo">
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row justify-between items-center mb-8">
           <div className="mb-4 md:mb-0">
@@ -21,7 +21,7 @@ const Footer: React.FC = () => {
           </div>
         </div>
 
-        <div className="border-t border-gray-800 pt-8 text-center md:text-left text-sm">
+        <div className="border-t border-zinc-800 pt-8 text-center md:text-left text-sm">
           <p className="mb-2">© {runtimeMetadata ? `${runtimeMetadata.currentYear} ` : ''}Anhangá Viagens. Todos os direitos reservados.</p>
           <p>
             Anhangá Viagens - Especialistas em experiências.

--- a/components/landings/lollapalooza/Hero.tsx
+++ b/components/landings/lollapalooza/Hero.tsx
@@ -93,7 +93,7 @@ const Hero: React.FC = () => {
         
         {/* Dynamic Headliner Title */}
         <div className="mb-2 md:mb-4 min-h-[5rem] md:min-h-[7rem] flex flex-col items-center justify-center w-full px-2">
-            <p className="text-gray-300 text-[10px] sm:text-xs md:text-sm lg:text-lg uppercase tracking-[0.2em] mb-1 md:mb-2">Prepare-se para ver</p>
+            <p className="text-zinc-300 text-[10px] sm:text-xs md:text-sm lg:text-lg uppercase tracking-[0.2em] mb-1 md:mb-2">Prepare-se para ver</p>
             <h2 
                 aria-live="polite"
                 className={`text-3xl sm:text-5xl md:text-6xl lg:text-7xl font-black uppercase italic tracking-tighter text-anhanga-yellow transition-all duration-500 transform text-center break-words w-full max-w-5xl leading-[0.9] sm:leading-tight pb-2 ${
@@ -125,7 +125,7 @@ const Hero: React.FC = () => {
             </span>
         </div>
         
-        <p className="text-sm sm:text-lg md:text-xl mb-8 md:mb-10 max-w-2xl mx-auto text-gray-200 font-medium drop-shadow-md leading-relaxed px-2">
+        <p className="text-sm sm:text-lg md:text-xl mb-8 md:mb-10 max-w-2xl mx-auto text-zinc-200 font-medium drop-shadow-md leading-relaxed px-2">
           Hospedagem selecionada, transporte exclusivo e suporte dedicado para você só se preocupar em curtir os shows.
         </p>
         
@@ -171,7 +171,7 @@ const Hero: React.FC = () => {
           </button>
         </div>
         
-        <div className="mt-6 md:mt-8 flex items-center justify-center gap-2 text-[10px] sm:text-xs md:text-sm text-gray-400 font-medium">
+        <div className="mt-6 md:mt-8 flex items-center justify-center gap-2 text-[10px] sm:text-xs md:text-sm text-zinc-400 font-medium">
             <Music2 size={14} className="text-anhanga-yellow" aria-hidden="true" />
             <span>Campanha 2026 encerrada. Cadastre-se para ser avisado sobre 2027.</span>
         </div>

--- a/components/landings/lollapalooza/LineupSection.tsx
+++ b/components/landings/lollapalooza/LineupSection.tsx
@@ -106,7 +106,7 @@ const LineupSection: React.FC = () => {
   ];
 
   return (
-    <section id="lineup" className="py-20 bg-gray-950 text-white relative overflow-hidden" aria-labelledby="lineup-heading" ref={elementRef}>
+    <section id="lineup" className="py-20 bg-zinc-950 text-white relative overflow-hidden" aria-labelledby="lineup-heading" ref={elementRef}>
       {/* Decorative blobs */}
       <div className="absolute top-0 right-0 size-64 bg-anhanga-blue opacity-20 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2" aria-hidden="true"></div>
       <div className="absolute bottom-0 left-0 size-96 bg-anhanga-yellow opacity-10 rounded-full blur-3xl translate-y-1/2 -translate-x-1/2" aria-hidden="true"></div>
@@ -139,7 +139,7 @@ const LineupSection: React.FC = () => {
             </div>
           </div>
 
-          <div className="inline-flex items-center justify-center p-3 bg-gray-800 rounded-full mb-4 animate-pulse">
+          <div className="inline-flex items-center justify-center p-3 bg-zinc-800 rounded-full mb-4 animate-pulse">
             <Music className="text-anhanga-yellow" size={24} aria-hidden="true" />
           </div>
 
@@ -147,7 +147,7 @@ const LineupSection: React.FC = () => {
             Lineup <span className="text-anhanga-yellow pr-2">2026</span>
           </h2>
 
-          <p className="text-xl md:text-2xl text-gray-300 max-w-4xl mx-auto font-light mb-8">
+          <p className="text-xl md:text-2xl text-zinc-300 max-w-4xl mx-auto font-light mb-8">
             Os maiores nomes da música mundial confirmados no Autódromo de Interlagos.
           </p>
         </div>
@@ -155,9 +155,9 @@ const LineupSection: React.FC = () => {
         {/* Headliners Grid */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-20">
           {headliners.map((artist, index) => (
-            <div key={artist.name} className={`group relative h-96 sm:h-80 lg:h-96 overflow-hidden rounded-2xl border border-gray-800 hover:border-anhanga-yellow transition-all duration-300 animate-on-scroll ${isVisible ? 'is-visible' : ''}`} style={{ transitionDelay: `${index * 50}ms` }}>
+            <div key={artist.name} className={`group relative h-96 sm:h-80 lg:h-96 overflow-hidden rounded-2xl border border-zinc-800 hover:border-anhanga-yellow transition-all duration-300 animate-on-scroll ${isVisible ? 'is-visible' : ''}`} style={{ transitionDelay: `${index * 50}ms` }}>
               {/* Background Image - Optimized to 600px width */}
-              <div className="absolute inset-0 bg-gray-900">
+              <div className="absolute inset-0 bg-zinc-900">
                 <img
                   src={getArtistImageUrl(artist.image, 600)}
                   alt={artist.name}
@@ -191,22 +191,22 @@ const LineupSection: React.FC = () => {
 
         {/* Daily Lineup - Festival Poster Style */}
         <div className={`mb-16 animate-on-scroll ${isVisible ? 'is-visible' : ''}`} style={{ transitionDelay: '300ms' }}>
-          <h3 className="text-center text-3xl font-black text-white mb-10 uppercase tracking-widest border-b border-gray-800 pb-4">
+          <h3 className="text-center text-3xl font-black text-white mb-10 uppercase tracking-widest border-b border-zinc-800 pb-4">
             Programação por Dia
           </h3>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {dailyLineup.map((day) => (
-              <div key={day.day} className="bg-gray-900 border border-gray-800 rounded-xl p-6 hover:border-anhanga-blue transition-colors">
+              <div key={day.day} className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:border-anhanga-blue transition-colors">
                 <div className="flex items-center gap-2 mb-6">
                   <Calendar className="text-anhanga-yellow" size={20} aria-hidden="true" />
-                  <span className="text-gray-400 font-bold uppercase text-sm tracking-wider">{day.day} • {day.date}</span>
+                  <span className="text-zinc-400 font-bold uppercase text-sm tracking-wider">{day.day} • {day.date}</span>
                 </div>
 
                 {/* Main Acts with Images - Optimized to 100px width for thumbnails */}
                 <div className="mb-6 space-y-4">
                   {day.main.map((act) => (
                     <div key={act.name} className="flex items-center gap-4 group/artist">
-                      <div className="size-12 rounded-full overflow-hidden border-2 border-gray-700 group-hover/artist:border-anhanga-yellow transition-colors shrink-0 bg-gray-800">
+                      <div className="size-12 rounded-full overflow-hidden border-2 border-zinc-700 group-hover/artist:border-anhanga-yellow transition-colors shrink-0 bg-zinc-800">
                         <img
                           src={getArtistImageUrl(act.image, 100, 100)}
                           alt={act.name}
@@ -226,7 +226,7 @@ const LineupSection: React.FC = () => {
                 </div>
 
                 {/* Other Acts */}
-                <p className="text-sm text-gray-400 leading-relaxed text-justify uppercase font-medium pt-4 border-t border-gray-800">
+                <p className="text-sm text-zinc-400 leading-relaxed text-justify uppercase font-medium pt-4 border-t border-zinc-800">
                   {day.others}
                 </p>
               </div>
@@ -235,19 +235,19 @@ const LineupSection: React.FC = () => {
         </div>
 
         {/* Value Proposition */}
-        <div className={`bg-gray-900/50 backdrop-blur-md rounded-3xl p-8 md:p-12 border border-gray-800 animate-on-scroll ${isVisible ? 'is-visible' : ''}`} style={{ transitionDelay: '500ms' }}>
+        <div className={`bg-zinc-900/50 backdrop-blur-md rounded-3xl p-8 md:p-12 border border-zinc-800 animate-on-scroll ${isVisible ? 'is-visible' : ''}`} style={{ transitionDelay: '500ms' }}>
           <div className="flex flex-col md:flex-row items-stretch gap-12">
             <div className="flex-1 flex flex-col justify-center">
               <h3 className="text-3xl font-bold mb-4 text-white">
                 <Zap className="inline-block mr-2 text-anhanga-yellow" aria-hidden="true" />
                 Foque apenas na música
               </h3>
-              <p className="text-gray-300 mb-6 leading-relaxed text-lg">
+              <p className="text-zinc-300 mb-6 leading-relaxed text-lg">
                 O Lollapalooza é gigante e a logística pode ser cansativa. Com nossos pacotes, você elimina o estresse do trânsito, a busca por hotéis e a insegurança na saída do festival.
               </p>
               <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 {['Chegada tranquila ao Autódromo', 'Descanso em hotel 4 estrelas', 'Suporte local para imprevistos', 'After-parties sugeridas'].map((item) => (
-                  <li key={item} className="flex items-center gap-3 text-base text-gray-200">
+                  <li key={item} className="flex items-center gap-3 text-base text-zinc-200">
                     <span className="flex-shrink-0 size-5 rounded-full bg-anhanga-blue flex items-center justify-center text-xs font-bold" aria-hidden="true">✓</span>
                     {item}
                   </li>
@@ -256,7 +256,7 @@ const LineupSection: React.FC = () => {
             </div>
 
             <div className="w-full md:w-1/3 p-6 bg-gradient-to-br from-anhanga-darkBlue to-black rounded-2xl border border-white/10 text-center flex flex-col justify-center">
-              <p className="text-gray-400 text-sm uppercase tracking-widest mb-2">Ingressos</p>
+              <p className="text-zinc-400 text-sm uppercase tracking-widest mb-2">Ingressos</p>
               <p className="text-white text-lg font-medium mb-6">
                 Compre os ingressos com a <span className="font-bold text-anhanga-yellow">Ticketmaster</span> e deixa que a gente cuida do resto.
               </p>
@@ -264,11 +264,11 @@ const LineupSection: React.FC = () => {
                 href="https://www.ticketmaster.com.br/event/lollapaloozabr?utm_source=site&utm_medium=site_festival&utm_campaign=ll-ingressos2026&utm_id=header&utm_term=botao_compreagora&utm_content=site_site_festival_header_ll-ingressos2026_botao_compreagora_contlol01090"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center justify-center gap-2 w-full py-3 bg-white text-anhanga-darkBlue font-bold rounded-full hover:bg-gray-200 transition-colors focus:outline-none focus:ring-4 focus:ring-anhanga-yellow/50"
+                className="inline-flex items-center justify-center gap-2 w-full py-3 bg-white text-anhanga-darkBlue font-bold rounded-full hover:bg-zinc-200 transition-colors focus:outline-none focus:ring-4 focus:ring-anhanga-yellow/50"
               >
                 Comprar Ingresso <ExternalLink size={16} />
               </a>
-              <p className="text-[10px] text-gray-500 mt-4 opacity-70">
+              <p className="text-[10px] text-zinc-500 mt-4 opacity-70">
                 *A Anhangá vende apenas o pacote de viagem.
               </p>
             </div>

--- a/components/landings/lollapalooza/LollapaloozaApp.tsx
+++ b/components/landings/lollapalooza/LollapaloozaApp.tsx
@@ -14,7 +14,7 @@ const VenueMap = lazy(() => import('./VenueMap'));
 const VenueMapFallback: React.FC = () => (
   <section className="relative z-20 -mt-10 mb-10 px-4" aria-label="Mapa da localização e pontos de interesse">
     <div className="container mx-auto">
-      <div className="bg-white rounded-3xl shadow-2xl overflow-hidden border border-gray-100">
+      <div className="bg-white rounded-3xl shadow-2xl overflow-hidden border border-zinc-100">
         <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(320px,42%)] p-6 md:p-8">
           <div>
             <p className="text-xs font-bold uppercase tracking-[0.18em] text-anhanga-blue mb-3">
@@ -23,12 +23,12 @@ const VenueMapFallback: React.FC = () => (
             <h3 className="text-2xl md:text-3xl font-black text-anhanga-darkBlue mb-3">
               Interlagos com acesso planejado
             </h3>
-            <p className="text-gray-700 leading-relaxed">
+            <p className="text-zinc-700 leading-relaxed">
               O Autodromo de Interlagos fica conectado a trem, aeroportos e bairros com boa rede hoteleira.
               No cliente, o mapa interativo carrega automaticamente com os pontos de apoio do festival.
             </p>
           </div>
-          <div className="rounded-2xl bg-gradient-to-br from-anhanga-blue to-slate-900 min-h-[280px] flex items-center justify-center p-6 text-center">
+          <div className="rounded-2xl bg-gradient-to-br from-anhanga-blue to-zinc-900 min-h-[280px] flex items-center justify-center p-6 text-center">
             <p className="text-white/90 text-sm md:text-base leading-relaxed">
               Mapa interativo carregado no navegador para preservar performance e compatibilidade do prerender.
             </p>
@@ -43,7 +43,7 @@ function LollapaloozaApp() {
   const shouldRenderInteractiveMap = typeof window !== 'undefined';
 
   return (
-    <div className="landing-lollapalooza font-sans antialiased text-gray-800 bg-white selection:bg-anhanga-yellow selection:text-anhanga-darkBlue">
+    <div className="landing-lollapalooza font-sans antialiased text-zinc-800 bg-white selection:bg-anhanga-yellow selection:text-anhanga-darkBlue">
       <Navbar />
       <Hero />
       <WaitlistSection />

--- a/components/landings/lollapalooza/Navbar.tsx
+++ b/components/landings/lollapalooza/Navbar.tsx
@@ -44,7 +44,7 @@ const Navbar: React.FC = () => {
             <a
               key={link.name}
               href={link.href}
-              className={`font-bold text-sm uppercase tracking-wide hover:text-anhanga-yellow transition-colors focus:outline-none focus:ring-2 focus:ring-anhanga-yellow rounded-sm px-2 ${scrolled ? 'text-gray-700' : 'text-white'}`}
+              className={`font-bold text-sm uppercase tracking-wide hover:text-anhanga-yellow transition-colors focus:outline-none focus:ring-2 focus:ring-anhanga-yellow rounded-sm px-2 ${scrolled ? 'text-zinc-700' : 'text-white'}`}
             >
               {link.name}
             </a>
@@ -68,7 +68,7 @@ const Navbar: React.FC = () => {
           aria-expanded={isOpen}
           aria-label={isOpen ? "Fechar menu de navegação" : "Abrir menu de navegação"}
         >
-          {isOpen ? <X size={32} className="text-gray-800" /> : <Menu size={32} color={scrolled ? '#0056D2' : '#FFD600'} />}
+          {isOpen ? <X size={32} className="text-zinc-800" /> : <Menu size={32} color={scrolled ? '#0056D2' : '#FFD600'} />}
         </button>
       </div>
 

--- a/components/landings/lollapalooza/PackageFeatures.tsx
+++ b/components/landings/lollapalooza/PackageFeatures.tsx
@@ -63,7 +63,7 @@ const PackageFeatures: React.FC = () => {
   ];
 
   return (
-    <section id="pacote" className="bg-gray-950 py-20 relative overflow-hidden" ref={elementRef}>
+    <section id="pacote" className="bg-zinc-950 py-20 relative overflow-hidden" ref={elementRef}>
       {/* Abstract Background Elements */}
       <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
         <div className="absolute top-[-10%] left-[-10%] size-[50%] bg-anhanga-blue rounded-full blur-[120px] opacity-20"></div>
@@ -123,7 +123,7 @@ const PackageFeatures: React.FC = () => {
                     {feature.title}
                   </h3>
                   <p className={`font-medium text-sm md:text-base leading-snug line-clamp-3 md:line-clamp-none
-                    ${feature.image ? 'text-gray-300' : (feature.bgColor === 'bg-anhanga-yellow' ? 'text-gray-800' : 'text-blue-100')}
+                    ${feature.image ? 'text-zinc-300' : (feature.bgColor === 'bg-anhanga-yellow' ? 'text-zinc-800' : 'text-blue-100')}
                   `}>
                     {feature.subtitle}
                   </p>

--- a/components/landings/lollapalooza/VenueMap.tsx
+++ b/components/landings/lollapalooza/VenueMap.tsx
@@ -244,7 +244,7 @@ const VenueMap: React.FC = () => {
 
           {/* Informações / Lista de Distâncias */}
           {/* Aumentei o max-h no mobile de 50vh para 600px para evitar cortes no card */}
-          <div className="w-full md:w-1/3 p-6 md:p-8 bg-white flex flex-col border-r border-gray-100 h-auto flex-shrink-0">
+          <div className="w-full md:w-1/3 p-6 md:p-8 bg-white flex flex-col border-r border-zinc-100 h-auto flex-shrink-0">
             <div className="inline-flex items-center gap-2 text-anhanga-blue font-bold uppercase tracking-wider text-xs mb-3">
               <MapPin size={16} aria-hidden="true" /> Localização & Referências
             </div>
@@ -253,7 +253,7 @@ const VenueMap: React.FC = () => {
               Explore os arredores de <br /><span className="text-anhanga-yellow">Interlagos</span>
             </h3>
 
-            <p className="text-gray-500 text-sm mb-6">
+            <p className="text-zinc-500 text-sm mb-6">
               Clique nos pontos abaixo para ver detalhes.
             </p>
 
@@ -273,7 +273,7 @@ const VenueMap: React.FC = () => {
                     onClick={() => handleListClick(idx)}
                     className={`w-full text-left transition-all duration-300 rounded-xl border-2 group overflow-hidden relative ${activeIndex === idx
                       ? 'border-anhanga-blue shadow-xl ring-2 ring-blue-100 z-10'
-                      : 'border-gray-100 hover:border-anhanga-yellow hover:shadow-md'
+                      : 'border-zinc-100 hover:border-anhanga-yellow hover:shadow-md'
                       }`}
                   >
                     {/* Imagem de Fundo Otimizada */}
@@ -305,10 +305,10 @@ const VenueMap: React.FC = () => {
                           <style.Icon size={14} />
                         </div>
                         <div className="min-w-0">
-                          <p className={`font-bold text-sm leading-tight transition-colors ${activeIndex === idx ? 'text-anhanga-darkBlue whitespace-normal' : 'text-gray-800 truncate'}`}>
+                          <p className={`font-bold text-sm leading-tight transition-colors ${activeIndex === idx ? 'text-anhanga-darkBlue whitespace-normal' : 'text-zinc-800 truncate'}`}>
                             {poi.name}
                           </p>
-                          <p className="text-[10px] text-gray-500 uppercase tracking-wider font-semibold">
+                          <p className="text-[10px] text-zinc-500 uppercase tracking-wider font-semibold">
                             {style.label}
                           </p>
                         </div>
@@ -319,7 +319,7 @@ const VenueMap: React.FC = () => {
                         ) : (
                           <>
                             <p className="font-black text-anhanga-darkBlue text-sm">{poi.distance}</p>
-                            <p className="text-xs text-gray-500 flex items-center justify-end gap-1">
+                            <p className="text-xs text-zinc-500 flex items-center justify-end gap-1">
                               <CarFront size={10} /> {poi.time}
                             </p>
                           </>
@@ -331,7 +331,7 @@ const VenueMap: React.FC = () => {
                     <div className={`relative z-10 grid transition-all duration-300 ease-in-out ${activeIndex === idx ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
                       }`}>
                       <div className="overflow-hidden min-h-0">
-                        <div className="p-3 pt-0 text-sm text-gray-600 border-t border-blue-100/50 mx-3 mt-1 space-y-3">
+                        <div className="p-3 pt-0 text-sm text-zinc-600 border-t border-blue-100/50 mx-3 mt-1 space-y-3">
 
                           {/* Descrição Geral */}
                           <div className="flex items-start gap-2 pt-3">
@@ -340,12 +340,12 @@ const VenueMap: React.FC = () => {
                           </div>
 
                           {/* Rota de Transporte Público */}
-                          <div className="bg-white/60 backdrop-blur-sm p-2.5 rounded-lg border border-gray-200">
-                            <div className="flex items-center gap-2 mb-1.5 text-gray-800 font-bold text-xs uppercase tracking-wide">
-                              <TrainFront size={12} className="text-gray-600" />
+                          <div className="bg-white/60 backdrop-blur-sm p-2.5 rounded-lg border border-zinc-200">
+                            <div className="flex items-center gap-2 mb-1.5 text-zinc-800 font-bold text-xs uppercase tracking-wide">
+                              <TrainFront size={12} className="text-zinc-600" />
                               Rota até o Autódromo (Transporte Público):
                             </div>
-                            <p className="text-xs text-gray-600 leading-snug pl-5 border-l-2 border-gray-300">
+                            <p className="text-xs text-zinc-600 leading-snug pl-5 border-l-2 border-zinc-300">
                               {poi.transitInfo}
                             </p>
                           </div>
@@ -363,7 +363,7 @@ const VenueMap: React.FC = () => {
               })}
             </div>
 
-            <div className="mt-4 pt-4 border-t border-gray-100 hidden md:block">
+            <div className="mt-4 pt-4 border-t border-zinc-100 hidden md:block">
               <div className="flex items-start gap-3 bg-blue-50 p-3 rounded-lg">
                 <Navigation className="text-anhanga-blue shrink-0 mt-0.5" size={16} />
                 <p className="text-xs text-blue-800 leading-snug">
@@ -374,7 +374,7 @@ const VenueMap: React.FC = () => {
           </div>
 
           {/* Mapa */}
-          <div className="w-full md:w-2/3 h-[400px] md:h-auto min-h-[400px] relative bg-gray-200">
+          <div className="w-full md:w-2/3 h-[400px] md:h-auto min-h-[400px] relative bg-zinc-200">
             <div
               ref={mapContainerRef}
               className="w-full h-full z-0 outline-none"

--- a/components/landings/lollapalooza/WaitlistSection.tsx
+++ b/components/landings/lollapalooza/WaitlistSection.tsx
@@ -63,7 +63,7 @@ const WaitlistSection: React.FC = () => {
   return (
     <section
       id={WAITLIST_SECTION_ID}
-      className="relative scroll-mt-28 bg-gray-950 py-24 sm:py-32 overflow-hidden"
+      className="relative scroll-mt-28 bg-zinc-950 py-24 sm:py-32 overflow-hidden"
       aria-labelledby="waitlist-heading"
     >
       {/* Background Graphic Elements */}
@@ -98,7 +98,7 @@ const WaitlistSection: React.FC = () => {
               Não fique de fora do <span className="text-anhanga-yellow">Lolla 2027.</span>
             </m.h2>
 
-            <m.p variants={itemVariants} className="text-lg md:text-xl text-gray-400 font-medium leading-relaxed max-w-xl mb-12">
+            <m.p variants={itemVariants} className="text-lg md:text-xl text-zinc-400 font-medium leading-relaxed max-w-xl mb-12">
               A jornada de 2026 lotou em tempo recorde. Garanta seu lugar na lista de prioridade para a edição 2027 e receba avisos antecipados sobre pacotes, logística e condições exclusivas Anhangá.
             </m.p>
 
@@ -109,7 +109,7 @@ const WaitlistSection: React.FC = () => {
                 </div>
                 <div>
                   <h3 className="font-black text-white uppercase tracking-wider mb-2">Prioridade Total</h3>
-                  <p className="text-sm text-gray-500 leading-relaxed font-medium">Recepção de ofertas antes do lançamento público geral.</p>
+                  <p className="text-sm text-zinc-500 leading-relaxed font-medium">Recepção de ofertas antes do lançamento público geral.</p>
                 </div>
               </m.div>
 
@@ -119,7 +119,7 @@ const WaitlistSection: React.FC = () => {
                 </div>
                 <div>
                   <h3 className="font-black text-white uppercase tracking-wider mb-2">Logística Hardcore</h3>
-                  <p className="text-sm text-gray-500 leading-relaxed font-medium">Saiba primeiro os hotéis mais próximos e as rotas mais eficientes.</p>
+                  <p className="text-sm text-zinc-500 leading-relaxed font-medium">Saiba primeiro os hotéis mais próximos e as rotas mais eficientes.</p>
                 </div>
               </m.div>
             </div>
@@ -195,7 +195,7 @@ const WaitlistSection: React.FC = () => {
                     <div className="size-5 border-2 border-white/20 peer-checked:border-anhanga-yellow peer-checked:bg-anhanga-yellow transition-all duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-anhanga-yellow peer-focus-visible:outline-offset-2" />
                     <CheckCircle2 size={12} className="absolute text-black opacity-0 peer-checked:opacity-100 transition-opacity" />
                   </div>
-                  <span className="text-xs text-gray-400 leading-snug group-hover:text-gray-300 transition-colors">
+                  <span className="text-xs text-zinc-400 leading-snug group-hover:text-zinc-300 transition-colors">
                     Autorizo a Anhangá a me enviar novidades exclusivas conforme a{' '}
                     <a
                       href="https://www.anhanga.tur.br/politica-privacidade/"

--- a/components/landings/lollapalooza/WhyUs.tsx
+++ b/components/landings/lollapalooza/WhyUs.tsx
@@ -15,7 +15,7 @@ const WhyUs: React.FC = () => {
           <div className={`w-full lg:w-1/2 animate-on-scroll ${isVisible ? 'is-visible' : ''}`}>
             <div className="relative group">
               {/* Image Display */}
-              <div className="relative overflow-hidden rounded-3xl shadow-2xl rotate-2 group-hover:rotate-0 transition-all duration-500 w-full aspect-[4/3] bg-gray-100">
+              <div className="relative overflow-hidden rounded-3xl shadow-2xl rotate-2 group-hover:rotate-0 transition-all duration-500 w-full aspect-[4/3] bg-zinc-100">
                  <img 
                     src={getMediaUrl('images/lollapalooza/why-us/multidao-festival.jpg')} 
                     alt="Multidão feliz em um festival de música com confetes e luzes" 
@@ -29,7 +29,7 @@ const WhyUs: React.FC = () => {
                   
                   <div className="absolute bottom-6 left-6 text-white max-w-xs">
                      <p className="font-bold text-lg mb-1">A vibe é sua.</p>
-                     <p className="text-sm text-gray-200">A logística é nossa.</p>
+                     <p className="text-sm text-zinc-200">A logística é nossa.</p>
                   </div>
               </div>
               
@@ -39,7 +39,7 @@ const WhyUs: React.FC = () => {
           </div>
           
           <div className={`w-full lg:w-1/2 animate-on-scroll ${isVisible ? 'is-visible' : ''}`} style={{ transitionDelay: '200ms' }}>
-            <h2 id="why-us-heading" className="text-3xl md:text-5xl font-black text-gray-900 mb-8 leading-tight">
+            <h2 id="why-us-heading" className="text-3xl md:text-5xl font-black text-zinc-900 mb-8 leading-tight">
               Você cuida da setlist.<br /><span className="text-anhanga-blue">A gente cuida do resto.</span>
             </h2>
 
@@ -56,8 +56,8 @@ const WhyUs: React.FC = () => {
                     </div>
                   </div>
                   <div>
-                    <h3 className="text-xl font-bold text-gray-900 mb-2">{item.title}</h3>
-                    <p className="text-gray-600">{item.text}</p>
+                    <h3 className="text-xl font-bold text-zinc-900 mb-2">{item.title}</h3>
+                    <p className="text-zinc-600">{item.text}</p>
                   </div>
                 </div>
               ))}

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -10,7 +10,7 @@ interface BadgeProps {
 }
 
 const colorClasses: Record<BadgeColor, string> = {
-    default: 'bg-white border-gray-200 text-anhanga-dark shadow-sm',
+    default: 'bg-white border-zinc-200 text-anhanga-dark shadow-sm',
     blue:    'bg-blue-50 border-blue-200 text-anhanga-blue',
     yellow:  'bg-yellow-50 border-yellow-200 text-yellow-800',
 };

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -19,7 +19,7 @@ const variantClasses: Record<ButtonVariant, string> = {
     primary: 'bg-anhanga-dark text-white rounded-xl shadow-hard-yellow hover:shadow-[2px_2px_0px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none',
     action:  'bg-anhanga-action text-white rounded-full hover:bg-anhanga-actionDark',
     cta:     'bg-anhanga-yellow text-anhanga-dark rounded-2xl shadow-hard hover:shadow-[2px_2px_0px_0px_rgba(15,23,42,1)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none',
-    ghost:   'bg-transparent text-gray-500 rounded-lg hover:text-anhanga-action',
+    ghost:   'bg-transparent text-zinc-500 rounded-lg hover:text-anhanga-action',
 };
 
 const sizeClasses: Record<ButtonSize, string> = {

--- a/components/ui/LazyImage.tsx
+++ b/components/ui/LazyImage.tsx
@@ -23,7 +23,7 @@ export const LazyImage = React.memo<LazyImageProps>(({
     src,
     alt,
     className = "",
-    placeholderClassName = "bg-gray-200",
+    placeholderClassName = "bg-zinc-200",
     width,
     height,
     ...props
@@ -74,7 +74,7 @@ export const LazyImage = React.memo<LazyImageProps>(({
         >
             {!isLoaded && (
                 <div className={`absolute inset-0 flex items-center justify-center z-10 ${placeholderClassName}`}>
-                    <ImageIcon className="size-8 text-gray-400 opacity-40" />
+                    <ImageIcon className="size-8 text-zinc-400 opacity-40" />
                 </div>
             )}
             {isVisible && (

--- a/components/ui/SectionHeader.tsx
+++ b/components/ui/SectionHeader.tsx
@@ -35,7 +35,7 @@ export const SectionHeader: React.FC<SectionHeaderProps> = ({
                 {title}
             </h2>
             {subtitle && (
-                <p className="text-gray-500 text-base font-medium">{subtitle}</p>
+                <p className="text-zinc-500 text-base font-medium">{subtitle}</p>
             )}
         </div>
 );

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -75,7 +75,7 @@ const About: React.FC = () => {
               design e zero estresse.
             </span>
           </h1>
-          <p className="max-w-2xl mx-auto text-gray-600 text-lg md:text-xl font-medium leading-relaxed mb-8">
+          <p className="max-w-2xl mx-auto text-zinc-600 text-lg md:text-xl font-medium leading-relaxed mb-8">
             Na Anhangá Viagens, acreditamos que viajar é mais do que carimbar um passaporte: é sobre colecionar histórias que valem a pena ser contadas.
           </p>
           <div className="flex justify-center">
@@ -110,13 +110,13 @@ const About: React.FC = () => {
                     className="w-full h-auto object-cover aspect-[4/3]"
                   />
                 </div>
-                <div className="absolute -bottom-6 -right-6 bg-white p-6 rounded-2xl shadow-xl border border-gray-100 hidden md:block">
+                <div className="absolute -bottom-6 -right-6 bg-white p-6 rounded-2xl shadow-xl border border-zinc-100 hidden md:block">
                   <div className="flex items-center gap-4">
                     <div className="size-12 bg-brand-cyan/10 rounded-full flex items-center justify-center text-brand-cyan">
                       <Heart className="size-6 fill-current" />
                     </div>
                     <div>
-                      <p className="text-xs font-bold text-gray-400 uppercase tracking-wider">Paixão por</p>
+                      <p className="text-xs font-bold text-zinc-400 uppercase tracking-wider">Paixão por</p>
                       <p className="text-lg font-black text-brand-dark leading-none">Pessoas</p>
                     </div>
                   </div>
@@ -133,7 +133,7 @@ const About: React.FC = () => {
               custom={2}
             >
               <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-6">Nossa História</h2>
-              <div className="space-y-4 text-gray-600 font-medium leading-relaxed text-lg">
+              <div className="space-y-4 text-zinc-600 font-medium leading-relaxed text-lg">
                 <p>
                   A Anhangá Viagens nasceu em São Paulo com um propósito claro: resgatar o prazer de planejar uma viagem sem as dores de cabeça da burocracia digital e dos roteiros engessados.
                 </p>
@@ -159,7 +159,7 @@ const About: React.FC = () => {
             custom={0}
           >
             <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Por que viajar com a Anhangá?</h2>
-            <p className="text-gray-500 font-medium">O que nos torna diferentes no mercado de turismo.</p>
+            <p className="text-zinc-500 font-medium">O que nos torna diferentes no mercado de turismo.</p>
           </m.div>
 
           <div className="grid md:grid-cols-3 gap-8">
@@ -185,7 +185,7 @@ const About: React.FC = () => {
             ].map((item, i) => (
               <m.div
                 key={item.title}
-                className="bg-white p-10 rounded-[2.5rem] border-2 border-gray-100 shadow-sm hover:shadow-xl transition-all duration-300"
+                className="bg-white p-10 rounded-[2.5rem] border-2 border-zinc-100 shadow-sm hover:shadow-xl transition-all duration-300"
                 initial="hidden"
                 whileInView="visible"
                 viewport={{ once: true }}
@@ -196,7 +196,7 @@ const About: React.FC = () => {
                   <item.icon className="size-8" />
                 </div>
                 <h3 className="text-xl font-black text-brand-dark mb-4">{item.title}</h3>
-                <p className="text-gray-500 font-medium leading-relaxed">{item.desc}</p>
+                <p className="text-zinc-500 font-medium leading-relaxed">{item.desc}</p>
               </m.div>
             ))}
           </div>
@@ -213,7 +213,7 @@ const About: React.FC = () => {
                 <Award className="size-4" /> Credibilidade & Confiança
               </div>
               <h2 className="text-3xl md:text-4xl font-black mb-6">Agência Certificada</h2>
-              <p className="text-gray-300 text-lg font-medium leading-relaxed mb-8">
+              <p className="text-zinc-300 text-lg font-medium leading-relaxed mb-8">
                 Sua segurança é nossa prioridade. A Anhangá Viagens é uma empresa devidamente registrada nos órgãos competentes, garantindo total conformidade legal para suas férias.
               </p>
 
@@ -224,7 +224,7 @@ const About: React.FC = () => {
                   </div>
                   <div>
                     <p className="font-bold text-lg leading-none mb-1">Cadastur Oficial</p>
-                    <p className="text-gray-400">Registro MTUR: 37.036.732/0001-41</p>
+                    <p className="text-zinc-400">Registro MTUR: 37.036.732/0001-41</p>
                   </div>
                 </li>
                 <li className="flex items-start gap-4">
@@ -233,7 +233,7 @@ const About: React.FC = () => {
                   </div>
                   <div>
                     <p className="font-bold text-lg leading-none mb-1">Sede Própria em São Paulo</p>
-                    <p className="text-gray-400">Av. Dom Pedro I, 773 - Vila Monumento</p>
+                    <p className="text-zinc-400">Av. Dom Pedro I, 773 - Vila Monumento</p>
                   </div>
                 </li>
               </ul>
@@ -277,7 +277,7 @@ const About: React.FC = () => {
         >
           <div className="bg-brand-cyan/5 rounded-[3rem] p-12 md:p-20 border-2 border-dashed border-brand-cyan/20">
             <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-6">Pronto para sua próxima história?</h2>
-            <p className="text-gray-600 text-lg font-medium mb-10 max-w-xl mx-auto">
+            <p className="text-zinc-600 text-lg font-medium mb-10 max-w-xl mx-auto">
               Seja para um festival épico ou um refúgio relaxante, nós desenhamos a viagem perfeita para você.
             </p>
             <button

--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -53,7 +53,7 @@ const BlogList: React.FC = () => {
                     <h1 className="text-3xl md:text-5xl lg:text-6xl font-black text-brand-dark mb-6">
                         Diário de <span className="text-brand-cyan">Bordo</span>
                     </h1>
-                    <p className="text-lg md:text-xl text-gray-500 font-medium mb-6">
+                    <p className="text-lg md:text-xl text-zinc-500 font-medium mb-6">
                         Explore nosso acervo completo de dicas, roteiros e segredos de viagem.
                     </p>
 
@@ -66,9 +66,9 @@ const BlogList: React.FC = () => {
                             placeholder="Buscar por título ou categoria..."
                             value={searchTerm}
                             onChange={(e) => setSearchTerm(e.target.value)}
-                            className="w-full px-6 py-4 rounded-full border-2 border-gray-200 focus:border-brand-cyan focus:outline-none shadow-sm pl-12 text-gray-700 font-medium transition-all"
+                            className="w-full px-6 py-4 rounded-full border-2 border-zinc-200 focus:border-brand-cyan focus:outline-none shadow-sm pl-12 text-zinc-700 font-medium transition-all"
                         />
-                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 size-5" />
+                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400 size-5" />
                     </div>
                 </div>
 
@@ -80,13 +80,13 @@ const BlogList: React.FC = () => {
                                 to={`/blog/${post.slug}`}
                                 key={post.slug}
                                 className={`
-                                group bg-white rounded-3xl p-5 shadow-[0_10px_20px_-5px_rgba(0,0,0,0.05)] border border-gray-100
+                                group bg-white rounded-3xl p-5 shadow-[0_10px_20px_-5px_rgba(0,0,0,0.05)] border border-zinc-100
                                 transform transition-all duration-300 hover:-translate-y-2 hover:shadow-xl
                                 flex flex-col h-full relative z-10
                             `}
                             >
                                 {/* Image Area — aspect ratio alternado para ritmo visual */}
-                                <div className={`relative ${index % 3 === 1 ? 'aspect-[4/3]' : index % 3 === 2 ? 'aspect-video' : 'aspect-[16/10]'} rounded-2xl overflow-hidden mb-5 bg-gray-100`}>
+                                <div className={`relative ${index % 3 === 1 ? 'aspect-[4/3]' : index % 3 === 2 ? 'aspect-video' : 'aspect-[16/10]'} rounded-2xl overflow-hidden mb-5 bg-zinc-100`}>
                                     <img
                                         src={optimizeRemoteImageUrl(post.image, 640, 400)}
                                         alt={post.title}
@@ -96,7 +96,7 @@ const BlogList: React.FC = () => {
                                         decoding="async"
                                         className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                                     />
-                                    <div className="absolute top-3 right-3 bg-white/90 backdrop-blur rounded-lg px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-gray-800 shadow-sm">
+                                    <div className="absolute top-3 right-3 bg-white/90 backdrop-blur rounded-lg px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-zinc-800 shadow-sm">
                                         {formatDate(post.date)}
                                     </div>
                                     <div className="absolute bottom-3 right-3 z-30">
@@ -116,18 +116,18 @@ const BlogList: React.FC = () => {
                                             {post.category}
                                         </span>
                                     </div>
-                                    <h4 className="text-2xl font-extrabold text-gray-800 mb-3 leading-tight group-hover:text-brand-cyan transition-colors">
+                                    <h4 className="text-2xl font-extrabold text-zinc-800 mb-3 leading-tight group-hover:text-brand-cyan transition-colors">
                                         {post.title}
                                     </h4>
-                                    <p className="text-gray-500 font-medium leading-relaxed mb-6 flex-1 line-clamp-3">
+                                    <p className="text-zinc-500 font-medium leading-relaxed mb-6 flex-1 line-clamp-3">
                                         {post.excerpt}
                                     </p>
 
-                                    <div className="pt-4 border-t border-dashed border-gray-100 flex items-center justify-between">
-                                        <span className="text-xs font-bold text-gray-400 flex items-center gap-1">
+                                    <div className="pt-4 border-t border-dashed border-zinc-100 flex items-center justify-between">
+                                        <span className="text-xs font-bold text-zinc-400 flex items-center gap-1">
                                             <User className="size-3" /> {AUTHORS[post.author]?.name ?? post.author}
                                         </span>
-                                        <span className="size-10 rounded-full flex items-center justify-center transition-colors bg-gray-100 text-gray-400 group-hover:bg-brand-cyan group-hover:text-white">
+                                        <span className="size-10 rounded-full flex items-center justify-center transition-colors bg-zinc-100 text-zinc-400 group-hover:bg-brand-cyan group-hover:text-white">
                                             <ArrowRight className="size-5" />
                                         </span>
                                     </div>
@@ -137,7 +137,7 @@ const BlogList: React.FC = () => {
                     </div>
                 ) : (
                     <div className="text-center py-20">
-                        <p className="text-gray-400 text-lg font-medium">Nenhum artigo encontrado com esse termo. 🕵️‍♂️</p>
+                        <p className="text-zinc-400 text-lg font-medium">Nenhum artigo encontrado com esse termo. 🕵️‍♂️</p>
                     </div>
                 )}
 
@@ -146,7 +146,7 @@ const BlogList: React.FC = () => {
                     <h2 className="text-3xl md:text-5xl font-black text-brand-dark mb-6">
                         Pronto para transformar essas dicas em <span className="text-brand-cyan">Realidade?</span>
                     </h2>
-                    <p className="text-xl text-gray-600 mb-10 max-w-2xl mx-auto">
+                    <p className="text-xl text-zinc-600 mb-10 max-w-2xl mx-auto">
                         Fale com nossos especialistas e comece a planejar sua viagem personalizada hoje mesmo.
                     </p>
                     <button

--- a/pages/BlogRedirect.tsx
+++ b/pages/BlogRedirect.tsx
@@ -24,7 +24,7 @@ const BlogRedirect: React.FC = () => {
       <main className="min-h-screen bg-[#fffdf5] pt-32 pb-24 px-6">
         <div className="max-w-2xl mx-auto text-center">
           <h1 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Redirecionando para o Blog</h1>
-          <p className="text-gray-600 mb-6">
+          <p className="text-zinc-600 mb-6">
             O blog agora está em um novo endereço.
           </p>
           <a

--- a/pages/NotFound.tsx
+++ b/pages/NotFound.tsx
@@ -38,7 +38,7 @@ const NotFound: React.FC = () => {
             <span className="text-brand-cyan">pegou outro rumo.</span>
           </h1>
 
-          <p className="text-xl text-gray-600 mb-12 max-w-2xl mx-auto font-medium leading-relaxed">
+          <p className="text-xl text-zinc-600 mb-12 max-w-2xl mx-auto font-medium leading-relaxed">
             Parece que o destino que você procurava não está no mapa. Que tal recomeçar a sua jornada por um desses caminhos?
           </p>
 
@@ -52,7 +52,7 @@ const NotFound: React.FC = () => {
               </div>
               <div className="text-left">
                 <p className="font-bold text-brand-dark">Página Inicial</p>
-                <p className="text-sm text-gray-500">Voltar ao começo</p>
+                <p className="text-sm text-zinc-500">Voltar ao começo</p>
               </div>
             </a>
 
@@ -65,7 +65,7 @@ const NotFound: React.FC = () => {
               </div>
               <div className="text-left">
                 <p className="font-bold text-brand-dark">Blog de Viagens</p>
-                <p className="text-sm text-gray-500">Dicas e roteiros</p>
+                <p className="text-sm text-zinc-500">Dicas e roteiros</p>
               </div>
             </a>
 
@@ -78,7 +78,7 @@ const NotFound: React.FC = () => {
               </div>
               <div className="text-left">
                 <p className="font-bold text-brand-dark">Orlando</p>
-                <p className="text-sm text-gray-500">Magia e diversão</p>
+                <p className="text-sm text-zinc-500">Magia e diversão</p>
               </div>
             </a>
 
@@ -93,7 +93,7 @@ const NotFound: React.FC = () => {
                 </div>
                 <div className="text-left">
                   <p className="font-bold text-brand-dark">Beto Carrero</p>
-                  <p className="text-sm text-gray-500">Aventura no Brasil</p>
+                  <p className="text-sm text-zinc-500">Aventura no Brasil</p>
                 </div>
               </a>
 
@@ -106,7 +106,7 @@ const NotFound: React.FC = () => {
                 </div>
                 <div className="text-left">
                   <p className="font-bold text-brand-dark">Lollapalooza</p>
-                  <p className="text-sm text-gray-500">Música e experiência</p>
+                  <p className="text-sm text-zinc-500">Música e experiência</p>
                 </div>
               </a>
             </div>

--- a/pages/SiteMap.tsx
+++ b/pages/SiteMap.tsx
@@ -36,7 +36,7 @@ const SiteMap: React.FC = () => {
       <main className="min-h-screen bg-[#fffdf5] pt-32 pb-24">
         <section className="container mx-auto px-6 max-w-4xl">
           <h1 className="text-4xl md:text-5xl font-black text-brand-dark mb-6">Mapa do Site</h1>
-          <p className="text-gray-600 mb-10">Acesse rapidamente as principais áreas do site.</p>
+          <p className="text-zinc-600 mb-10">Acesse rapidamente as principais áreas do site.</p>
 
           <h2 className="text-2xl font-extrabold text-brand-dark mb-4">Páginas Principais</h2>
           <ul className="space-y-3 mb-10">

--- a/pages/landings/BetoCarreroLanding.tsx
+++ b/pages/landings/BetoCarreroLanding.tsx
@@ -51,9 +51,9 @@ const BetoCarreroLanding: React.FC = () => {
         ]}
       />
       <FAQPageSchema items={BETO_FAQ_ITEMS} />
-      <div className="bg-[#fffdf5] py-2 border-b border-gray-100">
+      <div className="bg-[#fffdf5] py-2 border-b border-zinc-100">
         <div className="container mx-auto px-6">
-          <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-gray-500 hover:text-brand-cyan transition-colors flex items-center gap-1">
+          <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1">
             ← Voltar para o site principal
           </a>
         </div>
@@ -72,14 +72,14 @@ const BetoCarreroLanding: React.FC = () => {
       <section className="bg-[#fffdf5] border-t border-brand-cyan/10 py-14">
         <div className="container mx-auto px-6 max-w-5xl">
           <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Pacote Beto Carrero para viajar com tranquilidade</h2>
-          <p className="text-gray-700 text-lg leading-relaxed mb-5">
+          <p className="text-zinc-700 text-lg leading-relaxed mb-5">
             Nosso <strong>pacote Beto Carrero</strong> é desenhado para quem quer curtir o parque sem dor de cabeça com reservas, horários e deslocamentos.
           </p>
-          <p className="text-gray-700 text-lg leading-relaxed mb-5">
+          <p className="text-zinc-700 text-lg leading-relaxed mb-5">
             Você recebe planejamento completo com opções de hotel, logística e ingressos, além de orientação prática para aproveitar melhor cada dia de viagem em família.
           </p>
           <h3 className="text-xl md:text-2xl font-extrabold text-brand-dark mb-3">O que pode entrar no seu pacote</h3>
-          <ul className="list-disc list-inside text-gray-700 space-y-1 mb-6">
+          <ul className="list-disc list-inside text-zinc-700 space-y-1 mb-6">
             <li>Hospedagem com localização estratégica</li>
             <li>Ingressos para o parque e upgrades opcionais</li>
             <li>Roteiro de atrações por perfil do grupo</li>
@@ -97,13 +97,13 @@ const BetoCarreroLanding: React.FC = () => {
             >
               Falar com especialista
             </button>
-            <a href="https://www.anhanga.tur.br/orlando/" className="px-5 py-3 rounded-full bg-white border border-gray-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="https://www.anhanga.tur.br/orlando/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ver pacotes para Orlando
             </a>
-            <a href="/blog" className="px-5 py-3 rounded-full bg-white border border-gray-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="/blog" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ver dicas de planejamento
             </a>
-            <a href="https://www.betocarrero.com.br/" target="_blank" rel="noopener noreferrer" className="px-5 py-3 rounded-full bg-white border border-gray-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="https://www.betocarrero.com.br/" target="_blank" rel="noopener noreferrer" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Site Oficial Beto Carrero
             </a>
           </div>

--- a/pages/landings/BrazilPromotionDayLanding.tsx
+++ b/pages/landings/BrazilPromotionDayLanding.tsx
@@ -152,7 +152,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
             <div className="bg-[#fffdf5] min-h-screen font-sans">
 
                 {/* ── Nav ───────────────────────────────────────────────── */}
-                <nav className="bg-white/90 backdrop-blur-md border-b border-gray-100 sticky top-0 z-50 px-6 py-2">
+                <nav className="bg-white/90 backdrop-blur-md border-b border-zinc-100 sticky top-0 z-50 px-6 py-2">
                     <div className="container mx-auto flex items-center justify-between">
                         <a href="https://www.anhanga.tur.br/" aria-label="Voltar para o site principal">
                             <img
@@ -382,10 +382,10 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                             <Icon className={`size-8 ${item.iconColor}`} weight="fill" />
                                         </m.div>
 
-                                        <h3 className="text-xl font-extrabold text-gray-900 mb-3 leading-tight group-hover:text-brand-cyan transition-colors duration-300">
+                                        <h3 className="text-xl font-extrabold text-zinc-900 mb-3 leading-tight group-hover:text-brand-cyan transition-colors duration-300">
                                             {item.title}
                                         </h3>
-                                        <p className="text-gray-500 font-medium leading-relaxed text-sm">
+                                        <p className="text-zinc-500 font-medium leading-relaxed text-sm">
                                             {item.description}
                                         </p>
 
@@ -471,7 +471,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                     </span>
                                 </h2>
 
-                                <p className="text-gray-500 font-medium text-lg leading-relaxed mb-10 max-w-sm">
+                                <p className="text-zinc-500 font-medium text-lg leading-relaxed mb-10 max-w-sm">
                                     Preencha o formulário e um consultor entra em contato pelo canal que você preferir, sem enrolação.
                                 </p>
 
@@ -486,11 +486,11 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                                 <Icon className="size-5 text-blue-600" weight="fill" />
                                             </div>
                                             {href ? (
-                                                <a href={href} className="font-semibold text-gray-700 hover:text-brand-cyan transition-colors duration-150 pt-1.5">
+                                                <a href={href} className="font-semibold text-zinc-700 hover:text-brand-cyan transition-colors duration-150 pt-1.5">
                                                     {label}
                                                 </a>
                                             ) : (
-                                                <span className="font-semibold text-gray-700 leading-snug pt-1.5">{label}</span>
+                                                <span className="font-semibold text-zinc-700 leading-snug pt-1.5">{label}</span>
                                             )}
                                         </li>
                                     ))}
@@ -498,7 +498,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
 
                                 {/* Social links */}
                                 <div>
-                                    <p className="text-xs font-bold tracking-widest uppercase text-gray-500 mb-4">
+                                    <p className="text-xs font-bold tracking-widest uppercase text-zinc-500 mb-4">
                                         Nos siga nas redes
                                     </p>
                                     <div className="flex gap-3">
@@ -512,7 +512,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                                 href={href}
                                                 target="_blank"
                                                 rel="noopener noreferrer"
-                                                className="size-11 rounded-xl bg-white border-2 border-gray-200 flex items-center justify-center text-gray-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-[4px_4px_0px_#fbbf24] hover:-translate-y-1 transition-all duration-200"
+                                                className="size-11 rounded-xl bg-white border-2 border-zinc-200 flex items-center justify-center text-zinc-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-[4px_4px_0px_#fbbf24] hover:-translate-y-1 transition-all duration-200"
                                                 aria-label={label}
                                                 {...(contact ? { 'data-contact-intent': true, 'data-tracking': 'social-whatsapp-brazil-promotion-day' } : {})}
                                             >
@@ -530,7 +530,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                 whileInView="visible"
                                 viewport={{ once: true, amount: 0.2 }}
                                 custom={1}
-                                className="bg-white rounded-[2rem] border-2 border-gray-100 shadow-[0_30px_60px_-15px_rgba(0,0,0,0.15)] overflow-hidden"
+                                className="bg-white rounded-[2rem] border-2 border-zinc-100 shadow-[0_30px_60px_-15px_rgba(0,0,0,0.15)] overflow-hidden"
                             >
                                 {submitState === 'success' ? (
                                     <div className="flex flex-col items-center text-center p-12">
@@ -544,7 +544,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                         <h3 className="text-2xl font-black text-brand-dark mb-3">
                                             Mensagem recebida! 🎉
                                         </h3>
-                                        <p className="text-gray-500 max-w-xs leading-relaxed mb-8">
+                                        <p className="text-zinc-500 max-w-xs leading-relaxed mb-8">
                                             Um consultor da Anhangá vai entrar em contato em breve. Fique de olho no WhatsApp ou e-mail.
                                         </p>
                                         <a
@@ -562,17 +562,17 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                 ) : (
                                     <form onSubmit={handleSubmit} noValidate>
                                         {/* Form header strip */}
-                                        <div className="flex justify-between items-center px-8 py-5 border-b-2 border-dashed border-gray-100">
+                                        <div className="flex justify-between items-center px-8 py-5 border-b-2 border-dashed border-zinc-100">
                                             <span className="text-brand-cyan font-black tracking-widest text-sm uppercase flex items-center gap-2">
                                                 <AirplaneTilt className="size-4" weight="fill" /> Formulário de Contato
                                             </span>
-                                            <span className="text-gray-400 font-bold text-xs uppercase">Brazil Promotion Day</span>
+                                            <span className="text-zinc-400 font-bold text-xs uppercase">Brazil Promotion Day</span>
                                         </div>
 
                                         <div className="p-8 space-y-5">
                                             <div className="grid grid-cols-2 gap-4">
                                                 <div>
-                                                    <label htmlFor="firstName" className="block text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">
+                                                    <label htmlFor="firstName" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
                                                         Nome <span className="text-brand-cyan">*</span>
                                                     </label>
                                                     <input
@@ -583,11 +583,11 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                                         value={form.firstName}
                                                         onChange={handleField('firstName')}
                                                         required
-                                                        className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-gray-400"
+                                                        className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400"
                                                     />
                                                 </div>
                                                 <div>
-                                                    <label htmlFor="lastName" className="block text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">
+                                                    <label htmlFor="lastName" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
                                                         Sobrenome <span className="text-brand-cyan">*</span>
                                                     </label>
                                                     <input
@@ -598,13 +598,13 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                                         value={form.lastName}
                                                         onChange={handleField('lastName')}
                                                         required
-                                                        className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-gray-400"
+                                                        className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400"
                                                     />
                                                 </div>
                                             </div>
 
                                             <div>
-                                                <label htmlFor="email" className="block text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">
+                                                <label htmlFor="email" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
                                                     E-mail <span className="text-brand-cyan">*</span>
                                                 </label>
                                                 <input
@@ -615,12 +615,12 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                                     value={form.email}
                                                     onChange={handleField('email')}
                                                     required
-                                                    className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-gray-400"
+                                                    className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400"
                                                 />
                                             </div>
 
                                             <div>
-                                                <label htmlFor="whatsapp" className="block text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">
+                                                <label htmlFor="whatsapp" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
                                                     WhatsApp <span className="text-brand-cyan">*</span>
                                                 </label>
                                                 <input
@@ -631,12 +631,12 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                                     value={form.whatsapp}
                                                     onChange={handleField('whatsapp')}
                                                     required
-                                                    className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-gray-400"
+                                                    className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400"
                                                 />
                                             </div>
 
                                             <div>
-                                                <label htmlFor="destination" className="block text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">
+                                                <label htmlFor="destination" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
                                                     Destino de interesse
                                                 </label>
                                                 <input
@@ -646,7 +646,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                                     autoComplete="off"
                                                     value={form.destination}
                                                     onChange={handleField('destination')}
-                                                    className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-200 text-sm font-medium text-gray-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-gray-400"
+                                                    className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400"
                                                 />
                                             </div>
 
@@ -675,7 +675,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                                                 )}
                                             </button>
 
-                                            <p className="text-xs text-gray-400 text-center leading-relaxed">
+                                            <p className="text-xs text-zinc-400 text-center leading-relaxed">
                                                 Seus dados são usados apenas para entrar em contato. Não compartilhamos com terceiros.
                                             </p>
                                         </div>
@@ -687,7 +687,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                 </section>
 
                 {/* ── Footer ────────────────────────────────────────────── */}
-                <footer className="bg-brand-dark text-gray-300 py-10">
+                <footer className="bg-brand-dark text-zinc-300 py-10">
                     <div className="container mx-auto px-6 flex flex-col md:flex-row items-center justify-between gap-6">
                         <img
                             src={BRAND_LOGO_BLUE_URL}

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -104,14 +104,14 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       <FAQPageSchema items={FAQ_ITEMS} />
 
       {/* Mini Header */}
-      <header className="bg-white/90 backdrop-blur-sm border-b border-gray-100 sticky top-0 z-50 py-3">
+      <header className="bg-white/90 backdrop-blur-sm border-b border-zinc-100 sticky top-0 z-50 py-3">
         <div className="max-w-5xl mx-auto px-6 flex items-center justify-between">
           <Link
             to="/"
             className="inline-flex items-center gap-2 group"
             aria-label="Voltar para o site principal da Anhangá Viagens"
           >
-            <ArrowLeft className="size-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
+            <ArrowLeft className="size-4 text-zinc-400 group-hover:text-anhanga-blue transition-colors" />
             <span className="size-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
               <img src="/favicon.svg" alt="" aria-hidden="true" className="size-4" />
             </span>
@@ -139,7 +139,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
           <h1 className="text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1] font-serif">
             Planeje uma viagem sob medida sem depender de pacote pronto
           </h1>
-          <p className="text-xl text-gray-600 mb-10 leading-relaxed max-w-2xl">
+          <p className="text-xl text-zinc-600 mb-10 leading-relaxed max-w-2xl">
             Um consultor da Anhangá entende seu perfil, destino, orçamento e restrições para desenhar o melhor caminho antes de você fechar.
           </p>
           <button
@@ -152,7 +152,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             Falar com um consultor
             <ArrowRight className="size-5" />
           </button>
-          <p className="mt-4 text-sm text-gray-600">Sem taxa de consultoria. Gratuito.</p>
+          <p className="mt-4 text-sm text-zinc-600">Sem taxa de consultoria. Gratuito.</p>
         </div>
       </section>
 
@@ -162,7 +162,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
             Por que consultoria?
           </h2>
-          <p className="text-gray-600 text-lg mb-12">
+          <p className="text-zinc-600 text-lg mb-12">
             Porque viajar bem não é só escolher um destino.
           </p>
           <div className="grid md:grid-cols-3 gap-6">
@@ -187,7 +187,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                 <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
                   {title}
                 </h3>
-                <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-gray-600 leading-relaxed'}>
+                <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-zinc-600 leading-relaxed'}>
                   {desc}
                 </p>
               </div>
@@ -208,7 +208,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                 {FOR_WHO.map(item => (
                   <li key={item} className="flex items-start gap-3">
                     <CheckCircle className="size-5 text-anhanga-blue flex-shrink-0 mt-0.5" aria-hidden="true" />
-                    <span className="text-gray-700 leading-snug">{item}</span>
+                    <span className="text-zinc-700 leading-snug">{item}</span>
                   </li>
                 ))}
               </ul>
@@ -217,7 +217,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               <blockquote className="text-xl text-anhanga-dark font-semibold leading-relaxed">
                 "A Anhangá cuidou de cada detalhe. Só precisei aparecer no aeroporto."
               </blockquote>
-              <p className="mt-4 text-gray-600 text-sm">
+              <p className="mt-4 text-zinc-600 text-sm">
                 R.M. · São Paulo · Viagem para Portugal, 2025
               </p>
             </div>
@@ -235,14 +235,14 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             {HOW_IT_WORKS.map(({ step, title, desc }, idx) => (
               <div
                 key={step}
-                className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-gray-100' : ''}`}
+                className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-zinc-100' : ''}`}
               >
                 <div className="flex-shrink-0 size-12 rounded-full bg-anhanga-blue/10 flex items-center justify-center">
                   <span className="text-sm font-black text-anhanga-blue">{step}</span>
                 </div>
                 <div>
                   <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
-                  <p className="text-gray-600 leading-relaxed max-w-xl">{desc}</p>
+                  <p className="text-zinc-600 leading-relaxed max-w-xl">{desc}</p>
                 </div>
               </div>
             ))}
@@ -256,7 +256,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
             Sobre a Anhangá Viagens
           </h2>
-          <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mx-auto">
+          <p className="text-lg text-zinc-600 leading-relaxed max-w-2xl mx-auto">
             Agência de viagens em São Paulo, especializada em viagens personalizadas desde 2018. Atendimento humano, nota 5.0 no Google e consultor fixo do início ao fim da sua viagem.
           </p>
           <div className="mt-12 flex flex-wrap justify-center gap-12">
@@ -267,7 +267,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             ].map(({ label, value }) => (
               <div key={label}>
                 <div className="text-4xl font-black text-anhanga-blue">{value}</div>
-                <div className="text-sm text-gray-600 mt-1">{label}</div>
+                <div className="text-sm text-zinc-600 mt-1">{label}</div>
               </div>
             ))}
           </div>
@@ -308,7 +308,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Viagens para Executivos
               </div>
-              <div className="text-sm text-gray-600 mt-1">
+              <div className="text-sm text-zinc-600 mt-1">
                 Planejamento com precisão para profissionais
               </div>
             </Link>
@@ -319,7 +319,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Curadoria de Cruzeiros
               </div>
-              <div className="text-sm text-gray-600 mt-1">
+              <div className="text-sm text-zinc-600 mt-1">
                 Escolha o navio e a cabine certos para você
               </div>
             </Link>
@@ -330,7 +330,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Site principal
               </div>
-              <div className="text-sm text-gray-600 mt-1">
+              <div className="text-sm text-zinc-600 mt-1">
                 Conheça todos os serviços da Anhangá
               </div>
             </a>
@@ -346,7 +346,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       />
 
       {/* Footer */}
-      <footer className="py-8 bg-[#fffdf5] border-t border-gray-100 text-center text-sm text-gray-600">
+      <footer className="py-8 bg-[#fffdf5] border-t border-zinc-100 text-center text-sm text-zinc-600">
         <p>Anhangá Viagens · Agência de viagens em São Paulo</p>
         <p className="mt-1">Atualizado em abril de 2026</p>
       </footer>

--- a/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
+++ b/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
@@ -119,7 +119,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
             className="inline-flex items-center gap-2 group"
             aria-label="Voltar para o site principal da Anhangá Viagens"
           >
-            <ArrowLeft className="size-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
+            <ArrowLeft className="size-4 text-zinc-400 group-hover:text-anhanga-blue transition-colors" />
             <span className="size-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
               <img src="/favicon.svg" alt="" aria-hidden="true" className="size-4" />
             </span>
@@ -147,7 +147,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
           <h1 className="text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1] font-serif">
             Escolha o cruzeiro certo no Brasil antes de fechar
           </h1>
-          <p className="text-xl text-gray-600 mb-10 leading-relaxed max-w-2xl">
+          <p className="text-xl text-zinc-600 mb-10 leading-relaxed max-w-2xl">
             Entenda navio, cabine, roteiro, datas e perfil da viagem com uma curadoria consultiva da Anhangá.
           </p>
           <button
@@ -160,7 +160,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
             Falar com um especialista
             <ArrowRight className="size-5" />
           </button>
-          <p className="mt-4 text-sm text-gray-600">Sem taxa de curadoria. Gratuito.</p>
+          <p className="mt-4 text-sm text-zinc-600">Sem taxa de curadoria. Gratuito.</p>
         </div>
       </section>
 
@@ -170,14 +170,14 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4 font-serif">
             O que analisamos juntos
           </h2>
-          <p className="text-gray-600 text-lg mb-10">
+          <p className="text-zinc-600 text-lg mb-10">
             Na curadoria, passamos por todos esses pontos antes de você decidir.
           </p>
           <div className="grid sm:grid-cols-2 gap-4">
             {WHAT_WE_ANALYZE.map(item => (
               <div key={item} className="flex items-start gap-3 p-4 rounded-xl bg-anhanga-light">
                 <CheckCircle className="size-5 text-anhanga-blue flex-shrink-0 mt-0.5" aria-hidden="true" />
-                <span className="text-gray-700">{item}</span>
+                <span className="text-zinc-700">{item}</span>
               </div>
             ))}
           </div>
@@ -190,7 +190,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
             Por que curadoria?
           </h2>
-          <p className="text-gray-600 text-lg mb-12">
+          <p className="text-zinc-600 text-lg mb-12">
             Porque escolher um cruzeiro envolve mais variáveis do que parece.
           </p>
           <div className="grid md:grid-cols-3 gap-6">
@@ -215,7 +215,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
                 <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
                   {title}
                 </h3>
-                <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-gray-600 leading-relaxed'}>
+                <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-zinc-600 leading-relaxed'}>
                   {desc}
                 </p>
               </div>
@@ -234,7 +234,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
             {FOR_WHO.map(({ title, desc }) => (
               <div key={title} className="bg-anhanga-light rounded-2xl p-6">
                 <h3 className="font-black text-anhanga-dark mb-2">{title}</h3>
-                <p className="text-gray-600 text-sm leading-relaxed">{desc}</p>
+                <p className="text-zinc-600 text-sm leading-relaxed">{desc}</p>
               </div>
             ))}
           </div>
@@ -258,7 +258,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
                 </div>
                 <div>
                   <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
-                  <p className="text-gray-600 leading-relaxed max-w-xl">{desc}</p>
+                  <p className="text-zinc-600 leading-relaxed max-w-xl">{desc}</p>
                 </div>
               </div>
             ))}
@@ -272,7 +272,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
             Sobre a Anhangá Viagens
           </h2>
-          <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mx-auto">
+          <p className="text-lg text-zinc-600 leading-relaxed max-w-2xl mx-auto">
             Agência de viagens em São Paulo desde 2018, com especialistas em cruzeiros no Brasil e roteiros personalizados. Nota 5.0 no Google e atendimento humano do início ao fim.
           </p>
           <div className="mt-12 flex flex-wrap justify-center gap-12">
@@ -283,7 +283,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
             ].map(({ label, value }) => (
               <div key={label}>
                 <div className="text-4xl font-black text-anhanga-blue">{value}</div>
-                <div className="text-sm text-gray-600 mt-1">{label}</div>
+                <div className="text-sm text-zinc-600 mt-1">{label}</div>
               </div>
             ))}
           </div>
@@ -324,7 +324,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Consultoria de Viagem
               </div>
-              <div className="text-sm text-gray-600 mt-1">
+              <div className="text-sm text-zinc-600 mt-1">
                 Roteiro sob medida com consultor humano
               </div>
             </Link>
@@ -335,7 +335,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Viagens para Executivos
               </div>
-              <div className="text-sm text-gray-600 mt-1">
+              <div className="text-sm text-zinc-600 mt-1">
                 Planejamento com precisão para profissionais
               </div>
             </Link>
@@ -346,7 +346,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Site principal
               </div>
-              <div className="text-sm text-gray-600 mt-1">
+              <div className="text-sm text-zinc-600 mt-1">
                 Conheça todos os serviços da Anhangá
               </div>
             </a>
@@ -362,7 +362,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
       />
 
       {/* Footer */}
-      <footer className="py-8 bg-anhanga-light border-t border-anhanga-blue/10 text-center text-sm text-gray-600">
+      <footer className="py-8 bg-anhanga-light border-t border-anhanga-blue/10 text-center text-sm text-zinc-600">
         <p>Anhangá Viagens · Agência de viagens em São Paulo</p>
         <p className="mt-1">Atualizado em abril de 2026</p>
       </footer>

--- a/pages/landings/LollapaloozaLanding.tsx
+++ b/pages/landings/LollapaloozaLanding.tsx
@@ -53,9 +53,9 @@ const LollapaloozaLanding: React.FC = () => {
         ]}
       />
       <FAQPageSchema items={LOLLAPALOOZA_FAQ_ITEMS} />
-      <div className="bg-[#fffdf5] py-2 border-b border-gray-100 relative z-[60]">
+      <div className="bg-[#fffdf5] py-2 border-b border-zinc-100 relative z-[60]">
         <div className="container mx-auto px-6">
-          <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-gray-500 hover:text-brand-cyan transition-colors flex items-center gap-1 font-sans">
+          <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1 font-sans">
             ← Voltar para o site principal
           </a>
         </div>
@@ -74,10 +74,10 @@ const LollapaloozaLanding: React.FC = () => {
       <section className="bg-[#fffdf5] border-t border-brand-cyan/10 py-14">
         <div className="container mx-auto px-6 max-w-5xl">
           <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">2026 encerrou forte. 2027 já está no radar.</h2>
-          <p className="text-gray-700 text-lg leading-relaxed mb-5">
+          <p className="text-zinc-700 text-lg leading-relaxed mb-5">
             A página do <strong>Lollapalooza Brasil</strong> continua no ar porque a campanha 2026 foi um sucesso e segue relevante para quem pesquisa logística, hotel e planejamento de festival em São Paulo. Agora, o foco é transformar essa procura em prioridade para a próxima edição.
           </p>
-          <p className="text-gray-700 text-lg leading-relaxed mb-5">
+          <p className="text-zinc-700 text-lg leading-relaxed mb-5">
             Se você quer chegar antes da próxima abertura, entre na <strong>Lista de Espera Lolla 2027</strong>. A <strong>Anhangá Viagens</strong> é uma{' '}
             <a href="https://www.anhanga.tur.br/" className="text-brand-cyan font-semibold hover:underline">
               agência de viagens em São Paulo
@@ -85,20 +85,20 @@ const LollapaloozaLanding: React.FC = () => {
             com foco em atendimento consultivo e <strong>viagens personalizadas</strong>, do planejamento inicial ao suporte no destino.
           </p>
           <h3 className="text-xl md:text-2xl font-extrabold text-brand-dark mb-3">O que segue valendo para quem quer ir ao festival</h3>
-          <ul className="list-disc list-inside text-gray-700 space-y-1 mb-6">
+          <ul className="list-disc list-inside text-zinc-700 space-y-1 mb-6">
             <li>Hospedagem próxima a rotas de acesso ao festival</li>
             <li>Transporte com melhor custo-benefício (Linha 9 – Esmeralda ou Lolla Express)</li>
             <li>Planejamento diário para os três dias de evento</li>
             <li>Suporte rápido para ajustes durante a viagem</li>
             <li>Curadoria de restaurantes e experiências em São Paulo ao redor do festival</li>
           </ul>
-          <p className="text-gray-700 text-lg leading-relaxed mb-6">
+          <p className="text-zinc-700 text-lg leading-relaxed mb-6">
             Enquanto a próxima edição não abre, você também pode explorar outros roteiros da Anhangá e continuar pesquisando o festival com a referência desta landing evergreen.
           </p>
           <div className="flex flex-wrap gap-3">
             <a
               href={`#${WAITLIST_SECTION_ID}`}
-              className="px-5 py-3 rounded-full bg-white border border-gray-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors"
+              className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors"
               data-tracking="footer-lollapalooza-waitlist"
             >
               Entrar na lista de espera 2027
@@ -113,13 +113,13 @@ const LollapaloozaLanding: React.FC = () => {
             >
               Falar com especialista
             </button>
-            <a href="https://www.anhanga.tur.br/orlando/" className="px-5 py-3 rounded-full bg-white border border-gray-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="https://www.anhanga.tur.br/orlando/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ver pacotes para Orlando
             </a>
-            <a href="https://www.anhanga.tur.br/" className="px-5 py-3 rounded-full bg-white border border-gray-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="https://www.anhanga.tur.br/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Conhecer a Anhangá Viagens
             </a>
-            <a href="/blog" className="px-5 py-3 rounded-full bg-white border border-gray-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="/blog" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ler guia de festivais
             </a>
           </div>

--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -54,7 +54,7 @@ const MelhorIdadeLanding: React.FC = () => {
       <FAQPageSchema items={MELHOR_IDADE_FAQ_ITEMS} />
 
       {/* MINI HEADER */}
-      <div className="bg-white/80 backdrop-blur-md py-4 border-b border-gray-100 sticky top-0 z-[60]">
+      <div className="bg-white/80 backdrop-blur-md py-4 border-b border-zinc-100 sticky top-0 z-[60]">
         <div className="container mx-auto px-6 flex justify-between items-center">
           <Link to="/" className="text-sm font-bold text-brand-dark hover:text-brand-cyan transition-colors flex items-center gap-2">
             <span className="size-8 bg-brand-cyan/10 rounded-lg flex items-center justify-center">
@@ -98,7 +98,7 @@ const MelhorIdadeLanding: React.FC = () => {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.2 }}
-              className="text-xl text-gray-600 mb-10 leading-relaxed font-medium"
+              className="text-xl text-zinc-600 mb-10 leading-relaxed font-medium"
             >
               Na Anhangá, acreditamos que a "melhor idade" é a época perfeita para novas descobertas. Criamos roteiros 100% personalizados para quem não abre mão de conforto, segurança e boas histórias.
             </m.p>
@@ -134,7 +134,7 @@ const MelhorIdadeLanding: React.FC = () => {
                 <ShieldCheck className="size-8" />
               </div>
               <h3 className="text-2xl font-black text-brand-dark">Segurança em 1º lugar</h3>
-              <p className="text-gray-500 font-medium leading-relaxed">
+              <p className="text-zinc-500 font-medium leading-relaxed">
                 Hotéis com acessibilidade, seguro-viagem premium e suporte 24h para você viajar com tranquilidade total.
               </p>
             </div>
@@ -143,7 +143,7 @@ const MelhorIdadeLanding: React.FC = () => {
                 <Coffee className="size-8" />
               </div>
               <h3 className="text-2xl font-black text-brand-dark">Ritmo Desacelerado</h3>
-              <p className="text-gray-500 font-medium leading-relaxed">
+              <p className="text-zinc-500 font-medium leading-relaxed">
                 Nada de correrias. Roteiros desenhados para respeitar o seu tempo, com pausas estratégicas e menos deslocamentos.
               </p>
             </div>
@@ -152,7 +152,7 @@ const MelhorIdadeLanding: React.FC = () => {
                 <Sparkles className="size-8" />
               </div>
               <h3 className="text-2xl font-black text-brand-dark">Curadoria Personalizada</h3>
-              <p className="text-gray-500 font-medium leading-relaxed">
+              <p className="text-zinc-500 font-medium leading-relaxed">
                 Experiências gastronômicas, culturais e de lazer selecionadas a dedo para viajantes exigentes e experientes.
               </p>
             </div>
@@ -165,7 +165,7 @@ const MelhorIdadeLanding: React.FC = () => {
         <div className="container mx-auto px-6 max-w-4xl">
           <h2 className="text-3xl md:text-5xl font-black text-brand-dark mb-12 text-center">Por que planejar sua viagem 50+ com a Anhangá?</h2>
           
-          <div className="prose prose-lg prose-brand max-w-none text-gray-700 font-medium leading-[1.8]">
+          <div className="prose prose-lg prose-brand max-w-none text-zinc-700 font-medium leading-[1.8]">
             <p>
               Viajar na maturidade exige um olhar diferente. Não se trata apenas de escolher um destino, mas de garantir que cada etapa da jornada seja fluida e prazerosa. Na <strong>Anhangá Viagens</strong>, somos especialistas em transformar o planejamento em um processo leve e transparente.
             </p>
@@ -199,7 +199,7 @@ const MelhorIdadeLanding: React.FC = () => {
         <div className="bg-brand-dark text-white rounded-[3rem] p-12 md:p-24 relative overflow-hidden">
           <div className="absolute top-0 right-0 size-64 bg-brand-cyan/20 blur-[100px] rounded-full"></div>
           <h2 className="text-4xl md:text-6xl font-black mb-8 relative z-10">Sua próxima aventura <br className="hidden md:block" /> começa agora.</h2>
-          <p className="text-xl text-gray-300 mb-12 max-w-2xl mx-auto relative z-10">
+          <p className="text-xl text-zinc-300 mb-12 max-w-2xl mx-auto relative z-10">
             Fale conosco hoje mesmo e receba uma proposta exclusiva para sua viagem. Segurança, conforto e exclusividade em um só lugar.
           </p>
           <button

--- a/pages/landings/OrlandoLanding.tsx
+++ b/pages/landings/OrlandoLanding.tsx
@@ -56,9 +56,9 @@ const OrlandoLanding: React.FC = () => {
         ]}
       />
       <FAQPageSchema items={ORLANDO_FAQ_ITEMS} />
-      <div className="bg-[#fffdf5] py-2 border-b border-gray-100 relative z-[60]">
+      <div className="bg-[#fffdf5] py-2 border-b border-zinc-100 relative z-[60]">
         <div className="container mx-auto px-6">
-          <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-gray-500 hover:text-brand-cyan transition-colors flex items-center gap-1 font-sans">
+          <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1 font-sans">
             ← Voltar para o site principal
           </a>
         </div>
@@ -77,14 +77,14 @@ const OrlandoLanding: React.FC = () => {
       <section className="bg-[#fffdf5] border-t border-brand-cyan/10 py-14">
         <div className="container mx-auto px-6 max-w-5xl">
           <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Pacote para Orlando sem improviso</h2>
-          <p className="text-gray-700 text-lg leading-relaxed mb-5">
+          <p className="text-zinc-700 text-lg leading-relaxed mb-5">
             Se você busca <strong>pacotes para Orlando</strong> com planejamento profissional, a Anhangá estrutura sua viagem com foco em custo-benefício, logística e experiência.
           </p>
-          <p className="text-gray-700 text-lg leading-relaxed mb-5">
+          <p className="text-zinc-700 text-lg leading-relaxed mb-5">
             Definimos roteiro de parques, hospedagem por região, estratégia de ingressos e suporte antes e durante a viagem para você evitar erros comuns e aproveitar melhor cada dia de viagem.
           </p>
           <h3 className="text-xl md:text-2xl font-extrabold text-brand-dark mb-3">O que você pode incluir no pacote</h3>
-          <ul className="list-disc list-inside text-gray-700 space-y-1 mb-6">
+          <ul className="list-disc list-inside text-zinc-700 space-y-1 mb-6">
             <li>Aéreo e hotel com perfil ideal para sua viagem</li>
             <li>Ingressos Disney e Universal com orientação de uso</li>
             <li>Roteiro diário personalizado por prioridade</li>
@@ -102,13 +102,13 @@ const OrlandoLanding: React.FC = () => {
             >
               Falar com especialista
             </button>
-            <a href="https://www.anhanga.tur.br/beto-carrero/" className="px-5 py-3 rounded-full bg-white border border-gray-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="https://www.anhanga.tur.br/beto-carrero/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ver pacote Beto Carrero
             </a>
-            <a href="/blog" className="px-5 py-3 rounded-full bg-white border border-gray-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="/blog" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ler dicas no blog
             </a>
-            <a href="https://www.visitorlando.com/" target="_blank" rel="noopener noreferrer" className="px-5 py-3 rounded-full bg-white border border-gray-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="https://www.visitorlando.com/" target="_blank" rel="noopener noreferrer" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Guia Oficial Visit Orlando
             </a>
           </div>

--- a/pages/landings/ViagensParaExecutivosLanding.tsx
+++ b/pages/landings/ViagensParaExecutivosLanding.tsx
@@ -103,14 +103,14 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       <FAQPageSchema items={FAQ_ITEMS} />
 
       {/* Mini Header */}
-      <header className="bg-white/90 backdrop-blur-sm border-b border-gray-100 sticky top-0 z-50 py-3">
+      <header className="bg-white/90 backdrop-blur-sm border-b border-zinc-100 sticky top-0 z-50 py-3">
         <div className="max-w-5xl mx-auto px-6 flex items-center justify-between">
           <Link
             to="/"
             className="inline-flex items-center gap-2 group"
             aria-label="Voltar para o site principal da Anhangá Viagens"
           >
-            <ArrowLeft className="size-4 text-gray-400 group-hover:text-anhanga-blue transition-colors" />
+            <ArrowLeft className="size-4 text-zinc-400 group-hover:text-anhanga-blue transition-colors" />
             <span className="size-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
               <img src="/favicon.svg" alt="" aria-hidden="true" className="size-4" />
             </span>
@@ -138,7 +138,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
           <h1 className="text-4xl md:text-6xl font-black text-white mb-6 leading-[1.1] font-serif">
             Sua viagem planejada com precisão, conforto e atendimento humano
           </h1>
-          <p className="text-xl text-gray-300 mb-10 leading-relaxed max-w-2xl">
+          <p className="text-xl text-zinc-300 mb-10 leading-relaxed max-w-2xl">
             Para profissionais e famílias que não querem perder tempo comparando opções nem correr risco com detalhes importantes.
           </p>
           <button
@@ -151,7 +151,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
             Falar com um consultor
             <ArrowRight className="size-5" />
           </button>
-          <p className="mt-4 text-sm text-gray-400">Consultor fixo do início ao fim.</p>
+          <p className="mt-4 text-sm text-zinc-400">Consultor fixo do início ao fim.</p>
         </div>
       </section>
 
@@ -161,7 +161,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4 font-serif">
             Para quem é
           </h2>
-          <p className="text-gray-600 text-lg mb-10">
+          <p className="text-zinc-600 text-lg mb-10">
             Profissionais e famílias que valorizam tempo e têm aversão a erro.
           </p>
           <div className="flex flex-wrap gap-3">
@@ -174,7 +174,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
               </span>
             ))}
           </div>
-          <p className="mt-8 text-gray-600 max-w-2xl leading-relaxed">
+          <p className="mt-8 text-zinc-600 max-w-2xl leading-relaxed">
             Se você tem uma viagem importante para planejar e não quer perder tempo com pesquisa, comparação e burocracia, a Anhangá cuida de tudo enquanto você se concentra no que importa.
           </p>
         </div>
@@ -204,7 +204,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
                 <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
                   {title}
                 </h3>
-                <p className={variant === 'filled' ? 'text-gray-400 leading-relaxed' : 'text-gray-600 leading-relaxed'}>
+                <p className={variant === 'filled' ? 'text-zinc-400 leading-relaxed' : 'text-zinc-600 leading-relaxed'}>
                   {desc}
                 </p>
               </div>
@@ -223,14 +223,14 @@ const ViagensParaExecutivosLanding: React.FC = () => {
             {HOW_IT_WORKS.map(({ step, title, desc }, idx) => (
               <div
                 key={step}
-                className={`flex gap-8 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-gray-100' : ''}`}
+                className={`flex gap-8 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-zinc-100' : ''}`}
               >
                 <div className="flex-shrink-0 size-12 rounded-full bg-anhanga-blue/10 flex items-center justify-center">
                   <span className="text-sm font-black text-anhanga-blue">{step}</span>
                 </div>
                 <div>
                   <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
-                  <p className="text-gray-600 leading-relaxed max-w-xl">{desc}</p>
+                  <p className="text-zinc-600 leading-relaxed max-w-xl">{desc}</p>
                 </div>
               </div>
             ))}
@@ -244,7 +244,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
             Sobre a Anhangá Viagens
           </h2>
-          <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mb-10">
+          <p className="text-lg text-zinc-600 leading-relaxed max-w-2xl mb-10">
             Agência de viagens em São Paulo desde 2018, especializada em viagens sob medida. Consultor fixo do início ao fim, nota 5.0 no Google, atendimento sem robôs e sem formulários.
           </p>
           <div className="flex flex-wrap gap-12">
@@ -255,7 +255,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
             ].map(({ label, value }) => (
               <div key={label}>
                 <div className="text-3xl font-black text-anhanga-dark">{value}</div>
-                <div className="text-sm text-gray-600 mt-1">{label}</div>
+                <div className="text-sm text-zinc-600 mt-1">{label}</div>
               </div>
             ))}
           </div>
@@ -296,7 +296,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Consultoria de Viagem
               </div>
-              <div className="text-sm text-gray-600 mt-1">
+              <div className="text-sm text-zinc-600 mt-1">
                 Roteiro sob medida com consultor humano
               </div>
             </Link>
@@ -307,7 +307,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Curadoria de Cruzeiros
               </div>
-              <div className="text-sm text-gray-600 mt-1">
+              <div className="text-sm text-zinc-600 mt-1">
                 Escolha o navio e a cabine certos para você
               </div>
             </Link>
@@ -318,7 +318,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Site principal
               </div>
-              <div className="text-sm text-gray-600 mt-1">
+              <div className="text-sm text-zinc-600 mt-1">
                 Conheça todos os serviços da Anhangá
               </div>
             </a>
@@ -334,7 +334,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       />
 
       {/* Footer */}
-      <footer className="py-8 bg-[#fffdf5] border-t border-gray-100 text-center text-sm text-gray-600">
+      <footer className="py-8 bg-[#fffdf5] border-t border-zinc-100 text-center text-sm text-zinc-600">
         <p>Anhangá Viagens · Agência de viagens em São Paulo</p>
         <p className="mt-1">Atualizado em abril de 2026</p>
       </footer>

--- a/tests/e2e/hero_ux.spec.ts
+++ b/tests/e2e/hero_ux.spec.ts
@@ -41,7 +41,7 @@ test.describe('Hero UX and Accessibility', () => {
     // Open Calendar
     await page.getByTestId('dates-filter-btn').click();
     // Use a more specific locator for the calendar to avoid footer links
-    const calendarHeader = page.locator('span.text-gray-800').filter({ hasText: /202[56]/ });
+    const calendarHeader = page.locator('span.text-zinc-800').filter({ hasText: /202[56]/ });
     await expect(calendarHeader.first()).toBeVisible();
 
     await page.keyboard.press('Escape');


### PR DESCRIPTION
## Summary

- Substitui todas as classes `gray-*` e `slate-*` por `zinc-*` em 57 arquivos de componentes e páginas
- Elimina as 465 ocorrências da paleta "AI-default" flagada pela regra `react-doctor/design-no-default-tailwind-palette`
- Sem mudança visual intencional — `zinc` e `gray` compartilham a mesma escala de luminosidade; os tons `slate` usados aqui são visualmente equivalentes aos `zinc` correspondentes

## Test plan

- [x] `pnpm typecheck` — sem erros TypeScript
- [x] `pnpm test:regression` — 261/261 passando
- [x] Zero ocorrências de `gray-*` ou `slate-*` restantes nos diretórios `components/` e `pages/`

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)