### PR TITLE
perf(css): replace transition-all with scoped transitions + event handler ref fix (#485)

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -350,7 +350,7 @@ const AIChat: React.FC = memo(() => {
                     flex items-center justify-center gap-3
                     bg-brand-vibrant text-white
                     shadow-[0_8px_30px_rgba(255,107,53,0.3)] hover:shadow-[0_8px_30px_rgba(255,107,53,0.5)] hover:-translate-y-1
-                    transition-all duration-300
+                    transition duration-300
                     size-16 rounded-2xl sm:w-auto sm:h-auto sm:px-6 sm:py-3.5 sm:rounded-full
                     focus:outline-none focus:ring-4 focus:ring-brand-vibrant/30
                     ${isOrlandoPage ? 'orlando-chat-glow' : ''}`}
@@ -479,7 +479,7 @@ const AIChat: React.FC = memo(() => {
                       <button
                         key={chipIdx}
                         onClick={() => submitMessage(chip)}
-                        className="text-[12px] font-semibold text-zinc-600 bg-white border border-zinc-200 px-4 py-2 rounded-xl shadow-sm hover:shadow hover:border-brand-vibrant/30 hover:text-brand-vibrant hover:-translate-y-0.5 transition-all text-left"
+                        className="text-[12px] font-semibold text-zinc-600 bg-white border border-zinc-200 px-4 py-2 rounded-xl shadow-sm hover:shadow hover:border-brand-vibrant/30 hover:text-brand-vibrant hover:-translate-y-0.5 transition text-left"
                       >
                         {chip}
                       </button>
@@ -506,7 +506,7 @@ const AIChat: React.FC = memo(() => {
 
         {/* Input Area */}
         <div className="p-4 sm:p-5 bg-white border-t border-zinc-100 shrink-0 z-10 shadow-[0_-4px_20px_rgba(0,0,0,0.02)]">
-          <div className="relative flex items-end bg-zinc-50 border border-zinc-200 rounded-2xl focus-within:border-brand-vibrant/40 focus-within:bg-white focus-within:ring-4 focus-within:ring-brand-vibrant/10 transition-all">
+          <div className="relative flex items-end bg-zinc-50 border border-zinc-200 rounded-2xl focus-within:border-brand-vibrant/40 focus-within:bg-white focus-within:ring-4 focus-within:ring-brand-vibrant/10 transition">
             <label htmlFor="chat-textarea" className="sr-only">Sua mensagem</label>
             <textarea
               id="chat-textarea"
@@ -521,7 +521,7 @@ const AIChat: React.FC = memo(() => {
             <button
               onClick={() => submitMessage(input)}
               disabled={isLoading || !input.trim()}
-              className="absolute right-2 bottom-2 p-2.5 bg-brand-vibrant text-white rounded-[10px] shadow-sm hover:bg-brand-blue hover:shadow-md transition-all disabled:opacity-0 disabled:scale-75 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-vibrant/50"
+              className="absolute right-2 bottom-2 p-2.5 bg-brand-vibrant text-white rounded-[10px] shadow-sm hover:bg-brand-blue hover:shadow-md transition disabled:opacity-0 disabled:scale-75 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-vibrant/50"
               aria-label="Enviar mensagem"
             >
               <PaperPlaneTilt className="size-4 ml-0.5" weight="fill" />

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -99,7 +99,7 @@ const Blog: React.FC = memo(() => {
                                                 <span className="text-sm font-black text-brand-dark">{AUTHORS[featuredPost.author]?.name ?? featuredPost.author}</span>
                                             </div>
                                         </div>
-                                        <span className="flex items-center gap-2 text-brand-cyan font-black uppercase tracking-wide group-hover:gap-4 transition-all">
+                                        <span className="flex items-center gap-2 text-brand-cyan font-black uppercase tracking-wide group-hover:gap-4 transition-[gap,color]">
                                             Ler Agora <ArrowRight className="size-5" />
                                         </span>
                                     </div>
@@ -115,7 +115,7 @@ const Blog: React.FC = memo(() => {
                         <a
                             href={getBlogPostUrl(post.slug)}
                             key={post.slug}
-                            className="group bg-white rounded-3xl p-4 shadow-[0_10px_20px_-5px_rgba(0,0,0,0.05)] border border-zinc-100 transform transition-all duration-300 hover:-translate-y-2 hover:shadow-xl flex flex-col h-full"
+                            className="group bg-white rounded-3xl p-4 shadow-[0_10px_20px_-5px_rgba(0,0,0,0.05)] border border-zinc-100 transform transition duration-300 hover:-translate-y-2 hover:shadow-xl flex flex-col h-full"
                         >
                             {/* Image Area — aspect ratio alternado para quebrar ritmo uniforme */}
                             <div className={`relative ${index % 2 === 0 ? 'aspect-[4/3]' : 'aspect-video'} rounded-2xl overflow-hidden mb-5 bg-zinc-100`}>
@@ -171,7 +171,7 @@ const Blog: React.FC = memo(() => {
 
                 {/* View More Button */}
                 <div className="mt-16 text-center">
-                    <a href={getBlogHomeUrl()} className="inline-flex items-center gap-2 px-8 py-4 bg-white border-2 border-zinc-200 text-zinc-600 rounded-full font-bold hover:border-brand-cyan hover:text-brand-cyan transition-all shadow-sm hover:shadow-md group">
+                    <a href={getBlogHomeUrl()} className="inline-flex items-center gap-2 px-8 py-4 bg-white border-2 border-zinc-200 text-zinc-600 rounded-full font-bold hover:border-brand-cyan hover:text-brand-cyan transition shadow-sm hover:shadow-md group">
                         <Sparkles className="size-4 text-brand-yellow fill-brand-yellow" />
                         Ver Todos os Artigos
                         <ArrowRight className="size-4 group-hover:translate-x-1 transition-transform" />

--- a/components/Categories.tsx
+++ b/components/Categories.tsx
@@ -99,7 +99,7 @@ const Categories = memo(() => {
               </div>
 
               {/* Sticker Decor */}
-              <div className="absolute -bottom-4 -right-4 opacity-0 group-hover:opacity-100 transition-all duration-300 transform scale-0 group-hover:scale-110">
+              <div className="absolute -bottom-4 -right-4 opacity-0 group-hover:opacity-100 transition duration-300 transform scale-0 group-hover:scale-110">
                 <div className="bg-brand-yellow text-brand-dark rounded-full p-3 shadow-lg border-2 border-white">
                   <ArrowRight className="size-6 -rotate-45" />
                 </div>

--- a/components/ChatLeadForm.tsx
+++ b/components/ChatLeadForm.tsx
@@ -152,7 +152,7 @@ function TextField({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className={`w-full bg-white border ${error ? 'border-red-500' : 'border-zinc-200'} rounded-xl px-4 py-3 text-sm text-zinc-700 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-brand-vibrant/30 focus:border-brand-vibrant transition-all shadow-sm`}
+        className={`w-full bg-white border ${error ? 'border-red-500' : 'border-zinc-200'} rounded-xl px-4 py-3 text-sm text-zinc-700 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-brand-vibrant/30 focus:border-brand-vibrant transition shadow-sm`}
       />
       {error && <span className="text-[10px] text-red-500 font-bold ml-1 uppercase">{error}</span>}
     </div>
@@ -234,7 +234,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-brand-blue/10 shadow-[0_8px_30px_rgb(0,0,0,0.08)] w-full overflow-hidden transform transition-all hover:shadow-[0_8px_30px_rgb(0,0,0,0.12)] hover:-translate-y-1">
+    <div className="bg-white rounded-2xl border border-brand-blue/10 shadow-[0_8px_30px_rgb(0,0,0,0.08)] w-full overflow-hidden transform transition hover:shadow-[0_8px_30px_rgb(0,0,0,0.12)] hover:-translate-y-1">
       <div className="bg-gradient-to-r from-brand-vibrant/10 to-transparent p-3 flex items-center gap-2 border-b border-zinc-100">
         <CheckCircle2 className="size-5 text-green-500" />
         <span className="text-sm font-bold tracking-wide text-brand-dark uppercase">
@@ -285,7 +285,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
                 id="lead-country-code"
                 value={countryCode}
                 onChange={(e) => setCountryCode(e.target.value)}
-                className="w-[112px] shrink-0 bg-white border border-zinc-200 rounded-xl p-3 text-sm text-zinc-700 focus:outline-none focus:ring-2 focus:ring-brand-vibrant/30 focus:border-brand-vibrant transition-all shadow-sm"
+                className="w-[112px] shrink-0 bg-white border border-zinc-200 rounded-xl p-3 text-sm text-zinc-700 focus:outline-none focus:ring-2 focus:ring-brand-vibrant/30 focus:border-brand-vibrant transition shadow-sm"
               >
                 <option value="+55">+55 BR</option>
                 <option value="+1">+1 US/CA</option>
@@ -311,7 +311,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
                   type="checkbox"
                   checked={acceptedLGPD}
                   onChange={(e) => setAcceptedLGPD(e.target.checked)}
-                  className="peer size-4 cursor-pointer appearance-none rounded border border-zinc-300 bg-white checked:bg-brand-vibrant checked:border-brand-vibrant transition-all focus:ring-2 focus:ring-brand-vibrant/20"
+                  className="peer size-4 cursor-pointer appearance-none rounded border border-zinc-300 bg-white checked:bg-brand-vibrant checked:border-brand-vibrant transition focus:ring-2 focus:ring-brand-vibrant/20"
                 />
                 <CheckCircle2 className="absolute size-3 text-white opacity-0 peer-checked:opacity-100 left-0.5 pointer-events-none transition-opacity" />
               </div>
@@ -338,7 +338,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
           type="button"
           onClick={submitLeadForm}
           disabled={isSubmittingLead || isLocallySubmitting}
-          className={`group flex items-center justify-center gap-2 w-full bg-[#25D366] hover:bg-[#20bd5a] text-white font-bold py-3.5 px-4 rounded-xl shadow-md hover:shadow-lg transition-all ${isSubmittingLead || isLocallySubmitting ? 'opacity-90 cursor-wait' : ''}`}
+          className={`group flex items-center justify-center gap-2 w-full bg-[#25D366] hover:bg-[#20bd5a] text-white font-bold py-3.5 px-4 rounded-xl shadow-md hover:shadow-lg transition ${isSubmittingLead || isLocallySubmitting ? 'opacity-90 cursor-wait' : ''}`}
         >
           {isSubmittingLead || isLocallySubmitting ? (
             <>

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -30,6 +30,9 @@ const ContactModal: React.FC = () => {
         triggerRef.current?.focus();
     }, [reset]);
 
+    const closeRef = useRef(close);
+    useEffect(() => { closeRef.current = close; });
+
     useEffect(() => {
         const handleOpen = (event: Event) => {
             triggerRef.current = document.activeElement as HTMLElement | null;
@@ -58,7 +61,7 @@ const ContactModal: React.FC = () => {
 
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
-                close();
+                closeRef.current();
                 return;
             }
 
@@ -86,7 +89,7 @@ const ContactModal: React.FC = () => {
 
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [close, isOpen]);
+    }, [isOpen]);
 
     if (!isOpen) return null;
 

--- a/components/Destinations.tsx
+++ b/components/Destinations.tsx
@@ -539,7 +539,7 @@ const Destinations: React.FC = memo(() => {
                             <button
                                 key={filter}
                                 onClick={() => setActiveFilter(filter)}
-                                className={`px-5 py-2 rounded-lg text-sm font-bold border-2 transition-all whitespace-nowrap flex-shrink-0 shadow-[3px_3px_0px_rgba(0,0,0,0.1)] active:shadow-none active:translate-x-[2px] active:translate-y-[2px] ${activeFilter === filter
+                                className={`px-5 py-2 rounded-lg text-sm font-bold border-2 transition whitespace-nowrap flex-shrink-0 shadow-[3px_3px_0px_rgba(0,0,0,0.1)] active:shadow-none active:translate-x-[2px] active:translate-y-[2px] ${activeFilter === filter
                                     ? 'bg-brand-dark text-white border-brand-dark transform -rotate-1'
                                     : 'bg-white text-zinc-600 border-zinc-100 hover:border-brand-vibrant hover:text-brand-vibrant'
                                     }`}
@@ -580,14 +580,14 @@ const Destinations: React.FC = memo(() => {
                         <div className="absolute bottom-6 right-6 flex flex-col gap-2 z-[400]">
                             <button
                                 onClick={() => handleZoom('in')}
-                                className="size-10 bg-white border-2 border-zinc-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all text-zinc-700 font-black"
+                                className="size-10 bg-white border-2 border-zinc-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition text-zinc-700 font-black"
                                 aria-label="Aumentar zoom no mapa"
                             >
                                 <Plus className="size-5" />
                             </button>
                             <button
                                 onClick={() => handleZoom('out')}
-                                className="size-10 bg-white border-2 border-zinc-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all text-zinc-700 font-black"
+                                className="size-10 bg-white border-2 border-zinc-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition text-zinc-700 font-black"
                                 aria-label="Diminuir zoom no mapa"
                             >
                                 <Minus className="size-5" />
@@ -613,7 +613,7 @@ const Destinations: React.FC = memo(() => {
                             tabIndex={0}
                             role="button"
                             aria-label={`Ver detalhes de ${dest.city}, ${dest.country}`}
-                            className="group bg-white rounded-[2rem] border-2 border-zinc-100 p-4 pb-0 shadow-[6px_6px_0px_rgba(0,0,0,0.05)] hover:shadow-[10px_10px_0px_rgba(0,0,0,0.08)] hover:-translate-y-2 transition-all cursor-pointer flex flex-col focus:outline-none focus-visible:ring-4 focus-visible:ring-brand-cyan"
+                            className="group bg-white rounded-[2rem] border-2 border-zinc-100 p-4 pb-0 shadow-[6px_6px_0px_rgba(0,0,0,0.05)] hover:shadow-[10px_10px_0px_rgba(0,0,0,0.08)] hover:-translate-y-2 transition cursor-pointer flex flex-col focus:outline-none focus-visible:ring-4 focus-visible:ring-brand-cyan"
                             onClick={() => setSelectedDestination(dest)}
                             onKeyDown={(e) => {
                                 if (e.key === 'Enter' || e.key === ' ') {
@@ -646,7 +646,7 @@ const Destinations: React.FC = memo(() => {
                                 </div>
                                 <p className="text-zinc-500 text-sm font-medium mb-4">{dest.description}</p>
 
-                                <div className="flex items-center gap-2 text-brand-cyan font-bold text-sm uppercase tracking-wide group-hover:gap-3 transition-all">
+                                <div className="flex items-center gap-2 text-brand-cyan font-bold text-sm uppercase tracking-wide group-hover:gap-3 transition-[gap,color]">
                                     Saiba Mais <ArrowRight className="size-4" />
                                 </div>
                             </div>
@@ -716,7 +716,7 @@ const Destinations: React.FC = memo(() => {
                                     <Link
                                         to={selectedDestination.landingPage}
                                         onClick={() => setSelectedDestination(null)}
-                                        className="w-full bg-white border-2 border-brand-dark text-brand-dark py-4 rounded-xl font-black text-lg hover:bg-zinc-50 transition-all shadow-[4px_4px_0px_#0f172a] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2"
+                                        className="w-full bg-white border-2 border-brand-dark text-brand-dark py-4 rounded-xl font-black text-lg hover:bg-zinc-50 transition shadow-[4px_4px_0px_#0f172a] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2"
                                     >
                                         Ver detalhes do pacote <ArrowRight className="size-5" />
                                     </Link>
@@ -730,7 +730,7 @@ const Destinations: React.FC = memo(() => {
                                         });
                                         setSelectedDestination(null);
                                     }}
-                                    className={`btn-whatsapp btn-specialist w-full bg-brand-dark text-white py-4 rounded-xl font-black text-lg hover:bg-brand-vibrant transition-all shadow-[4px_4px_0px_#94a3b8] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2`}
+                                    className={`btn-whatsapp btn-specialist w-full bg-brand-dark text-white py-4 rounded-xl font-black text-lg hover:bg-brand-vibrant transition shadow-[4px_4px_0px_#94a3b8] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2`}
                                     data-tracking={`modal-destinations-${selectedDestination.city.toLowerCase()}`}
                                 >
                                     Solicitar Orçamento

--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -26,7 +26,7 @@ const FAQItem = memo(({ question, answer, idx }: FAQItemProps) => {
 
     return (
         <div
-            className={`mb-4 rounded-2xl overflow-hidden transition-all duration-300 border border-white/40 shadow-sm custom-backdrop ${isOpen ? 'shadow-md scale-[1.01]' : ''}`}
+            className={`mb-4 rounded-2xl overflow-hidden transition duration-300 border border-white/40 shadow-sm custom-backdrop ${isOpen ? 'shadow-md scale-[1.01]' : ''}`}
         >
             <button
                 className="w-full px-6 py-5 flex justify-between items-center text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan group bg-white/60 hover:bg-white/80 transition-colors"
@@ -45,7 +45,7 @@ const FAQItem = memo(({ question, answer, idx }: FAQItemProps) => {
                     </h3>
                 </div>
 
-                <div className={`size-10 rounded-xl flex items-center justify-center transition-all duration-300 ${isOpen
+                <div className={`size-10 rounded-xl flex items-center justify-center transition duration-300 ${isOpen
                     ? 'bg-brand-cyan text-white rotate-180'
                     : 'bg-white text-zinc-400 group-hover:text-brand-cyan'
                     }`}>
@@ -53,7 +53,7 @@ const FAQItem = memo(({ question, answer, idx }: FAQItemProps) => {
                 </div>
             </button>
             <div
-                className={`overflow-hidden transition-all duration-500 ease-in-out ${isOpen ? 'max-h-[800px] opacity-100' : 'max-h-0 opacity-0'}`}
+                className={`overflow-hidden transition-[max-height,opacity] duration-500 ease-in-out ${isOpen ? 'max-h-[800px] opacity-100' : 'max-h-0 opacity-0'}`}
             >
                 <div className="px-6 pb-8 pt-4 text-zinc-700 font-medium leading-relaxed text-lg bg-white/40">
                     {/* The answer content is injected here */}

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -53,7 +53,7 @@ const Header: React.FC = () => {
     <header
       data-testid="site-header"
       data-header-variant={isInternalPage ? 'internal' : 'home'}
-      className={`fixed top-0 w-full z-50 transition-all duration-500 ease-in-out ${headerToneClass} ${headerSizeClass}`}
+      className={`fixed top-0 w-full z-50 transition duration-500 ease-in-out ${headerToneClass} ${headerSizeClass}`}
     >
       <a
         href="#main-content"
@@ -64,7 +64,7 @@ const Header: React.FC = () => {
       <div className="container mx-auto px-6 flex justify-between items-center">
         <a
           href={`${SITE_URL}/`}
-          className="flex items-center gap-2 group rounded-lg p-1 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2"
+          className="flex items-center gap-2 group rounded-lg p-1 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2"
           aria-label="Anhangá Viagens - Ir para o topo"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         >
@@ -75,7 +75,7 @@ const Header: React.FC = () => {
             fetchPriority="high"
             width="185"
             height="96"
-            className={`w-auto transition-all duration-300 object-contain ${logoHeightClass}`}
+            className={`w-auto transition duration-300 object-contain ${logoHeightClass}`}
           />
         </a>
 
@@ -94,7 +94,7 @@ const Header: React.FC = () => {
               data-testid="desktop-fale-conosco-btn"
               data-tracking="navbar-desktop"
               onClick={handleContactClick}
-              className={`btn-whatsapp btn-specialist rounded-full font-medium text-sm transition-all duration-500 flex items-center gap-2 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-vibrant ${ctaPaddingClass} ${buttonClass}`}
+              className={`btn-whatsapp btn-specialist rounded-full font-medium text-sm transition duration-500 flex items-center gap-2 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-vibrant ${ctaPaddingClass} ${buttonClass}`}
             >
               <Phone className="size-4" weight="fill" />
               Fale Conosco

--- a/components/Header/HeaderNavigation.tsx
+++ b/components/Header/HeaderNavigation.tsx
@@ -47,7 +47,7 @@ export function DesktopNavigation({
                 <CaretDown className="size-4 transition-transform duration-300 group-hover:rotate-180" weight="bold" />
               </button>
 
-              <div className="absolute top-full z-10 w-48 translate-y-2 pt-4 opacity-0 invisible transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100 group-hover:visible focus-within:translate-y-0 focus-within:opacity-100 focus-within:visible">
+              <div className="absolute top-full z-10 w-48 translate-y-2 pt-4 opacity-0 invisible transition duration-300 group-hover:translate-y-0 group-hover:opacity-100 group-hover:visible focus-within:translate-y-0 focus-within:opacity-100 focus-within:visible">
                 <div className="rounded-md border border-zinc-100 bg-white py-2 shadow-lg">
                   {link.subLinks.map((subLink) => {
                     const href = isPageLink(subLink.href)

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -142,7 +142,7 @@ const Hero: React.FC = memo(() => {
 
           {/* SEO H1 - Optimized with visible keywords for search engines */}
           <h1
-            className={`font-sans font-extrabold text-white mb-6 leading-[0.9] tracking-tight drop-shadow-lg transition-all duration-500
+            className={`font-sans font-extrabold text-white mb-6 leading-[0.9] tracking-tight drop-shadow-lg transition duration-500
                 ${validCityForTitle ? 'text-4xl sm:text-5xl md:text-7xl' : 'text-5xl sm:text-6xl md:text-8xl'}
                 `}
           >
@@ -208,7 +208,7 @@ const Hero: React.FC = memo(() => {
                 type="submit"
                 data-testid="submit-search-btn-mobile"
                 data-tracking="hero-home-mobile"
-                className="btn-specialist w-full bg-brand-yellow text-brand-dark font-black text-base py-4 rounded-2xl shadow-[4px_4px_0px_rgba(0,0,0,0.2)] hover:shadow-[2px_2px_0px_rgba(0,0,0,0.2)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all"
+                className="btn-specialist w-full bg-brand-yellow text-brand-dark font-black text-base py-4 rounded-2xl shadow-[4px_4px_0px_rgba(0,0,0,0.2)] hover:shadow-[2px_2px_0px_rgba(0,0,0,0.2)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
               >
                 Quero meu orçamento →
               </button>
@@ -234,7 +234,7 @@ const Hero: React.FC = memo(() => {
                   hidden: { opacity: 0, y: 16, scale: 0.9 },
                   visible: { opacity: 1, y: 0, scale: 1, transition: { type: 'spring', stiffness: 400, damping: 20 } }
                 }}
-                className="flex items-center gap-2 text-white/90 font-bold text-sm bg-white/10 px-4 py-2 rounded-full backdrop-blur-md border border-white/10 hover:bg-white/20 transition-all duration-300 cursor-default"
+                className="flex items-center gap-2 text-white/90 font-bold text-sm bg-white/10 px-4 py-2 rounded-full backdrop-blur-md border border-white/10 hover:bg-white/20 transition duration-300 cursor-default"
                 whileHover={{ scale: 1.05, transition: { type: 'spring', stiffness: 400, damping: 15 } }}
               >
                 <feat.icon className="size-4 text-yellow-300" />

--- a/components/Highlights.tsx
+++ b/components/Highlights.tsx
@@ -134,7 +134,7 @@ const Highlights = memo(() => {
                                     e.preventDefault();
                                     openContactModal({ source: 'highlights' });
                                 }}
-                                className="flex items-center justify-center gap-3 w-full bg-brand-dark text-white px-6 py-4 rounded-xl font-bold transition-all duration-300 ease-spring shadow-[4px_4px_0px_#94a3b8] hover:shadow-[2px_2px_0px_#94a3b8] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none"
+                                className="flex items-center justify-center gap-3 w-full bg-brand-dark text-white px-6 py-4 rounded-xl font-bold transition duration-300 ease-spring shadow-[4px_4px_0px_#94a3b8] hover:shadow-[2px_2px_0px_#94a3b8] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none"
                             >
                                 <ShieldCheck className="size-5" weight="fill" />
                                 <span>Falar com Especialista</span>
@@ -212,7 +212,7 @@ const Highlights = memo(() => {
                                         </p>
 
                                         {/* Corner Arrow */}
-                                        <div className="absolute bottom-6 right-6 opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-x-4 group-hover:translate-x-0">
+                                        <div className="absolute bottom-6 right-6 opacity-0 group-hover:opacity-100 transition duration-300 transform translate-x-4 group-hover:translate-x-0">
                                             <ArrowRight className={`size-5 ${item.iconColor}`} />
                                         </div>
                                     </m.div>

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -128,7 +128,7 @@ const HowItWorks = memo(() => {
                             {/* The Card */}
                             <div className={`
                                 w-full md:w-[45%] bg-white p-8 rounded-[2rem] shadow-[8px_8px_0px_rgba(0,0,0,0.05)] border-2 ${step.borderColor}
-                                transform transition-all duration-300 hover:scale-105 hover:-translate-y-2 hover:shadow-[12px_12px_0px_rgba(0,0,0,0.08)]
+                                transform transition duration-300 hover:scale-105 hover:-translate-y-2 hover:shadow-[12px_12px_0px_rgba(0,0,0,0.08)]
                                 relative group overflow-visible ${step.rotate}
                             `}>
                                 {/* Fake Tape Effect */}
@@ -170,14 +170,14 @@ const HowItWorks = memo(() => {
         <div className="mt-24 text-center relative z-20">
             <div className="inline-block relative group">
                 {/* Blobs behind button - Adjusted opacity and size */}
-                <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-full bg-brand-yellow/30 rounded-full blur-2xl group-hover:blur-3xl transition-all duration-500"></div>
+                <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-full bg-brand-yellow/30 rounded-full blur-2xl group-hover:blur-3xl transition duration-500"></div>
                 
                 <button
                     onClick={(e) => {
                         e.preventDefault();
                         openContactModal({ source: 'how-it-works' });
                     }}
-                    className="relative z-10 flex items-center gap-4 bg-white text-brand-dark px-10 py-6 rounded-full font-black text-xl shadow-[0_20px_50px_rgba(8,_112,_184,_0.15)] hover:shadow-[0_20px_50px_rgba(8,_112,_184,_0.25)] transform transition-all hover:scale-105 active:scale-95 border-4 border-transparent hover:border-brand-yellow text-left"
+                    className="relative z-10 flex items-center gap-4 bg-white text-brand-dark px-10 py-6 rounded-full font-black text-xl shadow-[0_20px_50px_rgba(8,_112,_184,_0.15)] hover:shadow-[0_20px_50px_rgba(8,_112,_184,_0.25)] transform transition hover:scale-105 active:scale-95 border-4 border-transparent hover:border-brand-yellow text-left"
                 >
                     <Sparkle className="size-6 text-brand-yellow" weight="fill" />
                     <span>Quero meu roteiro agora!</span>

--- a/components/LandingFAQ.tsx
+++ b/components/LandingFAQ.tsx
@@ -16,7 +16,7 @@ const FAQItemComponent = memo(({ question, answer, isOpen, idx, onToggle }: FAQI
     const toggleFaqItem = useCallback(() => onToggle(idx), [idx, onToggle]);
     return (
         <div
-            className={`border-b border-brand-cyan/10 last:border-0 transition-all duration-300 ${isOpen ? 'bg-white/40' : ''}`}
+            className={`border-b border-brand-cyan/10 last:border-0 transition duration-300 ${isOpen ? 'bg-white/40' : ''}`}
         >
             <button
                 className="w-full py-6 flex justify-between items-center text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan group"
@@ -26,14 +26,14 @@ const FAQItemComponent = memo(({ question, answer, isOpen, idx, onToggle }: FAQI
                 <h3 className="text-xl font-bold text-brand-dark group-hover:text-brand-cyan transition-colors pr-8">
                     {question}
                 </h3>
-                <div className={`flex-shrink-0 size-8 rounded-full flex items-center justify-center transition-all duration-300 ${
+                <div className={`flex-shrink-0 size-8 rounded-full flex items-center justify-center transition duration-300 ${
                     isOpen ? 'bg-brand-cyan text-white rotate-180' : 'bg-brand-light text-brand-cyan'
                 }`}>
                     {isOpen ? <ChevronUp className="size-5" /> : <ChevronDown className="size-5" />}
                 </div>
             </button>
             <div
-                className={`overflow-hidden transition-all duration-300 ease-in-out ${
+                className={`overflow-hidden transition-[max-height,opacity] duration-300 ease-in-out ${
                     isOpen ? 'max-h-[500px] opacity-100 pb-8' : 'max-h-0 opacity-0'
                 }`}
             >

--- a/components/SearchForm.tsx
+++ b/components/SearchForm.tsx
@@ -161,7 +161,7 @@ const DestinationField = memo(({
 
   return (
     <div
-      className="w-full md:flex-[1.5] p-3 md:p-6 relative group text-left cursor-text hover:bg-zinc-50/80 transition-all duration-300 rounded-t-[2rem] md:rounded-tl-[2rem] md:rounded-tr-none"
+      className="w-full md:flex-[1.5] p-3 md:p-6 relative group text-left cursor-text hover:bg-zinc-50/80 transition duration-300 rounded-t-[2rem] md:rounded-tl-[2rem] md:rounded-tr-none"
       ref={destRef}
     >
       <label htmlFor="destination-input" className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-focus-within:text-brand-cyan transition-colors">
@@ -267,7 +267,7 @@ const DateField = memo(({
     <button
       type="button"
       onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
       aria-expanded={showCalendar}
       aria-haspopup="grid"
       data-testid="dates-filter-btn"
@@ -318,7 +318,7 @@ const DateField = memo(({
                 onClick={() => onDateClick(date)}
                 disabled={past}
                 aria-disabled={past}
-                className={`size-9 mx-auto flex items-center justify-center text-sm rounded-full transition-all duration-200 border-2
+                className={`size-9 mx-auto flex items-center justify-center text-sm rounded-full transition duration-200 border-2
                   ${past ? 'border-transparent text-zinc-300 cursor-not-allowed' : selected ? 'bg-brand-cyan border-brand-cyan text-white font-bold scale-110' : inRange ? 'bg-brand-light border-transparent text-brand-cyan font-bold' : 'border-transparent text-zinc-600 hover:bg-zinc-100'}`}
               >
                 {date.getDate()}
@@ -363,7 +363,7 @@ const GuestsField = memo(({
     <button
       type="button"
       onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition-all duration-300 md:rounded-tr-[2rem] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 md:rounded-tr-[2rem] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
       aria-expanded={showGuestDropdown}
       aria-haspopup="true"
       data-testid="guests-filter-btn"
@@ -386,7 +386,7 @@ const GuestsField = memo(({
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onAdultsChange(Math.max(1, adults - 1)); }}
               disabled={adults <= 1}
-              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition disabled:opacity-40 disabled:cursor-not-allowed"
               aria-label="Remover um adulto"
             >
               <Minus className="size-4" />
@@ -395,7 +395,7 @@ const GuestsField = memo(({
             <button
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onAdultsChange(adults + 1); }}
-              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition-all"
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition"
               aria-label="Adicionar um adulto"
             >
               <Plus className="size-4" />
@@ -409,7 +409,7 @@ const GuestsField = memo(({
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onChildCountChange('remove'); }}
               disabled={children <= 0}
-              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition disabled:opacity-40 disabled:cursor-not-allowed"
               aria-label="Remover uma criança"
             >
               <Minus className="size-4" />
@@ -418,7 +418,7 @@ const GuestsField = memo(({
             <button
               type="button"
               onClick={(event) => { event.preventDefault(); event.stopPropagation(); onChildCountChange('add'); }}
-              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition-all"
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition"
               aria-label="Adicionar uma criança"
             >
               <Plus className="size-4" />
@@ -447,7 +447,7 @@ const GuestsField = memo(({
           </div>
         )}
 
-        <button type="button" onClick={onClose} className="w-full mt-2 bg-brand-cyan text-white rounded-xl py-3 font-bold hover:bg-brand-cyanDark transition-all active:scale-95 shadow-[0_4px_0px_#0284c7] hover:shadow-[0_2px_0px_#0284c7] hover:translate-y-[2px]">Pronto</button>
+        <button type="button" onClick={onClose} className="w-full mt-2 bg-brand-cyan text-white rounded-xl py-3 font-bold hover:bg-brand-cyanDark transition active:scale-95 shadow-[0_4px_0px_#0284c7] hover:shadow-[0_2px_0px_#0284c7] hover:translate-y-[2px]">Pronto</button>
       </div>
     )}
   </div>
@@ -475,7 +475,7 @@ const TripTypeField = memo(({
     <button
       type="button"
       onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
       aria-expanded={showTripTypeDropdown}
       aria-haspopup="true"
       data-testid="trip-type-filter-btn"
@@ -504,7 +504,7 @@ const TripTypeField = memo(({
               key={type.label}
               type="button"
               onClick={() => onSelect(type.label)}
-              className={`flex flex-col items-start gap-2 p-3 rounded-2xl border-2 transition-all duration-200 text-left
+              className={`flex flex-col items-start gap-2 p-3 rounded-2xl border-2 transition duration-200 text-left
                 ${tripType === type.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-zinc-50 hover:border-zinc-100'}`}
             >
               <div className={`p-2 rounded-xl ${type.bg} ${type.color}`}>
@@ -543,7 +543,7 @@ const BudgetField = memo(({
     <button
       type="button"
       onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
       aria-expanded={showBudgetDropdown}
       aria-haspopup="true"
       data-testid="budget-filter-btn"
@@ -573,7 +573,7 @@ const BudgetField = memo(({
             key={option.label}
             type="button"
             onClick={() => onSelect(option.label)}
-            className={`w-full flex items-center gap-4 p-3 rounded-2xl border-2 transition-all duration-200 mb-2 last:mb-0
+            className={`w-full flex items-center gap-4 p-3 rounded-2xl border-2 transition duration-200 mb-2 last:mb-0
               ${budget === option.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-zinc-50 hover:border-zinc-100'}`}
           >
             <div className={`p-2 rounded-xl bg-zinc-100 text-zinc-600 ${budget === option.label ? 'bg-brand-vibrant text-white' : ''}`}>
@@ -621,7 +621,7 @@ const SearchButton = memo(({ isSearchLoading, validationError }: SearchButtonPro
       type="submit"
       disabled={isSearchLoading}
       data-testid="submit-search-btn"
-      className="btn-specialist w-full md:w-auto h-full min-h-[70px] bg-brand-yellow hover:bg-yellow-400 text-brand-dark rounded-2xl md:rounded-[1.5rem] shadow-lg flex items-center justify-center gap-2 px-6 transition-all duration-300 ease-spring hover:scale-105 hover:shadow-xl active:scale-90 group border-2 border-transparent whitespace-nowrap"
+      className="btn-specialist w-full md:w-auto h-full min-h-[70px] bg-brand-yellow hover:bg-yellow-400 text-brand-dark rounded-2xl md:rounded-[1.5rem] shadow-lg flex items-center justify-center gap-2 px-6 transition duration-300 ease-spring hover:scale-105 hover:shadow-xl active:scale-90 group border-2 border-transparent whitespace-nowrap"
       data-tracking="hero-home"
     >
       {isSearchLoading ? (
@@ -920,7 +920,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
   return (
     <form
       onSubmit={handleSubmit}
-      className={`w-full max-w-5xl mx-auto bg-white rounded-[2.5rem] shadow-[0_30px_60px_-15px_rgba(0,0,0,0.3)] p-2 relative z-50 border-[6px] border-white/20 backdrop-blur-sm flex flex-col transition-all duration-300 ${
+      className={`w-full max-w-5xl mx-auto bg-white rounded-[2.5rem] shadow-[0_30px_60px_-15px_rgba(0,0,0,0.3)] p-2 relative z-50 border-[6px] border-white/20 backdrop-blur-sm flex flex-col transition duration-300 ${
         validationError ? 'ring-4 ring-red-500/20 border-red-500/20' : ''
       }`}
     >

--- a/components/SocialShare.tsx
+++ b/components/SocialShare.tsx
@@ -65,7 +65,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                         handleNativeShare();
                     }}
                     onMouseEnter={prefetchHaptics}
-                    className="p-2 bg-white/80 hover:bg-brand-cyan hover:text-white text-zinc-600 rounded-full transition-all shadow-sm border border-zinc-100"
+                    className="p-2 bg-white/80 hover:bg-brand-cyan hover:text-white text-zinc-600 rounded-full transition shadow-sm border border-zinc-100"
                     title="Compartilhar"
                     aria-label="Compartilhar"
                 >
@@ -78,7 +78,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                         handleCopy();
                     }}
                     onMouseEnter={prefetchHaptics}
-                    className={`p-2 rounded-full transition-all shadow-sm border ${copied ? 'bg-green-700 text-white border-green-800' : 'bg-white/80 text-zinc-600 border-zinc-100 hover:bg-zinc-100'}`}
+                    className={`p-2 rounded-full transition shadow-sm border ${copied ? 'bg-green-700 text-white border-green-800' : 'bg-white/80 text-zinc-600 border-zinc-100 hover:bg-zinc-100'}`}
                     role={copied ? "status" : undefined}
                     title={copied ? "Link copiado!" : "Copiar link"}
                     aria-label={copied ? "Link copiado com sucesso" : "Copiar link"}
@@ -95,7 +95,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
             <button
                 onClick={handleNativeShare}
                 onMouseEnter={prefetchHaptics}
-                className="flex items-center gap-2 px-5 py-2.5 bg-brand-cyan text-white font-bold rounded-xl hover:bg-brand-cyanDark transition-all shadow-[0_4px_0px_#0369a1] active:shadow-none active:translate-y-1 lg:hidden"
+                className="flex items-center gap-2 px-5 py-2.5 bg-brand-cyan text-white font-bold rounded-xl hover:bg-brand-cyanDark transition shadow-[0_4px_0px_#0369a1] active:shadow-none active:translate-y-1 lg:hidden"
             >
                 <Share2 className="size-5" /> Compartilhar
             </button>
@@ -155,7 +155,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                 <button
                     onClick={handleNativeShare}
                     onMouseEnter={prefetchHaptics}
-                    className="hidden lg:flex p-2.5 bg-zinc-100 text-zinc-600 rounded-xl hover:bg-zinc-200 transition-all shadow-sm"
+                    className="hidden lg:flex p-2.5 bg-zinc-100 text-zinc-600 rounded-xl hover:bg-zinc-200 transition shadow-sm"
                     title="Mais opções de compartilhamento"
                     aria-label="Mais opções de compartilhamento"
                 >
@@ -166,7 +166,7 @@ export const SocialShare: React.FC<SocialShareProps> = ({ url, title, excerpt, c
                 <button
                     onClick={handleCopy}
                     onMouseEnter={prefetchHaptics}
-                    className={`p-2.5 rounded-xl transition-all shadow-sm border ${copied ? 'bg-green-700 text-white border-green-800' : 'bg-zinc-100 text-zinc-600 border-transparent hover:bg-zinc-200'}`}
+                    className={`p-2.5 rounded-xl transition shadow-sm border ${copied ? 'bg-green-700 text-white border-green-800' : 'bg-zinc-100 text-zinc-600 border-transparent hover:bg-zinc-200'}`}
                     role={copied ? "status" : undefined}
                     title={copied ? "Link copiado!" : "Copiar link"}
                     aria-label={copied ? "Link copiado com sucesso" : "Copiar link"}

--- a/components/Testimonials.tsx
+++ b/components/Testimonials.tsx
@@ -135,7 +135,7 @@ const Testimonials: React.FC = memo(() => {
                                 <button
                                     key={t.name}
                                     onClick={() => setCurrentIndex(i)}
-                                    className={`h-2 rounded-full transition-all duration-300 ${i === currentIndex ? 'bg-brand-cyan w-8' : 'bg-brand-cyan/20 w-2 hover:bg-brand-cyan/40'}`}
+                                    className={`h-2 rounded-full transition-[width,background-color] duration-300 ${i === currentIndex ? 'bg-brand-cyan w-8' : 'bg-brand-cyan/20 w-2 hover:bg-brand-cyan/40'}`}
                                     aria-label={`Ir para depoimento ${i + 1}`}
                                 />
                             ))}

--- a/components/blog/BlogPostContent.tsx
+++ b/components/blog/BlogPostContent.tsx
@@ -54,7 +54,7 @@ export const BlogPostContent: React.FC<BlogPostContentProps> = ({ post, canonica
                         prose md:prose-lg max-w-none
                         prose-headings:font-sans prose-headings:font-black prose-headings:tracking-tight prose-headings:text-brand-dark
                         prose-p:font-serif prose-p:text-zinc-600 prose-p:leading-relaxed prose-p:mb-6
-                        prose-a:text-brand-cyan prose-a:font-bold prose-a:no-underline prose-a:border-b-2 prose-a:border-brand-cyan/30 hover:prose-a:border-brand-cyan hover:prose-a:text-brand-cyanDark hover:prose-a:bg-brand-cyan/5 prose-a:transition-all
+                        prose-a:text-brand-cyan prose-a:font-bold prose-a:no-underline prose-a:border-b-2 prose-a:border-brand-cyan/30 hover:prose-a:border-brand-cyan hover:prose-a:text-brand-cyanDark hover:prose-a:bg-brand-cyan/5 prose-a:transition
                         prose-strong:text-brand-dark prose-strong:font-black
                         prose-ul:list-disc prose-ul:pl-6 prose-ul:marker:text-brand-yellow
                         prose-li:font-serif prose-li:text-zinc-600
@@ -99,7 +99,7 @@ export const BlogPostContent: React.FC<BlogPostContentProps> = ({ post, canonica
                 </h3>
                 <div className="grid sm:grid-cols-2 gap-6">
                     {relatedPosts.map(related => (
-                        <a href={getBlogPostUrl(related.slug)} key={`mobile-${related.slug}`} className="group flex flex-col bg-white rounded-2xl overflow-hidden border border-zinc-100 shadow-sm hover:shadow-md transition-all">
+                        <a href={getBlogPostUrl(related.slug)} key={`mobile-${related.slug}`} className="group flex flex-col bg-white rounded-2xl overflow-hidden border border-zinc-100 shadow-sm hover:shadow-md transition">
                             <div className="aspect-video w-full overflow-hidden relative">
                                 <img src={optimizeRemoteImageUrl(related.image, 400, 225)} alt={related.title} width="400" height="225" loading="lazy" className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700" />
                                 <div className="absolute top-3 left-3">

--- a/components/blog/BlogPostFinalCTA.tsx
+++ b/components/blog/BlogPostFinalCTA.tsx
@@ -23,7 +23,7 @@ export const BlogPostFinalCTA: React.FC<BlogPostFinalCTAProps> = ({ post }) => {
                     source: 'blog-post-footer',
                     message: `Olá! Li o post "${post.title}" e gostaria de planejar minha viagem.`,
                 })}
-                className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-cyan text-white text-lg font-bold px-10 py-5 rounded-2xl shadow-[4px_4px_0px_#FFD600] hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:shadow-none active:translate-x-[4px] active:translate-y-[4px] transition-all relative z-10"
+                className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-cyan text-white text-lg font-bold px-10 py-5 rounded-2xl shadow-[4px_4px_0px_#FFD600] hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:shadow-none active:translate-x-[4px] active:translate-y-[4px] transition relative z-10"
                 data-tracking="footer-blog-post"
             >
                 Conversar com um Especialista

--- a/components/blog/BlogPostSidebar.tsx
+++ b/components/blog/BlogPostSidebar.tsx
@@ -21,7 +21,7 @@ export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, author
     return (
         <div className="sticky top-32 space-y-8">
             <div className="bg-white rounded-3xl p-8 border-2 border-zinc-100 text-center relative overflow-hidden shadow-lg group hover:border-brand-yellow/30 transition-colors">
-                <div className="absolute top-0 right-0 size-32 bg-brand-yellow/10 rounded-bl-full -mr-10 -mt-10 transition-all group-hover:scale-110"></div>
+                <div className="absolute top-0 right-0 size-32 bg-brand-yellow/10 rounded-bl-full -mr-10 -mt-10 transition group-hover:scale-110"></div>
                 <div className="size-28 bg-zinc-200 rounded-full mx-auto mb-6 overflow-hidden border-[6px] border-white shadow-xl relative z-10">
                     {author?.image ? (
                         <img src={author.image} alt={author.name} width="112" height="112" loading="lazy" className="w-full h-full object-cover" />
@@ -55,7 +55,7 @@ export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, author
                 </h3>
                 <div className="space-y-4">
                     {relatedPosts.map(related => (
-                        <a href={getBlogPostUrl(related.slug)} key={related.slug} className="group flex gap-5 items-center bg-white p-4 rounded-2xl hover:bg-white hover:shadow-xl transition-all border border-transparent hover:border-zinc-100 duration-300">
+                        <a href={getBlogPostUrl(related.slug)} key={related.slug} className="group flex gap-5 items-center bg-white p-4 rounded-2xl hover:bg-white hover:shadow-xl transition border border-transparent hover:border-zinc-100 duration-300">
                             <div className="size-24 rounded-2xl overflow-hidden shrink-0 border border-zinc-100 shadow-sm relative">
                                 <img src={optimizeRemoteImageUrl(related.image, 200, 200)} alt={related.title} width="200" height="200" loading="lazy" className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700" />
                             </div>

--- a/components/blog/ChatCTA.tsx
+++ b/components/blog/ChatCTA.tsx
@@ -19,7 +19,7 @@ const ChatCTA: React.FC<ChatCTAProps> = ({ destino, mensagem, label }) => {
           destination: destino,
           message: mensagem,
         })}
-        className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-cyan text-white text-base font-bold px-8 py-4 rounded-2xl shadow-[4px_4px_0px_#003B8E] hover:shadow-none hover:translate-x-[2px] hover:translate-y-[2px] transition-all"
+        className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-cyan text-white text-base font-bold px-8 py-4 rounded-2xl shadow-[4px_4px_0px_#003B8E] hover:shadow-none hover:translate-x-[2px] hover:translate-y-[2px] transition"
         type="button"
         data-tracking="blog-chat-cta"
       >

--- a/components/cta/CtaBody.tsx
+++ b/components/cta/CtaBody.tsx
@@ -152,7 +152,7 @@ export function CtaBody() {
       <button
         type="button"
         onClick={() => setFormState('open')}
-        className="btn-specialist flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-8 py-4 rounded-xl shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all self-start"
+        className="btn-specialist flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-8 py-4 rounded-xl shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition self-start"
         data-tracking="cta-home-footer"
       >
         Solicitar meu Orçamento

--- a/components/landings/beto-carrero/Attractions.tsx
+++ b/components/landings/beto-carrero/Attractions.tsx
@@ -83,7 +83,7 @@ const Attractions: React.FC = () => {
           {attractions.map((item) => (
             <div
               key={item.id}
-              className={`group relative bg-white p-5 pb-8 rounded-[2rem] border-4 border-fun-dark shadow-hard transition-all duration-300 hover:-translate-y-3 hover:shadow-hard-hover hover:z-20 ${item.rotation}`}
+              className={`group relative bg-white p-5 pb-8 rounded-[2rem] border-4 border-fun-dark shadow-hard transition duration-300 hover:-translate-y-3 hover:shadow-hard-hover hover:z-20 ${item.rotation}`}
             >
               {/* Tape Effect on Card */}
               <div className="absolute -top-4 left-1/2 -translate-x-1/2 w-28 h-10 bg-white/40 backdrop-blur-sm border-l-2 border-r-2 border-white/60 transform rotate-1 shadow-sm z-20"></div>
@@ -116,7 +116,7 @@ const Attractions: React.FC = () => {
               </div>
 
               {/* Hover Action "Sticker" */}
-              <div className="absolute -bottom-5 -right-5 bg-fun-dark text-white p-3 rounded-full opacity-0 group-hover:opacity-100 transition-all duration-300 transform scale-0 group-hover:scale-100 rotate-12 border-2 border-white shadow-lg">
+              <div className="absolute -bottom-5 -right-5 bg-fun-dark text-white p-3 rounded-full opacity-0 group-hover:opacity-100 transition duration-300 transform scale-0 group-hover:scale-100 rotate-12 border-2 border-white shadow-lg">
                 <Camera size={28} />
               </div>
             </div>

--- a/components/landings/beto-carrero/BetoCarreroApp.tsx
+++ b/components/landings/beto-carrero/BetoCarreroApp.tsx
@@ -98,7 +98,7 @@ const App: React.FC = () => {
          3. Shadow appears only on scroll (shadow-hard).
       */}
       <nav
-        className={`fixed top-0 left-0 right-0 bg-white border-fun-dark z-50 transition-all duration-300 ease-in-out border-b-4 ${isScrolled
+        className={`fixed top-0 left-0 right-0 bg-white border-fun-dark z-50 transition-[padding,box-shadow] duration-300 ease-in-out border-b-4 ${isScrolled
           ? 'py-3 shadow-hard' // Scrolled: Compact padding, Solid Shadow
           : 'py-5 md:py-6 shadow-none' // Top: Spacious, No shadow
           }`}
@@ -121,7 +121,7 @@ const App: React.FC = () => {
               width="154"
               height="80"
               fetchPriority="high"
-              className={`transition-all duration-300 w-auto ${isScrolled ? 'h-9 md:h-16' : 'h-10 md:h-20'}`}
+              className={`transition-[height] duration-300 w-auto ${isScrolled ? 'h-9 md:h-16' : 'h-10 md:h-20'}`}
             />
           </a>
           <div className="hidden lg:flex items-center gap-8 xl:gap-12">
@@ -153,7 +153,7 @@ const App: React.FC = () => {
                 text="Falar no WhatsApp"
                 variant="secondary"
                 icon={true}
-                className={`transition-all duration-300 ${isScrolled ? 'py-1 px-3 text-xs lg:py-1.5 lg:px-4 lg:text-sm' : 'py-1.5 px-4 text-sm lg:py-2 lg:px-5 lg:text-base'}`}
+                className={`transition-[padding,font-size] duration-300 ${isScrolled ? 'py-1 px-3 text-xs lg:py-1.5 lg:px-4 lg:text-sm' : 'py-1.5 px-4 text-sm lg:py-2 lg:px-5 lg:text-base'}`}
                 tooltip="Atendimento rápido"
                 tooltipPosition="bottom"
                 dataTracking="navbar-desktop-betocarrero"
@@ -171,7 +171,7 @@ const App: React.FC = () => {
           </div>
 
           {/* Mobile Menu Dropdown */}
-          <div className={`absolute top-full left-0 w-full bg-white border-b-4 border-fun-dark shadow-hard p-6 flex flex-col gap-6 lg:hidden transition-all duration-300 origin-top ${mobileMenuOpen ? 'opacity-100 scale-y-100' : 'opacity-0 scale-y-0 pointer-events-none'}`}>
+          <div className={`absolute top-full left-0 w-full bg-white border-b-4 border-fun-dark shadow-hard p-6 flex flex-col gap-6 lg:hidden transition duration-300 origin-top ${mobileMenuOpen ? 'opacity-100 scale-y-100' : 'opacity-0 scale-y-0 pointer-events-none'}`}>
             {navLinks.map((link) => (
               <a
                 key={link.name}
@@ -209,7 +209,7 @@ const App: React.FC = () => {
       </div>
 
       {/* Desktop Sticky Bubble */}
-      <div className={`fixed bottom-8 right-8 transition-all duration-500 z-50 hidden xl:block ${showSticky ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-20'}`}>
+      <div className={`fixed bottom-8 right-8 transition duration-500 z-50 hidden xl:block ${showSticky ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-20'}`}>
         <Button text="Orçamento Rápido" tooltip="Receba em poucos minutos" dataTracking="sticky-desktop-betocarrero" />
       </div>
 

--- a/components/landings/beto-carrero/BetoCarreroApp.tsx
+++ b/components/landings/beto-carrero/BetoCarreroApp.tsx
@@ -153,7 +153,7 @@ const App: React.FC = () => {
                 text="Falar no WhatsApp"
                 variant="secondary"
                 icon={true}
-                className={`transition-[padding,font-size] duration-300 ${isScrolled ? 'py-1 px-3 text-xs lg:py-1.5 lg:px-4 lg:text-sm' : 'py-1.5 px-4 text-sm lg:py-2 lg:px-5 lg:text-base'}`}
+                className={`transition-[padding,font-size,line-height,transform,box-shadow] duration-300 ${isScrolled ? 'py-1 px-3 text-xs lg:py-1.5 lg:px-4 lg:text-sm' : 'py-1.5 px-4 text-sm lg:py-2 lg:px-5 lg:text-base'}`}
                 tooltip="Atendimento rápido"
                 tooltipPosition="bottom"
                 dataTracking="navbar-desktop-betocarrero"

--- a/components/landings/beto-carrero/Button.tsx
+++ b/components/landings/beto-carrero/Button.tsx
@@ -36,7 +36,7 @@ const Button: React.FC<ButtonProps> = ({
     };
   }, []);
 
-  const baseStyles = "inline-flex items-center justify-center font-sans font-bold text-lg md:text-xl px-8 py-4 rounded-full transition-all duration-200 transform hover:-translate-y-1 border-2 border-fun-dark relative z-10 focus:outline-none focus:ring-4 focus:ring-fun-blue focus:ring-offset-2 focus:ring-offset-white";
+  const baseStyles = "inline-flex items-center justify-center font-sans font-bold text-lg md:text-xl px-8 py-4 rounded-full transition duration-200 transform hover:-translate-y-1 border-2 border-fun-dark relative z-10 focus:outline-none focus:ring-4 focus:ring-fun-blue focus:ring-offset-2 focus:ring-offset-white";
 
   const variants = {
     primary: "bg-fun-green text-white shadow-hard hover:shadow-hard-hover",
@@ -76,7 +76,7 @@ const Button: React.FC<ButtonProps> = ({
       </button>
 
       {tooltip && (
-        <div className={`absolute left-1/2 transform -translate-x-1/2 w-max max-w-[200px] md:max-w-xs transition-all duration-200 opacity-0 group-hover:opacity-100 pointer-events-none z-50 ${positionStyles} ${animationStyles}`}>
+        <div className={`absolute left-1/2 transform -translate-x-1/2 w-max max-w-[200px] md:max-w-xs transition duration-200 opacity-0 group-hover:opacity-100 pointer-events-none z-50 ${positionStyles} ${animationStyles}`}>
           <div className="bg-fun-dark text-white text-sm font-bold py-2 px-3 rounded-xl shadow-lg border-2 border-white text-center relative">
             {tooltip}
             <div className={`absolute left-1/2 transform -translate-x-1/2 size-3 bg-fun-dark rotate-45 ${arrowStyles}`}></div>

--- a/components/landings/beto-carrero/DestinationsModal.tsx
+++ b/components/landings/beto-carrero/DestinationsModal.tsx
@@ -31,7 +31,7 @@ export function DestinationsModal({ isOpen, onClose }: DestinationsModalProps) {
         {/* Close Button */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 bg-fun-pink text-white p-2 rounded-full border-2 border-fun-dark shadow-hard hover:scale-110 hover:rotate-90 transition-all z-10"
+          className="absolute top-4 right-4 bg-fun-pink text-white p-2 rounded-full border-2 border-fun-dark shadow-hard hover:scale-110 hover:rotate-90 transition z-10"
           aria-label="Fechar janela"
         >
           <X size={20} strokeWidth={3} />
@@ -47,7 +47,7 @@ export function DestinationsModal({ isOpen, onClose }: DestinationsModalProps) {
         <div className="space-y-5 mb-4">
 
           {/* Item 1: Floripa */}
-          <div className="group bg-white p-5 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 flex items-center gap-5 cursor-default relative overflow-hidden">
+          <div className="group bg-white p-5 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition duration-300 flex items-center gap-5 cursor-default relative overflow-hidden">
             <div className="absolute right-0 top-0 size-16 bg-fun-yellow/20 rounded-bl-full z-0"></div>
 
             <div className="size-16 bg-fun-yellow border-2 border-fun-dark rounded-full flex items-center justify-center shadow-sm shrink-0 z-10 group-hover:rotate-12 transition-transform duration-300">
@@ -60,7 +60,7 @@ export function DestinationsModal({ isOpen, onClose }: DestinationsModalProps) {
           </div>
 
           {/* Item 2: Bombinhas */}
-          <div className="group bg-white p-5 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 flex items-center gap-5 cursor-default relative overflow-hidden">
+          <div className="group bg-white p-5 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition duration-300 flex items-center gap-5 cursor-default relative overflow-hidden">
             <div className="absolute right-0 top-0 size-16 bg-fun-green/20 rounded-bl-full z-0"></div>
 
             <div className="size-16 bg-fun-green border-2 border-fun-dark rounded-full flex items-center justify-center shadow-sm shrink-0 z-10 group-hover:-rotate-12 transition-transform duration-300">
@@ -73,7 +73,7 @@ export function DestinationsModal({ isOpen, onClose }: DestinationsModalProps) {
           </div>
 
           {/* Item 3: Balneário */}
-          <div className="group bg-white p-5 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 flex items-center gap-5 cursor-default relative overflow-hidden">
+          <div className="group bg-white p-5 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition duration-300 flex items-center gap-5 cursor-default relative overflow-hidden">
             <div className="absolute right-0 top-0 size-16 bg-fun-blue/20 rounded-bl-full z-0"></div>
 
             <div className="size-16 bg-fun-blue border-2 border-fun-dark rounded-full flex items-center justify-center shadow-sm shrink-0 z-10 group-hover:rotate-6 transition-transform duration-300">

--- a/components/landings/beto-carrero/FAQ.tsx
+++ b/components/landings/beto-carrero/FAQ.tsx
@@ -44,7 +44,7 @@ const FAQ: React.FC = () => {
                 return (
                   <div
                     key={item.question}
-                    className={`border-2 border-fun-dark rounded-2xl transition-all duration-300 overflow-hidden ${isOpen ? 'bg-blue-50 shadow-hard' : 'bg-white hover:bg-zinc-50'}`}
+                    className={`border-2 border-fun-dark rounded-2xl transition duration-300 overflow-hidden ${isOpen ? 'bg-blue-50 shadow-hard' : 'bg-white hover:bg-zinc-50'}`}
                   >
                     <button 
                       onClick={() => toggleAccordion(idx)}
@@ -54,7 +54,7 @@ const FAQ: React.FC = () => {
                       <span className={`font-sans font-bold text-lg md:text-xl pr-4 leading-tight ${isOpen ? 'text-fun-blue' : 'text-fun-dark'}`}>
                         {item.question}
                       </span>
-                      <div className={`flex-shrink-0 size-8 rounded-full border-2 border-fun-dark flex items-center justify-center transition-all duration-300 ${isOpen ? 'bg-fun-blue text-white rotate-180' : 'bg-white text-fun-dark'}`}>
+                      <div className={`flex-shrink-0 size-8 rounded-full border-2 border-fun-dark flex items-center justify-center transition duration-300 ${isOpen ? 'bg-fun-blue text-white rotate-180' : 'bg-white text-fun-dark'}`}>
                         <ChevronDown size={20} strokeWidth={3} />
                       </div>
                     </button>

--- a/components/landings/beto-carrero/Features.tsx
+++ b/components/landings/beto-carrero/Features.tsx
@@ -49,12 +49,12 @@ const Features: React.FC = () => {
               className="relative group perspective-1000"
             >
               {/* The Large Number Floating Behind */}
-              <div className="absolute -top-10 -left-2 text-[120px] font-sans font-black text-zinc-100 select-none z-0 transition-all duration-300 group-hover:text-zinc-200 group-hover:-translate-y-4 group-hover:scale-105">
+              <div className="absolute -top-10 -left-2 text-[120px] font-sans font-black text-zinc-100 select-none z-0 transition duration-300 group-hover:text-zinc-200 group-hover:-translate-y-4 group-hover:scale-105">
                 0{idx + 1}
               </div>
 
               {/* The Card */}
-              <div className="relative z-10 bg-white rounded-2xl border-4 border-fun-dark shadow-hard transition-all duration-300 transform group-hover:-translate-y-3 group-hover:rotate-1 group-hover:shadow-hard-hover h-full flex flex-col overflow-hidden">
+              <div className="relative z-10 bg-white rounded-2xl border-4 border-fun-dark shadow-hard transition duration-300 transform group-hover:-translate-y-3 group-hover:rotate-1 group-hover:shadow-hard-hover h-full flex flex-col overflow-hidden">
                 
                 {/* Header Bar */}
                 <div className={`h-4 w-full border-b-4 border-fun-dark ${feature.color}`}></div>
@@ -79,7 +79,7 @@ const Features: React.FC = () => {
                   )}
 
                   {/* Icon Badge - Highlighted & Larger */}
-                  <div className={`size-24 rounded-2xl border-4 border-fun-dark flex items-center justify-center mb-8 shadow-hard transition-all duration-300 group-hover:shadow-hard-hover group-hover:scale-110 ${feature.color} relative z-10`}>
+                  <div className={`size-24 rounded-2xl border-4 border-fun-dark flex items-center justify-center mb-8 shadow-hard transition duration-300 group-hover:shadow-hard-hover group-hover:scale-110 ${feature.color} relative z-10`}>
                     {feature.icon}
                   </div>
 
@@ -93,7 +93,7 @@ const Features: React.FC = () => {
                 </div>
 
                 {/* Bottom Highlight */}
-                <div className={`h-3 w-0 group-hover:w-full transition-all duration-500 ease-out ${feature.color}`}></div>
+                <div className={`h-3 w-0 group-hover:w-full transition-[width] duration-500 ease-out ${feature.color}`}></div>
               </div>
             </div>
           ))}

--- a/components/landings/beto-carrero/Hero.tsx
+++ b/components/landings/beto-carrero/Hero.tsx
@@ -67,10 +67,10 @@ const Hero: React.FC = () => {
         <div className="flex justify-center lg:justify-end order-2 lg:order-2 mt-8 lg:mt-0 perspective-1000 relative">
 
           {/* Visual Container: keeps stickers relative to image. Scaled up for Desktop. */}
-          <div className="relative w-64 h-80 sm:w-80 sm:h-96 lg:w-[26rem] lg:h-[32rem] xl:w-[38rem] xl:h-[46rem] transition-all duration-300">
+          <div className="relative w-64 h-80 sm:w-80 sm:h-96 lg:w-[26rem] lg:h-[32rem] xl:w-[38rem] xl:h-[46rem] transition duration-300">
 
             {/* 1. Main Photo (Polaroid Style) */}
-            <div className="absolute inset-0 bg-white p-3 pb-12 lg:pb-16 rounded-sm border-4 border-fun-dark shadow-hard-lg transform rotate-3 hover:rotate-0 transition-all duration-500 z-10 group">
+            <div className="absolute inset-0 bg-white p-3 pb-12 lg:pb-16 rounded-sm border-4 border-fun-dark shadow-hard-lg transform rotate-3 hover:rotate-0 transition duration-500 z-10 group">
               {/* Tape Effect */}
               <div className="absolute -top-4 lg:-top-6 left-1/2 -translate-x-1/2 w-20 md:w-24 lg:w-32 h-8 lg:h-12 bg-white/50 backdrop-blur-sm border-l-2 border-r-2 border-white/60 transform -rotate-2 shadow-sm z-20"></div>
 

--- a/components/landings/beto-carrero/Problem.tsx
+++ b/components/landings/beto-carrero/Problem.tsx
@@ -80,7 +80,7 @@ const Problem: React.FC = () => {
                <div className="lg:col-span-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-6 md:gap-8 lg:gap-10">
 
                   {/* Problem Card 1 */}
-                  <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 transform rotate-1 h-full">
+                  <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition duration-300 transform rotate-1 h-full">
                      <div className="flex gap-5 lg:gap-8 items-start h-full">
                         <div className="flex-shrink-0 size-14 lg:size-20 rounded-xl bg-red-100 flex items-center justify-center text-fun-pink border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
                            <HelpCircle size={28} className="lg:size-10" strokeWidth={2.5} />
@@ -98,7 +98,7 @@ const Problem: React.FC = () => {
                   </div>
 
                   {/* Problem Card 2 */}
-                  <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 transform -rotate-1 h-full">
+                  <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition duration-300 transform -rotate-1 h-full">
                      <div className="flex gap-5 lg:gap-8 items-start h-full">
                         <div className="flex-shrink-0 size-14 lg:size-20 rounded-xl bg-fun-yellow flex items-center justify-center text-fun-dark border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
                            <X size={28} className="lg:size-10" strokeWidth={2.5} />
@@ -113,7 +113,7 @@ const Problem: React.FC = () => {
                   </div>
 
                   {/* Problem Card 3 - Spans 2 columns on tablet to center it */}
-                  <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition-all duration-300 transform rotate-1 md:col-span-2 lg:col-span-1 md:w-3/4 md:mx-auto lg:w-full">
+                  <div className="group bg-white p-6 lg:p-8 rounded-2xl border-2 border-fun-dark shadow-hard hover:shadow-hard-hover hover:-translate-y-1 transition duration-300 transform rotate-1 md:col-span-2 lg:col-span-1 md:w-3/4 md:mx-auto lg:w-full">
                      <div className="flex gap-5 lg:gap-8 items-start h-full">
                         <div className="flex-shrink-0 size-14 lg:size-20 rounded-xl bg-blue-100 flex items-center justify-center text-fun-blue border-2 border-fun-dark shadow-sm group-hover:scale-110 transition-transform">
                            <AlertTriangle size={28} className="lg:size-10" strokeWidth={2.5} />

--- a/components/landings/beto-carrero/SolutionChecklist.tsx
+++ b/components/landings/beto-carrero/SolutionChecklist.tsx
@@ -35,7 +35,7 @@ export function SolutionChecklist({ onOpenModal }: SolutionChecklistProps) {
           {/* Left Side: Content */}
           <div className="p-3 pl-4 lg:p-6 lg:pl-8 flex-grow flex items-center gap-4 lg:gap-6">
             {/* Redesigned Icon: Blue Circle Token */}
-            <div className="size-14 lg:size-20 bg-fun-blue rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-6 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
+            <div className="size-14 lg:size-20 bg-fun-blue rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-6 group-hover:rotate-0 group-hover:scale-110 transition duration-300 flex-shrink-0">
               <Plane className="size-6 lg:size-9" strokeWidth={2.5} />
             </div>
             <div>
@@ -50,7 +50,7 @@ export function SolutionChecklist({ onOpenModal }: SolutionChecklistProps) {
           </div>
           {/* Right Side: Stamp */}
           <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
-            <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform rotate-12 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
+            <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform rotate-12 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition">
               <Check className="size-[18px] lg:size-6" strokeWidth={3} />
             </div>
           </div>
@@ -60,7 +60,7 @@ export function SolutionChecklist({ onOpenModal }: SolutionChecklistProps) {
         <div className="group bg-white rounded-xl border-2 border-fun-dark shadow-hard transform rotate-1 hover:rotate-0 transition-transform duration-300 flex overflow-hidden ml-0 md:ml-12 lg:ml-12 w-full max-w-sm lg:max-w-md">
           <div className="p-3 pl-4 lg:p-6 lg:pl-8 flex-grow flex items-center gap-4 lg:gap-6">
             {/* Redesigned Icon: Yellow Circle Token */}
-            <div className="size-14 lg:size-20 bg-fun-yellow rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-fun-dark transform rotate-3 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
+            <div className="size-14 lg:size-20 bg-fun-yellow rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-fun-dark transform rotate-3 group-hover:rotate-0 group-hover:scale-110 transition duration-300 flex-shrink-0">
               <BedDouble className="size-6 lg:size-9" strokeWidth={2.5} />
             </div>
             <div>
@@ -73,7 +73,7 @@ export function SolutionChecklist({ onOpenModal }: SolutionChecklistProps) {
             <div className="absolute -bottom-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
           </div>
           <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
-            <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform -rotate-6 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
+            <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform -rotate-6 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition">
               <Check className="size-[18px] lg:size-6" strokeWidth={3} />
             </div>
           </div>
@@ -95,7 +95,7 @@ export function SolutionChecklist({ onOpenModal }: SolutionChecklistProps) {
         >
           <div className="p-3 pl-4 lg:p-6 lg:pl-8 flex-grow flex items-center gap-4 lg:gap-6">
             {/* Redesigned Icon: Pink Circle Token */}
-            <div className="size-14 lg:size-20 bg-fun-pink rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-3 group-hover:rotate-0 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
+            <div className="size-14 lg:size-20 bg-fun-pink rounded-full flex items-center justify-center border-2 border-fun-dark shadow-[4px_4px_0px_0px_rgba(15,23,42,1)] text-white transform -rotate-3 group-hover:rotate-0 group-hover:scale-110 transition duration-300 flex-shrink-0">
               <Ticket className="size-6 lg:size-9" strokeWidth={2.5} />
             </div>
             <div>
@@ -108,7 +108,7 @@ export function SolutionChecklist({ onOpenModal }: SolutionChecklistProps) {
             <div className="absolute -bottom-3 -left-1.5 size-3 bg-fun-blue rounded-full"></div>
           </div>
           <div className="w-16 lg:w-20 bg-gray-50 flex items-center justify-center flex-shrink-0">
-            <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform rotate-3 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
+            <div className="bg-green-100 text-green-600 border-2 border-green-500 size-8 lg:size-10 rounded-full flex items-center justify-center transform rotate-3 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition">
               <Check className="size-[18px] lg:size-6" strokeWidth={3} />
             </div>
           </div>
@@ -124,7 +124,7 @@ export function SolutionChecklist({ onOpenModal }: SolutionChecklistProps) {
 
         <button
           onClick={onOpenModal}
-          className="bg-fun-yellow p-8 w-full rounded-xl border-4 border-fun-dark shadow-hard-lg transform -rotate-3 hover:rotate-0 hover:scale-105 active:scale-95 transition-all duration-300 text-left group focus:outline-none focus:ring-4 focus:ring-fun-blue focus:ring-offset-2"
+          className="bg-fun-yellow p-8 w-full rounded-xl border-4 border-fun-dark shadow-hard-lg transform -rotate-3 hover:rotate-0 hover:scale-105 active:scale-95 transition duration-300 text-left group focus:outline-none focus:ring-4 focus:ring-fun-blue focus:ring-offset-2"
           aria-label="Saiba mais sobre estender a viagem para praias próximas"
         >
 

--- a/components/landings/beto-carrero/Testimonials.tsx
+++ b/components/landings/beto-carrero/Testimonials.tsx
@@ -56,7 +56,7 @@ const Testimonials: React.FC = () => {
              return (
               <div 
                 key={t.id} 
-                className={`bg-white text-fun-dark p-8 rounded-sm shadow-hard border-4 border-white transition-all duration-300 group hover:scale-105 hover:z-20 relative flex flex-col ${rotationClasses[idx % 3]}`}
+                className={`bg-white text-fun-dark p-8 rounded-sm shadow-hard border-4 border-white transition duration-300 group hover:scale-105 hover:z-20 relative flex flex-col ${rotationClasses[idx % 3]}`}
               >
                  {/* Tape Effect (Top Center) */}
                  <div className={`absolute -top-4 left-1/2 -translate-x-1/2 w-32 h-10 ${tapeColors[idx % 3]} backdrop-blur-sm shadow-sm transform -rotate-1 border-l-2 border-r-2 border-white/20 z-20`}></div>

--- a/components/landings/brazil-promotion-day/BpdContactSection.tsx
+++ b/components/landings/brazil-promotion-day/BpdContactSection.tsx
@@ -153,7 +153,7 @@ export function BpdContactSection() {
                                         href={href}
                                         target="_blank"
                                         rel="noopener noreferrer"
-                                        className="size-11 rounded-xl bg-white border-2 border-zinc-200 flex items-center justify-center text-zinc-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-[4px_4px_0px_#fbbf24] hover:-translate-y-1 transition-all duration-200"
+                                        className="size-11 rounded-xl bg-white border-2 border-zinc-200 flex items-center justify-center text-zinc-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-[4px_4px_0px_#fbbf24] hover:-translate-y-1 transition duration-200"
                                         aria-label={label}
                                         {...(contact ? { 'data-contact-intent': true, 'data-tracking': 'social-whatsapp-brazil-promotion-day' } : {})}
                                     >
@@ -192,7 +192,7 @@ export function BpdContactSection() {
                                     href={whatsappUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all"
+                                    className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
                                     data-contact-intent
                                     data-tracking="success-brazil-promotion-day"
                                 >
@@ -300,7 +300,7 @@ export function BpdContactSection() {
                                     <button
                                         type="submit"
                                         disabled={isSubmitting}
-                                        className="w-full flex items-center justify-center gap-3 bg-brand-dark text-white py-4 rounded-xl font-bold text-base shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all disabled:opacity-60 disabled:pointer-events-none"
+                                        className="w-full flex items-center justify-center gap-3 bg-brand-dark text-white py-4 rounded-xl font-bold text-base shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition disabled:opacity-60 disabled:pointer-events-none"
                                         data-tracking="submit-form-brazil-promotion-day"
                                     >
                                         {isSubmitting ? (

--- a/components/landings/brazil-promotion-day/BpdHero.tsx
+++ b/components/landings/brazil-promotion-day/BpdHero.tsx
@@ -80,7 +80,7 @@ export function BpdHero() {
                         <button
                             type="button"
                             onClick={() => openContactModal({ source: 'brazil-promotion-day' })}
-                            className="btn-whatsapp btn-specialist flex items-center justify-center gap-3 bg-brand-yellow text-brand-dark px-8 py-4 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(0,0,0,0.2)] hover:shadow-[2px_2px_0px_rgba(0,0,0,0.2)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all"
+                            className="btn-whatsapp btn-specialist flex items-center justify-center gap-3 bg-brand-yellow text-brand-dark px-8 py-4 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(0,0,0,0.2)] hover:shadow-[2px_2px_0px_rgba(0,0,0,0.2)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
                             data-contact-intent
                             data-tracking="hero-brazil-promotion-day"
                         >
@@ -89,7 +89,7 @@ export function BpdHero() {
                         </button>
                         <a
                             href="#contato"
-                            className="btn-specialist flex items-center justify-center gap-2 border-2 border-white/40 text-white px-8 py-4 rounded-2xl font-bold text-lg hover:border-white hover:bg-white/10 transition-all duration-200"
+                            className="btn-specialist flex items-center justify-center gap-2 border-2 border-white/40 text-white px-8 py-4 rounded-2xl font-bold text-lg hover:border-white hover:bg-white/10 transition duration-200"
                         >
                             Prefiro ser contatado
                             <ArrowRight className="size-5" />
@@ -121,7 +121,7 @@ export function BpdHero() {
                                         transition: { type: 'spring', stiffness: 400, damping: 20 },
                                     },
                                 }}
-                                className="flex items-center gap-2 text-white/90 font-bold text-sm bg-white/10 px-4 py-2 rounded-full backdrop-blur-md border border-white/10 hover:bg-white/20 transition-all duration-300 cursor-default"
+                                className="flex items-center gap-2 text-white/90 font-bold text-sm bg-white/10 px-4 py-2 rounded-full backdrop-blur-md border border-white/10 hover:bg-white/20 transition duration-300 cursor-default"
                             >
                                 <span>{feat.icon}</span>
                                 {feat.text}

--- a/components/landings/brazil-promotion-day/BpdNav.tsx
+++ b/components/landings/brazil-promotion-day/BpdNav.tsx
@@ -18,7 +18,7 @@ export function BpdNav() {
                 <button
                     type="button"
                     onClick={() => openContactModal({ source: 'brazil-promotion-day' })}
-                    className="btn-whatsapp btn-specialist hidden sm:flex items-center gap-2 bg-brand-dark text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all"
+                    className="btn-whatsapp btn-specialist hidden sm:flex items-center gap-2 bg-brand-dark text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
                     data-contact-intent
                     data-tracking="header-brazil-promotion-day"
                 >

--- a/components/landings/brazil-promotion-day/BpdPillars.tsx
+++ b/components/landings/brazil-promotion-day/BpdPillars.tsx
@@ -78,7 +78,7 @@ export function BpdPillars() {
                                     {item.description}
                                 </p>
 
-                                <div className="absolute bottom-6 right-6 opacity-0 group-hover:opacity-100 transition-all duration-300 translate-x-4 group-hover:translate-x-0">
+                                <div className="absolute bottom-6 right-6 opacity-0 group-hover:opacity-100 transition duration-300 translate-x-4 group-hover:translate-x-0">
                                     <ArrowRight className={`size-5 ${item.iconColor}`} />
                                 </div>
                             </m.div>

--- a/components/landings/brazil-promotion-day/BpdWhatsAppBand.tsx
+++ b/components/landings/brazil-promotion-day/BpdWhatsAppBand.tsx
@@ -30,7 +30,7 @@ export function BpdWhatsAppBand() {
                     <button
                         type="button"
                         onClick={() => openContactModal({ source: 'brazil-promotion-day' })}
-                        className="btn-whatsapp btn-specialist shrink-0 flex items-center gap-3 bg-brand-yellow text-brand-dark px-10 py-5 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(255,255,255,0.15)] hover:shadow-[2px_2px_0px_rgba(255,255,255,0.15)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all whitespace-nowrap"
+                        className="btn-whatsapp btn-specialist shrink-0 flex items-center gap-3 bg-brand-yellow text-brand-dark px-10 py-5 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(255,255,255,0.15)] hover:shadow-[2px_2px_0px_rgba(255,255,255,0.15)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition whitespace-nowrap"
                         data-contact-intent
                         data-tracking="whatsapp-band-brazil-promotion-day"
                     >

--- a/components/landings/lollapalooza/Button.tsx
+++ b/components/landings/lollapalooza/Button.tsx
@@ -22,7 +22,7 @@ interface ButtonProps {
  * A navegação é 100% nativa, garantindo funcionamento no iOS/Safari.
  */
 const Button: React.FC<ButtonProps> = ({ text, className = '', variant = 'primary', fullWidth = false, href, id, dataTestId, dataWhatsappLocation, dataTracking }) => {
-  const baseStyles = "inline-flex items-center justify-center gap-2 px-8 py-4 rounded-full font-bold transition-all duration-300 transform hover:scale-105 shadow-lg text-lg uppercase tracking-wide cursor-pointer select-none";
+  const baseStyles = "inline-flex items-center justify-center gap-2 px-8 py-4 rounded-full font-bold transition duration-300 transform hover:scale-105 shadow-lg text-lg uppercase tracking-wide cursor-pointer select-none";
 
   const variants = {
     primary: "bg-anhanga-yellow text-anhanga-darkBlue hover:bg-anhanga-yellowHover",

--- a/components/landings/lollapalooza/Hero.tsx
+++ b/components/landings/lollapalooza/Hero.tsx
@@ -96,7 +96,7 @@ const Hero: React.FC = () => {
             <p className="text-zinc-300 text-[10px] sm:text-xs md:text-sm lg:text-lg uppercase tracking-[0.2em] mb-1 md:mb-2">Prepare-se para ver</p>
             <h2 
                 aria-live="polite"
-                className={`text-3xl sm:text-5xl md:text-6xl lg:text-7xl font-black uppercase italic tracking-tighter text-anhanga-yellow transition-all duration-500 transform text-center break-words w-full max-w-5xl leading-[0.9] sm:leading-tight pb-2 ${
+                className={`text-3xl sm:text-5xl md:text-6xl lg:text-7xl font-black uppercase italic tracking-tighter text-anhanga-yellow transition duration-500 transform text-center break-words w-full max-w-5xl leading-[0.9] sm:leading-tight pb-2 ${
                     isVisible ? 'opacity-100 translate-y-0 scale-100' : 'opacity-0 translate-y-4 scale-95'
                 }`}
                 style={{ paddingRight: '0.1em' }}
@@ -149,7 +149,7 @@ const Hero: React.FC = () => {
           <button 
             onClick={handleShare}
             className={`
-              group relative flex items-center justify-center gap-2 px-6 py-4 rounded-full border-2 transition-all duration-300 w-full sm:w-auto
+              group relative flex items-center justify-center gap-2 px-6 py-4 rounded-full border-2 transition duration-300 w-full sm:w-auto
               ${shareStatus === 'copied' 
                 ? 'bg-green-500 border-green-500 text-white' 
                 : 'border-white/20 text-white hover:bg-white/10 hover:border-anhanga-yellow hover:text-anhanga-yellow'

--- a/components/landings/lollapalooza/LineupSection.tsx
+++ b/components/landings/lollapalooza/LineupSection.tsx
@@ -117,7 +117,7 @@ const LineupSection: React.FC = () => {
           {/* Artist Avatars Cluster */}
           <div className="flex justify-center items-center -space-x-4 mb-8" aria-hidden="true">
             {headliners.slice(0, 5).map((artist) => (
-              <div key={artist.name} className="relative z-0 hover:z-10 transition-all duration-300 transform hover:scale-110 hover:-translate-y-2 group">
+              <div key={artist.name} className="relative z-0 hover:z-10 transition duration-300 transform hover:scale-110 hover:-translate-y-2 group">
                 <div className="size-16 md:size-24 rounded-full border-4 border-black group-hover:border-anhanga-yellow overflow-hidden relative shadow-lg">
                   <img
                     src={getArtistImageUrl(artist.image, 96, 96)}
@@ -155,7 +155,7 @@ const LineupSection: React.FC = () => {
         {/* Headliners Grid */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-20">
           {headliners.map((artist, index) => (
-            <div key={artist.name} className={`group relative h-96 sm:h-80 lg:h-96 overflow-hidden rounded-2xl border border-zinc-800 hover:border-anhanga-yellow transition-all duration-300 animate-on-scroll ${isVisible ? 'is-visible' : ''}`} style={{ transitionDelay: `${index * 50}ms` }}>
+            <div key={artist.name} className={`group relative h-96 sm:h-80 lg:h-96 overflow-hidden rounded-2xl border border-zinc-800 hover:border-anhanga-yellow transition duration-300 animate-on-scroll ${isVisible ? 'is-visible' : ''}`} style={{ transitionDelay: `${index * 50}ms` }}>
               {/* Background Image - Optimized to 600px width */}
               <div className="absolute inset-0 bg-zinc-900">
                 <img

--- a/components/landings/lollapalooza/Navbar.tsx
+++ b/components/landings/lollapalooza/Navbar.tsx
@@ -25,7 +25,7 @@ const Navbar: React.FC = () => {
   const logoUrl = BRAND_LOGO_BLUE_URL;
 
   return (
-    <nav className={`fixed w-full z-50 transition-all duration-300 ${scrolled ? 'bg-white shadow-md py-2' : 'bg-transparent py-4'}`} aria-label="Menu principal">
+    <nav className={`fixed w-full z-50 transition-[padding,background-color,box-shadow] duration-300 ${scrolled ? 'bg-white shadow-md py-2' : 'bg-transparent py-4'}`} aria-label="Menu principal">
       <div className="container mx-auto px-4 flex justify-between items-center">
         {/* Logo */}
         <a href={`${SITE_URL}/`} className="flex items-center" aria-label="Anhangá Viagens - Página Inicial">
@@ -34,7 +34,7 @@ const Navbar: React.FC = () => {
             alt="Anhangá Viagens"
             width="154"
             height="80"
-            className={`h-16 md:h-20 w-auto transition-all duration-300 ${!scrolled ? 'brightness-0 invert' : ''}`}
+            className={`h-16 md:h-20 w-auto transition duration-300 ${!scrolled ? 'brightness-0 invert' : ''}`}
           />
         </a>
 

--- a/components/landings/lollapalooza/PackageFeatures.tsx
+++ b/components/landings/lollapalooza/PackageFeatures.tsx
@@ -87,7 +87,7 @@ const PackageFeatures: React.FC = () => {
             <div
               key={feature.id}
               className={`
-                group relative rounded-3xl overflow-hidden transition-all duration-500 hover:scale-[1.02] hover:shadow-2xl
+                group relative rounded-3xl overflow-hidden transition duration-500 hover:scale-[1.02] hover:shadow-2xl
                 ${feature.className}
                 animate-on-scroll ${isVisible ? 'is-visible' : ''}
               `}

--- a/components/landings/lollapalooza/VenuePoiList.tsx
+++ b/components/landings/lollapalooza/VenuePoiList.tsx
@@ -41,7 +41,7 @@ export function VenuePoiList({ pois, activeIndex, listContainerRef, itemsRef, on
                 itemsRef.current[idx] = el;
               }}
               onClick={() => onItemClick(idx)}
-              className={`w-full text-left transition-all duration-300 rounded-xl border-2 group overflow-hidden relative ${activeIndex === idx
+              className={`w-full text-left transition duration-300 rounded-xl border-2 group overflow-hidden relative ${activeIndex === idx
                 ? 'border-anhanga-blue shadow-xl ring-2 ring-blue-100 z-10'
                 : 'border-gray-100 hover:border-anhanga-yellow hover:shadow-md'
                 }`}
@@ -98,7 +98,7 @@ export function VenuePoiList({ pois, activeIndex, listContainerRef, itemsRef, on
               </div>
 
               {/* Detalhes Expandidos */}
-              <div className={`relative z-10 grid transition-all duration-300 ease-in-out ${activeIndex === idx ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+              <div className={`relative z-10 grid transition-[grid-template-rows,opacity] duration-300 ease-in-out ${activeIndex === idx ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
                 }`}>
                 <div className="overflow-hidden min-h-0">
                   <div className="p-3 pt-0 text-sm text-gray-600 border-t border-blue-100/50 mx-3 mt-1 space-y-3">

--- a/components/landings/lollapalooza/WaitlistSection.tsx
+++ b/components/landings/lollapalooza/WaitlistSection.tsx
@@ -154,13 +154,13 @@ const WaitlistSection: React.FC = () => {
                       type="text"
                       value={name}
                       onChange={(event) => setName(event.target.value)}
-                      className="peer w-full bg-anhanga-darkBlue/80 border-l-2 border-white/10 px-6 py-4 text-white placeholder-white/50 outline-none transition-all duration-300 focus:border-anhanga-yellow focus:bg-anhanga-yellow/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-anhanga-yellow focus-visible:outline-offset-2"
+                      className="peer w-full bg-anhanga-darkBlue/80 border-l-2 border-white/10 px-6 py-4 text-white placeholder-white/50 outline-none transition duration-300 focus:border-anhanga-yellow focus:bg-anhanga-yellow/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-anhanga-yellow focus-visible:outline-offset-2"
                       placeholder="EX: SABRINA CARPENTER"
                       autoComplete="name"
                     />
                     {/* Focus geometric accent */}
-                    <div className="absolute left-0 bottom-0 h-0.5 w-0 bg-anhanga-yellow transition-all duration-500 peer-focus:w-full" />
-                    <div className="absolute -left-[2px] top-0 h-0 w-2.5 bg-anhanga-yellow transition-all duration-500 peer-focus:h-full" />
+                    <div className="absolute left-0 bottom-0 h-0.5 w-0 bg-anhanga-yellow transition-[width] duration-500 peer-focus:w-full" />
+                    <div className="absolute -left-[2px] top-0 h-0 w-2.5 bg-anhanga-yellow transition-[height] duration-500 peer-focus:h-full" />
                   </div>
                 </div>
 
@@ -174,13 +174,13 @@ const WaitlistSection: React.FC = () => {
                       type="email"
                       value={email}
                       onChange={(event) => setEmail(event.target.value)}
-                      className="peer w-full bg-anhanga-darkBlue/80 border-l-2 border-white/10 px-6 py-4 text-white placeholder-white/50 outline-none transition-all duration-300 focus:border-anhanga-blue focus:bg-anhanga-blue/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-anhanga-blue focus-visible:outline-offset-2"
+                      className="peer w-full bg-anhanga-darkBlue/80 border-l-2 border-white/10 px-6 py-4 text-white placeholder-white/50 outline-none transition duration-300 focus:border-anhanga-blue focus:bg-anhanga-blue/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-anhanga-blue focus-visible:outline-offset-2"
                       placeholder="VOICE@EXEMPLO.COM"
                       autoComplete="email"
                     />
                     {/* Focus geometric accent */}
-                    <div className="absolute left-0 bottom-0 h-0.5 w-0 bg-anhanga-blue transition-all duration-500 peer-focus:w-full" />
-                    <div className="absolute -left-[2px] top-0 h-0 w-2.5 bg-anhanga-blue transition-all duration-500 peer-focus:h-full" />
+                    <div className="absolute left-0 bottom-0 h-0.5 w-0 bg-anhanga-blue transition-[width] duration-500 peer-focus:w-full" />
+                    <div className="absolute -left-[2px] top-0 h-0 w-2.5 bg-anhanga-blue transition-[height] duration-500 peer-focus:h-full" />
                   </div>
                 </div>
 
@@ -192,7 +192,7 @@ const WaitlistSection: React.FC = () => {
                       onChange={(event) => setAcceptedLgpd(event.target.checked)}
                       className="peer sr-only"
                     />
-                    <div className="size-5 border-2 border-white/20 peer-checked:border-anhanga-yellow peer-checked:bg-anhanga-yellow transition-all duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-anhanga-yellow peer-focus-visible:outline-offset-2" />
+                    <div className="size-5 border-2 border-white/20 peer-checked:border-anhanga-yellow peer-checked:bg-anhanga-yellow transition duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-anhanga-yellow peer-focus-visible:outline-offset-2" />
                     <CheckCircle2 size={12} className="absolute text-black opacity-0 peer-checked:opacity-100 transition-opacity" />
                   </div>
                   <span className="text-xs text-zinc-400 leading-snug group-hover:text-zinc-300 transition-colors">
@@ -249,7 +249,7 @@ const WaitlistSection: React.FC = () => {
                 <button
                   type="submit"
                   disabled={isSubmitting}
-                  className="group relative flex w-full items-center justify-center gap-3 rounded-[1px] bg-anhanga-yellow px-8 py-5 text-sm font-black text-black transition-all duration-300 hover:tracking-[0.1em] disabled:cursor-wait disabled:opacity-50"
+                  className="group relative flex w-full items-center justify-center gap-3 rounded-[1px] bg-anhanga-yellow px-8 py-5 text-sm font-black text-black transition-[letter-spacing,opacity] duration-300 hover:tracking-[0.1em] disabled:cursor-wait disabled:opacity-50"
                 >
                   <span className="relative z-10 flex items-center gap-2">
                     {isSubmitting ? (

--- a/components/landings/lollapalooza/WhyUs.tsx
+++ b/components/landings/lollapalooza/WhyUs.tsx
@@ -15,7 +15,7 @@ const WhyUs: React.FC = () => {
           <div className={`w-full lg:w-1/2 animate-on-scroll ${isVisible ? 'is-visible' : ''}`}>
             <div className="relative group">
               {/* Image Display */}
-              <div className="relative overflow-hidden rounded-3xl shadow-2xl rotate-2 group-hover:rotate-0 transition-all duration-500 w-full aspect-[4/3] bg-zinc-100">
+              <div className="relative overflow-hidden rounded-3xl shadow-2xl rotate-2 group-hover:rotate-0 transition duration-500 w-full aspect-[4/3] bg-zinc-100">
                  <img 
                     src={getMediaUrl('images/lollapalooza/why-us/multidao-festival.jpg')} 
                     alt="Multidão feliz em um festival de música com confetes e luzes" 

--- a/components/ui/BackToTop.tsx
+++ b/components/ui/BackToTop.tsx
@@ -45,7 +45,7 @@ const BackToTop: React.FC = () => {
         fixed bottom-24 right-4 sm:bottom-32 sm:right-8 z-[9980]
         p-3 rounded-2xl bg-white text-brand-cyan border-2 border-brand-cyan/20
         shadow-lg shadow-brand-cyan/10 hover:shadow-brand-cyan/20
-        transition-all duration-300 ease-spring
+        transition duration-300 ease-spring
         hover:-translate-y-1 active:scale-90
         focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-cyan
         ${isVisible ? 'opacity-100 translate-y-0 pointer-events-auto' : 'opacity-0 translate-y-4 pointer-events-none'}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -28,7 +28,7 @@ const sizeClasses: Record<ButtonSize, string> = {
     lg: 'text-base px-7 py-3.5',
 };
 
-const baseClasses = 'inline-flex items-center justify-center gap-2 font-bold transition-all duration-150 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none';
+const baseClasses = 'inline-flex items-center justify-center gap-2 font-bold transition duration-150 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none';
 
 export const Button: React.FC<ButtonProps> = ({
     children,

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -185,7 +185,7 @@ const About: React.FC = () => {
             ].map((item, i) => (
               <m.div
                 key={item.title}
-                className="bg-white p-10 rounded-[2.5rem] border-2 border-zinc-100 shadow-sm hover:shadow-xl transition-all duration-300"
+                className="bg-white p-10 rounded-[2.5rem] border-2 border-zinc-100 shadow-sm hover:shadow-xl transition duration-300"
                 initial="hidden"
                 whileInView="visible"
                 viewport={{ once: true }}

--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -66,7 +66,7 @@ const BlogList: React.FC = () => {
                             placeholder="Buscar por título ou categoria..."
                             value={searchTerm}
                             onChange={(e) => setSearchTerm(e.target.value)}
-                            className="w-full px-6 py-4 rounded-full border-2 border-zinc-200 focus:border-brand-cyan focus:outline-none shadow-sm pl-12 text-zinc-700 font-medium transition-all"
+                            className="w-full px-6 py-4 rounded-full border-2 border-zinc-200 focus:border-brand-cyan focus:outline-none shadow-sm pl-12 text-zinc-700 font-medium transition"
                         />
                         <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400 size-5" />
                     </div>
@@ -81,7 +81,7 @@ const BlogList: React.FC = () => {
                                 key={post.slug}
                                 className={`
                                 group bg-white rounded-3xl p-5 shadow-[0_10px_20px_-5px_rgba(0,0,0,0.05)] border border-zinc-100
-                                transform transition-all duration-300 hover:-translate-y-2 hover:shadow-xl
+                                transform transition duration-300 hover:-translate-y-2 hover:shadow-xl
                                 flex flex-col h-full relative z-10
                             `}
                             >
@@ -154,7 +154,7 @@ const BlogList: React.FC = () => {
                             e.preventDefault();
                             openContactModal({ source: 'blog-list' });
                         }}
-                        className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-10 py-5 rounded-2xl shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all"
+                        className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-10 py-5 rounded-2xl shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
                         data-tracking="footer-blog-list"
                     >
                         Solicitar Orçamento

--- a/pages/NotFound.tsx
+++ b/pages/NotFound.tsx
@@ -45,7 +45,7 @@ const NotFound: React.FC = () => {
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-12">
             <a
               href={`${SITE_URL}/`}
-              className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition-all duration-300 group"
+              className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition duration-300 group"
             >
               <div className="size-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
                 <HomeIcon className="size-6" />
@@ -58,7 +58,7 @@ const NotFound: React.FC = () => {
 
             <a
               href={getBlogHomeUrl()}
-              className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition-all duration-300 group"
+              className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition duration-300 group"
             >
               <div className="size-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
                 <BookOpen className="size-6" />
@@ -71,7 +71,7 @@ const NotFound: React.FC = () => {
 
             <a
               href={`${SITE_URL}/orlando/`}
-              className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition-all duration-300 group"
+              className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition duration-300 group"
             >
               <div className="size-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
                 <MapPin className="size-6" />
@@ -86,7 +86,7 @@ const NotFound: React.FC = () => {
             <div className="sm:col-span-2 lg:col-span-3 grid grid-cols-1 sm:grid-cols-2 gap-4 lg:max-w-2xl lg:mx-auto w-full">
               <a
                 href={`${SITE_URL}/beto-carrero/`}
-                className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition-all duration-300 group"
+                className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition duration-300 group"
               >
                 <div className="size-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
                   <MapPin className="size-6" />
@@ -99,7 +99,7 @@ const NotFound: React.FC = () => {
 
               <a
                 href={`${SITE_URL}/lollapalooza/`}
-                className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition-all duration-300 group"
+                className="flex items-center gap-4 p-6 bg-white rounded-3xl border-2 border-transparent hover:border-brand-cyan shadow-sm hover:shadow-xl transition duration-300 group"
               >
                 <div className="size-12 rounded-2xl bg-brand-light flex items-center justify-center text-brand-cyan group-hover:bg-brand-cyan group-hover:text-white transition-colors">
                   <MapPin className="size-6" />
@@ -114,7 +114,7 @@ const NotFound: React.FC = () => {
 
           <a
             href={`${SITE_URL}/`}
-            className="inline-flex items-center gap-2 text-brand-cyan font-bold hover:gap-4 transition-all duration-300"
+            className="inline-flex items-center gap-2 text-brand-cyan font-bold hover:gap-4 transition-[gap,color] duration-300"
           >
             <ArrowLeft className="size-5" />
             Voltar para a Home


### PR DESCRIPTION
## Summary

- **Replace all `transition-all`** across 49 files (100+ occurrences) with scoped transition properties, eliminating unnecessary layout recalculations during hover/scroll/focus animations
- **Fix event handler ref pattern** in `ContactModal.tsx` — keydown listener now subscribes once when modal opens instead of re-subscribing on every `close` callback identity change
- **`animate-bounce` already removed** in prior refactors (zero occurrences found in codebase)

### Transition replacement strategy

| Scenario | Before | After |
|---|---|---|
| Visual-only (color, opacity, shadow, transform, scale) | `transition-all` | `transition` |
| Layout + visual (width, height, gap, max-height, padding, font-size, letter-spacing, grid-template-rows) | `transition-all` | `transition-[specific-props]` |

Key specific transitions:
- FAQ/LandingFAQ accordions → `transition-[max-height,opacity]`
- BetoCarrero logo → `transition-[height]`
- BetoCarrero nav → `transition-[padding,box-shadow]`
- Lollapalooza nav → `transition-[padding,background-color,box-shadow]`
- Testimonials dots → `transition-[width,background-color]`
- Blog/Destinations "ver mais" → `transition-[gap,color]`
- VenuePoiList accordion → `transition-[grid-template-rows,opacity]`
- WaitlistSection accent lines → `transition-[width]` / `transition-[height]`

### Issue count discrepancy note

Issue #485 listed count=1 for `transition-all`, 4 for `animate-bounce`, and 1 for event handler ref. Actual findings: 100+ `transition-all` occurrences, 0 `animate-bounce` (already cleaned up), and 1 event handler ref fix applied.

Closes #485

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:regression` — 261 tests pass
- [x] `pnpm build` — production build succeeds, zero `transition-all` remaining
- [x] Visual verification: FAQ accordion, Beto Carrero nav/logo, Lollapalooza nav transitions all animate correctly in dev server
- [x] Inspected computed `transition-property` values in browser — confirmed correct scoped properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)