### PR TITLE
[codex] Fix home prerender CLS

### DIFF
--- a/ssr.tsx
+++ b/ssr.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { PassThrough } from 'node:stream';
 import { renderToPipeableStream, renderToString } from 'react-dom/server';
 import App from './App';
-import { createHeadManager, renderHeadTags } from './lib/head';
+import { createHeadManager, renderHeadTags, type HeadManager } from './lib/head';
 
 export interface RenderResult {
   appHtml: string;
@@ -14,8 +14,10 @@ const parsedTimeout = Number.parseInt(process.env.SSR_TIMEOUT_MS ?? '', 10);
 const SSR_TIMEOUT_MS = Number.isFinite(parsedTimeout) && parsedTimeout > 0
   ? parsedTimeout
   : DEFAULT_SSR_TIMEOUT_MS;
+const QUERY_HASH_REGEX = /[?#]/;
+const TRAILING_SLASH_REGEX = /\/+$/;
 
-function renderApp(url: string, headManager: ReturnType<typeof createHeadManager>): React.ReactElement {
+function renderApp(url: string, headManager: HeadManager): React.ReactElement {
   return (
     <React.StrictMode>
       <App
@@ -29,10 +31,11 @@ function renderApp(url: string, headManager: ReturnType<typeof createHeadManager
 }
 
 function isHomeRoute(url: string): boolean {
-  return url === '/' || url.replace(/\/+$/, '') === '';
+  const pathname = url.split(QUERY_HASH_REGEX)[0];
+  return pathname.replace(TRAILING_SLASH_REGEX, '') === '';
 }
 
-async function renderStreamingHtml(url: string, headManager: ReturnType<typeof createHeadManager>): Promise<string> {
+async function renderStreamingHtml(url: string, headManager: HeadManager): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const stream = new PassThrough();
     let html = '';

--- a/ssr.tsx
+++ b/ssr.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PassThrough } from 'node:stream';
-import { renderToPipeableStream } from 'react-dom/server';
+import { renderToPipeableStream, renderToString } from 'react-dom/server';
 import App from './App';
 import { createHeadManager, renderHeadTags } from './lib/head';
 
@@ -15,10 +15,25 @@ const SSR_TIMEOUT_MS = Number.isFinite(parsedTimeout) && parsedTimeout > 0
   ? parsedTimeout
   : DEFAULT_SSR_TIMEOUT_MS;
 
-export async function render(url: string): Promise<RenderResult> {
-  const headManager = createHeadManager();
+function renderApp(url: string, headManager: ReturnType<typeof createHeadManager>): React.ReactElement {
+  return (
+    <React.StrictMode>
+      <App
+        router="memory"
+        initialEntries={[url]}
+        headManager={headManager}
+        includeClientFeatures={false}
+      />
+    </React.StrictMode>
+  );
+}
 
-  const appHtml = await new Promise<string>((resolve, reject) => {
+function isHomeRoute(url: string): boolean {
+  return url === '/' || url.replace(/\/+$/, '') === '';
+}
+
+async function renderStreamingHtml(url: string, headManager: ReturnType<typeof createHeadManager>): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
     const stream = new PassThrough();
     let html = '';
     let settled = false;
@@ -61,14 +76,7 @@ export async function render(url: string): Promise<RenderResult> {
     });
 
     const { pipe, abort } = renderToPipeableStream(
-      <React.StrictMode>
-        <App
-          router="memory"
-          initialEntries={[url]}
-          headManager={headManager}
-          includeClientFeatures={false}
-        />
-      </React.StrictMode>,
+      renderApp(url, headManager),
       {
         onAllReady() {
           if (startedPiping) {
@@ -91,6 +99,13 @@ export async function render(url: string): Promise<RenderResult> {
       }
     );
   });
+}
+
+export async function render(url: string): Promise<RenderResult> {
+  const headManager = createHeadManager();
+  const appHtml = isHomeRoute(url)
+    ? renderToString(renderApp(url, headManager))
+    : await renderStreamingHtml(url, headManager);
 
   return {
     appHtml,

--- a/tests/hydration.test.ts
+++ b/tests/hydration.test.ts
@@ -5,6 +5,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { ClientOnly } from '../components/ClientOnly';
 import Footer from '../components/Footer';
 import { shouldHydratePrerenderedRoute } from '../lib/hydration.ts';
+import { render } from '../ssr.tsx';
 
 function withMockedNow<T>(iso: string, callback: () => T): T {
   const RealDate = Date;
@@ -67,4 +68,18 @@ test('Footer prerender should be deterministic across different runtime dates', 
 
   assert.equal(marchMarkup, januaryMarkup);
   assert.match(marchMarkup, /https:\/\/media\.anhanga\.tur\.br\/images\/brand\/LOGO%20ANHANGA%20VIAGENS%20-%20BRANCO\.svg/);
+});
+
+test('Home prerender renders primary content before the footer without streaming reveal shifts', async () => {
+  const { appHtml } = await render('/');
+
+  assert.doesNotMatch(appHtml, /hidden id="S:/);
+  assert.doesNotMatch(appHtml, /min-h-\[40vh\] bg-white/);
+
+  const heroIndex = appHtml.indexOf('Sua Próxima');
+  const footerIndex = appHtml.indexOf('<footer');
+
+  assert.notEqual(heroIndex, -1);
+  assert.notEqual(footerIndex, -1);
+  assert.ok(heroIndex < footerIndex);
 });

--- a/tests/hydration.test.ts
+++ b/tests/hydration.test.ts
@@ -83,3 +83,15 @@ test('Home prerender renders primary content before the footer without streaming
   assert.notEqual(footerIndex, -1);
   assert.ok(heroIndex < footerIndex);
 });
+
+test('Home prerender keeps the CLS-safe path when URL contains tracking query or hash', async () => {
+  const urls = ['/?utm_source=review', '/#contato'];
+
+  for (const url of urls) {
+    const { appHtml } = await render(url);
+
+    assert.doesNotMatch(appHtml, /hidden id="S:/);
+    assert.doesNotMatch(appHtml, /min-h-\[40vh\] bg-white/);
+    assert.match(appHtml, /Sua Próxima/);
+  }
+});


### PR DESCRIPTION
## Summary
- Fixes the home prerender path so the primary home content is emitted before the global footer.
- Keeps streaming SSR for the other lazy routes, while using static SSR for `/` to avoid the footer-first reveal shift.
- Adds regression coverage to prevent the home prerender from shipping only the route fallback before the footer again.

## Root Cause
The prerendered home HTML was produced through React streaming markup where the shell placed a `40vh` route fallback in `<main>`, rendered the footer immediately after it, and then injected the actual home content through a hidden streaming reveal block. In field CLS reports, the footer was reported as the shifted element because it appeared too early and then got pushed down when the real home content was revealed.

## Validation
- `pnpm exec tsx --test tests/hydration.test.ts`
- `pnpm build`
- `pnpm test:regression`
- `pnpm typecheck`
- Local preview at `http://localhost:4173/`
- Local CLS probe at `1877x1068`: `0.0029`
