### PR TITLE
chore: migrate console logs in geminiService and rate-limit to logger (#568)

### DIFF
--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,3 +1,5 @@
+import { logger } from './logger';
+
 export interface RateLimitResult {
   allowed: boolean;
   remaining: number;
@@ -36,7 +38,7 @@ async function getRedisClient(): Promise<RedisLike | null> {
       // isolate — the in-memory Map above resets on every request and provides
       // no real protection. Configure Upstash Redis to enable shared rate
       // limiting across all edge instances.
-      console.error(
+      logger.error(
         'RateLimit: Upstash Redis not configured. ' +
         'In-memory fallback is non-functional on edge runtimes (isolated V8 contexts per request). ' +
         'Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN in your environment variables.'
@@ -49,7 +51,7 @@ async function getRedisClient(): Promise<RedisLike | null> {
     const { Redis } = await import('@upstash/redis');
     return new Redis({ url, token });
   } catch {
-    console.warn('RateLimit: @upstash/redis not available, using in-memory fallback');
+    logger.warn('RateLimit: @upstash/redis not available, using in-memory fallback');
     return null;
   }
 }
@@ -95,7 +97,7 @@ export async function checkRateLimit(
         resetIn,
       };
     } catch (error) {
-      console.error('RateLimit: Redis error, falling back to in-memory', error);
+      logger.error('RateLimit: Redis error, falling back to in-memory', error);
       // Fallback to in-memory if Redis fails
     }
   }
@@ -133,7 +135,7 @@ function checkInMemoryRateLimit(
   }
 
   if (inMemoryStore.size >= IN_MEMORY_MAX_ENTRIES && !entry) {
-    console.warn(`RateLimit: In-memory store capacity reached. Rejecting new key for ${clientIP}.`);
+    logger.warn(`RateLimit: In-memory store capacity reached. Rejecting new key for ${clientIP}.`);
     return {
       allowed: false,
       remaining: 0,

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,6 +1,7 @@
 import { getWhatsAppLink } from "../utils/whatsapp.ts";
 import { buildGenerateHandoff, type GenerateHandoff } from "../lib/ai/handoff.ts";
 import type { BudgetToolArgs } from "../lib/ai/types.ts";
+import { logger } from "../lib/logger";
 
 interface ChatResponse {
   text?: string;
@@ -84,7 +85,7 @@ const buildServerErrorResponse = (status: number, errorData: GenerateApiResponse
 
   if (status !== 500) return null;
 
-  console.error('[GeminiService] Server error:', errorData);
+  logger.error('[GeminiService] Server error', { code: errorData.code, error: errorData.error });
   if (errorData.code === 'SERVER_CONFIG_ERROR' || errorData.code === 'GEMINI_MODEL_ERROR') {
     return buildContactFallbackResponse(
       '⚠️ O chat está com um problema de configuração no servidor. Nossa equipe já precisa revisar isso.'
@@ -174,7 +175,7 @@ function applyGenerateApiData(result: ChatResponse, data: GenerateApiResponse): 
 }
 
 function buildUnexpectedServiceError(error: unknown): ChatResponse {
-  console.error("[GeminiService] Erro ao consultar Gemini:", error);
+  logger.error('[GeminiService] Erro ao consultar Gemini', error);
   const errorMessage = getErrorMessage(error);
   const errorName = getErrorName(error);
 
@@ -210,7 +211,7 @@ export const getTravelAdvice = async (history: { role: 'user' | 'model', text: s
 
     const apiEndpoint = '/api/generate';
 
-    console.log('[GeminiService] Using endpoint:', apiEndpoint);
+    logger.debug('[GeminiService] Using endpoint', { endpoint: apiEndpoint });
 
     const response = await fetch(apiEndpoint, {
       method: 'POST',

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,7 +1,7 @@
 import { getWhatsAppLink } from "../utils/whatsapp.ts";
 import { buildGenerateHandoff, type GenerateHandoff } from "../lib/ai/handoff.ts";
 import type { BudgetToolArgs } from "../lib/ai/types.ts";
-import { logger } from "../lib/logger";
+import { logger } from "../lib/logger.ts";
 
 interface ChatResponse {
   text?: string;

--- a/tests/logging-migration.test.ts
+++ b/tests/logging-migration.test.ts
@@ -64,7 +64,7 @@ for (const filePath of MIGRATED_API_FILES) {
     test(`${filePath} should use the shared logger instead of direct console calls`, async () => {
         const source = await readProjectFile(filePath);
 
-        assert.match(source, /from ['"](?:\.\.\/lib\/|\.\/|@\/lib\/)logger['"]/);
+        assert.match(source, /from ['"](?:\.\.\/lib\/|\.\/|@\/lib\/)logger(?:\.ts)?['"]/);
         assert.doesNotMatch(source, /\bconsole\.(?:log|info|warn|error)\b/);
     });
 }

--- a/tests/logging-migration.test.ts
+++ b/tests/logging-migration.test.ts
@@ -6,6 +6,8 @@ import { logger } from '../lib/logger.ts';
 const MIGRATED_API_FILES = [
     'api/generate.ts',
     'api/submit-lead.ts',
+    'services/geminiService.ts',
+    'lib/rate-limit.ts',
 ];
 
 async function readProjectFile(path: string): Promise<string> {
@@ -62,7 +64,7 @@ for (const filePath of MIGRATED_API_FILES) {
     test(`${filePath} should use the shared logger instead of direct console calls`, async () => {
         const source = await readProjectFile(filePath);
 
-        assert.match(source, /from ['"]\.\.\/lib\/logger['"]/);
+        assert.match(source, /from ['"](?:\.\.\/lib\/|\.\/|@\/lib\/)logger['"]/);
         assert.doesNotMatch(source, /\bconsole\.(?:log|info|warn|error)\b/);
     });
 }


### PR DESCRIPTION
## Summary

- Replaces `console.error` / `console.log` / `console.warn` calls in `services/geminiService.ts` and `lib/rate-limit.ts` with the shared `logger` utility from `lib/logger.ts`
- The endpoint debug log in `geminiService` is demoted to `logger.debug` (gated by `DEBUG=true`, no-op in browser and in production by default)
- The 500 error log extracts only `code` and `error` fields from the API response to avoid logging raw upstream Gemini payloads
- Extends `tests/logging-migration.test.ts` to enforce the migration contract on both new files

## Test plan

- [x] `pnpm test:regression` — 279 tests passing (2 new migration contract tests added)
- [x] `pnpm typecheck` — clean

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)