### PR TITLE
docs(cloudflare): cache rule for media zone videos

### DIFF
--- a/docs/cloudflare-cache-rules.md
+++ b/docs/cloudflare-cache-rules.md
@@ -1,0 +1,94 @@
+# Cloudflare Cache Rules — media.anhanga.tur.br
+
+## Visão geral
+
+A media zone (`media.anhanga.tur.br`) serve assets estáticos do R2.
+Imagens já passam por Cloudflare Image Transformations e são cacheadas automaticamente.
+Vídeos, porém, retornam `cf-cache-status: DYNAMIC` por padrão — sem cache na borda.
+
+Esta regra corrige isso para o path `/videos/*`.
+
+## Regra: Cache de vídeos estáticos
+
+### Expressão
+
+```
+(http.host eq "media.anhanga.tur.br" and starts_with(http.request.uri.path, "/videos/"))
+```
+
+### Configuração
+
+| Parâmetro | Valor | Motivo |
+|---|---|---|
+| Cache eligibility | Eligible for cache | Torna vídeos cacheáveis na borda |
+| Edge TTL | 1 year (31536000s) | Assets estáticos versionados por nome de arquivo |
+| Browser TTL | 1 day (86400s) | Equilíbrio entre performance e capacidade de atualização |
+| Respect origin | Override origin | R2 não envia Cache-Control por padrão |
+
+### Onde criar
+
+Cloudflare Dashboard → zona `anhanga.tur.br` → Caching → Cache Rules → Create rule.
+
+### Resultado esperado
+
+Após ativar a regra, requisições repetidas devem mostrar progressão:
+
+```
+cf-cache-status: MISS    → primeiro request (popula o cache)
+cf-cache-status: HIT     → requests subsequentes
+```
+
+`Accept-Ranges: bytes` deve continuar presente para suportar range requests (Safari/iOS).
+
+## Vídeos cobertos
+
+Todos os vídeos referenciados em `data/mediaConfig.ts` e landings:
+
+| Arquivo | Tamanho | Uso |
+|---|---|---|
+| `videos/hero/rio.mp4` | ~19 MB | Hero principal |
+| `videos/hero/paris.mp4` | ~4 MB | Hero principal |
+| `videos/hero/maldivas.mp4` | ~8 MB | Hero principal |
+| `videos/hero/new-york.mp4` | ~40 MB | Hero principal |
+| `videos/hero/natureza.mp4` | ~5 MB | Hero principal |
+| `videos/lollapalooza/hero/crowd-background.mp4` | ~8 MB | Landing Lollapalooza |
+
+**Total: ~84 MB de vídeo servidos sem cache de borda.**
+
+## Validação
+
+Após criar a regra, verificar com:
+
+```bash
+# Primeiro request (espera MISS)
+curl -sSI https://media.anhanga.tur.br/videos/hero/rio.mp4 | grep -i "cf-cache\|cache-control\|accept-ranges"
+
+# Segundo request (espera HIT)
+curl -sSI https://media.anhanga.tur.br/videos/hero/rio.mp4 | grep -i "cf-cache\|cache-control\|accept-ranges"
+
+# Verificar todos os vídeos
+for v in videos/hero/rio.mp4 videos/hero/paris.mp4 videos/hero/maldivas.mp4 videos/hero/new-york.mp4 videos/hero/natureza.mp4 videos/lollapalooza/hero/crowd-background.mp4; do
+  echo "=== $v ==="
+  curl -sSI "https://media.anhanga.tur.br/$v" | grep -i "cf-cache\|cache-control\|accept-ranges"
+done
+```
+
+## Política de versionamento
+
+A regra usa Edge TTL de 1 ano. Se um vídeo precisar ser substituído:
+
+1. **Preferido:** Upload com nome de arquivo diferente (ex: `rio-v2.mp4`) e atualizar `data/mediaConfig.ts`.
+2. **Alternativa:** Purge manual via Dashboard → Caching → Purge Cache → Custom Purge → URL específica.
+
+Não usar query strings para versionamento — Cloudflare por padrão inclui query string na cache key, mas a configuração pode variar.
+
+## Observação sobre new-york.mp4
+
+O vídeo `new-york.mp4` tem ~40 MB — significativamente maior que os demais.
+Considerar reencoding com bitrate menor ou substituição por versão mais leve em tarefa futura.
+
+## Referências
+
+- [Cloudflare Cache Rules](https://developers.cloudflare.com/cache/how-to/cache-rules/)
+- [Cloudflare R2 + Custom Domains](https://developers.cloudflare.com/r2/buckets/public-buckets/#custom-domains)
+- [Cloudflare Default Cache Behavior](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/)

--- a/tests/static-media-assets.test.ts
+++ b/tests/static-media-assets.test.ts
@@ -303,6 +303,32 @@ test('remaining runtime media dependencies should use managed Cloudflare assets'
   assert.match(blogPost, /image: "images\/blog\/blog-viagem-solo-feminina\.png"/);
 });
 
+test('hero videos should all point to the media zone /videos/ path with .mp4 extension', async () => {
+  const mediaConfig = await readRepoFile('data/mediaConfig.ts');
+
+  const videoUrlMatches = [...mediaConfig.matchAll(/getMediaUrl\('(videos\/.+?\.mp4)'\)/g)];
+  assert.ok(videoUrlMatches.length >= 5, `Expected at least 5 hero video URLs, found ${videoUrlMatches.length}`);
+
+  for (const [, path] of videoUrlMatches) {
+    assert.ok(
+      path.startsWith('videos/'),
+      `Video path ${path} should start with videos/`,
+    );
+    assert.ok(
+      path.endsWith('.mp4'),
+      `Video path ${path} should end with .mp4`,
+    );
+  }
+
+  const posterMatches = [...mediaConfig.matchAll(/getMediaUrl\('(images\/hero\/.+?-poster\.jpg)'\)/g)];
+  assert.ok(posterMatches.length >= 5, `Expected at least 5 poster URLs, found ${posterMatches.length}`);
+});
+
+test('lollapalooza landing video should point to the media zone /videos/ path', async () => {
+  const lollaHero = await readRepoFile('components/landings/lollapalooza/Hero.tsx');
+  assert.match(lollaHero, /videos\/lollapalooza\/hero\/crowd-background\.mp4/);
+});
+
 test('blog posts should not hotlink third-party cover images', async () => {
   const filenames = await readdir(new URL('../content/blog', import.meta.url));
   const postFiles = filenames.filter((filename) => filename.endsWith('.mdx') && !filename.startsWith('_'));

--- a/tests/static-media-assets.test.ts
+++ b/tests/static-media-assets.test.ts
@@ -306,21 +306,10 @@ test('remaining runtime media dependencies should use managed Cloudflare assets'
 test('hero videos should all point to the media zone /videos/ path with .mp4 extension', async () => {
   const mediaConfig = await readRepoFile('data/mediaConfig.ts');
 
-  const videoUrlMatches = [...mediaConfig.matchAll(/getMediaUrl\('(videos\/.+?\.mp4)'\)/g)];
+  const videoUrlMatches = [...mediaConfig.matchAll(/getMediaUrl\(['\"](videos\/.+?\.mp4)['"]\)/g)];
   assert.ok(videoUrlMatches.length >= 5, `Expected at least 5 hero video URLs, found ${videoUrlMatches.length}`);
 
-  for (const [, path] of videoUrlMatches) {
-    assert.ok(
-      path.startsWith('videos/'),
-      `Video path ${path} should start with videos/`,
-    );
-    assert.ok(
-      path.endsWith('.mp4'),
-      `Video path ${path} should end with .mp4`,
-    );
-  }
-
-  const posterMatches = [...mediaConfig.matchAll(/getMediaUrl\('(images\/hero\/.+?-poster\.jpg)'\)/g)];
+  const posterMatches = [...mediaConfig.matchAll(/getMediaUrl\(['\"](images\/hero\/.+?-poster\.jpg)['"]\)/g)];
   assert.ok(posterMatches.length >= 5, `Expected at least 5 poster URLs, found ${posterMatches.length}`);
 });
 


### PR DESCRIPTION
## Summary

- Adds `docs/cloudflare-cache-rules.md` with operational documentation for a Cloudflare Cache Rule targeting `media.anhanga.tur.br/videos/*`
- Adds regression tests verifying video URL shapes in `data/mediaConfig.ts` and landing pages
- All 6 video assets currently return `cf-cache-status: DYNAMIC` (~84 MB total served without edge cache)

## Context

Confirmed via `curl -I` on 2026-05-22 that all hero videos and the Lollapalooza landing video bypass Cloudflare edge cache. The fix requires a Cache Rule in the Cloudflare Dashboard (documented in the new file), not code changes.

## What needs to happen after merge

1. Create the Cache Rule in Cloudflare Dashboard → zona `anhanga.tur.br` → Caching → Cache Rules
2. Run the validation commands from the doc to confirm `cf-cache-status` transitions from `MISS` → `HIT`

## Test plan

- [x] `pnpm test:regression` — 412 tests pass (including 2 new video URL shape tests)
- [x] `pnpm build` — clean build
- [ ] After Cache Rule activation: `curl -sSI` validation per doc

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)