### PR TITLE
Add immutable cache headers for hashed Vite assets

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -6,5 +6,8 @@
   Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="https://www.rfc-editor.org/info/rfc9727"
   Vary: Accept
 
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
 /admin/*
   X-Robots-Tag: noindex, nofollow

--- a/tests/cloudflare-config.test.ts
+++ b/tests/cloudflare-config.test.ts
@@ -39,7 +39,9 @@ function collectHeadersBlocks(source: string): Map<string, Map<string, string>> 
 
     if (!rawLine.startsWith(' ') && !rawLine.startsWith('\t')) {
       currentPath = line;
-      blocks.set(currentPath, new Map());
+      if (!blocks.has(currentPath)) {
+        blocks.set(currentPath, new Map());
+      }
       continue;
     }
 
@@ -94,10 +96,12 @@ test('Cloudflare Pages headers should cache hashed Vite assets immutably', async
   const headers = await readFile(new URL('../public/_headers', import.meta.url), 'utf8');
   const blocks = collectHeadersBlocks(headers);
   const assetHeaders = blocks.get('/assets/*');
+  const globalHeaders = blocks.get('/*');
 
   assert.ok(assetHeaders);
+  assert.ok(globalHeaders);
   assert.equal(assetHeaders.get('Cache-Control'), 'public, max-age=31536000, immutable');
-  assert.notEqual(blocks.get('/*')?.get('Cache-Control'), assetHeaders.get('Cache-Control'));
+  assert.notEqual(globalHeaders.get('Cache-Control'), assetHeaders.get('Cache-Control'));
 });
 
 test('Cloudflare splat redirects should come after exact redirects', async () => {

--- a/tests/cloudflare-config.test.ts
+++ b/tests/cloudflare-config.test.ts
@@ -27,6 +27,33 @@ function collectTomlVarsSection(source: string, sectionName: string): Map<string
   return vars;
 }
 
+function collectHeadersBlocks(source: string): Map<string, Map<string, string>> {
+  const blocks = new Map<string, Map<string, string>>();
+  let currentPath: string | undefined;
+
+  for (const rawLine of source.split(/\r?\n/)) {
+    if (!rawLine.trim()) continue;
+
+    const line = rawLine.trim();
+    if (line.startsWith('#')) continue;
+
+    if (!rawLine.startsWith(' ') && !rawLine.startsWith('\t')) {
+      currentPath = line;
+      blocks.set(currentPath, new Map());
+      continue;
+    }
+
+    if (!currentPath) continue;
+
+    const headerMatch = line.match(/^([^:]+):\s*(.+)$/);
+    if (headerMatch) {
+      blocks.get(currentPath)?.set(headerMatch[1], headerMatch[2]);
+    }
+  }
+
+  return blocks;
+}
+
 test('Cloudflare Pages build should use the repo Node runtime target', async () => {
   const nodeVersion = await readFile(new URL('../.node-version', import.meta.url), 'utf8');
 
@@ -61,6 +88,16 @@ test('Cloudflare redirects should avoid redundant SPA fallback rewrites', async 
   const redirects = await readFile(new URL('../public/_redirects', import.meta.url), 'utf8');
 
   assert.doesNotMatch(redirects, /^\/\*\s+\/index\.html\s+200$/m);
+});
+
+test('Cloudflare Pages headers should cache hashed Vite assets immutably', async () => {
+  const headers = await readFile(new URL('../public/_headers', import.meta.url), 'utf8');
+  const blocks = collectHeadersBlocks(headers);
+  const assetHeaders = blocks.get('/assets/*');
+
+  assert.ok(assetHeaders);
+  assert.equal(assetHeaders.get('Cache-Control'), 'public, max-age=31536000, immutable');
+  assert.notEqual(blocks.get('/*')?.get('Cache-Control'), assetHeaders.get('Cache-Control'));
 });
 
 test('Cloudflare splat redirects should come after exact redirects', async () => {


### PR DESCRIPTION
## Summary
- Add a Cloudflare Pages `_headers` rule for `/assets/*` with `Cache-Control: public, max-age=31536000, immutable`
- Add regression coverage to ensure hashed Vite assets keep the immutable cache policy without affecting the global HTML header block

## Testing
- Added a focused unit regression test for the new `_headers` rule
- Verified locally with `pnpm test:regression`, `pnpm build`, and `pnpm typecheck`