### PR TITLE
Migrate API logging to the shared logger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,9 @@ HUBSPOT_DEAL_STAGE_ID=id_do_stage_deals
 # Override this in development/staging environments as needed
 # ALLOWED_ORIGIN=https://www.anhanga.tur.br
 
+# Optional: enable verbose debug logs from the shared logger.
+DEBUG=false
+
 # =============================================================================
 # REQUIRED (prod) - n8n Webhook Secret (para purchase-dispatch)
 # =============================================================================

--- a/api/generate.ts
+++ b/api/generate.ts
@@ -5,6 +5,7 @@ export const config = {
 import type { ContentListUnion } from '@google/genai';
 import { checkRateLimit } from '../lib/rate-limit';
 import { buildCorsHeaders, getClientIP } from '../lib/network';
+import { logger } from '../lib/logger';
 import { budgetTool } from '../lib/ai/tools';
 import { SYSTEM_INSTRUCTION } from '../lib/ai/prompt';
 import {
@@ -187,7 +188,10 @@ async function getRateLimitState(
         return { rateLimit };
     }
 
-    console.warn(`RATE_LIMIT: IP ${clientIP} exceeded limit. Reset in ${Math.ceil(rateLimit.resetIn / 1000)}s`);
+    logger.warn('RATE_LIMIT', {
+        clientIP,
+        retryAfterSeconds: Math.ceil(rateLimit.resetIn / 1000),
+    });
     return buildJsonResponse({
         error: 'Muitas requisições. Por favor, aguarde um momento.',
         retryAfter: Math.ceil(rateLimit.resetIn / 1000)
@@ -203,7 +207,7 @@ function buildConfigErrorResponse(
     config: Extract<GeminiProviderConfig, { ok: false }>,
     corsHeaders: Record<string, string>,
 ): Response {
-    console.error('SERVER: Gemini provider configuration is incomplete', {
+    logger.error('SERVER: Gemini provider configuration is incomplete', {
         missing: config.missing,
     });
 
@@ -214,7 +218,7 @@ function buildConfigErrorResponse(
 }
 
 function logProviderStatus(config: ResolvedGeminiProviderConfig): void {
-    console.log('SERVER: Gemini provider configured', {
+    logger.info('SERVER: Gemini provider configured', {
         modelName: config.modelName,
         useGateway: config.useGateway,
         gatewayId: config.useGateway ? config.gatewayId : undefined,
@@ -348,7 +352,7 @@ function logEmptyModelResponse(response: ModelResponseShape): void {
     const promptBlockReason = response.promptFeedback?.blockReason;
 
     if (promptBlockReason) {
-        console.warn('SERVER: Gemini blocked prompt', {
+        logger.warn('SERVER: Gemini blocked prompt', {
             blockReason: promptBlockReason,
             responseId: response.responseId,
             modelVersion: response.modelVersion,
@@ -356,7 +360,7 @@ function logEmptyModelResponse(response: ModelResponseShape): void {
         return;
     }
 
-    console.warn('SERVER: Gemini returned empty payload', {
+    logger.warn('SERVER: Gemini returned empty payload', {
         finishReason: candidate?.finishReason,
         responseId: response.responseId,
         modelVersion: response.modelVersion,
@@ -431,7 +435,7 @@ async function repairTextualHandoff(
     responseText: string,
     options: BuildGenerateSuccessOptions,
 ): Promise<GenerateSuccessBody | null> {
-    console.warn('SERVER: invalid textual handoff detected', {
+    logger.warn('SERVER: invalid textual handoff detected', {
         responseId: response.responseId,
         modelVersion: response.modelVersion,
         preview: responseText.slice(0, 160),
@@ -458,7 +462,7 @@ async function repairTextualHandoff(
     const repairedHandoff = buildStructuredHandoff(repairNormalizedOutput.responseFunctionCall, 'repair');
 
     if (repairedHandoff) {
-        console.log('SERVER: handoff repaired', {
+        logger.info('SERVER: handoff repaired', {
             responseId: response.responseId,
             repairResponseId: repairResponse.responseId,
             source: repairedHandoff.source,
@@ -471,7 +475,7 @@ async function repairTextualHandoff(
         };
     }
 
-    console.warn('SERVER: handoff repair failed', {
+    logger.warn('SERVER: handoff repair failed', {
         responseId: response.responseId,
         repairResponseId: repairResponse.responseId,
         missing: repairValidation?.missing || [],
@@ -513,7 +517,7 @@ export async function buildGenerateSuccessBody(
 
 function buildGeminiErrorResponse(error: unknown, corsHeaders: Record<string, string>): Response {
     const normalized = normalizeError(error);
-    console.error('SERVER: Error proxying to Gemini:', normalized);
+    logger.error('SERVER: Error proxying to Gemini', normalized);
 
     if (normalized.status === 401 || normalized.status === 403) {
         return buildJsonResponse({

--- a/api/submit-lead.ts
+++ b/api/submit-lead.ts
@@ -2,6 +2,7 @@ import type { SubmitLeadRequest, SubmitLeadResponse } from '../types/leadCapture
 import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import { cleanString, maskEmail, maskName, maskPhone, validatePayload } from '../lib/lead-logic';
+import { logger } from '../lib/logger';
 import { buildN8nLeadPayload } from '../lib/n8n-payloads';
 import { sendLeadToN8n } from '../services/n8n';
 
@@ -34,16 +35,16 @@ function emitLeadLog(level: LeadLogLevel, requestId: string, stage: string, deta
     };
 
     if (level === 'warn') {
-        console.warn('SUBMIT_LEAD', payload);
+        logger.warn('SUBMIT_LEAD', payload);
         return;
     }
 
     if (level === 'error') {
-        console.error('SUBMIT_LEAD', payload);
+        logger.error('SUBMIT_LEAD', payload);
         return;
     }
 
-    console.log('SUBMIT_LEAD', payload);
+    logger.info('SUBMIT_LEAD', payload);
 }
 
 function buildJsonResponse(

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,24 @@
+type LoggerData = unknown;
+
+function isDebugEnabled(): boolean {
+    return process.env.DEBUG === 'true';
+}
+
+export const logger = {
+    debug(message: string, data?: LoggerData): void {
+        if (!isDebugEnabled()) return;
+        console.log('[debug]', message, data);
+    },
+
+    info(message: string, data?: LoggerData): void {
+        console.log('[info]', message, data);
+    },
+
+    warn(message: string, data?: LoggerData): void {
+        console.warn('[warn]', message, data);
+    },
+
+    error(message: string, data?: LoggerData): void {
+        console.error('[error]', message, data);
+    },
+};

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,24 +1,35 @@
 type LoggerData = unknown;
+type ConsoleMethod = 'log' | 'info' | 'warn' | 'error';
 
 function isDebugEnabled(): boolean {
-    return process.env.DEBUG === 'true';
+    const debug = process.env.DEBUG;
+    return typeof debug === 'string' && debug.toLowerCase() === 'true';
+}
+
+function writeLog(method: ConsoleMethod, prefix: string, message: string, data?: LoggerData): void {
+    if (data !== undefined) {
+        console[method](prefix, message, data);
+        return;
+    }
+
+    console[method](prefix, message);
 }
 
 export const logger = {
     debug(message: string, data?: LoggerData): void {
         if (!isDebugEnabled()) return;
-        console.log('[debug]', message, data);
+        writeLog('log', '[debug]', message, data);
     },
 
     info(message: string, data?: LoggerData): void {
-        console.log('[info]', message, data);
+        writeLog('info', '[info]', message, data);
     },
 
     warn(message: string, data?: LoggerData): void {
-        console.warn('[warn]', message, data);
+        writeLog('warn', '[warn]', message, data);
     },
 
     error(message: string, data?: LoggerData): void {
-        console.error('[error]', message, data);
+        writeLog('error', '[error]', message, data);
     },
 };

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -5,7 +5,7 @@ import { logger } from '../lib/logger.ts';
 
 type ConsoleMethod = (...args: unknown[]) => void;
 
-function captureConsole(method: 'log' | 'warn' | 'error') {
+function captureConsole(method: 'log' | 'info' | 'warn' | 'error') {
     const original = console[method];
     const calls: unknown[][] = [];
 
@@ -44,7 +44,7 @@ test('logger.debug escreve apenas quando DEBUG=true', () => {
 });
 
 test('logger escreve os níveis públicos com prefixos estáveis', () => {
-    const log = captureConsole('log');
+    const info = captureConsole('info');
     const warn = captureConsole('warn');
     const error = captureConsole('error');
 
@@ -53,33 +53,33 @@ test('logger escreve os níveis públicos com prefixos estáveis', () => {
         logger.warn('warn com dados', { code: 'WARN_TEST' });
         logger.error('error com causa', new Error('falha'));
 
-        assert.deepEqual(log.calls, [['[info]', 'info sem dados']]);
+        assert.deepEqual(info.calls, [['[info]', 'info sem dados']]);
         assert.deepEqual(warn.calls, [['[warn]', 'warn com dados', { code: 'WARN_TEST' }]]);
         assert.equal(error.calls.length, 1);
         assert.deepEqual(error.calls[0]?.slice(0, 2), ['[error]', 'error com causa']);
         assert.ok(error.calls[0]?.[2] instanceof Error);
     } finally {
-        log.restore();
+        info.restore();
         warn.restore();
         error.restore();
     }
 });
 
 test('logger chama métodos do console preservando o binding do objeto', () => {
-    const originalLog = console.log;
+    const originalInfo = console.info;
     const calls: unknown[][] = [];
 
     try {
-        console.log = function boundConsoleCapture(this: Console, ...args: unknown[]) {
+        console.info = function boundConsoleCapture(this: Console, ...args: unknown[]) {
             assert.equal(this, console);
             calls.push(args);
-        } as typeof console.log;
+        } as typeof console.info;
 
         logger.info('info com binding preservado');
 
         assert.deepEqual(calls, [['[info]', 'info com binding preservado']]);
     } finally {
-        console.log = originalLog;
+        console.info = originalInfo;
     }
 });
 

--- a/tests/logging-migration.test.ts
+++ b/tests/logging-migration.test.ts
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const MIGRATED_API_FILES = [
+    'api/generate.ts',
+    'api/submit-lead.ts',
+];
+
+async function readProjectFile(path: string): Promise<string> {
+    return await readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+test('logger service should exist and document DEBUG gating', async () => {
+    const [loggerSource, envExample] = await Promise.all([
+        readProjectFile('lib/logger.ts'),
+        readProjectFile('.env.example'),
+    ]);
+
+    assert.match(loggerSource, /export const logger/);
+    assert.match(loggerSource, /process\.env\.DEBUG/);
+    assert.match(envExample, /^DEBUG=/m);
+});
+
+for (const filePath of MIGRATED_API_FILES) {
+    test(`${filePath} should use the shared logger instead of direct console calls`, async () => {
+        const source = await readProjectFile(filePath);
+
+        assert.match(source, /from ['"]\.\.\/lib\/logger['"]/);
+        assert.doesNotMatch(source, /\bconsole\.(?:log|warn|error)\b/);
+    });
+}

--- a/tests/logging-migration.test.ts
+++ b/tests/logging-migration.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
+import { logger } from '../lib/logger.ts';
 
 const MIGRATED_API_FILES = [
     'api/generate.ts',
@@ -22,11 +23,46 @@ test('logger service should exist and document DEBUG gating', async () => {
     assert.match(envExample, /^DEBUG=/m);
 });
 
+test('logger should normalize DEBUG and omit missing optional data', () => {
+    const originalDebug = process.env.DEBUG;
+    const originalConsoleLog = console.log;
+    const originalConsoleInfo = console.info;
+    const calls: unknown[][] = [];
+
+    console.log = ((...args: unknown[]) => {
+        calls.push(args);
+    }) as typeof console.log;
+    console.info = ((...args: unknown[]) => {
+        calls.push(args);
+    }) as typeof console.info;
+
+    try {
+        process.env.DEBUG = 'TRUE';
+
+        logger.debug('debug enabled');
+        logger.info('info without data');
+
+        assert.deepEqual(calls, [
+            ['[debug]', 'debug enabled'],
+            ['[info]', 'info without data'],
+        ]);
+    } finally {
+        console.log = originalConsoleLog;
+        console.info = originalConsoleInfo;
+
+        if (originalDebug === undefined) {
+            delete process.env.DEBUG;
+        } else {
+            process.env.DEBUG = originalDebug;
+        }
+    }
+});
+
 for (const filePath of MIGRATED_API_FILES) {
     test(`${filePath} should use the shared logger instead of direct console calls`, async () => {
         const source = await readProjectFile(filePath);
 
         assert.match(source, /from ['"]\.\.\/lib\/logger['"]/);
-        assert.doesNotMatch(source, /\bconsole\.(?:log|warn|error)\b/);
+        assert.doesNotMatch(source, /\bconsole\.(?:log|info|warn|error)\b/);
     });
 }


### PR DESCRIPTION
## Summary
- Added a shared `lib/logger.ts` with `debug` gating via `DEBUG=true`.
- Replaced ad-hoc `console.log`, `console.warn`, and `console.error` calls in `api/generate.ts` and `api/submit-lead.ts` with the shared logger.
- Documented `DEBUG=false` in `.env.example`.
- Added a regression test to verify the logger exists, is DEBUG-gated, and is used by both handlers.

## Testing
- `pnpm exec tsx --test tests/logging-migration.test.ts`
- `pnpm test:regression`
- `pnpm typecheck`
- `git diff --check`