### PR TITLE
chore(design): unify color tokens and eliminate hard-coded values

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -415,7 +415,7 @@ const AIChat: React.FC = memo(() => {
                     bottom-4 right-4 sm:bottom-6 sm:right-6 z-[9990]
                     flex items-center justify-center gap-3
                     bg-brand-vibrant text-white
-                    shadow-[0_8px_30px_rgba(14,165,233,0.3)] hover:shadow-[0_8px_30px_rgba(14,165,233,0.5)] hover:-translate-y-1
+                    shadow-[0_8px_30px_theme(colors.brand.cyan/30%)] hover:shadow-[0_8px_30px_theme(colors.brand.cyan/50%)] hover:-translate-y-1
                     transition duration-300
                     size-16 rounded-2xl sm:w-auto sm:h-auto sm:px-6 sm:py-3.5 sm:rounded-full
                     focus:outline-none focus-visible:ring-4 focus-visible:ring-brand-vibrant/30

--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -415,7 +415,7 @@ const AIChat: React.FC = memo(() => {
                     bottom-4 right-4 sm:bottom-6 sm:right-6 z-[9990]
                     flex items-center justify-center gap-3
                     bg-brand-vibrant text-white
-                    shadow-[0_8px_30px_rgba(255,107,53,0.3)] hover:shadow-[0_8px_30px_rgba(255,107,53,0.5)] hover:-translate-y-1
+                    shadow-[0_8px_30px_rgba(14,165,233,0.3)] hover:shadow-[0_8px_30px_rgba(14,165,233,0.5)] hover:-translate-y-1
                     transition duration-300
                     size-16 rounded-2xl sm:w-auto sm:h-auto sm:px-6 sm:py-3.5 sm:rounded-full
                     focus:outline-none focus-visible:ring-4 focus-visible:ring-brand-vibrant/30
@@ -448,7 +448,7 @@ const AIChat: React.FC = memo(() => {
       <div
         ref={drawerRef}
         tabIndex={-1}
-        className={`fixed top-0 right-0 h-full w-full sm:w-[450px] z-[9999] bg-[#fdfdfc] flex flex-col shadow-[-10px_0_40px_rgba(0,0,0,0.1)] transition-all duration-500 ease-[cubic-bezier(0.19,1,0.22,1)] sm:rounded-l-[2rem] overflow-hidden outline-none ${isOpen ? 'translate-x-0 visible opacity-100' : 'translate-x-full invisible opacity-0'
+        className={`fixed top-0 right-0 h-full w-full sm:w-[450px] z-[9999] bg-white flex flex-col shadow-[-10px_0_40px_rgba(0,0,0,0.1)] transition-all duration-500 ease-[cubic-bezier(0.19,1,0.22,1)] sm:rounded-l-[2rem] overflow-hidden outline-none ${isOpen ? 'translate-x-0 visible opacity-100' : 'translate-x-full invisible opacity-0'
           }`}
         role="dialog"
         aria-modal="true"
@@ -490,7 +490,7 @@ const AIChat: React.FC = memo(() => {
         </div>
 
         {/* Messages Area - Scrapbook vibe */}
-        <div className="flex-1 overflow-y-auto p-6 space-y-6 scroll-smooth bg-[#fdfdfc] relative">
+        <div className="flex-1 overflow-y-auto p-6 space-y-6 scroll-smooth bg-white relative">
           {/* Fundo suave */}
           <div className="absolute inset-0 opacity-[0.03] pointer-events-none" style={{ backgroundImage: 'radial-gradient(circle at 1px 1px, black 1px, transparent 0)', backgroundSize: '32px 32px' }}></div>
 

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -28,7 +28,7 @@ const Blog: React.FC = memo(() => {
         <section id="blog" className="py-24 bg-white relative overflow-hidden dynamic-blog-content">
             {/* Background Decorations */}
             <div className="absolute top-0 right-0 size-96 bg-brand-cyan/5 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2"></div>
-            <div className="absolute bottom-0 left-0 w-full h-24 bg-[#fffdf5] skew-y-2 translate-y-12"></div>
+            <div className="absolute bottom-0 left-0 w-full h-24 bg-brand-surface skew-y-2 translate-y-12"></div>
 
             <div className="container mx-auto px-6 relative z-10">
                 {/* Header Section */}
@@ -48,7 +48,7 @@ const Blog: React.FC = memo(() => {
                 {featuredPost && (
                     <div className="mb-16 cursor-pointer relative">
                         <a href={getBlogPostUrl(featuredPost.slug)} className="group">
-                            <div className="bg-[#fffdf5] rounded-[2.5rem] p-6 md:p-8 border-4 border-zinc-100 shadow-[0_20px_40px_-10px_rgba(0,0,0,0.1)] flex flex-col md:flex-row gap-8 items-center transition-transform duration-300 hover:scale-[1.01]">
+                            <div className="bg-brand-surface rounded-[2.5rem] p-6 md:p-8 border-4 border-zinc-100 shadow-[0_20px_40px_-10px_rgba(0,0,0,0.1)] flex flex-col md:flex-row gap-8 items-center transition-transform duration-300 hover:scale-[1.01]">
 
                                 {/* Featured Image */}
                                 <div className="w-full md:w-1/2 relative">

--- a/components/Categories.tsx
+++ b/components/Categories.tsx
@@ -45,7 +45,7 @@ const POPULAR_DESTINATIONS = [
 const Categories = memo(() => {
 
   return (
-    <section className="py-24 bg-[#fffdf5] relative">
+    <section className="py-24 bg-brand-surface relative">
       <div className="container mx-auto px-6">
 
         {/* Header */}

--- a/components/Destinations.tsx
+++ b/components/Destinations.tsx
@@ -551,7 +551,7 @@ const Destinations: React.FC = memo(() => {
     };
 
     return (
-        <section id="destinos" className="py-24 bg-[#fffdf5] relative overflow-hidden">
+        <section id="destinos" className="py-24 bg-brand-surface relative overflow-hidden">
 
             {/* Background Doodles */}
             <div className="absolute top-0 right-0 w-full h-full opacity-[0.03] pointer-events-none z-0" style={{ backgroundImage: 'radial-gradient(circle at 1px 1px, black 1px, transparent 0)', backgroundSize: '40px 40px' }}></div>
@@ -697,7 +697,7 @@ const Destinations: React.FC = memo(() => {
                         role="dialog"
                         aria-modal="true"
                         aria-labelledby="dest-modal-title"
-                        className="bg-[#fffdf5] w-full max-w-4xl rounded-[2.5rem] shadow-2xl overflow-hidden relative flex flex-col md:flex-row max-h-[90vh] border-8 border-white transform rotate-1"
+                        className="bg-brand-surface w-full max-w-4xl rounded-[2.5rem] shadow-2xl overflow-hidden relative flex flex-col md:flex-row max-h-[90vh] border-8 border-white transform rotate-1"
                         onClick={e => e.stopPropagation()}
                     >
 

--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -200,9 +200,7 @@ const FAQ = memo(() => {
     return (
         <section
             id="faq-section"
-            className="py-24 relative overflow-hidden"
-            // Soft background request
-            style={{ backgroundColor: '#fffdf5' }}
+            className="py-24 relative overflow-hidden bg-brand-surface"
         >
             {/* Decorative blob for background interest */}
             <div className="absolute top-0 right-0 size-[500px] bg-yellow-100/40 rounded-full blur-3xl pointer-events-none -z-10 translate-x-1/3 -translate-y-1/3"></div>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -148,11 +148,11 @@ const Hero: React.FC = memo(() => {
               Agência de Viagens em São Paulo
             </span>
             Sua Próxima <br />
-            <span className="text-yellow-400 relative inline-block pb-2">
+            <span className="text-anhanga-yellow relative inline-block pb-2">
               {validCityForTitle ? `Aventura em ${validCityForTitle}` : 'Aventura'}
 
               {/* Underline Scribble - orgânico via Framer Motion pathLength */}
-              <svg className="absolute w-full h-4 -bottom-0 left-0 text-yellow-400 overflow-visible" viewBox="0 0 100 10" preserveAspectRatio="none">
+              <svg className="absolute w-full h-4 -bottom-0 left-0 text-anhanga-yellow overflow-visible" viewBox="0 0 100 10" preserveAspectRatio="none">
                 <m.path
                   d="M0 5 Q 50 15 100 5"
                   stroke="currentColor"
@@ -211,7 +211,7 @@ const Hero: React.FC = memo(() => {
       {/* Wavy Bottom Separator */}
       <div className="absolute bottom-0 left-0 w-full overflow-hidden leading-none rotate-180">
         <svg className="relative block w-[calc(100%+1.3px)] h-[60px]" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none">
-          <path d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z" fill="#fffdf5"></path>
+          <path d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z" className="fill-brand-surface"></path>
         </svg>
       </div>
     </section>

--- a/components/Highlights.tsx
+++ b/components/Highlights.tsx
@@ -81,7 +81,7 @@ const HIGHLIGHTS: HighlightItem[] = [
 
 const Highlights = memo(() => {
     return (
-        <section id="experiencia" className="py-24 bg-[#fffdf5] relative overflow-hidden">
+        <section id="experiencia" className="py-24 bg-brand-surface relative overflow-hidden">
 
             {/* Dot Pattern Background */}
             <div className="absolute inset-0 z-0 opacity-[0.3]"

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -77,7 +77,7 @@ const STEPS = [
 const HowItWorks = memo(() => {
 
   return (
-    <section id="como-funciona" className="pt-24 pb-32 relative overflow-hidden bg-[#fffdf5]" aria-label="Como Funciona">
+    <section id="como-funciona" className="pt-24 pb-32 relative overflow-hidden bg-brand-surface" aria-label="Como Funciona">
       
       {/* Background Pattern - Dot Grid */}
       <div className="absolute inset-0 z-0 opacity-[0.4]" 

--- a/components/LandingFAQ.tsx
+++ b/components/LandingFAQ.tsx
@@ -71,7 +71,7 @@ export const LandingFAQ: React.FC<LandingFAQProps> = ({
                     </p>
                 </div>
 
-                <div className="bg-[#fffdf5]/50 rounded-3xl p-4 md:p-8 border border-brand-cyan/10">
+                <div className="bg-brand-surface/50 rounded-3xl p-4 md:p-8 border border-brand-cyan/10">
                     {items.map((item, idx) => (
                         <FAQItemComponent
                             key={item.question}

--- a/components/SearchForm.tsx
+++ b/components/SearchForm.tsx
@@ -621,7 +621,7 @@ const SearchButton = memo(({ isSearchLoading, validationError }: SearchButtonPro
       type="submit"
       disabled={isSearchLoading}
       data-testid="submit-search-btn"
-      className="btn-specialist w-full md:w-auto h-full min-h-[70px] bg-brand-yellow hover:bg-yellow-400 text-brand-dark rounded-2xl md:rounded-[1.5rem] shadow-lg flex items-center justify-center gap-2 px-6 transition duration-300 ease-spring hover:scale-105 hover:shadow-xl active:scale-90 group border-2 border-transparent whitespace-nowrap"
+      className="btn-specialist w-full md:w-auto h-full min-h-[70px] bg-brand-yellow hover:bg-anhanga-yellowHover text-brand-dark rounded-2xl md:rounded-[1.5rem] shadow-lg flex items-center justify-center gap-2 px-6 transition duration-300 ease-spring hover:scale-105 hover:shadow-xl active:scale-90 group border-2 border-transparent whitespace-nowrap"
       data-tracking="hero-home"
     >
       {isSearchLoading ? (

--- a/components/cta/CtaBody.tsx
+++ b/components/cta/CtaBody.tsx
@@ -152,7 +152,7 @@ export function CtaBody() {
       <button
         type="button"
         onClick={() => setFormState('open')}
-        className="btn-specialist flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-8 py-4 rounded-xl shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition self-start"
+        className="btn-specialist flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-8 py-4 rounded-xl shadow-hard-yellow hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition self-start"
         data-tracking="cta-home-footer"
       >
         Solicitar meu Orçamento

--- a/components/cta/CtaBody.tsx
+++ b/components/cta/CtaBody.tsx
@@ -152,7 +152,7 @@ export function CtaBody() {
       <button
         type="button"
         onClick={() => setFormState('open')}
-        className="btn-specialist flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-8 py-4 rounded-xl shadow-hard-yellow hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition self-start"
+        className="btn-specialist flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-8 py-4 rounded-xl shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition self-start"
         data-tracking="cta-home-footer"
       >
         Solicitar meu Orçamento

--- a/components/landings/brazil-promotion-day/BpdContactSection.tsx
+++ b/components/landings/brazil-promotion-day/BpdContactSection.tsx
@@ -192,7 +192,7 @@ export function BpdContactSection() {
                                     href={whatsappUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-hard-yellow hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
+                                    className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
                                     data-contact-intent
                                     data-tracking="success-brazil-promotion-day"
                                 >
@@ -300,7 +300,7 @@ export function BpdContactSection() {
                                     <button
                                         type="submit"
                                         disabled={isSubmitting}
-                                        className="w-full flex items-center justify-center gap-3 bg-brand-dark text-white py-4 rounded-xl font-bold text-base shadow-hard-yellow hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition disabled:opacity-60 disabled:pointer-events-none"
+                                        className="w-full flex items-center justify-center gap-3 bg-brand-dark text-white py-4 rounded-xl font-bold text-base shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition disabled:opacity-60 disabled:pointer-events-none"
                                         data-tracking="submit-form-brazil-promotion-day"
                                     >
                                         {isSubmitting ? (

--- a/components/landings/brazil-promotion-day/BpdContactSection.tsx
+++ b/components/landings/brazil-promotion-day/BpdContactSection.tsx
@@ -80,7 +80,7 @@ export function BpdContactSection() {
     }
 
     return (
-        <section id="contato" className="py-24 bg-[#fffdf5] relative overflow-hidden">
+        <section id="contato" className="py-24 bg-brand-surface relative overflow-hidden">
 
             <div
                 className="absolute inset-0 z-0 opacity-[0.3]"
@@ -153,7 +153,7 @@ export function BpdContactSection() {
                                         href={href}
                                         target="_blank"
                                         rel="noopener noreferrer"
-                                        className="size-11 rounded-xl bg-white border-2 border-zinc-200 flex items-center justify-center text-zinc-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-[4px_4px_0px_#fbbf24] hover:-translate-y-1 transition duration-200"
+                                        className="size-11 rounded-xl bg-white border-2 border-zinc-200 flex items-center justify-center text-zinc-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-hard-yellow hover:-translate-y-1 transition duration-200"
                                         aria-label={label}
                                         {...(contact ? { 'data-contact-intent': true, 'data-tracking': 'social-whatsapp-brazil-promotion-day' } : {})}
                                     >
@@ -192,7 +192,7 @@ export function BpdContactSection() {
                                     href={whatsappUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
+                                    className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-hard-yellow hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
                                     data-contact-intent
                                     data-tracking="success-brazil-promotion-day"
                                 >
@@ -300,7 +300,7 @@ export function BpdContactSection() {
                                     <button
                                         type="submit"
                                         disabled={isSubmitting}
-                                        className="w-full flex items-center justify-center gap-3 bg-brand-dark text-white py-4 rounded-xl font-bold text-base shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition disabled:opacity-60 disabled:pointer-events-none"
+                                        className="w-full flex items-center justify-center gap-3 bg-brand-dark text-white py-4 rounded-xl font-bold text-base shadow-hard-yellow hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition disabled:opacity-60 disabled:pointer-events-none"
                                         data-tracking="submit-form-brazil-promotion-day"
                                     >
                                         {isSubmitting ? (

--- a/components/landings/brazil-promotion-day/BpdHero.tsx
+++ b/components/landings/brazil-promotion-day/BpdHero.tsx
@@ -136,7 +136,7 @@ export function BpdHero() {
                 <svg className="relative block w-[calc(100%+1.3px)] h-[60px]" viewBox="0 0 1200 120" preserveAspectRatio="none">
                     <path
                         d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"
-                        fill="#fffdf5"
+                        className="fill-brand-surface"
                     />
                 </svg>
             </div>

--- a/components/landings/brazil-promotion-day/BpdNav.tsx
+++ b/components/landings/brazil-promotion-day/BpdNav.tsx
@@ -18,7 +18,7 @@ export function BpdNav() {
                 <button
                     type="button"
                     onClick={() => openContactModal({ source: 'brazil-promotion-day' })}
-                    className="btn-whatsapp btn-specialist hidden sm:flex items-center gap-2 bg-brand-dark text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
+                    className="btn-whatsapp btn-specialist hidden sm:flex items-center gap-2 bg-brand-dark text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-hard-yellow hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
                     data-contact-intent
                     data-tracking="header-brazil-promotion-day"
                 >

--- a/components/landings/brazil-promotion-day/BpdNav.tsx
+++ b/components/landings/brazil-promotion-day/BpdNav.tsx
@@ -18,7 +18,7 @@ export function BpdNav() {
                 <button
                     type="button"
                     onClick={() => openContactModal({ source: 'brazil-promotion-day' })}
-                    className="btn-whatsapp btn-specialist hidden sm:flex items-center gap-2 bg-brand-dark text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-hard-yellow hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
+                    className="btn-whatsapp btn-specialist hidden sm:flex items-center gap-2 bg-brand-dark text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
                     data-contact-intent
                     data-tracking="header-brazil-promotion-day"
                 >

--- a/components/landings/brazil-promotion-day/BpdPillars.tsx
+++ b/components/landings/brazil-promotion-day/BpdPillars.tsx
@@ -4,7 +4,7 @@ import { PILLARS, fadeUp } from './constants';
 
 export function BpdPillars() {
     return (
-        <section className="py-24 bg-[#fffdf5] relative overflow-hidden">
+        <section className="py-24 bg-brand-surface relative overflow-hidden">
 
             {/* Dot pattern — same as Highlights */}
             <div

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -40,7 +40,7 @@ const About: React.FC = () => {
   }, [hash]);
 
   return (
-    <div className="bg-[#fffdf5] pt-32 pb-20">
+    <div className="bg-brand-surface pt-32 pb-20">
       <SEO
         title="Sobre a Anhangá Viagens | Agência de Viagens em São Paulo"
         description="Conheça a história e os valores da Anhangá Viagens. Somos uma agência de turismo certificada pela Cadastur em São Paulo, especializada em roteiros personalizados."

--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -154,7 +154,7 @@ const BlogList: React.FC = () => {
                             e.preventDefault();
                             openContactModal({ source: 'blog-list' });
                         }}
-                        className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-10 py-5 rounded-2xl shadow-hard-yellow hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
+                        className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-10 py-5 rounded-2xl shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
                         data-tracking="footer-blog-list"
                     >
                         Solicitar Orçamento

--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -42,7 +42,7 @@ const BlogList: React.FC = () => {
                 { name: 'Home', item: 'https://www.anhanga.tur.br/' },
                 { name: 'Blog', item: getBlogHomeUrl() }
             ]} />
-            <div className="min-h-screen bg-[#fffdf5] pt-32 md:pt-36 lg:pt-40 pb-24">
+            <div className="min-h-screen bg-brand-surface pt-32 md:pt-36 lg:pt-40 pb-24">
                 <div className="container mx-auto px-6">
 
                 {/* Header */}
@@ -154,7 +154,7 @@ const BlogList: React.FC = () => {
                             e.preventDefault();
                             openContactModal({ source: 'blog-list' });
                         }}
-                        className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-10 py-5 rounded-2xl shadow-[4px_4px_0px_#fbbf24] hover:shadow-[2px_2px_0px_#fbbf24] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
+                        className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-10 py-5 rounded-2xl shadow-hard-yellow hover:shadow-[2px_2px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
                         data-tracking="footer-blog-list"
                     >
                         Solicitar Orçamento

--- a/pages/BlogPost.tsx
+++ b/pages/BlogPost.tsx
@@ -61,7 +61,7 @@ const BlogPost: React.FC = () => {
 
     if (!post) {
         return (
-            <div className="min-h-screen flex flex-col items-center justify-center bg-[#fffdf5]">
+            <div className="min-h-screen flex flex-col items-center justify-center bg-brand-surface">
                 <h2 className="text-4xl font-black text-brand-dark mb-4 text-center px-6">Ops! Artigo não encontrado.</h2>
                 <a href={getBlogHomeUrl()} className="text-brand-cyan font-bold hover:underline flex items-center gap-2">
                     <ArrowLeft className="size-4" /> Voltar para o Blog
@@ -91,7 +91,7 @@ const BlogPost: React.FC = () => {
     const MdxContent = getMdxComponent(slug!);
 
     return (
-        <article className="min-h-screen bg-[#fffdf5]">
+        <article className="min-h-screen bg-brand-surface">
             <SEO
                 title={post.title}
                 description={post.excerpt}

--- a/pages/BlogRedirect.tsx
+++ b/pages/BlogRedirect.tsx
@@ -21,7 +21,7 @@ const BlogRedirect: React.FC = () => {
         canonical={destination}
         robots="noindex, follow"
       />
-      <main className="min-h-screen bg-[#fffdf5] pt-32 pb-24 px-6">
+      <main className="min-h-screen bg-brand-surface pt-32 pb-24 px-6">
         <div className="max-w-2xl mx-auto text-center">
           <h1 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Redirecionando para o Blog</h1>
           <p className="text-zinc-600 mb-6">

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -127,52 +127,52 @@ const Home: React.FC = () => {
 
       {shouldRenderBelowFold ? (
         <>
-          <Suspense fallback={<section id="experiencia" className="min-h-[700px] bg-[#fffdf5]" />}>
+          <Suspense fallback={<section id="experiencia" className="min-h-[700px] bg-brand-surface" />}>
             <Highlights />
           </Suspense>
-          <Suspense fallback={<section className="min-h-[300px] bg-[#fffdf5]" />}>
+          <Suspense fallback={<section className="min-h-[300px] bg-brand-surface" />}>
             <Categories />
           </Suspense>
         </>
       ) : (
         <>
-          <section id="experiencia" className="min-h-[700px] bg-[#fffdf5]" />
-          <section className="min-h-[300px] bg-[#fffdf5]" />
+          <section id="experiencia" className="min-h-[700px] bg-brand-surface" />
+          <section className="min-h-[300px] bg-brand-surface" />
         </>
       )}
       <div id="destinos" ref={destinationsSentinelRef} />
       {shouldRenderBelowFold && shouldLoadDestinations ? (
-        <Suspense fallback={<section className="min-h-[900px] bg-[#fffdf5]" />}>
+        <Suspense fallback={<section className="min-h-[900px] bg-brand-surface" />}>
           <Destinations />
         </Suspense>
       ) : (
-        <section className="min-h-[900px] bg-[#fffdf5]" />
+        <section className="min-h-[900px] bg-brand-surface" />
       )}
       {shouldRenderBelowFold ? (
         <>
-          <Suspense fallback={<section id="como-funciona" className="min-h-[800px] bg-[#fffdf5]" />}>
+          <Suspense fallback={<section id="como-funciona" className="min-h-[800px] bg-brand-surface" />}>
             <HowItWorks />
           </Suspense>
-          <Suspense fallback={<section id="faq" className="min-h-[600px] bg-[#fffdf5]" />}>
+          <Suspense fallback={<section id="faq" className="min-h-[600px] bg-brand-surface" />}>
             <FAQ />
           </Suspense>
-          <Suspense fallback={<section id="depoimentos" className="min-h-[500px] bg-[#fffdf5]" />}>
+          <Suspense fallback={<section id="depoimentos" className="min-h-[500px] bg-brand-surface" />}>
             <Testimonials />
           </Suspense>
-          <Suspense fallback={<section id="blog" className="min-h-[500px] bg-[#fffdf5]" />}>
+          <Suspense fallback={<section id="blog" className="min-h-[500px] bg-brand-surface" />}>
             <Blog />
           </Suspense>
-          <Suspense fallback={<section id="contato" className="min-h-[400px] bg-[#fffdf5]" />}>
+          <Suspense fallback={<section id="contato" className="min-h-[400px] bg-brand-surface" />}>
             <CallToAction />
           </Suspense>
         </>
       ) : (
         <>
-          <section id="como-funciona" className="min-h-[800px] bg-[#fffdf5]" />
-          <section id="faq" className="min-h-[600px] bg-[#fffdf5]" />
-          <section id="depoimentos" className="min-h-[500px] bg-[#fffdf5]" />
-          <section id="blog" className="min-h-[500px] bg-[#fffdf5]" />
-          <section id="contato" className="min-h-[400px] bg-[#fffdf5]" />
+          <section id="como-funciona" className="min-h-[800px] bg-brand-surface" />
+          <section id="faq" className="min-h-[600px] bg-brand-surface" />
+          <section id="depoimentos" className="min-h-[500px] bg-brand-surface" />
+          <section id="blog" className="min-h-[500px] bg-brand-surface" />
+          <section id="contato" className="min-h-[400px] bg-brand-surface" />
         </>
       )}
     </>

--- a/pages/SiteMap.tsx
+++ b/pages/SiteMap.tsx
@@ -33,7 +33,7 @@ const SiteMap: React.FC = () => {
           { name: 'Mapa do Site', item: 'https://www.anhanga.tur.br/mapa-do-site/' }
         ]}
       />
-      <main className="min-h-screen bg-[#fffdf5] pt-32 pb-24">
+      <main className="min-h-screen bg-brand-surface pt-32 pb-24">
         <section className="container mx-auto px-6 max-w-4xl">
           <h1 className="text-4xl md:text-5xl font-black text-brand-dark mb-6">Mapa do Site</h1>
           <p className="text-zinc-600 mb-10">Acesse rapidamente as principais áreas do site.</p>

--- a/pages/landings/BetoCarreroLanding.tsx
+++ b/pages/landings/BetoCarreroLanding.tsx
@@ -51,7 +51,7 @@ const BetoCarreroLanding: React.FC = () => {
         ]}
       />
       <FAQPageSchema items={BETO_FAQ_ITEMS} />
-      <div className="bg-[#fffdf5] py-2 border-b border-zinc-100">
+      <div className="bg-brand-surface py-2 border-b border-zinc-100">
         <div className="container mx-auto px-6">
           <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1">
             ← Voltar para o site principal
@@ -69,7 +69,7 @@ const BetoCarreroLanding: React.FC = () => {
 
       <BetoCarreroApp />
       <LandingFAQ items={BETO_FAQ_ITEMS} />
-      <section className="bg-[#fffdf5] border-t border-brand-cyan/10 py-14">
+      <section className="bg-brand-surface border-t border-brand-cyan/10 py-14">
         <div className="container mx-auto px-6 max-w-5xl">
           <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Pacote Beto Carrero para viajar com tranquilidade</h2>
           <p className="text-zinc-700 text-lg leading-relaxed mb-5">

--- a/pages/landings/BrazilPromotionDayLanding.tsx
+++ b/pages/landings/BrazilPromotionDayLanding.tsx
@@ -26,7 +26,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
                 description="Conheça a Anhangá Viagens na Brazil Promotion Day. Agência de viagens em SP com roteiros exclusivos feitos do zero, sem pacote pronto."
                 canonical="https://www.anhanga.tur.br/brazil-promotion-day/"
             />
-            <div className="bg-[#fffdf5] min-h-screen font-sans">
+            <div className="bg-brand-surface min-h-screen font-sans">
                 <BpdNav />
                 <BpdHero />
                 <BpdPillars />

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -80,7 +80,7 @@ const PILLARS = [
 
 const ConsultoriaDeViagemLanding: React.FC = () => {
   return (
-    <div className="bg-[#fffdf5] min-h-screen font-sans">
+    <div className="bg-brand-surface min-h-screen font-sans">
       <SEO
         title="Consultoria de Viagem Sob Medida em SP — Anhangá Viagens"
         description="Planeje sua viagem com consultores humanos. Sem pacote pronto, sem improviso. Roteiro personalizado com suporte antes, durante e depois."
@@ -172,7 +172,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                 className={`p-8 rounded-2xl ${
                   variant === 'filled'
                     ? 'bg-anhanga-blue text-white'
-                    : 'bg-[#fffdf5]'
+                    : 'bg-brand-surface'
                 }`}
               >
                 <div
@@ -197,7 +197,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       </section>
 
       {/* Para quem é */}
-      <section className="py-20 bg-[#fffdf5]">
+      <section className="py-20 bg-brand-surface">
         <div className="max-w-5xl mx-auto px-6">
           <div className="md:grid md:grid-cols-2 md:gap-16 items-start">
             <div>
@@ -251,7 +251,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       </section>
 
       {/* Sobre a Anhangá */}
-      <section className="py-20 bg-[#fffdf5]">
+      <section className="py-20 bg-brand-surface">
         <div className="max-w-4xl mx-auto px-6 text-center">
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
             Sobre a Anhangá Viagens
@@ -297,13 +297,13 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       </section>
 
       {/* Outros serviços */}
-      <section className="py-16 bg-[#fffdf5]">
+      <section className="py-16 bg-brand-surface">
         <div className="max-w-5xl mx-auto px-6">
           <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
           <div className="grid md:grid-cols-3 gap-4">
             <Link
               to="/viagens-para-executivos"
-              className="block p-5 rounded-xl bg-[#fffdf5] hover:bg-anhanga-blue/5 transition-colors group"
+              className="block p-5 rounded-xl bg-brand-surface hover:bg-anhanga-blue/5 transition-colors group"
             >
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Viagens para Executivos
@@ -314,7 +314,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             </Link>
             <Link
               to="/curadoria-cruzeiros-brasil"
-              className="block p-5 rounded-xl bg-[#fffdf5] hover:bg-anhanga-blue/5 transition-colors group"
+              className="block p-5 rounded-xl bg-brand-surface hover:bg-anhanga-blue/5 transition-colors group"
             >
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Curadoria de Cruzeiros
@@ -325,7 +325,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             </Link>
             <a
               href="https://www.anhanga.tur.br/"
-              className="block p-5 rounded-xl bg-[#fffdf5] hover:bg-anhanga-blue/5 transition-colors group"
+              className="block p-5 rounded-xl bg-brand-surface hover:bg-anhanga-blue/5 transition-colors group"
             >
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                 Site principal
@@ -346,7 +346,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       />
 
       {/* Footer */}
-      <footer className="py-8 bg-[#fffdf5] border-t border-zinc-100 text-center text-sm text-zinc-600">
+      <footer className="py-8 bg-brand-surface border-t border-zinc-100 text-center text-sm text-zinc-600">
         <p>Anhangá Viagens · Agência de viagens em São Paulo</p>
         <p className="mt-1">Atualizado em abril de 2026</p>
       </footer>

--- a/pages/landings/LollapaloozaLanding.tsx
+++ b/pages/landings/LollapaloozaLanding.tsx
@@ -53,7 +53,7 @@ const LollapaloozaLanding: React.FC = () => {
         ]}
       />
       <FAQPageSchema items={LOLLAPALOOZA_FAQ_ITEMS} />
-      <div className="bg-[#fffdf5] py-2 border-b border-zinc-100 relative z-[60]">
+      <div className="bg-brand-surface py-2 border-b border-zinc-100 relative z-[60]">
         <div className="container mx-auto px-6">
           <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1 font-sans">
             ← Voltar para o site principal
@@ -71,7 +71,7 @@ const LollapaloozaLanding: React.FC = () => {
 
       <LollapaloozaApp />
       <LandingFAQ items={LOLLAPALOOZA_FAQ_ITEMS} />
-      <section className="bg-[#fffdf5] border-t border-brand-cyan/10 py-14">
+      <section className="bg-brand-surface border-t border-brand-cyan/10 py-14">
         <div className="container mx-auto px-6 max-w-5xl">
           <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">2026 encerrou forte. 2027 já está no radar.</h2>
           <p className="text-zinc-700 text-lg leading-relaxed mb-5">

--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -30,7 +30,7 @@ const MELHOR_IDADE_FAQ_ITEMS = [
 
 const MelhorIdadeLanding: React.FC = () => {
   return (
-    <div className="bg-[#fffdf5] min-h-screen font-sans">
+    <div className="bg-brand-surface min-h-screen font-sans">
       <SEO
         title="Turismo 50+: Viagens Seguras e Personalizadas"
         description="Experiências de viagem exclusivas para o público 50+. Roteiros com conforto, segurança e atendimento humano. Planeje sua próxima aventura com a Anhangá."
@@ -161,7 +161,7 @@ const MelhorIdadeLanding: React.FC = () => {
       </section>
 
       {/* CONTENT RICH SECTION FOR GEO */}
-      <section className="py-24 bg-[#fffdf5]">
+      <section className="py-24 bg-brand-surface">
         <div className="container mx-auto px-6 max-w-4xl">
           <h2 className="text-3xl md:text-5xl font-black text-brand-dark mb-12 text-center">Por que planejar sua viagem 50+ com a Anhangá?</h2>
           

--- a/pages/landings/OrlandoLanding.tsx
+++ b/pages/landings/OrlandoLanding.tsx
@@ -56,7 +56,7 @@ const OrlandoLanding: React.FC = () => {
         ]}
       />
       <FAQPageSchema items={ORLANDO_FAQ_ITEMS} />
-      <div className="bg-[#fffdf5] py-2 border-b border-zinc-100 relative z-[60]">
+      <div className="bg-brand-surface py-2 border-b border-zinc-100 relative z-[60]">
         <div className="container mx-auto px-6">
           <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1 font-sans">
             ← Voltar para o site principal
@@ -74,7 +74,7 @@ const OrlandoLanding: React.FC = () => {
 
       <OrlandoApp />
       <LandingFAQ items={ORLANDO_FAQ_ITEMS} />
-      <section className="bg-[#fffdf5] border-t border-brand-cyan/10 py-14">
+      <section className="bg-brand-surface border-t border-brand-cyan/10 py-14">
         <div className="container mx-auto px-6 max-w-5xl">
           <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Pacote para Orlando sem improviso</h2>
           <p className="text-zinc-700 text-lg leading-relaxed mb-5">

--- a/pages/landings/ViagensParaExecutivosLanding.tsx
+++ b/pages/landings/ViagensParaExecutivosLanding.tsx
@@ -181,7 +181,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       </section>
 
       {/* O que a gente resolve */}
-      <section className="py-20 bg-[#fffdf5]">
+      <section className="py-20 bg-brand-surface">
         <div className="max-w-5xl mx-auto px-6">
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
             O que a gente resolve
@@ -239,7 +239,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       </section>
 
       {/* Sobre a Anhangá */}
-      <section className="py-20 bg-[#fffdf5]">
+      <section className="py-20 bg-brand-surface">
         <div className="max-w-4xl mx-auto px-6">
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
             Sobre a Anhangá Viagens
@@ -285,7 +285,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       </section>
 
       {/* Outros serviços */}
-      <section className="py-16 bg-[#fffdf5]">
+      <section className="py-16 bg-brand-surface">
         <div className="max-w-5xl mx-auto px-6">
           <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
           <div className="grid md:grid-cols-3 gap-4">
@@ -334,7 +334,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
       />
 
       {/* Footer */}
-      <footer className="py-8 bg-[#fffdf5] border-t border-zinc-100 text-center text-sm text-zinc-600">
+      <footer className="py-8 bg-brand-surface border-t border-zinc-100 text-center text-sm text-zinc-600">
         <p>Anhangá Viagens · Agência de viagens em São Paulo</p>
         <p className="mt-1">Atualizado em abril de 2026</p>
       </footer>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -21,9 +21,10 @@ export default {
                     cyanDark: '#0284c7', // Sky 600
                     blue: '#1e40af', // Blue 800
                     vibrant: '#0ea5e9', // Cyan
-                    yellow: '#fbbf24', // Amber 400
+                    yellow: '#FFD600', // Âmbar Vivo — canonical brand yellow
                     dark: '#0f172a', // Slate 900
                     light: '#f0f9ff', // Sky 50
+                    surface: '#fffdf5', // Superfície Quente — warm cream background
                 },
                 'fun-yellow': '#FFD23F',
                 'fun-blue': '#3B82F6',


### PR DESCRIPTION
## Summary

- **Novo token `brand.surface`** — `#fffdf5` (Superfície Quente) adicionado ao `tailwind.config.mjs`; ~50 ocorrências de `bg-[#fffdf5]` substituídas por `bg-brand-surface` em componentes, páginas e landings
- **`brand.yellow` corrigido** — `#fbbf24` (Amber 400 errado) → `#FFD600` (Âmbar Vivo canônico); hard shadows `shadow-[4px_4px_0px_#fbbf24]` migrados para o token `shadow-hard-yellow`
- **Outros rouges eliminados** — shadow laranja no FAB do AIChat → cyan; `bg-[#fdfdfc]` no drawer → `bg-white`; `hover:bg-yellow-400` no SearchForm → `hover:bg-anhanga-yellowHover`; `text-yellow-400` no Hero → `text-anhanga-yellow`

## Contexto

Originado do `/impeccable audit` que identificou o score de theming em 2/4 devido à fragmentação de tokens. O design system tem dois tokens amarelos (`brand.yellow` e `anhanga.yellow`) apontando para cores diferentes; a superfície quente (`#fffdf5`) era usada em 50+ lugares sem token. Este PR fecha ambas as lacunas.

## Test plan

- [x] `pnpm typecheck` — zero erros (verificado antes do commit)
- [ ] Inspeção visual: todas as seções com fundo creme devem manter aparência idêntica (token aponta para o mesmo hex)
- [ ] Hover no botão de busca — amarelo não deve sofrer shift para amber ao passar o mouse
- [ ] FAB do chat — sombra deve ser azul-ciano, não laranja
- [ ] CI `build-and-test` deve passar

🤖 Generated with [Claude Code](https://claude.com/claude-code)