### PR TITLE
refactor(react19): remove forwardRef and useContext deprecated APIs

### DIFF
--- a/components/landings/orlando/OrlandoApp.tsx
+++ b/components/landings/orlando/OrlandoApp.tsx
@@ -35,14 +35,19 @@ interface CardProps {
   };
 }
 
-const Card = React.forwardRef<HTMLDivElement, CardProps>(
-  ({ className, imgSrc, imgAlt, label, tape }, ref) => (
-    <div className={`card ${className}`} ref={ref}>
-      <img src={imgSrc} alt={imgAlt} width="300" height="300" />
-      <div className="card-label">{label}</div>
-      {tape && <WashiTape style={tape.style} />}
-    </div>
-  ),
+const Card = ({
+  className,
+  imgSrc,
+  imgAlt,
+  label,
+  tape,
+  ref,
+}: CardProps & { ref?: React.Ref<HTMLDivElement> }) => (
+  <div className={`card ${className}`} ref={ref}>
+    <img src={imgSrc} alt={imgAlt} width="300" height="300" />
+    <div className="card-label">{label}</div>
+    {tape && <WashiTape style={tape.style} />}
+  </div>
 );
 
 interface BadgeProps {

--- a/components/landings/orlando/OrlandoApp.tsx
+++ b/components/landings/orlando/OrlandoApp.tsx
@@ -30,6 +30,7 @@ interface CardProps {
   imgSrc: string;
   imgAlt: string;
   label: string;
+  ref?: React.Ref<HTMLDivElement>;
   tape?: {
     style: React.CSSProperties;
   };
@@ -42,7 +43,7 @@ const Card = ({
   label,
   tape,
   ref,
-}: CardProps & { ref?: React.Ref<HTMLDivElement> }) => (
+}: CardProps) => (
   <div className={`card ${className}`} ref={ref}>
     <img src={imgSrc} alt={imgAlt} width="300" height="300" />
     <div className="card-label">{label}</div>


### PR DESCRIPTION
## Summary
- Remove `forwardRef` from Orlando `Card` component, using `ref` as a regular prop (React 19 pattern)
- Zero occurrences of `forwardRef` or `useContext` remain in the codebase

Closes #482

## Test plan
- [x] TypeScript compiles without errors
- [ ] Orlando landing page renders correctly with Card components

🤖 Generated with [Claude Code](https://claude.com/claude-code)