### PR TITLE
Prioritize Cloudflare IP headers in shared rate-limit lookup

### DIFF
--- a/lib/network.ts
+++ b/lib/network.ts
@@ -34,28 +34,34 @@ export function buildJsonError(status: number, code: string, message: string): R
 
 /**
  * Extracts the client IP from the request headers.
- * Specialized for Vercel's environment.
+ * Prioritizes Cloudflare's edge-provided header before legacy fallbacks.
  */
 export function getClientIP(request: Request): string {
-    // Prioritize X-Real-IP as it is more reliable on Vercel
-    const realIP = request.headers.get('x-real-ip');
-    if (realIP) {
-        return realIP.trim();
+    const cfConnectingIP = getTrimmedHeader(request, 'cf-connecting-ip');
+    if (cfConnectingIP) {
+        return cfConnectingIP;
     }
 
-    // Vercel-specific header
-    const vercelForwardedFor = request.headers.get('x-vercel-forwarded-for');
+    const realIP = getTrimmedHeader(request, 'x-real-ip');
+    if (realIP) {
+        return realIP;
+    }
+
+    const vercelForwardedFor = getTrimmedHeader(request, 'x-vercel-forwarded-for');
     if (vercelForwardedFor) {
         return vercelForwardedFor.split(',')[0].trim();
     }
 
-    // Fallback to X-Forwarded-For
-    const forwardedFor = request.headers.get('x-forwarded-for');
+    const forwardedFor = getTrimmedHeader(request, 'x-forwarded-for');
     if (forwardedFor) {
-        const ips = forwardedFor.split(',').map(ip => ip.trim());
-        // Standard practice: use the first one (original client)
-        return ips[0];
+        const ips = forwardedFor.split(',').map(ip => ip.trim()).filter(Boolean);
+        return ips[ips.length - 1] || 'unknown';
     }
 
     return 'unknown';
+}
+
+function getTrimmedHeader(request: Request, headerName: string): string | undefined {
+    const value = request.headers.get(headerName)?.trim();
+    return value || undefined;
 }

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getClientIP } from '../lib/network.ts';
+
+test('getClientIP uses Cloudflare connecting IP before spoofable headers', () => {
+    const request = new Request('https://example.com/api/generate', {
+        headers: {
+            'cf-connecting-ip': '203.0.113.10',
+            'x-real-ip': '10.0.0.99',
+            'x-vercel-forwarded-for': '10.0.0.98',
+            'x-forwarded-for': '10.0.0.97, 198.51.100.20',
+        },
+    });
+
+    assert.equal(getClientIP(request), '203.0.113.10');
+});
+
+test('getClientIP uses the proxy-appended X-Forwarded-For value as generic fallback', () => {
+    const request = new Request('https://example.com/api/generate', {
+        headers: {
+            'x-forwarded-for': '10.0.0.42, 198.51.100.30',
+        },
+    });
+
+    assert.equal(getClientIP(request), '198.51.100.30');
+});


### PR DESCRIPTION
## Summary
- Use `cf-connecting-ip` first in `getClientIP` so Cloudflare Pages requests are keyed by the edge-provided client IP instead of spoofable headers.
- Keep legacy Vercel fallbacks for existing environments and tighten `x-forwarded-for` handling to prefer the proxy-appended value.
- Add regression coverage for Cloudflare header priority and the generic `X-Forwarded-For` fallback.

## Testing
- Added `tests/network.test.ts` to cover the new IP-extraction behavior.
- Ran the regression suite and TypeScript typecheck locally; both passed.