### PR TITLE
perf(images): add WebP/AVIF format support to LazyImage via <picture> element

### DIFF
--- a/components/ui/LazyImage.tsx
+++ b/components/ui/LazyImage.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { Image as ImageIcon } from 'lucide-react';
-import { optimizeRemoteImageUrl } from '../../data/mediaConfig';
+import { optimizeRemoteImageUrl, generateAvifSrcSet, generateWebpSrcSet, generateSrcSet } from '../../data/mediaConfig';
 
 interface LazyImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
     src: string;
     alt: string;
     className?: string;
     placeholderClassName?: string;
+    sizes?: string;
     width?: number | string;
     height?: number | string;
 }
@@ -24,6 +25,7 @@ export const LazyImage = React.memo<LazyImageProps>(({
     alt,
     className = "",
     placeholderClassName = "bg-zinc-200",
+    sizes,
     width,
     height,
     ...props
@@ -32,14 +34,16 @@ export const LazyImage = React.memo<LazyImageProps>(({
     const [isLoaded, setIsLoaded] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
 
-    // Optimize URL only when source or dimensions change
-    const optimizedSrc = useMemo(() => {
-        if (!src) return '';
-        // If width is provided as a number, use it for optimization.
-        // If it's a string (like "100%") or undefined, use default optimization.
+    const { optimizedSrc, avifSrcSet, webpSrcSet, srcSet } = useMemo(() => {
+        if (!src) return { optimizedSrc: '', avifSrcSet: '', webpSrcSet: '', srcSet: '' };
         const numericWidth = typeof width === 'number' ? width : 1200;
         const numericHeight = typeof height === 'number' ? height : undefined;
-        return optimizeRemoteImageUrl(src, numericWidth, numericHeight);
+        return {
+            optimizedSrc: optimizeRemoteImageUrl(src, numericWidth, numericHeight),
+            avifSrcSet: generateAvifSrcSet(src),
+            webpSrcSet: generateWebpSrcSet(src),
+            srcSet: generateSrcSet(src),
+        };
     }, [src, width, height]);
 
     useEffect(() => {
@@ -78,18 +82,28 @@ export const LazyImage = React.memo<LazyImageProps>(({
                 </div>
             )}
             {isVisible && (
-                <img
-                    src={optimizedSrc}
-                    alt={alt}
-                    width={width}
-                    height={height}
-                    loading={props.loading ?? "lazy"}
-                    fetchPriority={props.fetchPriority ?? "low"}
-                    decoding="async"
-                    onLoad={() => setIsLoaded(true)}
-                    className={`transition-opacity duration-500 w-full h-full object-cover ${isLoaded ? 'opacity-100' : 'opacity-0'}`}
-                    {...props}
-                />
+                <picture>
+                    {avifSrcSet && (
+                        <source srcSet={avifSrcSet} type="image/avif" sizes={sizes} />
+                    )}
+                    {webpSrcSet && (
+                        <source srcSet={webpSrcSet} type="image/webp" sizes={sizes} />
+                    )}
+                    <img
+                        src={optimizedSrc}
+                        srcSet={srcSet || undefined}
+                        sizes={sizes}
+                        alt={alt}
+                        width={width}
+                        height={height}
+                        loading={props.loading ?? "lazy"}
+                        fetchPriority={props.fetchPriority ?? "low"}
+                        decoding="async"
+                        onLoad={() => setIsLoaded(true)}
+                        className={`transition-opacity duration-500 w-full h-full object-cover ${isLoaded ? 'opacity-100' : 'opacity-0'}`}
+                        {...props}
+                    />
+                </picture>
             )}
         </div>
     );

--- a/data/mediaConfig.ts
+++ b/data/mediaConfig.ts
@@ -97,7 +97,8 @@ export const getMediaUrl = (path: string): string => {
 export const optimizeRemoteImageUrl = (
     rawUrl: string,
     width: number = 1200,
-    height?: number
+    height?: number,
+    format?: 'auto' | 'avif' | 'webp',
 ): string => {
     const { mediaBaseUrl, transformZoneUrl, enableTransforms } = getMediaRuntimeConfig();
     return optimizeImageUrl(rawUrl, {
@@ -106,6 +107,7 @@ export const optimizeRemoteImageUrl = (
         enableTransforms,
         width,
         height,
+        format,
     });
 };
 
@@ -260,11 +262,8 @@ export const getDestinationImage = (city: string): string => {
 export const optimizeCloudinaryUrl = (
     url: string,
     width: number = 800,
-    format: 'auto' | 'webp' | 'avif' = 'auto'
-): string => {
-    void format;
-    return optimizeRemoteImageUrl(url, width);
-};
+    format: 'auto' | 'webp' | 'avif' = 'auto',
+): string => optimizeRemoteImageUrl(url, width, undefined, format);
 
 /**
  * Generate srcset for responsive images using the active media provider.
@@ -273,4 +272,36 @@ export const generateSrcSet = (url: string, sizes: number[] = [400, 800, 1200]):
     return sizes
         .map(size => `${optimizeRemoteImageUrl(url, size)} ${size}w`)
         .join(', ');
+};
+
+/**
+ * Generate an AVIF srcset for use inside a <picture> <source> element.
+ * Returns an empty string when Cloudflare transforms are not enabled, preventing
+ * browsers from requesting JPEG/PNG origins with type="image/avif".
+ */
+export const generateAvifSrcSet = (url: string, sizes: number[] = [400, 800, 1200]): string => {
+    const entries = sizes
+        .map(size => {
+            const formatted = optimizeRemoteImageUrl(url, size, undefined, 'avif');
+            const unformatted = optimizeRemoteImageUrl(url, size);
+            return formatted !== unformatted ? `${formatted} ${size}w` : '';
+        })
+        .filter(Boolean);
+    return entries.join(', ');
+};
+
+/**
+ * Generate a WebP srcset for use inside a <picture> <source> element.
+ * Returns an empty string when Cloudflare transforms are not enabled, preventing
+ * browsers from requesting JPEG/PNG origins with type="image/webp".
+ */
+export const generateWebpSrcSet = (url: string, sizes: number[] = [400, 800, 1200]): string => {
+    const entries = sizes
+        .map(size => {
+            const formatted = optimizeRemoteImageUrl(url, size, undefined, 'webp');
+            const unformatted = optimizeRemoteImageUrl(url, size);
+            return formatted !== unformatted ? `${formatted} ${size}w` : '';
+        })
+        .filter(Boolean);
+    return entries.join(', ');
 };

--- a/lib/media-url.ts
+++ b/lib/media-url.ts
@@ -13,6 +13,7 @@ export interface OptimizeImageUrlOptions {
     enableTransforms?: boolean;
     width?: number;
     height?: number;
+    format?: 'auto' | 'avif' | 'webp';
 }
 
 const RATIO_TOLERANCE = 0.08;
@@ -95,10 +96,11 @@ export function buildCloudflareImageUrl(
     sourcePathOrUrl: string,
     transformZoneUrl: string,
     preset: ImagePreset,
+    format: 'auto' | 'avif' | 'webp' = 'auto',
 ): string {
     const normalizedZone = stripTrailingSlash(transformZoneUrl);
     const params = [
-        'format=auto',
+        `format=${format}`,
         `quality=${DEFAULT_QUALITY}`,
         'metadata=none',
         `fit=${preset.fit}`,
@@ -167,5 +169,5 @@ export function optimizeImageUrl(rawUrl: string, options: OptimizeImageUrlOption
     }
 
     const preset = selectImagePreset(options.width, options.height);
-    return buildCloudflareImageUrl(sourcePath, options.transformZoneUrl, preset);
+    return buildCloudflareImageUrl(sourcePath, options.transformZoneUrl, preset, options.format ?? 'auto');
 }

--- a/tests/media-config.test.ts
+++ b/tests/media-config.test.ts
@@ -2,7 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { AUTHORS } from '../data/blogData.ts';
-import { getMediaRuntimeConfig, HERO_VIDEOS } from '../data/mediaConfig.ts';
+import {
+    getMediaRuntimeConfig,
+    HERO_VIDEOS,
+    generateAvifSrcSet,
+    generateWebpSrcSet,
+    optimizeCloudinaryUrl,
+} from '../data/mediaConfig.ts';
 import { BLOG_POST_MANIFEST } from '../data/blogManifest.ts';
 
 test('getMediaRuntimeConfig should enable same-host transforms from env values', () => {
@@ -75,6 +81,33 @@ test('migrated author avatars should use the Cloudflare R2 origin', () => {
         AUTHORS['queila-oliveira'].image,
         'https://media.anhanga.tur.br/images/authors/queila.jpg',
     );
+});
+
+test('generateAvifSrcSet should return empty string when transforms are not enabled', () => {
+    // Without VITE_MEDIA_ENABLE_TRANSFORMS=true, optimizeRemoteImageUrl returns
+    // the resolved URL without /cdn-cgi/image/ — format param has no effect, so
+    // formatted === unformatted and every entry is filtered out.
+    const result = generateAvifSrcSet('https://media.anhanga.tur.br/images/destinations/paris.jpg');
+    assert.equal(result, '');
+});
+
+test('generateWebpSrcSet should return empty string when transforms are not enabled', () => {
+    const result = generateWebpSrcSet('https://media.anhanga.tur.br/images/destinations/paris.jpg');
+    assert.equal(result, '');
+});
+
+test('optimizeCloudinaryUrl should pass format to the underlying helper (not silently ignore it)', () => {
+    // When transforms are disabled the URL falls back to the resolved source, so
+    // format has no visible effect — but the function must not throw and must not
+    // return a string containing the *wrong* format token.
+    const withAuto = optimizeCloudinaryUrl('https://media.anhanga.tur.br/images/destinations/paris.jpg', 800, 'auto');
+    const withWebp = optimizeCloudinaryUrl('https://media.anhanga.tur.br/images/destinations/paris.jpg', 800, 'webp');
+    const withAvif = optimizeCloudinaryUrl('https://media.anhanga.tur.br/images/destinations/paris.jpg', 800, 'avif');
+
+    // All three should resolve to the same plain URL when transforms are off.
+    assert.equal(withAuto, 'https://media.anhanga.tur.br/images/destinations/paris.jpg');
+    assert.equal(withWebp, 'https://media.anhanga.tur.br/images/destinations/paris.jpg');
+    assert.equal(withAvif, 'https://media.anhanga.tur.br/images/destinations/paris.jpg');
 });
 
 test('migrated blog cover images should be serialized as absolute URLs', () => {

--- a/tests/media-url.test.ts
+++ b/tests/media-url.test.ts
@@ -158,3 +158,58 @@ test('optimizeImageUrl should not double-wrap existing Cloudflare transformation
         transformed,
     );
 });
+
+test('buildCloudflareImageUrl should use format=avif when format is avif', () => {
+    const url = buildCloudflareImageUrl(
+        '/images/home/hero.jpg',
+        'https://media.anhanga.tur.br',
+        selectImagePreset(1280, 720),
+        'avif',
+    );
+
+    assert.equal(
+        url,
+        'https://media.anhanga.tur.br/cdn-cgi/image/format=avif,quality=85,metadata=none,fit=cover,width=1280,height=720/images/home/hero.jpg',
+    );
+});
+
+test('buildCloudflareImageUrl should use format=webp when format is webp', () => {
+    const url = buildCloudflareImageUrl(
+        '/images/home/hero.jpg',
+        'https://media.anhanga.tur.br',
+        selectImagePreset(640, 400),
+        'webp',
+    );
+
+    assert.equal(
+        url,
+        'https://media.anhanga.tur.br/cdn-cgi/image/format=webp,quality=85,metadata=none,fit=cover,width=640,height=400/images/home/hero.jpg',
+    );
+});
+
+test('optimizeImageUrl should propagate format=avif into the Cloudflare transform URL', () => {
+    assert.equal(
+        optimizeImageUrl('images/home/hero.jpg', {
+            mediaBaseUrl: 'https://media.anhanga.tur.br',
+            transformZoneUrl: 'https://media.anhanga.tur.br',
+            enableTransforms: true,
+            width: 1200,
+            height: 675,
+            format: 'avif',
+        }),
+        'https://media.anhanga.tur.br/cdn-cgi/image/format=avif,quality=85,metadata=none,fit=cover,width=1200,height=675/images/home/hero.jpg',
+    );
+});
+
+test('optimizeImageUrl should propagate format=webp into the Cloudflare transform URL', () => {
+    assert.equal(
+        optimizeImageUrl('images/home/hero.jpg', {
+            mediaBaseUrl: 'https://media.anhanga.tur.br',
+            transformZoneUrl: 'https://media.anhanga.tur.br',
+            enableTransforms: true,
+            width: 800,
+            format: 'webp',
+        }),
+        'https://media.anhanga.tur.br/cdn-cgi/image/format=webp,quality=85,metadata=none,fit=scale-down,width=800/images/home/hero.jpg',
+    );
+});


### PR DESCRIPTION
Closes #563

## Summary

- **`lib/media-url.ts`** — Adds `format?: 'auto' | 'avif' | 'webp'` to `OptimizeImageUrlOptions`; `buildCloudflareImageUrl` now accepts an explicit format parameter (defaults to `'auto'`); `optimizeImageUrl` threads it through
- **`data/mediaConfig.ts`** — `optimizeRemoteImageUrl` propagates `format`; `optimizeCloudinaryUrl` fixed (was silently ignoring the `format` arg via `void format`); new `generateAvifSrcSet` and `generateWebpSrcSet` helpers — return `''` when Cloudflare transforms are disabled, preventing the critical bug of serving JPEG origins with `type="image/avif"`
- **`components/ui/LazyImage.tsx`** — Replaces `<img>` with `<picture>` + conditional `<source type="image/avif">` and `<source type="image/webp">` elements; adds optional `sizes` prop (backward-compatible); preserves `React.memo` and `IntersectionObserver` lazy loading
- **Tests** — 7 new unit tests covering format propagation (`buildCloudflareImageUrl`, `optimizeImageUrl`) and the guard that returns an empty srcset when transforms are off

## Test plan

- [x] `pnpm test:regression` — 404 tests, 0 failures (up from 397)
- [x] `pnpm typecheck` — clean
- [ ] Visual check in Chrome: DevTools → Network → filter images → confirm `Accept: image/avif,image/webp` in requests and correct `Content-Type` in responses (requires `VITE_MEDIA_ENABLE_TRANSFORMS=true` in prod)
- [ ] Visual check in Safari: confirm `<img>` fallback loads correctly (AVIF support arrived in Safari 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)