### PR TITLE
refactor: replace unsafe type assertions with type guards (#561)

### DIFF
--- a/lib/lead-logic.ts
+++ b/lib/lead-logic.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { LeadTracking, LeadUtms, SubmitLeadRequest } from '../types/leadCapture';
 import { SubmitLeadBodySchema } from './schemas/submit-lead';
+import { isRecord } from './type-guards';
 
 const MIN_PHONE_DIGITS = 10;
 const MAX_PHONE_DIGITS = 15;
@@ -102,7 +103,7 @@ export function normalizeWhatsappNumber(value: unknown, defaultCountryCode = '+5
  * Normalizes UTM parameters.
  */
 export function normalizeUtms(value: unknown): LeadUtms {
-    const source = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+    const source = isRecord(value) ? value : {};
 
     return {
         utm_source: normalizeNullable(source.utm_source),
@@ -114,7 +115,7 @@ export function normalizeUtms(value: unknown): LeadUtms {
 }
 
 function toRecord(value: unknown): Record<string, unknown> {
-    return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+    return isRecord(value) ? value : {};
 }
 
 function sanitizeTrackingKey(key: string): string {

--- a/lib/type-guards.ts
+++ b/lib/type-guards.ts
@@ -1,10 +1,10 @@
-export function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord<T>(value: T): value is T & Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-export function isObjectWithProp<K extends string>(
-    value: unknown,
+export function isObjectWithProp<T, K extends string>(
+    value: T,
     key: K,
-): value is Record<K, unknown> {
+): value is T & Record<K, unknown> {
     return isRecord(value) && key in value;
 }

--- a/lib/type-guards.ts
+++ b/lib/type-guards.ts
@@ -1,0 +1,10 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isObjectWithProp<K extends string>(
+    value: unknown,
+    key: K,
+): value is Record<K, unknown> {
+    return isRecord(value) && key in value;
+}

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -2,6 +2,7 @@ import { getWhatsAppLink } from "../utils/whatsapp.ts";
 import { buildGenerateHandoff, type GenerateHandoff } from "../lib/ai/handoff.ts";
 import type { BudgetToolArgs } from "../lib/ai/types.ts";
 import { logger } from "../lib/logger.ts";
+import { isObjectWithProp } from "../lib/type-guards.ts";
 
 interface ChatResponse {
   text?: string;
@@ -36,18 +37,16 @@ const INVALID_HANDOFF_MESSAGE = 'Tive um problema ao concluir seu orçamento ago
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
-  if (typeof error === 'object' && error !== null && 'message' in error) {
-    const message = (error as { message?: unknown }).message;
-    if (typeof message === 'string') return message;
+  if (isObjectWithProp(error, 'message') && typeof error.message === 'string') {
+    return error.message;
   }
   return '';
 }
 
 function getErrorName(error: unknown): string {
   if (error instanceof Error) return error.name;
-  if (typeof error === 'object' && error !== null && 'name' in error) {
-    const name = (error as { name?: unknown }).name;
-    if (typeof name === 'string') return name;
+  if (isObjectWithProp(error, 'name') && typeof error.name === 'string') {
+    return error.name;
   }
   return '';
 }

--- a/tests/type-guards.test.ts
+++ b/tests/type-guards.test.ts
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isRecord, isObjectWithProp } from '../lib/type-guards.ts';
+
+test('isRecord retorna true para objetos simples', () => {
+    assert.equal(isRecord({}), true);
+    assert.equal(isRecord({ a: 1 }), true);
+});
+
+test('isRecord retorna false para não-objetos', () => {
+    assert.equal(isRecord(null), false);
+    assert.equal(isRecord([]), false);
+    assert.equal(isRecord('string'), false);
+    assert.equal(isRecord(42), false);
+    assert.equal(isRecord(undefined), false);
+});
+
+test('isObjectWithProp retorna true quando prop existe', () => {
+    assert.equal(isObjectWithProp({ message: 'erro' }, 'message'), true);
+    assert.equal(isObjectWithProp({ message: undefined }, 'message'), true);
+});
+
+test('isObjectWithProp retorna false quando prop não existe', () => {
+    assert.equal(isObjectWithProp({}, 'message'), false);
+    assert.equal(isObjectWithProp(null, 'message'), false);
+    assert.equal(isObjectWithProp('string', 'message'), false);
+    assert.equal(isObjectWithProp(42, 'message'), false);
+});


### PR DESCRIPTION
## Summary

- Cria `lib/type-guards.ts` com os guards `isRecord` e `isObjectWithProp`
- Refatora `services/geminiService.ts`: `getErrorMessage` e `getErrorName` eliminam `as { message?: unknown }` e `as { name?: unknown }`
- Refatora `lib/lead-logic.ts`: `normalizeUtms` e `toRecord` eliminam `as Record<string, unknown>`
- Adiciona `tests/type-guards.test.ts` com cobertura dos dois guards

Closes #561

## Test plan

- [x] `pnpm typecheck` — sem erros
- [x] `pnpm test:regression` — 337 testes, 0 falhas (incluindo os 4 novos de `type-guards`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)