### PR TITLE
Adicionar Felipe e Queila ao select de autores do CMS

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -35,12 +35,8 @@ collections:
         name: author
         widget: select
         options:
-          - { label: Equipe Anhangá, value: equipe-anhanga }
-          - { label: Ana Souza, value: ana-souza }
-          - { label: Rafa Tech, value: rafa-tech }
-          - { label: Chef Luigi, value: luigi }
-          - { label: Mariana S., value: mariana }
-          - { label: Carlos Viajante, value: carlos }
+          - { label: Queila de Oliveira, value: queila-oliveira }
+          - { label: Felipe William, value: felipe-william }
       - label: Categoria
         name: category
         widget: select

--- a/tests/decap-config.test.ts
+++ b/tests/decap-config.test.ts
@@ -17,12 +17,13 @@ interface SelectOption {
 
 function extractAuthorOptions(configText: string): SelectOption[] {
   const authorField = configText.match(
-    /^\s+- label: Autor\n\s+name: author\n\s+widget: select\n\s+options:\n(?<options>(?:\s+- \{ label: .+\n?)+)/m,
+    /^\s+- label: Autor\r?\n\s+name: author\r?\n\s+widget: select\r?\n\s+options:\r?\n(?<options>(?:\s+- \{ label: .+\r?\n?)+)/m,
   );
 
-  assert.ok(authorField?.groups?.options, 'Expected Decap author field options to be declared');
+  const options = authorField?.groups?.options;
+  assert.ok(options, 'Expected Decap author field options to be declared');
 
-  return [...authorField.groups.options.matchAll(/label: ([^,]+), value: ([^ }]+)/g)].map(
+  return [...options.matchAll(/label: ([^,]+), value: ([^ }]+)/g)].map(
     ([, label, value]) => ({ label, value }),
   );
 }
@@ -39,6 +40,12 @@ test('Decap CMS author select mirrors the site author registry', () => {
     .sort((a, b) => a.value.localeCompare(b.value));
 
   assert.deepEqual(authorOptions, registeredAuthors);
+});
+
+test('Decap CMS author select parser accepts CRLF line endings', () => {
+  const configWithCrlf = adminConfig.replace(/\n/g, '\r\n');
+
+  assert.deepEqual(extractAuthorOptions(configWithCrlf), extractAuthorOptions(adminConfig));
 });
 
 test('Decap CMS admin HTML sets an explicit base path for config resolution', () => {

--- a/tests/decap-config.test.ts
+++ b/tests/decap-config.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import { AUTHORS } from '../data/blogData.ts';
 
 const adminConfigPath = path.resolve(process.cwd(), 'public/admin/config.yml');
 const adminIndexPath = path.resolve(process.cwd(), 'public/admin/index.html');
@@ -9,9 +10,35 @@ const adminIndexPath = path.resolve(process.cwd(), 'public/admin/index.html');
 const adminConfig = fs.readFileSync(adminConfigPath, 'utf8');
 const adminIndex = fs.readFileSync(adminIndexPath, 'utf8');
 
+interface SelectOption {
+  label: string;
+  value: string;
+}
+
+function extractAuthorOptions(configText: string): SelectOption[] {
+  const authorField = configText.match(
+    /^\s+- label: Autor\n\s+name: author\n\s+widget: select\n\s+options:\n(?<options>(?:\s+- \{ label: .+\n?)+)/m,
+  );
+
+  assert.ok(authorField?.groups?.options, 'Expected Decap author field options to be declared');
+
+  return [...authorField.groups.options.matchAll(/label: ([^,]+), value: ([^ }]+)/g)].map(
+    ([, label, value]) => ({ label, value }),
+  );
+}
+
 test('Decap CMS config points GitHub OAuth to the production auth proxy', () => {
   assert.match(adminConfig, /base_url:\s+https:\/\/www\.anhanga\.tur\.br\b/);
   assert.match(adminConfig, /auth_endpoint:\s+api\/auth\b/);
+});
+
+test('Decap CMS author select mirrors the site author registry', () => {
+  const authorOptions = extractAuthorOptions(adminConfig).sort((a, b) => a.value.localeCompare(b.value));
+  const registeredAuthors = Object.values(AUTHORS)
+    .map((author) => ({ label: author.name, value: author.id }))
+    .sort((a, b) => a.value.localeCompare(b.value));
+
+  assert.deepEqual(authorOptions, registeredAuthors);
 });
 
 test('Decap CMS admin HTML sets an explicit base path for config resolution', () => {

--- a/tests/e2e/decap-admin.spec.ts
+++ b/tests/e2e/decap-admin.spec.ts
@@ -32,7 +32,8 @@ test.describe('Decap CMS admin', () => {
       expect(configText).toMatch(new RegExp(`name:\\s+${fieldName}\\b`));
     }
 
-    expect(configText).toMatch(/value:\s+equipe-anhanga\b/);
+    expect(configText).toMatch(/value:\s+queila-oliveira\b/);
+    expect(configText).toMatch(/value:\s+felipe-william\b/);
 
     page.on('console', (message) => {
       if (message.type() === 'error' || message.type() === 'warning') {


### PR DESCRIPTION
## Summary
- Atualiza o select de `author` do Decap CMS para expor os autores reais `Queila de Oliveira` e `Felipe William`.
- Adiciona regressão unitária para garantir que o CMS continue espelhando o registry de autores do site.
- Ajusta o spec E2E do admin para validar os dois autores presentes no `config.yml`.

## Testing
- `pnpm exec tsx --test tests/decap-config.test.ts`
- `pnpm test:regression`
- `pnpm test:e2e tests/e2e/decap-admin.spec.ts --project=chromium`
- `pnpm typecheck`