### PR TITLE
perf: replace width transitions with transform scaleX (#468)

### DIFF
--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -318,7 +318,7 @@ const PROGRESS_MILESTONES: Record<number, string> = {
 };
 
 function Progress({ current, total }: { current: number; total: number }) {
-    const progress = current / total;
+    const progress = total > 0 ? current / total : 0;
     const milestone = PROGRESS_MILESTONES[current];
     return (
         <div className="quiz-progress">

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -318,7 +318,7 @@ const PROGRESS_MILESTONES: Record<number, string> = {
 };
 
 function Progress({ current, total }: { current: number; total: number }) {
-    const pct = (current / total) * 100;
+    const progress = current / total;
     const milestone = PROGRESS_MILESTONES[current];
     return (
         <div className="quiz-progress">
@@ -329,7 +329,7 @@ function Progress({ current, total }: { current: number; total: number }) {
                 }
             </div>
             <div className="quiz-progress-bar" role="progressbar" aria-valuenow={current} aria-valuemin={1} aria-valuemax={total}>
-                <div className="quiz-progress-fill" style={{ width: `${pct}%` }} />
+                <div className="quiz-progress-fill" style={{ '--progress': progress } as React.CSSProperties} />
             </div>
         </div>
     );

--- a/pages/landings/orlando.css
+++ b/pages/landings/orlando.css
@@ -932,14 +932,16 @@
 .landing-orlando .social-links a::after {
     content: "";
     display: block;
-    width: 0;
+    width: 100%;
     height: 1px;
     background: var(--accent-pink);
-    transition: width 0.3s;
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.3s;
 }
 
 .landing-orlando .social-links a:hover::after {
-    width: 100%;
+    transform: scaleX(1);
 }
 
 .landing-orlando .footer-bottom {

--- a/pages/landings/quiz-anhanga.css
+++ b/pages/landings/quiz-anhanga.css
@@ -325,9 +325,11 @@
 }
 .quiz-progress-fill {
   height: 100%;
+  width: 100%;
   background: linear-gradient(90deg, var(--av-yellow), var(--layer-4));
-  transition: width 0.55s var(--av-ease-spring);
-  border-right: 2px solid var(--av-dark);
+  transform: scaleX(var(--progress, 0));
+  transform-origin: left;
+  transition: transform 0.55s var(--av-ease-spring);
 }
 
 .quiz-q-body { width: 100%; max-width: 880px; display: flex; flex-direction: column; align-items: center; text-align: center; }


### PR DESCRIPTION
## Summary

Closes #468

- **orlando.css**: social link underline hover animation migrated from `width: 0 → 100%` to `transform: scaleX(0) → scaleX(1)` with `transform-origin: left`
- **quiz-anhanga.css**: progress bar fill migrated from `transition: width` to `transform: scaleX(var(--progress))` driven by a CSS custom property
- **QuizAnhangaLanding.tsx**: passes `--progress` (0–1 ratio) instead of `width` percentage; simplified variable from `pct / 100` to `current / total`
- Removed `border-right` from `.quiz-progress-fill` — `scaleX()` scales borders too, causing them to appear thinner at low progress values. The parent `.quiz-progress-bar` already has a 2px border providing the visual boundary.

## Why

Animating `width` forces the browser to recalculate layout every frame (layout thrash), causing janky animations especially on mobile. `transform: scaleX()` runs entirely on the GPU compositor — no layout, no paint, just composition.

## Test plan

- [ ] Visit `/orlando` landing, hover social links in the footer — underline should grow from left smoothly
- [ ] Visit `/quiz-anhanga`, progress through quiz questions — progress bar should fill smoothly with spring easing
- [ ] Test on mobile viewport — animations should be smooth without jank
- [ ] Verify no `transition: width` remains in either CSS file

🤖 Generated with [Claude Code](https://claude.com/claude-code)