### PR TITLE
test: add unit tests for API handlers and shared lib

### DIFF
--- a/api/generate.ts
+++ b/api/generate.ts
@@ -519,7 +519,7 @@ export async function buildGenerateSuccessBody(
     };
 }
 
-function buildGeminiErrorResponse(error: unknown, corsHeaders: Record<string, string>): Response {
+export function buildGeminiErrorResponse(error: unknown, corsHeaders: Record<string, string>): Response {
     const normalized = normalizeError(error);
     logger.error('SERVER: Error proxying to Gemini', normalized);
 

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -228,7 +228,7 @@ function buildSubmitLeadPayload(
     };
 }
 
-function isPreparedSubmitLeadRequest(value: LeadDraftPartial | SubmitLeadRequest): value is SubmitLeadRequest {
+export function isPreparedSubmitLeadRequest(value: LeadDraftPartial | SubmitLeadRequest): value is SubmitLeadRequest {
     const candidate = value as Partial<SubmitLeadRequest>;
 
     return Boolean(

--- a/tests/api-generate.test.ts
+++ b/tests/api-generate.test.ts
@@ -1,0 +1,239 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler, { buildGeminiErrorResponse } from '../api/generate.ts';
+import { buildCorsHeaders } from '../lib/network.ts';
+
+const originalEnv = {
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+    AI_GATEWAY_ENABLED: process.env.AI_GATEWAY_ENABLED,
+    CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,
+    CLOUDFLARE_AI_GATEWAY_TOKEN: process.env.CLOUDFLARE_AI_GATEWAY_TOKEN,
+};
+
+function restoreEnv() {
+    for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+            delete process.env[key];
+        } else {
+            process.env[key] = value;
+        }
+    }
+}
+
+function buildPostRequest(body: unknown, ip?: string): Request {
+    const suffix = Math.floor(Math.random() * 200) + 1;
+    return new Request('http://localhost/api/generate', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-real-ip': ip ?? `192.168.1.${suffix}`,
+        },
+        body: JSON.stringify(body),
+    });
+}
+
+function validBody() {
+    return {
+        contents: [{ role: 'user', parts: [{ text: 'Quero ir para Maldivas.' }] }],
+    };
+}
+
+// ─── Method gate ─────────────────────────────────────────────────────────────
+
+test('generate handler returns 204 for OPTIONS preflight', async () => {
+    const response = await handler(new Request('http://localhost/api/generate', { method: 'OPTIONS' }));
+    assert.equal(response.status, 204);
+});
+
+test('generate handler returns 405 for GET requests', async () => {
+    const response = await handler(new Request('http://localhost/api/generate', { method: 'GET' }));
+    assert.equal(response.status, 405);
+
+    const body = await response.json() as { error: string };
+    assert.equal(body.error, 'Method not allowed');
+});
+
+// ─── Validation errors ───────────────────────────────────────────────────────
+
+test('generate handler returns 400 VALIDATION_ERROR for empty contents array', async (t) => {
+    t.after(restoreEnv);
+
+    process.env.GEMINI_API_KEY = 'test-key';
+    delete process.env.AI_GATEWAY_ENABLED;
+
+    const response = await handler(buildPostRequest({ contents: [] }));
+    const body = await response.json() as { error: string };
+
+    assert.equal(response.status, 400);
+    assert.equal(body.error, 'VALIDATION_ERROR');
+});
+
+test('generate handler returns 400 VALIDATION_ERROR for missing contents field', async (t) => {
+    t.after(restoreEnv);
+
+    process.env.GEMINI_API_KEY = 'test-key';
+    delete process.env.AI_GATEWAY_ENABLED;
+
+    const response = await handler(buildPostRequest({}));
+    const body = await response.json() as { error: string };
+
+    assert.equal(response.status, 400);
+    assert.equal(body.error, 'VALIDATION_ERROR');
+});
+
+test('generate handler returns 400 VALIDATION_ERROR for contents exceeding 50 entries', async (t) => {
+    t.after(restoreEnv);
+
+    process.env.GEMINI_API_KEY = 'test-key';
+    delete process.env.AI_GATEWAY_ENABLED;
+
+    const contents = Array.from({ length: 51 }, (_, i) => ({
+        role: i % 2 === 0 ? 'user' : 'model',
+        parts: [{ text: 'mensagem' }],
+    }));
+
+    const response = await handler(buildPostRequest({ contents }));
+    const body = await response.json() as { error: string };
+
+    assert.equal(response.status, 400);
+    assert.equal(body.error, 'VALIDATION_ERROR');
+});
+
+test('generate handler returns 400 for malformed JSON body', async (t) => {
+    t.after(restoreEnv);
+
+    process.env.GEMINI_API_KEY = 'test-key';
+    delete process.env.AI_GATEWAY_ENABLED;
+
+    const response = await handler(new Request('http://localhost/api/generate', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-real-ip': '192.168.2.1',
+        },
+        body: '{ invalid json',
+    }));
+
+    assert.equal(response.status, 400);
+});
+
+// ─── Rate limiting ────────────────────────────────────────────────────────────
+
+test('generate handler returns 429 after exceeding rate limit', async (t) => {
+    t.after(restoreEnv);
+
+    process.env.GEMINI_API_KEY = 'test-key';
+    delete process.env.AI_GATEWAY_ENABLED;
+
+    const sharedIp = `172.16.${Math.floor(Math.random() * 254) + 1}.1`;
+
+    const makeRequest = () => new Request('http://localhost/api/generate', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-real-ip': sharedIp,
+        },
+        body: JSON.stringify(validBody()),
+    });
+
+    // The handler calls Gemini after rate limit check; to avoid that, we use
+    // an invalid config so it returns 500 before touching the AI provider.
+    // The rate limiter still increments on every request (including 5xx).
+    delete process.env.GEMINI_API_KEY;
+
+    for (let i = 0; i < 10; i++) {
+        await handler(makeRequest());
+    }
+
+    const limited = await handler(makeRequest());
+    const body = await limited.json() as { error: string };
+
+    assert.equal(limited.status, 429);
+    assert.match(body.error, /Muitas requisições/i);
+    assert.ok(limited.headers.get('Retry-After'), 'Retry-After header must be set');
+    assert.ok(limited.headers.get('X-RateLimit-Remaining'), 'X-RateLimit-Remaining must be set');
+});
+
+// ─── Config error ────────────────────────────────────────────────────────────
+
+test('generate handler returns 500 SERVER_CONFIG_ERROR when GEMINI_API_KEY is missing', async (t) => {
+    t.after(restoreEnv);
+
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.AI_GATEWAY_ENABLED;
+
+    const response = await handler(buildPostRequest(validBody()));
+    const body = await response.json() as { code: string };
+
+    assert.equal(response.status, 500);
+    assert.equal(body.code, 'SERVER_CONFIG_ERROR');
+});
+
+// ─── Gemini error mapping (via buildGeminiErrorResponse) ─────────────────────
+
+test('buildGeminiErrorResponse maps 401 to GEMINI_AUTH_ERROR', () => {
+    const corsHeaders = buildCorsHeaders();
+    const error = { status: 401, message: 'Unauthorized' };
+
+    const response = buildGeminiErrorResponse(error, corsHeaders);
+
+    assert.equal(response.status, 401);
+});
+
+test('buildGeminiErrorResponse maps 403 to GEMINI_AUTH_ERROR', async () => {
+    const corsHeaders = buildCorsHeaders();
+    const error = { status: 403, message: 'Forbidden' };
+
+    const response = buildGeminiErrorResponse(error, corsHeaders);
+    const body = await response.json() as { code: string; error: string };
+
+    assert.equal(response.status, 401);
+    assert.equal(body.code, 'GEMINI_AUTH_ERROR');
+    assert.ok(!body.error.toLowerCase().includes('forbidden'), 'must not leak raw error details');
+});
+
+test('buildGeminiErrorResponse maps 429 to GEMINI_RATE_LIMIT', async () => {
+    const corsHeaders = buildCorsHeaders();
+    const error = { status: 429, message: 'Too Many Requests' };
+
+    const response = buildGeminiErrorResponse(error, corsHeaders);
+    const body = await response.json() as { code: string; error: string };
+
+    assert.equal(response.status, 429);
+    assert.equal(body.code, 'GEMINI_RATE_LIMIT');
+    assert.ok(!body.error.toLowerCase().includes('too many'), 'must not leak raw error details');
+});
+
+test('buildGeminiErrorResponse maps 500+ to GEMINI_UPSTREAM_ERROR without leaking details', async () => {
+    const corsHeaders = buildCorsHeaders();
+    const error = { status: 503, message: 'Service Unavailable — upstream overloaded' };
+
+    const response = buildGeminiErrorResponse(error, corsHeaders);
+    const body = await response.json() as { code: string; error: string };
+
+    assert.equal(response.status, 503);
+    assert.equal(body.code, 'GEMINI_UPSTREAM_ERROR');
+    assert.ok(!body.error.includes('upstream overloaded'), 'must not leak raw upstream error');
+});
+
+test('buildGeminiErrorResponse maps 404 with model message to GEMINI_MODEL_ERROR', async () => {
+    const corsHeaders = buildCorsHeaders();
+    const error = { status: 404, message: 'model not found: gemini-99-flash' };
+
+    const response = buildGeminiErrorResponse(error, corsHeaders);
+    const body = await response.json() as { code: string };
+
+    assert.equal(response.status, 500);
+    assert.equal(body.code, 'GEMINI_MODEL_ERROR');
+});
+
+test('buildGeminiErrorResponse maps unknown errors to GEMINI_INTERNAL_ERROR', async () => {
+    const corsHeaders = buildCorsHeaders();
+    const error = { message: 'something unexpected happened' };
+
+    const response = buildGeminiErrorResponse(error, corsHeaders);
+    const body = await response.json() as { code: string };
+
+    assert.equal(response.status, 500);
+    assert.equal(body.code, 'GEMINI_INTERNAL_ERROR');
+});

--- a/tests/api-generate.test.ts
+++ b/tests/api-generate.test.ts
@@ -125,7 +125,7 @@ test('generate handler returns 429 after exceeding rate limit', async (t) => {
     process.env.GEMINI_API_KEY = 'test-key';
     delete process.env.AI_GATEWAY_ENABLED;
 
-    const sharedIp = `172.16.${Math.floor(Math.random() * 254) + 1}.1`;
+    const sharedIp = `172.16.${Math.floor(Math.random() * 254) + 1}.${Math.floor(Math.random() * 254) + 1}`;
 
     const makeRequest = () => new Request('http://localhost/api/generate', {
         method: 'POST',

--- a/tests/hooks-useLeadCapture.test.ts
+++ b/tests/hooks-useLeadCapture.test.ts
@@ -1,0 +1,199 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    isPreparedSubmitLeadRequest,
+    extractUtms,
+    buildLeadWhatsAppMessage,
+    createLeadEventId,
+    type LeadDraft,
+} from '../hooks/useLeadCapture.ts';
+import type { SubmitLeadRequest } from '../types/leadCapture.ts';
+
+function validPayload(overrides?: Partial<SubmitLeadRequest>): SubmitLeadRequest {
+    return {
+        firstName: 'Maria',
+        lastName: 'Silva',
+        email: 'maria@example.com',
+        whatsapp: '+5511988314487',
+        bantSummary: 'Need: praia | Authority: casal | Budget: 15k | Timeline: outubro',
+        destination: 'Porto de Galinhas',
+        utms: {
+            utm_source: 'google',
+            utm_medium: 'cpc',
+            utm_campaign: 'praia',
+            utm_term: null,
+            utm_content: null,
+        },
+        tracking: {
+            utm_source: 'google',
+            utm_medium: 'cpc',
+            utm_campaign: 'praia',
+            utm_term: null,
+            utm_content: null,
+            cid: null,
+            sid: null,
+            gclid: null,
+            fbclid: null,
+            msclkid: null,
+            ttclid: null,
+            wbraid: null,
+            gbraid: null,
+            fbc: null,
+            fbp: null,
+        },
+        ...overrides,
+    };
+}
+
+// ─── isPreparedSubmitLeadRequest ─────────────────────────────────────────────
+
+test('isPreparedSubmitLeadRequest returns true for a complete valid payload', () => {
+    assert.equal(isPreparedSubmitLeadRequest(validPayload()), true);
+});
+
+test('isPreparedSubmitLeadRequest returns false when email is missing', () => {
+    const payload = { ...validPayload(), email: undefined } as unknown as SubmitLeadRequest;
+    assert.equal(isPreparedSubmitLeadRequest(payload), false);
+});
+
+test('isPreparedSubmitLeadRequest returns false for null', () => {
+    assert.equal(isPreparedSubmitLeadRequest(null as unknown as SubmitLeadRequest), false);
+});
+
+test('isPreparedSubmitLeadRequest returns false for primitive values', () => {
+    assert.equal(isPreparedSubmitLeadRequest(42 as unknown as SubmitLeadRequest), false);
+    assert.equal(isPreparedSubmitLeadRequest('string' as unknown as SubmitLeadRequest), false);
+});
+
+test('isPreparedSubmitLeadRequest returns false when utms is missing', () => {
+    const payload = { ...validPayload(), utms: undefined } as unknown as SubmitLeadRequest;
+    assert.equal(isPreparedSubmitLeadRequest(payload), false);
+});
+
+test('isPreparedSubmitLeadRequest passes even when optional UTM fields are null', () => {
+    const payload = validPayload({
+        utms: {
+            utm_source: null,
+            utm_medium: null,
+            utm_campaign: null,
+            utm_term: null,
+            utm_content: null,
+        },
+    });
+    assert.equal(isPreparedSubmitLeadRequest(payload), true);
+});
+
+test('isPreparedSubmitLeadRequest passes without event_id (optional field)', () => {
+    const payload = validPayload({ event_id: undefined });
+    assert.equal(isPreparedSubmitLeadRequest(payload), true);
+});
+
+// ─── extractUtms ─────────────────────────────────────────────────────────────
+
+test('extractUtms extracts UTM fields from a tracking object', () => {
+    const tracking = {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        utm_campaign: 'summer',
+        utm_term: 'praia',
+        utm_content: 'ad-1',
+        cid: 'cid-123',
+        sid: null,
+        gclid: null,
+        fbclid: null,
+        msclkid: null,
+        ttclid: null,
+        wbraid: null,
+        gbraid: null,
+        fbc: null,
+        fbp: null,
+    };
+
+    const result = extractUtms(tracking);
+
+    assert.equal(result.utm_source, 'google');
+    assert.equal(result.utm_medium, 'cpc');
+    assert.equal(result.utm_campaign, 'summer');
+    assert.equal(result.utm_term, 'praia');
+    assert.equal(result.utm_content, 'ad-1');
+    assert.equal('cid' in result, false, 'extractUtms should not include non-UTM fields');
+});
+
+test('extractUtms preserves null UTM values', () => {
+    const tracking = {
+        utm_source: null,
+        utm_medium: null,
+        utm_campaign: null,
+        utm_term: null,
+        utm_content: null,
+        cid: null,
+        sid: null,
+        gclid: null,
+        fbclid: null,
+        msclkid: null,
+        ttclid: null,
+        wbraid: null,
+        gbraid: null,
+        fbc: null,
+        fbp: null,
+    };
+
+    const result = extractUtms(tracking);
+
+    assert.equal(result.utm_source, null);
+    assert.equal(result.utm_medium, null);
+});
+
+// ─── buildLeadWhatsAppMessage ─────────────────────────────────────────────────
+
+test('buildLeadWhatsAppMessage includes origin, destination, and dates', () => {
+    const lead: LeadDraft = {
+        firstName: 'Ana',
+        lastName: 'Lima',
+        email: 'ana@example.com',
+        whatsapp: '+5521988001234',
+        bantSummary: 'Need: aventura',
+        origin: 'Rio de Janeiro',
+        destination: 'Chapada dos Veadeiros',
+        dates: 'novembro 2026',
+        baggagePreference: '',
+    };
+
+    const message = buildLeadWhatsAppMessage(lead);
+
+    assert.match(message, /Rio de Janeiro/);
+    assert.match(message, /Chapada dos Veadeiros/);
+    assert.match(message, /novembro 2026/);
+});
+
+test('buildLeadWhatsAppMessage uses fallback text when origin or destination is empty', () => {
+    const lead: LeadDraft = {
+        firstName: 'Carlos',
+        lastName: 'Mota',
+        email: '',
+        whatsapp: '',
+        bantSummary: '',
+        origin: '',
+        destination: '',
+        dates: '',
+        baggagePreference: '',
+    };
+
+    const message = buildLeadWhatsAppMessage(lead);
+
+    assert.match(message, /A definir/);
+});
+
+// ─── createLeadEventId ────────────────────────────────────────────────────────
+
+test('createLeadEventId returns a non-empty string prefixed with lead_', () => {
+    const id = createLeadEventId();
+    assert.equal(typeof id, 'string');
+    assert.match(id, /^lead_/);
+    assert.ok(id.length > 5);
+});
+
+test('createLeadEventId generates unique IDs on successive calls', () => {
+    const ids = new Set(Array.from({ length: 10 }, () => createLeadEventId()));
+    assert.equal(ids.size, 10, 'each call should produce a unique ID');
+});

--- a/tests/lib-lead-logic.test.ts
+++ b/tests/lib-lead-logic.test.ts
@@ -1,0 +1,186 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    normalizeWhatsappNumber,
+    maskEmail,
+    maskPhone,
+    maskName,
+    normalizeNullable,
+    normalizeUtms,
+    normalizeTracking,
+} from '../lib/lead-logic.ts';
+
+// ─── normalizeWhatsappNumber ─────────────────────────────────────────────────
+
+test('normalizeWhatsappNumber normalizes a Brazilian number with spaces and dashes', () => {
+    assert.equal(normalizeWhatsappNumber(' (11) 98831-4487 '), '+5511988314487');
+});
+
+test('normalizeWhatsappNumber normalizes a number already prefixed with +55', () => {
+    assert.equal(normalizeWhatsappNumber('+55 (11) 98831-4487'), '+5511988314487');
+});
+
+test('normalizeWhatsappNumber normalizes a raw 11-digit number without country code', () => {
+    // 11 digits → prepends 55 → 13 digits total → valid
+    assert.equal(normalizeWhatsappNumber('11988314487'), '+5511988314487');
+});
+
+test('normalizeWhatsappNumber accepts a number starting with country code digits', () => {
+    // digits already start with '55', kept as-is
+    assert.equal(normalizeWhatsappNumber('5511988314487'), '+5511988314487');
+});
+
+test('normalizeWhatsappNumber accepts a non-Brazilian international number', () => {
+    // Starts with '+', digits used as-is: 11 digits → valid
+    assert.equal(normalizeWhatsappNumber('+12025551234'), '+12025551234');
+});
+
+test('normalizeWhatsappNumber returns null for a number with too few digits', () => {
+    // 5 raw digits + '55' = 7 digits → below MIN_PHONE_DIGITS (10)
+    assert.equal(normalizeWhatsappNumber('12345'), null);
+});
+
+test('normalizeWhatsappNumber returns null for a number with too many digits', () => {
+    // 16 digits → exceeds MAX_PHONE_DIGITS (15)
+    assert.equal(normalizeWhatsappNumber('1234567890123456'), null);
+});
+
+test('normalizeWhatsappNumber returns null for non-string input', () => {
+    assert.equal(normalizeWhatsappNumber(null), null);
+    assert.equal(normalizeWhatsappNumber(undefined), null);
+    assert.equal(normalizeWhatsappNumber(11988314487), null);
+});
+
+test('normalizeWhatsappNumber returns null for empty string', () => {
+    assert.equal(normalizeWhatsappNumber(''), null);
+    assert.equal(normalizeWhatsappNumber('   '), null);
+});
+
+// ─── maskEmail ───────────────────────────────────────────────────────────────
+
+test('maskEmail masks the local part keeping only first character', () => {
+    assert.equal(maskEmail('felipe@example.com'), 'f***@example.com');
+});
+
+test('maskEmail returns hidden for malformed email without @', () => {
+    assert.equal(maskEmail('notanemail'), 'hidden');
+});
+
+// ─── maskPhone ───────────────────────────────────────────────────────────────
+
+test('maskPhone masks middle digits keeping first 3 and last 3', () => {
+    assert.equal(maskPhone('+5511988314487'), '+55***487');
+});
+
+test('maskPhone returns *** for very short phone', () => {
+    assert.equal(maskPhone('123'), '***');
+});
+
+// ─── maskName ────────────────────────────────────────────────────────────────
+
+test('maskName keeps only first character', () => {
+    assert.equal(maskName('Felipe'), 'F***');
+});
+
+test('maskName returns *** for empty string', () => {
+    assert.equal(maskName(''), '***');
+    assert.equal(maskName('   '), '***');
+});
+
+// ─── normalizeNullable with control characters and whitespace ────────────────
+
+test('normalizeNullable trims and returns null for whitespace-only input', () => {
+    assert.equal(normalizeNullable('   '), null);
+    assert.equal(normalizeNullable('\t\n'), null);
+});
+
+test('normalizeNullable escapes HTML entities in the value', () => {
+    assert.equal(normalizeNullable('<b>test</b>'), '&lt;b&gt;test&lt;/b&gt;');
+});
+
+// ─── normalizeUtms ───────────────────────────────────────────────────────────
+
+test('normalizeUtms extracts standard UTM parameters', () => {
+    const result = normalizeUtms({
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        utm_campaign: 'trip',
+        utm_term: 'rio',
+        utm_content: 'ad-1',
+    });
+
+    assert.equal(result.utm_source, 'google');
+    assert.equal(result.utm_medium, 'cpc');
+    assert.equal(result.utm_campaign, 'trip');
+    assert.equal(result.utm_term, 'rio');
+    assert.equal(result.utm_content, 'ad-1');
+});
+
+test('normalizeUtms returns null for absent UTM fields', () => {
+    const result = normalizeUtms({});
+
+    assert.equal(result.utm_source, null);
+    assert.equal(result.utm_medium, null);
+    assert.equal(result.utm_campaign, null);
+    assert.equal(result.utm_term, null);
+    assert.equal(result.utm_content, null);
+});
+
+test('normalizeUtms returns null fields for non-object input', () => {
+    const result = normalizeUtms(null);
+
+    assert.equal(result.utm_source, null);
+    assert.equal(result.utm_medium, null);
+});
+
+// ─── normalizeTracking with null/undefined BANT-like fields ─────────────────
+
+test('normalizeTracking handles null and undefined tracking values without throwing', () => {
+    const utms = { utm_source: null, utm_medium: null, utm_campaign: null, utm_term: null, utm_content: null };
+
+    const result = normalizeTracking({
+        utm_source: null,
+        cid: undefined,
+        gclid: null,
+        fbp: undefined,
+    }, utms);
+
+    assert.equal(result.utm_source, null);
+    assert.equal(result.cid, null);
+    assert.equal(result.gclid, null);
+    assert.equal(result.fbp, null);
+    assert.equal(result.extras, undefined);
+});
+
+test('normalizeTracking sanitizes XSS in tracking keys and values', () => {
+    const utms = { utm_source: null, utm_medium: null, utm_campaign: null, utm_term: null, utm_content: null };
+
+    const result = normalizeTracking({
+        extras: {
+            '<script>key</script>': '<img src=x onerror=alert(1)>',
+        },
+    }, utms);
+
+    const extraKeys = Object.keys(result.extras ?? {});
+    assert.ok(extraKeys.every((k) => !k.includes('<')), 'extra keys must be sanitized');
+    assert.ok(
+        Object.values(result.extras ?? {}).every((v) => !v.includes('<')),
+        'extra values must be sanitized',
+    );
+});
+
+test('normalizeTracking falls back to UTMs for missing tracking UTM fields', () => {
+    const utms = {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        utm_campaign: 'summer',
+        utm_term: null,
+        utm_content: null,
+    };
+
+    const result = normalizeTracking({}, utms);
+
+    assert.equal(result.utm_source, 'google');
+    assert.equal(result.utm_medium, 'cpc');
+    assert.equal(result.utm_campaign, 'summer');
+});

--- a/tests/lib-rate-limit.test.ts
+++ b/tests/lib-rate-limit.test.ts
@@ -1,0 +1,126 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { checkRateLimit } from '../lib/rate-limit.ts';
+
+// Force in-memory fallback for all tests in this file
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+function uid(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+test('rate limit allows first request in window', async () => {
+    const result = await checkRateLimit(`10.0.0.${uid()}`, {
+        limit: 5,
+        windowMs: 60_000,
+        prefix: `test-rl-first-${uid()}`,
+    });
+
+    assert.equal(result.allowed, true);
+    assert.equal(result.remaining, 4);
+    assert.ok(result.resetIn > 0);
+});
+
+test('rate limit allows all requests within limit', async () => {
+    const ip = `10.1.0.${uid()}`;
+    const prefix = `test-rl-within-${uid()}`;
+    const limit = 3;
+
+    for (let i = 0; i < limit; i++) {
+        const result = await checkRateLimit(ip, { limit, windowMs: 60_000, prefix });
+        assert.equal(result.allowed, true, `request ${i + 1} should be allowed`);
+    }
+});
+
+test('rate limit blocks request that exceeds limit and returns retryAfter', async () => {
+    const ip = `10.2.0.${uid()}`;
+    const prefix = `test-rl-exceed-${uid()}`;
+
+    for (let i = 0; i < 3; i++) {
+        await checkRateLimit(ip, { limit: 3, windowMs: 60_000, prefix });
+    }
+
+    const exceeded = await checkRateLimit(ip, { limit: 3, windowMs: 60_000, prefix });
+
+    assert.equal(exceeded.allowed, false);
+    assert.equal(exceeded.remaining, 0);
+    assert.ok(exceeded.resetIn > 0, 'resetIn should indicate when to retry');
+});
+
+test('rate limit correctly decrements remaining count on each request', async () => {
+    const ip = `10.3.0.${uid()}`;
+    const prefix = `test-rl-decrement-${uid()}`;
+    const limit = 5;
+
+    for (let i = 0; i < limit; i++) {
+        const result = await checkRateLimit(ip, { limit, windowMs: 60_000, prefix });
+        assert.equal(result.remaining, limit - (i + 1));
+    }
+});
+
+test('rate limit resets counter after window expires', async () => {
+    const ip = `10.4.0.${uid()}`;
+    const prefix = `test-rl-reset-${uid()}`;
+
+    // Exhaust limit with a short window
+    for (let i = 0; i < 2; i++) {
+        await checkRateLimit(ip, { limit: 2, windowMs: 10, prefix });
+    }
+
+    const blocked = await checkRateLimit(ip, { limit: 2, windowMs: 10, prefix });
+    assert.equal(blocked.allowed, false);
+
+    // Wait for window to expire
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const fresh = await checkRateLimit(ip, { limit: 2, windowMs: 10, prefix });
+    assert.equal(fresh.allowed, true, 'should be allowed in new window');
+    assert.equal(fresh.remaining, 1);
+});
+
+test('in-memory fallback works correctly without Redis configured', async () => {
+    // UPSTASH env vars are already deleted at top of file
+    const ip = `10.5.0.${uid()}`;
+    const prefix = `test-rl-fallback-${uid()}`;
+
+    const r1 = await checkRateLimit(ip, { limit: 2, windowMs: 60_000, prefix });
+    assert.equal(r1.allowed, true);
+    assert.equal(r1.remaining, 1);
+
+    const r2 = await checkRateLimit(ip, { limit: 2, windowMs: 60_000, prefix });
+    assert.equal(r2.allowed, true);
+    assert.equal(r2.remaining, 0);
+
+    const r3 = await checkRateLimit(ip, { limit: 2, windowMs: 60_000, prefix });
+    assert.equal(r3.allowed, false);
+});
+
+test('in-memory store GC runs when size exceeds 2000 and cleans expired entries', async () => {
+    // Create 2100 entries with a 1ms window so they expire almost immediately.
+    // The store accumulates entries from all tests in this process, so total
+    // size will exceed the GC threshold (2000) once these are added.
+    const gcPrefix = `test-rl-gc-${uid()}`;
+
+    for (let i = 0; i < 2100; i++) {
+        await checkRateLimit(`gc-ip-${i}-${uid()}`, {
+            limit: 1,
+            windowMs: 1,
+            prefix: gcPrefix,
+        });
+    }
+
+    // Wait for entries to expire
+    await new Promise((resolve) => setTimeout(resolve, 15));
+
+    // This call triggers GC (store.size > 2000). After cleanup, the new
+    // request should go through normally since it's a fresh key.
+    const result = await checkRateLimit(`gc-trigger-${uid()}`, {
+        limit: 5,
+        windowMs: 60_000,
+        prefix: `test-rl-post-gc-${uid()}`,
+    });
+
+    assert.equal(result.allowed, true);
+    assert.equal(result.remaining, 4);
+});

--- a/tests/lib-rate-limit.test.ts
+++ b/tests/lib-rate-limit.test.ts
@@ -2,15 +2,33 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { checkRateLimit } from '../lib/rate-limit.ts';
 
-// Force in-memory fallback for all tests in this file
-delete process.env.UPSTASH_REDIS_REST_URL;
-delete process.env.UPSTASH_REDIS_REST_TOKEN;
-
 function uid(): string {
     return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-test('rate limit allows first request in window', async () => {
+/** Deletes UPSTASH env vars for the duration of a test and restores them in after(). */
+function useInMemoryFallback(t: { after: (fn: () => void) => void }): void {
+    const savedUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const savedToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    t.after(() => {
+        if (savedUrl === undefined) {
+            delete process.env.UPSTASH_REDIS_REST_URL;
+        } else {
+            process.env.UPSTASH_REDIS_REST_URL = savedUrl;
+        }
+        if (savedToken === undefined) {
+            delete process.env.UPSTASH_REDIS_REST_TOKEN;
+        } else {
+            process.env.UPSTASH_REDIS_REST_TOKEN = savedToken;
+        }
+    });
+}
+
+test('rate limit allows first request in window', async (t) => {
+    useInMemoryFallback(t);
+
     const result = await checkRateLimit(`10.0.0.${uid()}`, {
         limit: 5,
         windowMs: 60_000,
@@ -22,7 +40,9 @@ test('rate limit allows first request in window', async () => {
     assert.ok(result.resetIn > 0);
 });
 
-test('rate limit allows all requests within limit', async () => {
+test('rate limit allows all requests within limit', async (t) => {
+    useInMemoryFallback(t);
+
     const ip = `10.1.0.${uid()}`;
     const prefix = `test-rl-within-${uid()}`;
     const limit = 3;
@@ -33,7 +53,9 @@ test('rate limit allows all requests within limit', async () => {
     }
 });
 
-test('rate limit blocks request that exceeds limit and returns retryAfter', async () => {
+test('rate limit blocks request that exceeds limit and returns retryAfter', async (t) => {
+    useInMemoryFallback(t);
+
     const ip = `10.2.0.${uid()}`;
     const prefix = `test-rl-exceed-${uid()}`;
 
@@ -48,7 +70,9 @@ test('rate limit blocks request that exceeds limit and returns retryAfter', asyn
     assert.ok(exceeded.resetIn > 0, 'resetIn should indicate when to retry');
 });
 
-test('rate limit correctly decrements remaining count on each request', async () => {
+test('rate limit correctly decrements remaining count on each request', async (t) => {
+    useInMemoryFallback(t);
+
     const ip = `10.3.0.${uid()}`;
     const prefix = `test-rl-decrement-${uid()}`;
     const limit = 5;
@@ -59,7 +83,9 @@ test('rate limit correctly decrements remaining count on each request', async ()
     }
 });
 
-test('rate limit resets counter after window expires', async () => {
+test('rate limit resets counter after window expires', async (t) => {
+    useInMemoryFallback(t);
+
     const ip = `10.4.0.${uid()}`;
     const prefix = `test-rl-reset-${uid()}`;
 
@@ -79,8 +105,9 @@ test('rate limit resets counter after window expires', async () => {
     assert.equal(fresh.remaining, 1);
 });
 
-test('in-memory fallback works correctly without Redis configured', async () => {
-    // UPSTASH env vars are already deleted at top of file
+test('in-memory fallback works correctly without Redis configured', async (t) => {
+    useInMemoryFallback(t);
+
     const ip = `10.5.0.${uid()}`;
     const prefix = `test-rl-fallback-${uid()}`;
 
@@ -96,7 +123,9 @@ test('in-memory fallback works correctly without Redis configured', async () => 
     assert.equal(r3.allowed, false);
 });
 
-test('in-memory store GC runs when size exceeds 2000 and cleans expired entries', async () => {
+test('in-memory store GC runs when size exceeds 2000 and cleans expired entries', async (t) => {
+    useInMemoryFallback(t);
+
     // Create 2100 entries with a 1ms window so they expire almost immediately.
     // The store accumulates entries from all tests in this process, so total
     // size will exceed the GC threshold (2000) once these are added.


### PR DESCRIPTION
## Summary

Closes #560 (parent issue) and sub-issues #572, #574, #575, #576.

- **`tests/api-generate.test.ts`** (#572): Handler-level tests — method gate (OPTIONS/GET), validation 400, rate limit 429, config error 500, Gemini error mapping (401/403→GEMINI_AUTH_ERROR, 429→GEMINI_RATE_LIMIT, 5xx→GEMINI_UPSTREAM_ERROR, 404+model→GEMINI_MODEL_ERROR). Exports `buildGeminiErrorResponse` for pure-function testability.
- **`tests/lib-rate-limit.test.ts`** (#575): In-memory fallback (UPSTASH absent), first-request allowed, within-limit allowed, exceeds-limit blocked with `retryAfter`, window reset after expiry, GC trigger at store.size > 2000.
- **`tests/lib-lead-logic.test.ts`** (#574): `normalizeWhatsappNumber` (BR formatting, country code, edge cases), `maskEmail`/`maskPhone`/`maskName`, `normalizeTracking` XSS sanitization, `normalizeUtms` null handling. Complements existing `lead-logic.test.ts` which covered `cleanString`/`normalizeNullable`.
- **`tests/hooks-useLeadCapture.test.ts`** (#576): Exports `isPreparedSubmitLeadRequest` for testability; tests the type guard (true/false scenarios), `extractUtms`, `buildLeadWhatsAppMessage`, `createLeadEventId`.
- **#573 (`tests/api-submit-nps.test.ts`)**: All required scenarios (score 0-10 boundaries, rate limit 429, webhook 502, sanitized error messages) are already comprehensively covered by the existing `tests/submit-nps.test.ts`. No new file needed.

## Test plan

- [x] `pnpm test:regression` — 390 tests, 0 failures (up from 333 baseline)
- [x] All 57 new tests verified in output
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)