### PR TITLE
fix(deps): pin qs >=6.15.2 — CVE-2026-8723

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
   "overrides": {
     "rimraf": "^6.1.3",
     "glob": "^13.0.6",
-    "minimatch": "^10.2.2"
+    "minimatch": "^10.2.2",
+    "qs": "^6.15.2"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -82,7 +83,8 @@
     "overrides": {
       "rimraf": "^6.1.3",
       "glob": "^13.0.6",
-      "minimatch": "^10.2.2"
+      "minimatch": "^10.2.2",
+      "qs": "^6.15.2"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   rimraf: ^6.1.3
   glob: ^13.0.6
   minimatch: ^10.2.2
+  qs: ^6.15.2
 
 importers:
 
@@ -2573,8 +2574,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -4032,7 +4033,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -4432,7 +4433,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -5540,7 +5541,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.14.2:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
## Resumo

- Adiciona override de `qs` para `^6.15.2` em `overrides` e `pnpm.overrides` no `package.json`
- Atualiza `pnpm-lock.yaml` de `qs@6.14.2` para `qs@6.15.2`
- Resolve Dependabot alert #30 (GHSA-q8mj-m7cp-5q26 / CVE-2026-8723)

**Vulnerabilidade:** `qs.stringify` lançava `TypeError` ao receber arrays com `null`/`undefined` com `arrayFormat:'comma'` + `encodeValuesOnly:true`, causando DoS em request handlers sem error boundary.

**Cadeia:** `decap-server` (devDep) → `express` → `body-parser` → `qs`
**Impacto real:** baixo — dependência de desenvolvimento, não entra no bundle de produção.
**Fix:** pino via override para a versão corrigida `6.15.2`.

## Plano de testes

- [x] `pnpm why qs` confirma `qs@6.15.2` instalado
- [ ] CI `build-and-test` passa

Fecha: https://github.com/felipewilliam2/AV-SITE/security/dependabot/30

🤖 Generated with [Claude Code](https://claude.com/claude-code)