### PR TITLE
fix(a11y): harden accessibility across nav, chat, and section components

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -113,6 +113,7 @@ const AIChat: React.FC = memo(() => {
   const isOrlandoPage = location.pathname.startsWith('/orlando');
 
   const [liveAnnouncement, setLiveAnnouncement] = useState('');
+  const prevMessagesCount = useRef(messages.length);
 
   // PERFORMANCE: Pre-calculate the index of the last model message to avoid O(N^2)
   // lookup inside the render loop's map function.
@@ -124,10 +125,18 @@ const AIChat: React.FC = memo(() => {
   }, [messages]);
 
   useEffect(() => {
-    if (lastModelIndex >= 0 && !messages[lastModelIndex].isAction) {
-      setLiveAnnouncement(messages[lastModelIndex].text);
+    if (messages.length > prevMessagesCount.current) {
+      const newModelMessages = messages
+        .slice(prevMessagesCount.current)
+        .filter(m => m.role === 'model' && !m.isAction);
+
+      if (newModelMessages.length > 0) {
+        const fullText = newModelMessages.map(m => m.text).join(' ');
+        setLiveAnnouncement(fullText.replace(/\*\*|\*|- /g, ''));
+      }
     }
-  }, [lastModelIndex, messages]);
+    prevMessagesCount.current = messages.length;
+  }, [messages]);
 
   useEffect(() => {
     messagesRef.current = messages;

--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -112,6 +112,8 @@ const AIChat: React.FC = memo(() => {
   const navigate = useNavigate();
   const isOrlandoPage = location.pathname.startsWith('/orlando');
 
+  const [liveAnnouncement, setLiveAnnouncement] = useState('');
+
   // PERFORMANCE: Pre-calculate the index of the last model message to avoid O(N^2)
   // lookup inside the render loop's map function.
   const lastModelIndex = useMemo(() => {
@@ -120,6 +122,12 @@ const AIChat: React.FC = memo(() => {
     }
     return -1;
   }, [messages]);
+
+  useEffect(() => {
+    if (lastModelIndex >= 0 && !messages[lastModelIndex].isAction) {
+      setLiveAnnouncement(messages[lastModelIndex].text);
+    }
+  }, [lastModelIndex, messages]);
 
   useEffect(() => {
     messagesRef.current = messages;
@@ -465,6 +473,11 @@ const AIChat: React.FC = memo(() => {
           >
             <X className="size-5" weight="bold" />
           </button>
+        </div>
+
+        {/* Screen-reader announcer for new AI messages */}
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {liveAnnouncement}
         </div>
 
         {/* Messages Area - Scrapbook vibe */}

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -96,7 +96,7 @@ const Header: React.FC = () => {
               onClick={handleContactClick}
               className={`btn-whatsapp btn-specialist rounded-full font-medium text-sm transition duration-500 flex items-center gap-2 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-vibrant ${ctaPaddingClass} ${buttonClass}`}
             >
-              <Phone className="size-4" weight="fill" />
+              <Phone className="size-4" weight="fill" aria-hidden="true" />
               Fale Conosco
             </a>
           </div>
@@ -108,7 +108,7 @@ const Header: React.FC = () => {
             aria-expanded={isMobileMenuOpen}
             aria-controls="mobile-menu"
           >
-            {isMobileMenuOpen ? <X className="size-6" weight="bold" /> : <List className="size-6" weight="bold" />}
+            {isMobileMenuOpen ? <X className="size-6" weight="bold" aria-hidden="true" /> : <List className="size-6" weight="bold" aria-hidden="true" />}
           </button>
         </div>
       </div>

--- a/components/Header/HeaderNavigation.tsx
+++ b/components/Header/HeaderNavigation.tsx
@@ -42,7 +42,7 @@ export function DesktopNavigation({
         <div key={link.name} className="relative group">
           {link.subLinks ? (
             <>
-              <button className={`flex items-center gap-1 cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-yellow focus-visible:ring-offset-2 focus-visible:rounded ${navTextClass}`}>
+              <button className={`flex items-center gap-1 cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-yellow focus-visible:outline-offset-2 rounded ${navTextClass}`}>
                 {link.name}
                 <CaretDown className="size-4 transition-transform duration-300 group-hover:rotate-180" weight="bold" />
               </button>
@@ -80,7 +80,7 @@ export function DesktopNavigation({
                   onNavClick(event, link.href!);
                 }
               }}
-              className={`cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-yellow focus-visible:ring-offset-2 focus-visible:rounded ${navTextClass}`}
+              className={`cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-yellow focus-visible:outline-offset-2 rounded ${navTextClass}`}
             >
               {link.name}
             </a>
@@ -90,7 +90,7 @@ export function DesktopNavigation({
 
       <a
         href={getBlogHomeUrl()}
-        className={`font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-yellow focus-visible:ring-offset-2 focus-visible:rounded ${navTextClass}`}
+        className={`font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-yellow focus-visible:outline-offset-2 rounded ${navTextClass}`}
       >
         Blog de Viagens
       </a>
@@ -125,7 +125,7 @@ export function MobileNavigationMenu({
               <a
                 key={subLink.name}
                 href={href}
-                className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant focus-visible:ring-offset-1 focus-visible:rounded"
+                className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-vibrant focus-visible:outline-offset-1 rounded"
                 onClick={(event) => {
                   if (!isPageLink(subLink.href) && isHome) {
                     onNavClick(event, subLink.href);
@@ -144,7 +144,7 @@ export function MobileNavigationMenu({
           <a
             key={link.name}
             href={buildSectionHref(link.href!, isHome)}
-            className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant focus-visible:ring-offset-1 focus-visible:rounded"
+            className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-vibrant focus-visible:outline-offset-1 rounded"
             onClick={(event) => {
               if (isHome) {
                 onNavClick(event, link.href!);
@@ -160,7 +160,7 @@ export function MobileNavigationMenu({
 
       <a
         href={getBlogHomeUrl()}
-        className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant focus-visible:ring-offset-1 focus-visible:rounded"
+        className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-vibrant focus-visible:outline-offset-1 rounded"
         onClick={onCloseMenu}
       >
         Blog de Viagens

--- a/components/Header/HeaderNavigation.tsx
+++ b/components/Header/HeaderNavigation.tsx
@@ -42,7 +42,7 @@ export function DesktopNavigation({
         <div key={link.name} className="relative group">
           {link.subLinks ? (
             <>
-              <button className={`flex items-center gap-1 cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus:underline decoration-2 underline-offset-4 ${navTextClass}`}>
+              <button className={`flex items-center gap-1 cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-yellow focus-visible:ring-offset-2 focus-visible:rounded ${navTextClass}`}>
                 {link.name}
                 <CaretDown className="size-4 transition-transform duration-300 group-hover:rotate-180" weight="bold" />
               </button>
@@ -80,7 +80,7 @@ export function DesktopNavigation({
                   onNavClick(event, link.href!);
                 }
               }}
-              className={`cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus:underline decoration-2 underline-offset-4 ${navTextClass}`}
+              className={`cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-yellow focus-visible:ring-offset-2 focus-visible:rounded ${navTextClass}`}
             >
               {link.name}
             </a>
@@ -90,7 +90,7 @@ export function DesktopNavigation({
 
       <a
         href={getBlogHomeUrl()}
-        className={`font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus:underline decoration-2 underline-offset-4 ${navTextClass}`}
+        className={`font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-yellow focus-visible:ring-offset-2 focus-visible:rounded ${navTextClass}`}
       >
         Blog de Viagens
       </a>
@@ -125,7 +125,7 @@ export function MobileNavigationMenu({
               <a
                 key={subLink.name}
                 href={href}
-                className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:text-brand-vibrant focus:outline-none"
+                className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant focus-visible:ring-offset-1 focus-visible:rounded"
                 onClick={(event) => {
                   if (!isPageLink(subLink.href) && isHome) {
                     onNavClick(event, subLink.href);
@@ -144,7 +144,7 @@ export function MobileNavigationMenu({
           <a
             key={link.name}
             href={buildSectionHref(link.href!, isHome)}
-            className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:text-brand-vibrant focus:outline-none"
+            className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant focus-visible:ring-offset-1 focus-visible:rounded"
             onClick={(event) => {
               if (isHome) {
                 onNavClick(event, link.href!);
@@ -160,7 +160,7 @@ export function MobileNavigationMenu({
 
       <a
         href={getBlogHomeUrl()}
-        className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:text-brand-vibrant focus:outline-none"
+        className="text-zinc-700 font-medium py-2 border-b border-zinc-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant focus-visible:ring-offset-1 focus-visible:rounded"
         onClick={onCloseMenu}
       >
         Blog de Viagens

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -204,10 +204,10 @@ const HowItWorks = memo(() => {
                     }}
                     className="relative z-10 flex items-center gap-4 bg-white text-brand-dark px-10 py-6 rounded-full font-black text-xl shadow-[0_20px_50px_rgba(8,_112,_184,_0.15)] hover:shadow-[0_20px_50px_rgba(8,_112,_184,_0.25)] transform transition hover:scale-105 active:scale-95 border-4 border-transparent hover:border-brand-yellow text-left"
                 >
-                    <Sparkle className="size-6 text-brand-yellow" weight="fill" />
+                    <Sparkle className="size-6 text-brand-yellow" weight="fill" aria-hidden="true" />
                     <span>Quero meu roteiro agora!</span>
                     <div className="size-10 bg-brand-dark rounded-full flex items-center justify-center text-white">
-                        <ArrowRight className="size-5" weight="bold" />
+                        <ArrowRight className="size-5" weight="bold" aria-hidden="true" />
                     </div>
                 </button>
             </div>

--- a/components/Testimonials.tsx
+++ b/components/Testimonials.tsx
@@ -57,7 +57,7 @@ const Testimonials: React.FC = memo(() => {
                 <SectionHeader
                     badge="Love Notes"
                     badgeIcon={<MessageSquareHeart className="size-4 text-red-500 fill-red-500" />}
-                    title="Mural do Amor ❤️"
+                    title={<>Mural do Amor <span aria-hidden="true">❤️</span></>}
                     subtitle="Depoimentos reais de quem viajou com a gente"
                     className="mb-16"
                 />

--- a/components/ui/SectionHeader.tsx
+++ b/components/ui/SectionHeader.tsx
@@ -7,7 +7,7 @@ const alignClasses: Record<'center' | 'left', string> = {
 };
 
 interface SectionHeaderProps {
-    title: string;
+    title: React.ReactNode;
     badge?: string;
     badgeIcon?: React.ReactNode;
     badgeColor?: BadgeColor;


### PR DESCRIPTION
## Summary

- **AIChat**: adiciona região `aria-live="polite"` visualmente oculta que anuncia cada resposta da IA para leitores de tela — anteriormente o container de mensagens não tinha nenhum live region
- **Testimonials / SectionHeader**: emoji decorativo `❤️` no título agora envolvido em `<span aria-hidden="true">`; prop `title` de `SectionHeader` alargado de `string` para `React.ReactNode` (não-breaking)
- **HeaderNavigation**: indicadores de foco nos links de nav substituídos por `focus-visible:ring-2` com cor contrastante — visíveis tanto sobre o hero transparente quanto sobre o header branco
- **Header / HowItWorks**: `aria-hidden="true"` adicionado em ícones decorativos dentro de elementos interativos com texto visível (`Phone`, `X`, `List`, `Sparkle`, `ArrowRight`)

## Test plan

- [x] Navegar pela página com Tab e verificar que o anel amarelo/cyan aparece claramente em todos os links do menu (desktop e mobile)
- [ ] Abrir o chat com leitor de tela (VoiceOver/NVDA) e confirmar que cada mensagem da IA é anunciada automaticamente
- [ ] Verificar que o título "Mural do Amor" é lido como "Mural do Amor" (sem o emoji) pelo leitor de tela
- [ ] `pnpm typecheck` — sem erros nos arquivos alterados

🤖 Generated with [Claude Code](https://claude.com/claude-code)