### PR TITLE
Add gated logger utility and debug env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ GEMINI_API_KEY=sua_chave_api_aqui
 # CLOUDFLARE_AI_GATEWAY_ID=default
 # CLOUDFLARE_AI_GATEWAY_TOKEN=seu_token_com_permissao_run
 
+# Optional: Enable debug-level server logs.
+DEBUG=
+
 # =============================================================================
 # REQUIRED - HubSpot CRM (para captura de leads via chatbot)
 # =============================================================================

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,17 +1,22 @@
 type LogPayload = unknown;
-type LogWriter = (prefix: string, message: string, payload?: LogPayload) => void;
+type LogMethod = 'log' | 'warn' | 'error';
 
 function isDebugEnabled(): boolean {
-    return typeof process !== 'undefined' && process.env.DEBUG === 'true';
+    if (typeof process === 'undefined') {
+        return false;
+    }
+
+    const debugValue = process.env.DEBUG;
+    return debugValue?.toLowerCase() === 'true';
 }
 
-function writeLog(writer: LogWriter, prefix: string, message: string, payload?: LogPayload): void {
+function writeLog(method: LogMethod, prefix: string, message: string, payload?: LogPayload): void {
     if (payload === undefined) {
-        writer(prefix, message);
+        console[method](prefix, message);
         return;
     }
 
-    writer(prefix, message, payload);
+    console[method](prefix, message, payload);
 }
 
 export const logger = {
@@ -20,15 +25,15 @@ export const logger = {
             return;
         }
 
-        writeLog(console.log, '[debug]', message, data);
+        writeLog('log', '[debug]', message, data);
     },
     info: (message: string, data?: LogPayload): void => {
-        writeLog(console.log, '[info]', message, data);
+        writeLog('log', '[info]', message, data);
     },
     warn: (message: string, data?: LogPayload): void => {
-        writeLog(console.warn, '[warn]', message, data);
+        writeLog('warn', '[warn]', message, data);
     },
     error: (message: string, error?: LogPayload): void => {
-        writeLog(console.error, '[error]', message, error);
+        writeLog('error', '[error]', message, error);
     },
 };

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,34 @@
+type LogPayload = unknown;
+type LogWriter = (prefix: string, message: string, payload?: LogPayload) => void;
+
+function isDebugEnabled(): boolean {
+    return typeof process !== 'undefined' && process.env.DEBUG === 'true';
+}
+
+function writeLog(writer: LogWriter, prefix: string, message: string, payload?: LogPayload): void {
+    if (payload === undefined) {
+        writer(prefix, message);
+        return;
+    }
+
+    writer(prefix, message, payload);
+}
+
+export const logger = {
+    debug: (message: string, data?: LogPayload): void => {
+        if (!isDebugEnabled()) {
+            return;
+        }
+
+        writeLog(console.log, '[debug]', message, data);
+    },
+    info: (message: string, data?: LogPayload): void => {
+        writeLog(console.log, '[info]', message, data);
+    },
+    warn: (message: string, data?: LogPayload): void => {
+        writeLog(console.warn, '[warn]', message, data);
+    },
+    error: (message: string, error?: LogPayload): void => {
+        writeLog(console.error, '[error]', message, error);
+    },
+};

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -64,3 +64,40 @@ test('logger escreve os níveis públicos com prefixos estáveis', () => {
         error.restore();
     }
 });
+
+test('logger chama métodos do console preservando o binding do objeto', () => {
+    const originalLog = console.log;
+    const calls: unknown[][] = [];
+
+    try {
+        console.log = function boundConsoleCapture(this: Console, ...args: unknown[]) {
+            assert.equal(this, console);
+            calls.push(args);
+        } as typeof console.log;
+
+        logger.info('info com binding preservado');
+
+        assert.deepEqual(calls, [['[info]', 'info com binding preservado']]);
+    } finally {
+        console.log = originalLog;
+    }
+});
+
+test('logger.debug normaliza DEBUG antes de comparar', () => {
+    const originalDebug = process.env.DEBUG;
+    const log = captureConsole('log');
+
+    try {
+        process.env.DEBUG = 'TRUE';
+        logger.debug('debug maiusculo');
+
+        assert.deepEqual(log.calls, [['[debug]', 'debug maiusculo']]);
+    } finally {
+        if (originalDebug === undefined) {
+            delete process.env.DEBUG;
+        } else {
+            process.env.DEBUG = originalDebug;
+        }
+        log.restore();
+    }
+});

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { logger } from '../lib/logger.ts';
+
+type ConsoleMethod = (...args: unknown[]) => void;
+
+function captureConsole(method: 'log' | 'warn' | 'error') {
+    const original = console[method];
+    const calls: unknown[][] = [];
+
+    console[method] = ((...args: unknown[]) => {
+        calls.push(args);
+    }) as ConsoleMethod;
+
+    return {
+        calls,
+        restore: () => {
+            console[method] = original;
+        },
+    };
+}
+
+test('logger.debug escreve apenas quando DEBUG=true', () => {
+    const originalDebug = process.env.DEBUG;
+    const log = captureConsole('log');
+
+    try {
+        delete process.env.DEBUG;
+        logger.debug('debug oculto', { source: 'test' });
+        assert.deepEqual(log.calls, []);
+
+        process.env.DEBUG = 'true';
+        logger.debug('debug visivel', { source: 'test' });
+        assert.deepEqual(log.calls, [['[debug]', 'debug visivel', { source: 'test' }]]);
+    } finally {
+        if (originalDebug === undefined) {
+            delete process.env.DEBUG;
+        } else {
+            process.env.DEBUG = originalDebug;
+        }
+        log.restore();
+    }
+});
+
+test('logger escreve os níveis públicos com prefixos estáveis', () => {
+    const log = captureConsole('log');
+    const warn = captureConsole('warn');
+    const error = captureConsole('error');
+
+    try {
+        logger.info('info sem dados');
+        logger.warn('warn com dados', { code: 'WARN_TEST' });
+        logger.error('error com causa', new Error('falha'));
+
+        assert.deepEqual(log.calls, [['[info]', 'info sem dados']]);
+        assert.deepEqual(warn.calls, [['[warn]', 'warn com dados', { code: 'WARN_TEST' }]]);
+        assert.equal(error.calls.length, 1);
+        assert.deepEqual(error.calls[0]?.slice(0, 2), ['[error]', 'error com causa']);
+        assert.ok(error.calls[0]?.[2] instanceof Error);
+    } finally {
+        log.restore();
+        warn.restore();
+        error.restore();
+    }
+});


### PR DESCRIPTION
## Summary
- Added `lib/logger.ts` with `debug`, `info`, `warn`, and `error` helpers.
- Gated `debug` output behind `DEBUG=true` while keeping public log levels stable.
- Documented the new `DEBUG=` env var in `.env.example`.
- Added unit coverage for the logger contract and console output behavior.

## Testing
- Passed new unit tests for `lib/logger.ts`.
- `pnpm test:regression` passed.
- `pnpm typecheck` passed.
- `git diff --check` passed.