### PR TITLE
security: remove dangerouslySetInnerHTML from PassportStamp (#558)

### DIFF
--- a/components/ui/PassportStamp.tsx
+++ b/components/ui/PassportStamp.tsx
@@ -26,20 +26,29 @@ export const PassportStamp: React.FC<PassportStampProps> = ({
     // Random rotation between -15 and 15 degrees for an organic look
     const rotation = React.useMemo(() => Math.floor(Math.random() * 30) - 15, []);
 
+    // Unique animation name per instance so concurrent stamps don't overwrite each other's keyframes
+    const uid = React.useId().replace(/:/g, '');
+    const animName = `stamp-${uid}`;
+
+    React.useEffect(() => {
+        const style = document.createElement('style');
+        style.textContent = `
+      @keyframes ${animName} {
+        0% { transform: scale(2) rotate(${rotation - 10}deg); opacity: 0; }
+        50% { transform: scale(0.9) rotate(${rotation}deg); opacity: 0.9; }
+        100% { transform: scale(1) rotate(${rotation}deg); opacity: 0.60; }
+      }
+    `;
+        document.head.appendChild(style);
+        return () => { document.head.removeChild(style); };
+    }, [animName, rotation]);
+
     return (
         <div
-            className={`pointer-events-none select-none absolute z-20 opacity-60 flex items-center justify-center animate-[stamp_0.4s_cubic-bezier(0.16,1,0.3,1)_forwards] ${className}`}
-            style={{ transform: `rotate(${rotation}deg)` }}
+            className={`pointer-events-none select-none absolute z-20 opacity-60 flex items-center justify-center ${className}`}
+            style={{ transform: `rotate(${rotation}deg)`, animation: `${animName} 0.4s cubic-bezier(0.16,1,0.3,1) forwards` }}
             aria-hidden="true"
         >
-            <style dangerouslySetInnerHTML={{
-                __html: `
-        @keyframes stamp {
-          0% { transform: scale(2) rotate(${rotation - 10}deg); opacity: 0; }
-          50% { transform: scale(0.9) rotate(${rotation}deg); opacity: 0.9; }
-          100% { transform: scale(1) rotate(${rotation}deg); opacity: 0.60; }
-        }
-      `}} />
 
             <div className="relative size-24 md:size-28 shrink-0">
                 {/* Outer distressed ring */}

--- a/pages/Privacy.tsx
+++ b/pages/Privacy.tsx
@@ -360,7 +360,7 @@ const Privacy = () => {
                 </article>
             </main>
 
-            {/* Structured Data */}
+            {/* Structured Data — safe: JSON.stringify of a static object literal, no user input */}
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{

--- a/pages/Terms.tsx
+++ b/pages/Terms.tsx
@@ -262,7 +262,7 @@ const Terms = () => {
                 </article>
             </main>
 
-            {/* Structured Data */}
+            {/* Structured Data — safe: JSON.stringify of a static object literal, no user input */}
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Resumo

- **`components/ui/PassportStamp.tsx`** — substitui `<style dangerouslySetInnerHTML>` por `useEffect` que cria/remove um `<style>` element via API DOM. Usa `React.useId()` para nomear o `@keyframes` de forma única por instância (`stamp-r0`, `stamp-r1`…), evitando colisão de keyframes quando múltiplos selos aparecem no chat simultaneamente.
- **`pages/Privacy.tsx` e `pages/Terms.tsx`** — mantém o `dangerouslySetInnerHTML` existente (correto para `<script type="application/ld+json">` com `JSON.stringify()` de objetos estáticos). Adiciona comentário documentando a segurança conforme exigido pelo `security.md`. DOMPurify foi descartado: ele sanitiza HTML, não JSON — aplicá-lo aqui quebraria o payload para o Google.

Closes #558

## Desvio intencional do checklist da issue

A issue pedia instalação de `dompurify` em Privacy/Terms. O `dangerouslySetInnerHTML` nesses arquivos está em `<script type="application/ld+json">` com conteúdo totalmente estático — sem entrada de usuário, sem HTML renderizado no DOM. O `security.md` do projeto cobre explicitamente esse caso como exceção permitida, exigindo apenas documentação inline.

## Plano de testes

- [x] `pnpm typecheck` — sem erros
- [x] `pnpm test:regression` — 279 testes, 0 falhas
- [ ] Verificação visual: abrir o chatbot, gerar uma resposta de destino e confirmar que a animação do PassportStamp ainda funciona corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)