### PR TITLE
chore(ci): harden workflows and add Playwright as required check

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -5,31 +5,33 @@ on:
     types: [opened, closed, reopened]
   pull_request:
     types: [opened, closed, reopened]
-  project_card:
-    types: [moved]
 
 jobs:
   notify:
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
+    permissions:
+      contents: none
     steps:
       - name: Notify Discord
-        uses: Ilshidur/action-discord@master
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
-        with:
-          args: |
-            ${{ github.event_name == 'issues' && format('📝 Issue {0}: #{1} - {2}', 
-              github.event.action, 
-              github.event.issue.number, 
-              github.event.issue.title
-            ) || '' }}
-            
-            ${{ github.event_name == 'pull_request' && format('🔀 PR {0}: #{1} - {2}', 
-              github.event.action, 
-              github.event.pull_request.number, 
-              github.event.pull_request.title
-            ) || '' }}
-            
-            Link: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+        run: |
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            TITLE="${{ github.event.issue.title }}"
+            URL="${{ github.event.issue.html_url }}"
+            MSG="$(printf '📝 Issue %s: #%s - %s\nLink: %s' \
+              "${{ github.event.action }}" \
+              "${{ github.event.issue.number }}" \
+              "$TITLE" "$URL")"
+          else
+            TITLE="${{ github.event.pull_request.title }}"
+            URL="${{ github.event.pull_request.html_url }}"
+            MSG="$(printf '🔀 PR %s: #%s - %s\nLink: %s' \
+              "${{ github.event.action }}" \
+              "${{ github.event.pull_request.number }}" \
+              "$TITLE" "$URL")"
+          fi
+          PAYLOAD="$(jq -n --arg content "$MSG" '{"content": $content}')"
+          curl -s -X POST "$DISCORD_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -15,21 +15,21 @@ jobs:
       - name: Notify Discord
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          if [ "${{ github.event_name }}" = "issues" ]; then
-            TITLE="${{ github.event.issue.title }}"
-            URL="${{ github.event.issue.html_url }}"
+          if [ "$EVENT_NAME" = "issues" ]; then
             MSG="$(printf '📝 Issue %s: #%s - %s\nLink: %s' \
-              "${{ github.event.action }}" \
-              "${{ github.event.issue.number }}" \
-              "$TITLE" "$URL")"
+              "$EVENT_ACTION" "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_URL")"
           else
-            TITLE="${{ github.event.pull_request.title }}"
-            URL="${{ github.event.pull_request.html_url }}"
             MSG="$(printf '🔀 PR %s: #%s - %s\nLink: %s' \
-              "${{ github.event.action }}" \
-              "${{ github.event.pull_request.number }}" \
-              "$TITLE" "$URL")"
+              "$EVENT_ACTION" "$PR_NUMBER" "$PR_TITLE" "$PR_URL")"
           fi
           PAYLOAD="$(jq -n --arg content "$MSG" '{"content": $content}')"
           curl -s -X POST "$DISCORD_WEBHOOK" \

--- a/.github/workflows/generate-blog-manifest.yml
+++ b/.github/workflows/generate-blog-manifest.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   generate-manifest:
@@ -34,14 +35,23 @@ jobs:
       - name: Generate blog manifest
         run: pnpm run generate:blog-manifest
 
-      - name: Commit updated manifest
+      - name: Open PR with updated manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/blogManifest.ts
           if git diff --cached --quiet; then
-            echo "No changes to blogManifest.ts — skipping commit."
-          else
-            git commit -m "chore: regenerate blogManifest.ts [skip ci]"
-            git push origin main
+            echo "No changes to blogManifest.ts — skipping."
+            exit 0
           fi
+          BRANCH="chore/update-blog-manifest-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          git commit -m "chore: regenerate blogManifest.ts"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: regenerate blogManifest.ts" \
+            --body "Regeneração automática do blog manifest disparada por mudança em \`content/blog/\`." \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - Preview
 
 jobs:
   build:

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -5,7 +5,7 @@ on:
       branch:
         description: 'Branch to update snapshots on'
         required: true
-        default: 'feat/copy-typography-cleanup'
+        default: 'main'
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
## Summary

- **generate-blog-manifest**: agora abre PR em vez de commitar direto na `main` (que quebraria com a branch protection ativa)
- **discord-notify**: substituído `Ilshidur/action-discord@master` (action não pinada) por `curl + jq` nativo; removido evento `project_card` que está deprecated no GitHub
- **todo**: removida branch `Preview` stale que não existe mais
- **update-snapshots**: corrigida branch default de `feat/copy-typography-cleanup` para `main`
- **branch protection**: adicionado job `test` (Playwright) como required status check

## Test plan

- [ ] Verificar que CI `build-and-test` e `test` aparecem como obrigatórios no próximo PR
- [ ] Confirmar que Discord notifica corretamente ao abrir/fechar issue ou PR
- [ ] Ao mergear conteúdo em `content/blog/`, confirmar que um PR é aberto (não push direto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)