### PR TITLE
Corrigir redirect legado do blog

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,7 +1,6 @@
-# Blog redirects
-/blog/tag/dicas  https://blog.anhanga.tur.br/tag/dicas-de-expert/  301
-/blog/tag/dicas/  https://blog.anhanga.tur.br/tag/dicas-de-expert/  301
-/blog    https://blog.anhanga.tur.br    301
+# Legacy blog tag redirects
+/blog/tag/dicas  /blog  301
+/blog/tag/dicas/  /blog  301
 
 # Lollapalooza slug change
 /lollapalooza-2026    /lollapalooza    301
@@ -16,6 +15,3 @@
 /.well-known/api-catalog    /api/api-catalog    302
 /.well-known/api-docs       /api/api-docs       302
 /.well-known/openapi.json   /api/openapi        302
-
-# Blog catch-all must stay after exact redirects.
-/blog/*  https://blog.anhanga.tur.br/:splat  301

--- a/tests/cloudflare-config.test.ts
+++ b/tests/cloudflare-config.test.ts
@@ -2,6 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
+const LEGACY_BLOG_HOST_REDIRECT_RE = /^\/blog(?:[\/\s*].*)?\s+https:\/\/blog\.anhanga\.tur\.br\b/m;
+
 function collectTomlVarsSection(source: string, sectionName: string): Map<string, string> {
   const vars = new Map<string, string>();
   let inSection = false;
@@ -56,6 +58,35 @@ function collectHeadersBlocks(source: string): Map<string, Map<string, string>> 
   return blocks;
 }
 
+function normalizeRedirectLine(line: string): string {
+  return line.trim().replace(/^["']|["']$/g, '');
+}
+
+function collectRedirectRules(source: string): string[] {
+  return source
+    .split(/\r?\n/)
+    .flatMap((line) => {
+      const normalized = normalizeRedirectLine(line);
+      return normalized && !normalized.startsWith('#') ? [normalized] : [];
+    });
+}
+
+function hasLegacyBlogHostRedirect(source: string): boolean {
+  return collectRedirectRules(source).some((line) => LEGACY_BLOG_HOST_REDIRECT_RE.test(line));
+}
+
+function hasExactRedirectAfterFirstSplat(source: string): boolean {
+  const lines = collectRedirectRules(source);
+  const firstSplatIndex = lines.findIndex((line) => normalizeRedirectLine(line).includes('*'));
+
+  if (firstSplatIndex === -1) return false;
+
+  return lines.slice(firstSplatIndex + 1).some((line) => {
+    const normalized = normalizeRedirectLine(line);
+    return normalized.length > 0 && !normalized.includes('*');
+  });
+}
+
 test('Cloudflare Pages build should use the repo Node runtime target', async () => {
   const nodeVersion = await readFile(new URL('../.node-version', import.meta.url), 'utf8');
 
@@ -95,7 +126,13 @@ test('Cloudflare redirects should avoid redundant SPA fallback rewrites', async 
 test('Cloudflare redirects should keep blog routes on the main site', async () => {
   const redirects = await readFile(new URL('../public/_redirects', import.meta.url), 'utf8');
 
-  assert.doesNotMatch(redirects, /^\/blog(?:\s|\/\*)\s+https:\/\/blog\.anhanga\.tur\.br\b/m);
+  assert.equal(hasLegacyBlogHostRedirect(redirects), false);
+});
+
+test('Cloudflare blog redirect guard should catch nested legacy blog routes', () => {
+  const redirects = '/blog/post-1  https://blog.anhanga.tur.br/post-1  301';
+
+  assert.equal(hasLegacyBlogHostRedirect(redirects), true);
 });
 
 test('Cloudflare Pages headers should cache hashed Vite assets immutably', async () => {
@@ -112,18 +149,15 @@ test('Cloudflare Pages headers should cache hashed Vite assets immutably', async
 
 test('Cloudflare splat redirects should come after exact redirects when present', async () => {
   const redirects = await readFile(new URL('../public/_redirects', import.meta.url), 'utf8');
-  const lines = redirects
-    .split(/\r?\n/)
-    .flatMap((line) => {
-      const t = line.trim();
-      return t && !t.startsWith('#') ? [t] : [];
-    });
-  const blogSplatIndex = lines.findIndex((line) => line.startsWith('/blog/* '));
 
-  if (blogSplatIndex === -1) return;
+  assert.equal(hasExactRedirectAfterFirstSplat(redirects), false);
+});
 
-  assert.equal(
-    lines.slice(blogSplatIndex + 1).some((line) => !line.includes('*')),
-    false,
-  );
+test('Cloudflare splat redirect ordering guard should handle non-blog splats', () => {
+  const redirects = [
+    '/assets/*  /assets/:splat  301',
+    '/admin  /admin/  301',
+  ].join('\n');
+
+  assert.equal(hasExactRedirectAfterFirstSplat(redirects), true);
 });

--- a/tests/cloudflare-config.test.ts
+++ b/tests/cloudflare-config.test.ts
@@ -92,6 +92,12 @@ test('Cloudflare redirects should avoid redundant SPA fallback rewrites', async 
   assert.doesNotMatch(redirects, /^\/\*\s+\/index\.html\s+200$/m);
 });
 
+test('Cloudflare redirects should keep blog routes on the main site', async () => {
+  const redirects = await readFile(new URL('../public/_redirects', import.meta.url), 'utf8');
+
+  assert.doesNotMatch(redirects, /^\/blog(?:\s|\/\*)\s+https:\/\/blog\.anhanga\.tur\.br\b/m);
+});
+
 test('Cloudflare Pages headers should cache hashed Vite assets immutably', async () => {
   const headers = await readFile(new URL('../public/_headers', import.meta.url), 'utf8');
   const blocks = collectHeadersBlocks(headers);
@@ -104,7 +110,7 @@ test('Cloudflare Pages headers should cache hashed Vite assets immutably', async
   assert.notEqual(globalHeaders.get('Cache-Control'), assetHeaders.get('Cache-Control'));
 });
 
-test('Cloudflare splat redirects should come after exact redirects', async () => {
+test('Cloudflare splat redirects should come after exact redirects when present', async () => {
   const redirects = await readFile(new URL('../public/_redirects', import.meta.url), 'utf8');
   const lines = redirects
     .split(/\r?\n/)
@@ -114,7 +120,8 @@ test('Cloudflare splat redirects should come after exact redirects', async () =>
     });
   const blogSplatIndex = lines.findIndex((line) => line.startsWith('/blog/* '));
 
-  assert.notEqual(blogSplatIndex, -1);
+  if (blogSplatIndex === -1) return;
+
   assert.equal(
     lines.slice(blogSplatIndex + 1).some((line) => !line.includes('*')),
     false,


### PR DESCRIPTION
## Resumo
- remove os redirects de `/blog` e `/blog/*` para `blog.anhanga.tur.br`
- mantém os redirects legados de tag apontando para `/blog` dentro do site principal
- adiciona regressão para impedir que `/blog` volte a sair para o subdomínio antigo

## Validação
- `pnpm exec tsx --test tests/cloudflare-config.test.ts`
- `pnpm typecheck`
- `pnpm test:regression`
- `pnpm build`
- `git diff --check`

Observação: o site público ainda redireciona até essa PR ser mergeada e a Cloudflare Pages publicar `main`.