### PR TITLE
Ative o modo strict do TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
       "node"
     ],
     "moduleResolution": "bundler",
+    "strict": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "allowJs": true,


### PR DESCRIPTION
## Summary
- Habilita `strict: true` no `tsconfig.json` para reforçar a checagem de tipos do projeto.
- Mantém a configuração existente do compilador intacta fora isso.

## Testing
- `pnpm typecheck`
- `pnpm test:regression`
- `git diff --check`