### PR TITLE
feat(animation): animação de assinatura na seção HowItWorks

### DIFF
--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { m } from 'framer-motion';
 import {
   ChatCircleDots,
   PaintBrushBroad,
@@ -10,6 +11,9 @@ import {
   Heart,
 } from '@phosphor-icons/react';
 import { openContactModal } from '../utils/contactForm';
+
+const PATH_D = "M 500 50 C 500 150, 200 150, 200 250 C 200 350, 800 350, 800 450 C 800 550, 200 550, 200 650 C 200 750, 500 750, 500 800";
+const EASE_EXPO = [0.16, 1, 0.3, 1] as const;
 
 // Moved outside component to prevent re-allocation on every render
 const STEPS = [
@@ -105,13 +109,26 @@ const HowItWorks = memo(() => {
             {/* The Winding Path (Dashed Line SVG) - Desktop Only */}
             <div className="hidden md:block absolute top-0 left-0 w-full h-full pointer-events-none z-0">
                 <svg className="w-full h-full" viewBox="0 0 1000 800" preserveAspectRatio="none">
-                    <path 
-                        d="M 500 50 C 500 150, 200 150, 200 250 C 200 350, 800 350, 800 450 C 800 550, 200 550, 200 650 C 200 750, 500 750, 500 800" 
-                        fill="none" 
-                        stroke="#cbd5e1" 
-                        strokeWidth="4" 
+                    {/* Ghost trail — sempre visível como guia */}
+                    <path
+                        d={PATH_D}
+                        fill="none"
+                        stroke="#cbd5e1"
+                        strokeWidth="4"
                         strokeDasharray="12 12"
-                        className="opacity-60"
+                        className="opacity-30"
+                    />
+                    {/* Caminho animado — desenha-se sobre o ghost ao entrar na viewport */}
+                    <m.path
+                        d={PATH_D}
+                        fill="none"
+                        stroke="#cbd5e1"
+                        strokeWidth="4"
+                        strokeLinecap="round"
+                        initial={{ pathLength: 0 }}
+                        whileInView={{ pathLength: 1 }}
+                        viewport={{ once: true, amount: 0.1 }}
+                        transition={{ duration: 2.2, ease: "easeInOut" }}
                     />
                 </svg>
             </div>
@@ -123,7 +140,14 @@ const HowItWorks = memo(() => {
                 {STEPS.map((step, idx) => {
                     const isEven = idx % 2 === 0;
                     return (
-                        <div key={step.id} className={`flex flex-col md:flex-row items-center w-full relative z-10 ${isEven ? 'md:justify-start' : 'md:justify-end'}`}>
+                        <m.div
+                            key={step.id}
+                            initial={{ opacity: 0, x: isEven ? -32 : 32, y: 20 }}
+                            whileInView={{ opacity: 1, x: 0, y: 0 }}
+                            viewport={{ once: true, amount: 0.25 }}
+                            transition={{ duration: 0.7, ease: EASE_EXPO, delay: idx * 0.15 }}
+                            className={`flex flex-col md:flex-row items-center w-full relative z-10 ${isEven ? 'md:justify-start' : 'md:justify-end'}`}
+                        >
                             
                             {/* The Card */}
                             <div className={`
@@ -160,7 +184,7 @@ const HowItWorks = memo(() => {
                             
                             {/* Empty space for the zig-zag on desktop */}
                             <div className="hidden md:block md:w-[10%]"></div>
-                        </div>
+                        </m.div>
                     );
                 })}
             </div>

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -116,6 +116,7 @@ const HowItWorks = memo(() => {
                         stroke="#cbd5e1"
                         strokeWidth="4"
                         strokeDasharray="12 12"
+                        strokeLinecap="round"
                         className="opacity-30"
                     />
                     {/* Caminho animado — desenha-se sobre o ghost ao entrar na viewport */}
@@ -128,7 +129,7 @@ const HowItWorks = memo(() => {
                         initial={{ pathLength: 0 }}
                         whileInView={{ pathLength: 1 }}
                         viewport={{ once: true, amount: 0.1 }}
-                        transition={{ duration: 2.2, ease: "easeInOut" }}
+                        transition={{ duration: 2.2, ease: EASE_EXPO }}
                     />
                 </svg>
             </div>


### PR DESCRIPTION
## Resumo

- SVG winding path se desenha ao entrar na viewport via `m.path` com `pathLength: 0 → 1` em 2.2s
- Cada um dos 4 step cards revela com stagger de 150ms e slide alternado esquerda/direita (`x: ±32, y: 20 → 0`)
- Abordagem de duas camadas no SVG: ghost dashed estático (opacity 30%) + overlay animado sólido — evita conflito com `strokeDasharray` interno do Framer Motion
- Transforms CSS de rotação nos cards (`-rotate-2`, `rotate-3` etc.) preservados no `div` interno sem conflito com o `m.div` externo
- `prefers-reduced-motion` coberto pelo reset global já existente em `src/index.css`
- Easing: `[0.16, 1, 0.3, 1]` (EASE_OUT_EXPO do design system)

## Test plan

- [ ] Abrir `http://localhost:3000` e scrollar até a seção "Como a mágica acontece?"
- [ ] Verificar que o path SVG se desenha ao entrar na viewport (desktop)
- [ ] Verificar que os 4 cards aparecem em sequência com slide alternado esquerda/direita
- [ ] Confirmar que os hovers existentes (scale, translate, rotate do ícone, sticker) continuam funcionando
- [ ] Testar no mobile: sem SVG animado (hidden md:block), cards revelam com y slide
- [ ] Testar com `prefers-reduced-motion: reduce` nas configurações do SO — animações devem ser instantâneas

🤖 Generated with [Claude Code](https://claude.com/claude-code)