### PR TITLE
fix(build): lazy-load rollup-plugin-visualizer only when ANALYZE=true

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -174,8 +174,8 @@ function stripMdxFrontmatterPlugin() {
   };
 }
 
-const visualizerPlugin = process.env.ANALYZE === 'true'
-  ? (await import('rollup-plugin-visualizer')).visualizer({ filename: 'dist/stats.html', open: false, gzipSize: true })
+const visualizerModule = process.env.ANALYZE === 'true'
+  ? await import('rollup-plugin-visualizer')
   : null;
 
 export default defineConfig(({ mode, isSsrBuild }) => {
@@ -194,6 +194,10 @@ export default defineConfig(({ mode, isSsrBuild }) => {
   const devHost = env.VITE_DEV_HOST || process.env.VITE_DEV_HOST || '0.0.0.0';
   const devPort = Number(env.VITE_DEV_PORT || process.env.VITE_DEV_PORT || '3000');
   const devStrictPort = (env.VITE_DEV_STRICT_PORT || process.env.VITE_DEV_STRICT_PORT || 'false') === 'true';
+  const shouldAnalyze = (env.ANALYZE || process.env.ANALYZE) === 'true';
+  const visualizerPlugin = visualizerModule && shouldAnalyze && !isSsrBuild
+    ? visualizerModule.visualizer({ filename: 'dist/stats.html', open: false, gzipSize: true })
+    : null;
 
   // Logs de debug (útil para verificar se a variável está sendo carregada)
   logger.debug(`🔧 Building with base path: ${base}`);
@@ -236,7 +240,7 @@ export default defineConfig(({ mode, isSsrBuild }) => {
       minify: 'esbuild',
       rollupOptions: {
         output: {
-          manualChunks: isSsrBuild ? undefined : (id) => {
+          manualChunks: isSsrBuild ? undefined : (id: string) => {
             if (id.includes('/node_modules/react/') || id.includes('/node_modules/react-dom/') || id.includes('/node_modules/react-router-dom/')) {
               return 'react-vendor';
             }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,6 @@ import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import mdx from '@mdx-js/rollup';
 import remarkGfm from 'remark-gfm';
-import { visualizer } from 'rollup-plugin-visualizer';
 import { DEFAULT_GEMINI_MODEL } from './lib/ai/constants.ts';
 import { stripYamlFrontmatter } from './lib/mdx-frontmatter.ts';
 import { logger } from './lib/logger.ts';
@@ -175,6 +174,10 @@ function stripMdxFrontmatterPlugin() {
   };
 }
 
+const visualizerPlugin = process.env.ANALYZE === 'true'
+  ? (await import('rollup-plugin-visualizer')).visualizer({ filename: 'dist/stats.html', open: false, gzipSize: true })
+  : null;
+
 export default defineConfig(({ mode, isSsrBuild }) => {
   // Carregar variáveis de ambiente do arquivo .env e do sistema
   // O segundo parâmetro '.' significa o diretório atual (raiz do projeto)
@@ -216,7 +219,7 @@ export default defineConfig(({ mode, isSsrBuild }) => {
       react({ include: /\.(jsx|tsx|mdx)$/ }),
       adminHtmlDevPlugin(),
       apiDevPlugin(),
-      visualizer({ filename: 'dist/stats.html', open: false, gzipSize: true }),
+      ...(visualizerPlugin ? [visualizerPlugin] : []),
     ],
     define: {
       'process.env.GEMINI_MODEL': JSON.stringify(geminiModel)


### PR DESCRIPTION
## Problema

`pnpm build` e `pnpm typecheck` falhavam com:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'rollup-plugin-visualizer'
```

O import estático no topo de `vite.config.ts` tentava carregar o pacote em tempo de módulo — antes mesmo de qualquer código de configuração rodar. Em ambientes de CI onde `devDependencies` não são instaladas (`pnpm install --prod` ou `NODE_ENV=production`), isso causava falha imediata no build.

## Fix

Removido o import estático e substituído por um top-level `await import(...)` condicional, gateado pela variável `ANALYZE=true`:

```ts
// antes
import { visualizer } from 'rollup-plugin-visualizer';
// ...
visualizer({ filename: 'dist/stats.html', open: false, gzipSize: true }),

// depois
const visualizerPlugin = process.env.ANALYZE === 'true'
  ? (await import('rollup-plugin-visualizer')).visualizer({ filename: 'dist/stats.html', open: false, gzipSize: true })
  : null;
// ...
...(visualizerPlugin ? [visualizerPlugin] : []),
```

**Como usar o bundle analyzer:**
```bash
ANALYZE=true pnpm build  # gera dist/stats.html
pnpm build               # build normal, sem carregar o plugin
```

## Testes

- `pnpm typecheck` ✅
- `pnpm test:regression` — 414 testes, 0 falhas ✅

Closes #643