### PR TITLE
refactor(arch): rename generic handlers and extract render-in-render

### DIFF
--- a/components/ChatLeadForm.tsx
+++ b/components/ChatLeadForm.tsx
@@ -181,7 +181,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
   const [isLocallySubmitting, setIsLocallySubmitting] = useState(false);
   const isProcessingRef = React.useRef(false);
 
-  const handleClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
+  const submitLeadForm = async (e: React.MouseEvent<HTMLButtonElement>) => {
     if (isSubmittingLead || isLocallySubmitting || isProcessingRef.current) return;
     e.preventDefault();
     isProcessingRef.current = true;
@@ -336,7 +336,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
 
         <button
           type="button"
-          onClick={handleClick}
+          onClick={submitLeadForm}
           disabled={isSubmittingLead || isLocallySubmitting}
           className={`group flex items-center justify-center gap-2 w-full bg-[#25D366] hover:bg-[#20bd5a] text-white font-bold py-3.5 px-4 rounded-xl shadow-md hover:shadow-lg transition-all ${isSubmittingLead || isLocallySubmitting ? 'opacity-90 cursor-wait' : ''}`}
         >

--- a/components/LandingFAQ.tsx
+++ b/components/LandingFAQ.tsx
@@ -13,14 +13,14 @@ interface LandingFAQProps {
 }
 
 const FAQItemComponent = memo(({ question, answer, isOpen, idx, onToggle }: FAQItem & { isOpen: boolean; idx: number; onToggle: (idx: number) => void }) => {
-    const handleClick = useCallback(() => onToggle(idx), [idx, onToggle]);
+    const toggleFaqItem = useCallback(() => onToggle(idx), [idx, onToggle]);
     return (
         <div
             className={`border-b border-brand-cyan/10 last:border-0 transition-all duration-300 ${isOpen ? 'bg-white/40' : ''}`}
         >
             <button
                 className="w-full py-6 flex justify-between items-center text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan group"
-                onClick={handleClick}
+                onClick={toggleFaqItem}
                 aria-expanded={isOpen}
             >
                 <h3 className="text-xl font-bold text-brand-dark group-hover:text-brand-cyan transition-colors pr-8">

--- a/components/landings/beto-carrero/Button.tsx
+++ b/components/landings/beto-carrero/Button.tsx
@@ -44,10 +44,6 @@ const Button: React.FC<ButtonProps> = ({
     outline: "bg-white text-fun-dark shadow-hard hover:shadow-hard-hover",
   };
 
-  const handleClick = () => {
-    if (onClick) onClick();
-  };
-
   const positionStyles = tooltipPosition === 'top'
     ? 'bottom-full mb-3'
     : 'top-full mt-3';
@@ -69,7 +65,7 @@ const Button: React.FC<ButtonProps> = ({
         onClick={(e) => {
           e.preventDefault();
           openContactModal({ source: 'beto-carrero' });
-          handleClick();
+          onClick?.();
         }}
         className={`btn-whatsapp btn-specialist ${baseStyles} ${variants[variant]} ${fullWidth ? 'w-full' : ''} ${className}`}
         aria-label={computedAriaLabel}

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -867,6 +867,73 @@ function ResultScreen({ profile, mainDest, inspirations, lead, onRestart, baseWa
 }
 
 /* ==========================================================================
+   StageContent — renderiza a tela correta do quiz
+   ========================================================================== */
+
+interface StageContentProps {
+    stage: Stage;
+    answers: Record<string, string[]>;
+    profileKey: ProfileKey | null;
+    leadForm: LeadForm | null;
+    baseWaUrl: string;
+    submitFailed: boolean;
+    onStart: () => void;
+    onAnswerQ: (qId: string, value: string[]) => void;
+    onNextQ: (currentIndex: number) => void;
+    onBackQ: (currentIndex: number) => void;
+    onLeadSubmit: (data: LeadForm, skipped?: boolean) => void;
+    onRestart: () => void;
+    onGo: (next: Stage, dir?: 'forward' | 'back') => void;
+}
+
+function StageContent({
+    stage, answers, profileKey, leadForm, baseWaUrl, submitFailed,
+    onStart, onAnswerQ, onNextQ, onBackQ, onLeadSubmit, onRestart, onGo,
+}: StageContentProps) {
+    if (stage.kind === 'hero') return <HeroScreen onStart={onStart} />;
+    if (stage.kind === 'question') {
+        const q = QUIZ_QUESTIONS[stage.index];
+        return (
+            <QuestionScreen
+                q={q}
+                qIndex={stage.index}
+                total={QUIZ_QUESTIONS.length}
+                value={answers[q.id]}
+                onChange={(v) => onAnswerQ(q.id, v)}
+                onNext={() => onNextQ(stage.index)}
+                onBack={() => onBackQ(stage.index)}
+            />
+        );
+    }
+    if (stage.kind === 'lead') {
+        const leadProfileKey = matchProfile(answers);
+        return (
+            <PreLeadScreen
+                profile={TRAVELER_PROFILES[leadProfileKey]}
+                onSubmit={onLeadSubmit}
+                onBack={() => onGo({ kind: 'question', index: QUIZ_QUESTIONS.length - 1 }, 'back')}
+            />
+        );
+    }
+    if (stage.kind === 'result' && profileKey && leadForm) {
+        const mainDest = selectMainDestination(profileKey, answers.destino ?? []);
+        const inspirations = selectInspirationDestinations(profileKey, mainDest);
+        return (
+            <ResultScreen
+                profile={TRAVELER_PROFILES[profileKey]}
+                mainDest={mainDest}
+                inspirations={inspirations}
+                lead={leadForm}
+                onRestart={onRestart}
+                baseWaUrl={baseWaUrl}
+                submitFailed={submitFailed}
+            />
+        );
+    }
+    return null;
+}
+
+/* ==========================================================================
    Componente principal
    ========================================================================== */
 
@@ -960,50 +1027,6 @@ export default function QuizAnhangaLanding() {
 
     const stageKey = stage.kind === 'question' ? `q-${stage.index}` : stage.kind;
 
-    function renderStage() {
-        if (stage.kind === 'hero') return <HeroScreen onStart={start} />;
-        if (stage.kind === 'question') {
-            const q = QUIZ_QUESTIONS[stage.index];
-            return (
-                <QuestionScreen
-                    q={q}
-                    qIndex={stage.index}
-                    total={QUIZ_QUESTIONS.length}
-                    value={answers[q.id]}
-                    onChange={(v) => answerQ(q.id, v)}
-                    onNext={() => nextQ(stage.index)}
-                    onBack={() => backQ(stage.index)}
-                />
-            );
-        }
-        if (stage.kind === 'lead') {
-            const leadProfileKey = matchProfile(answers);
-            return (
-                <PreLeadScreen
-                    profile={TRAVELER_PROFILES[leadProfileKey]}
-                    onSubmit={handleLeadSubmit}
-                    onBack={() => go({ kind: 'question', index: QUIZ_QUESTIONS.length - 1 }, 'back')}
-                />
-            );
-        }
-        if (stage.kind === 'result' && profileKey && leadForm) {
-            const mainDest = selectMainDestination(profileKey, answers.destino ?? []);
-            const inspirations = selectInspirationDestinations(profileKey, mainDest);
-            return (
-                <ResultScreen
-                    profile={TRAVELER_PROFILES[profileKey]}
-                    mainDest={mainDest}
-                    inspirations={inspirations}
-                    lead={leadForm}
-                    onRestart={restart}
-                    baseWaUrl={baseWaUrl}
-                    submitFailed={submitFailed}
-                />
-            );
-        }
-        return null;
-    }
-
     return (
         <>
             <SEO
@@ -1016,7 +1039,21 @@ export default function QuizAnhangaLanding() {
                 <div className="quiz-app">
                     <div className={`quiz-stage quiz-stage--slide quiz-stage--${direction}`}>
                         <div className="quiz-stage-inner" key={stageKey}>
-                            {renderStage()}
+                            <StageContent
+                                stage={stage}
+                                answers={answers}
+                                profileKey={profileKey}
+                                leadForm={leadForm}
+                                baseWaUrl={baseWaUrl}
+                                submitFailed={submitFailed}
+                                onStart={start}
+                                onAnswerQ={answerQ}
+                                onNextQ={nextQ}
+                                onBackQ={backQ}
+                                onLeadSubmit={handleLeadSubmit}
+                                onRestart={restart}
+                                onGo={go}
+                            />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Closes #483

## Summary

- **LandingFAQ** — `handleClick` → `toggleFaqItem`
- **ChatLeadForm** — `handleClick` → `submitLeadForm`
- **Beto Carrero Button** — removed `handleClick` wrapper, inlined `onClick?.()`
- **QuizAnhangaLanding** — extracted inline `renderStage()` to a typed `StageContent` component for correct React reconciliation

## Test plan

- [x] `tsc --noEmit` — zero errors
- [x] `pnpm test:regression` — 261/261 pass
- [ ] Smoke-test FAQ accordion, chat lead form submission, Beto Carrero CTA button, and quiz flow in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)