### PR TITLE
fix(security): authenticate NPS outbound webhook calls with X-Webhook-Secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,4 +119,4 @@ GITHUB_CLIENT_SECRET=seu_github_oauth_client_secret
 # =============================================================================
 # URL do webhook n8n que recebe as respostas do formulário de NPS.
 # Nunca use VITE_ nesta variável — ela nunca deve ser exposta ao navegador.
-# NPS_WEBHOOK_URL=https://seu-n8n.com/webhook/nps-pos-viagem
+NPS_WEBHOOK_URL=https://seu-n8n.com/webhook/nps-pos-viagem

--- a/api/submit-nps.ts
+++ b/api/submit-nps.ts
@@ -158,7 +158,7 @@ export default async function handler(request: Request): Promise<Response> {
     await sendNpsToN8n(webhookUrl, webhookSecret, requestId, npsPayload);
   } catch (error: unknown) {
     const { status, stage } = classifyNpsWebhookError(error);
-    logger.error('SUBMIT_NPS', { requestId, stage });
+    logger.error('SUBMIT_NPS', { requestId, stage, error: error instanceof Error ? error.message : String(error) });
     return buildJsonResponse(
       {
         ok: false,

--- a/api/submit-nps.ts
+++ b/api/submit-nps.ts
@@ -4,6 +4,8 @@ import { checkRateLimit } from '../lib/rate-limit';
 import { cleanString, maskEmail } from '../lib/lead-logic';
 import { logger } from '../lib/logger';
 import { SubmitNpsBodySchema } from '../lib/schemas/submit-nps';
+import { sendNpsToN8n } from '../services/n8n';
+import type { N8nNpsPayload } from '../lib/n8n-payloads';
 
 export const config = {
   runtime: 'edge',
@@ -11,6 +13,7 @@ export const config = {
 
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 3;
+const N8N_WEBHOOK_ERROR_PATTERN = /^N8N_WEBHOOK_ERROR:(\d{3}):/;
 
 function buildJsonResponse(
   body: unknown,
@@ -39,6 +42,17 @@ function mapNpsZodError(error: z.ZodError): string {
   return 'Payload inválido.';
 }
 
+function classifyNpsWebhookError(error: unknown): { status: number; stage: string } {
+  const message = error instanceof Error ? error.message : String(error);
+  const match = message.match(N8N_WEBHOOK_ERROR_PATTERN);
+  if (!match) return { status: 500, stage: 'unexpected' };
+  const upstreamStatus = Number.parseInt(match[1], 10);
+  return {
+    status: upstreamStatus === 504 ? 504 : 502,
+    stage: upstreamStatus === 504 ? 'webhook_timeout' : 'webhook_failed',
+  };
+}
+
 export default async function handler(request: Request): Promise<Response> {
   const requestId = createRequestId();
   const corsHeaders = buildCorsHeaders();
@@ -57,7 +71,8 @@ export default async function handler(request: Request): Promise<Response> {
   }
 
   const webhookUrl = process.env.NPS_WEBHOOK_URL?.trim();
-  if (!webhookUrl) {
+  const webhookSecret = process.env.N8N_WEBHOOK_SECRET?.trim();
+  if (!webhookUrl || !webhookSecret) {
     logger.error('SUBMIT_NPS', { requestId, stage: 'config', code: 'SERVER_CONFIG_ERROR' });
     return buildJsonResponse(
       { ok: false, requestId, code: 'SERVER_CONFIG_ERROR', error: 'Serviço de NPS indisponível no momento.' },
@@ -122,68 +137,48 @@ export default async function handler(request: Request): Promise<Response> {
   }
 
   const raw = parsed.data;
-  const payload = {
-    firstname: cleanString(raw.firstname),
-    email:     cleanString(raw.email),
-    score:     raw.score,
-    reason:    cleanString(raw.reason),
-    highlight: cleanString(raw.highlight),
+  const npsPayload: N8nNpsPayload = {
+    requestId,
+    firstname:   cleanString(raw.firstname),
+    email:       cleanString(raw.email),
+    score:       raw.score,
+    reason:      cleanString(raw.reason),
+    highlight:   cleanString(raw.highlight),
+    submittedAt: new Date().toISOString(),
   };
 
   logger.info('SUBMIT_NPS', {
     requestId,
     stage: 'sending',
-    email: maskEmail(payload.email),
-    score: payload.score,
+    email: maskEmail(npsPayload.email),
+    score: npsPayload.score,
   });
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 8000);
-
   try {
-    const webhookRes = await fetch(webhookUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...payload, submittedAt: new Date().toISOString(), requestId }),
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
-
-    if (!webhookRes.ok) {
-      const text = await webhookRes.text().catch(() => '');
-      logger.error('SUBMIT_NPS', {
-        requestId,
-        stage: 'webhook_failed',
-        status: webhookRes.status,
-        detail: text.slice(0, 200),
-      });
-      return buildJsonResponse(
-        { ok: false, requestId, code: 'WEBHOOK_ERROR', error: 'Erro ao registrar avaliação. Tente novamente.' },
-        502,
-        corsHeaders,
-        requestId,
-      );
-    }
-
-    logger.info('SUBMIT_NPS', { requestId, stage: 'done', score: payload.score });
+    await sendNpsToN8n(webhookUrl, webhookSecret, requestId, npsPayload);
+  } catch (error: unknown) {
+    const { status, stage } = classifyNpsWebhookError(error);
+    logger.error('SUBMIT_NPS', { requestId, stage });
     return buildJsonResponse(
-      { ok: true, requestId, message: 'Avaliação registrada com sucesso.' },
-      201,
-      corsHeaders,
-      requestId,
-    );
-  } catch (err) {
-    clearTimeout(timeoutId);
-    logger.error('SUBMIT_NPS', {
-      requestId,
-      stage: err instanceof Error && err.name === 'AbortError' ? 'webhook_timeout' : 'unexpected',
-      errorType: err instanceof Error ? err.name : typeof err,
-    });
-    return buildJsonResponse(
-      { ok: false, requestId, code: 'INTERNAL_ERROR', error: 'Erro interno. Tente novamente.' },
-      500,
+      {
+        ok: false,
+        requestId,
+        code: status === 500 ? 'INTERNAL_ERROR' : 'WEBHOOK_ERROR',
+        error: status === 500
+          ? 'Erro interno. Tente novamente.'
+          : 'Erro ao registrar avaliação. Tente novamente.',
+      },
+      status,
       corsHeaders,
       requestId,
     );
   }
+
+  logger.info('SUBMIT_NPS', { requestId, stage: 'done', score: npsPayload.score });
+  return buildJsonResponse(
+    { ok: true, requestId, message: 'Avaliação registrada com sucesso.' },
+    201,
+    corsHeaders,
+    requestId,
+  );
 }

--- a/lib/n8n-payloads.ts
+++ b/lib/n8n-payloads.ts
@@ -239,3 +239,13 @@ export function buildN8nQuizPayload(payload: SubmitQuizRequest, requestId: strin
         },
     };
 }
+
+export interface N8nNpsPayload {
+    requestId: string;
+    firstname: string;
+    email: string;
+    score: number;
+    reason: string;
+    highlight: string;
+    submittedAt: string;
+}

--- a/services/n8n.ts
+++ b/services/n8n.ts
@@ -1,4 +1,4 @@
-import type { N8nContactPayload, N8nLeadPayload, N8nQuizPayload, N8nWaitlistPayload } from '../lib/n8n-payloads';
+import type { N8nContactPayload, N8nLeadPayload, N8nNpsPayload, N8nQuizPayload, N8nWaitlistPayload } from '../lib/n8n-payloads';
 
 // 5 seconds gives self-hosted n8n enough headroom for cold-start workflows
 // without hanging the edge function indefinitely. Override with N8N_WEBHOOK_TIMEOUT_MS.
@@ -119,6 +119,15 @@ export function sendQuizToN8n(
     secret: string,
     requestId: string,
     payload: N8nQuizPayload,
+): Promise<Response> {
+    return n8nRequest(url, secret, requestId, payload);
+}
+
+export function sendNpsToN8n(
+    url: string,
+    secret: string,
+    requestId: string,
+    payload: N8nNpsPayload,
 ): Promise<Response> {
     return n8nRequest(url, secret, requestId, payload);
 }

--- a/tests/submit-nps.test.ts
+++ b/tests/submit-nps.test.ts
@@ -4,12 +4,18 @@ import handler from '../api/submit-nps.ts';
 
 const originalFetch = global.fetch;
 const originalNpsWebhookUrl = process.env.NPS_WEBHOOK_URL;
+const originalN8nWebhookSecret = process.env.N8N_WEBHOOK_SECRET;
 
 function restoreEnv() {
     if (originalNpsWebhookUrl === undefined) {
         delete process.env.NPS_WEBHOOK_URL;
     } else {
         process.env.NPS_WEBHOOK_URL = originalNpsWebhookUrl;
+    }
+    if (originalN8nWebhookSecret === undefined) {
+        delete process.env.N8N_WEBHOOK_SECRET;
+    } else {
+        process.env.N8N_WEBHOOK_SECRET = originalN8nWebhookSecret;
     }
 }
 
@@ -34,7 +40,19 @@ function buildRequest(
 interface MockWebhookCall {
     url: string;
     method: string;
+    headers: Record<string, string>;
     body?: Record<string, unknown>;
+}
+
+function extractHeaders(raw: HeadersInit | undefined): Record<string, string> {
+    if (!raw) return {};
+    if (raw instanceof Headers) {
+        const result: Record<string, string> = {};
+        raw.forEach((value, key) => { result[key] = value; });
+        return result;
+    }
+    if (Array.isArray(raw)) return Object.fromEntries(raw) as Record<string, string>;
+    return raw as Record<string, string>;
 }
 
 function createMockWebhookFetch(
@@ -42,10 +60,11 @@ function createMockWebhookFetch(
     response: Response,
 ): typeof fetch {
     return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
         calls.push({
             url,
             method: init?.method ?? 'GET',
+            headers: extractHeaders(init?.headers),
             body: init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : undefined,
         });
         return response;
@@ -63,6 +82,11 @@ function validBody(overrides?: Record<string, unknown>) {
     };
 }
 
+function setValidEnv() {
+    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    process.env.N8N_WEBHOOK_SECRET = 'test-secret-abc';
+}
+
 // ─── Config errors ──────────────────────────────────────────────────────────
 
 test('submit-nps returns 500 SERVER_CONFIG_ERROR when NPS_WEBHOOK_URL is absent', async (t) => {
@@ -72,6 +96,25 @@ test('submit-nps returns 500 SERVER_CONFIG_ERROR when NPS_WEBHOOK_URL is absent'
     });
 
     delete process.env.NPS_WEBHOOK_URL;
+    process.env.N8N_WEBHOOK_SECRET = 'test-secret-abc';
+    global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
+
+    const response = await handler(buildRequest(validBody()));
+    const body = await response.json() as Record<string, unknown>;
+
+    assert.equal(response.status, 500);
+    assert.equal(body.ok, false);
+    assert.equal(body.code, 'SERVER_CONFIG_ERROR');
+});
+
+test('submit-nps returns 500 SERVER_CONFIG_ERROR when N8N_WEBHOOK_SECRET is absent', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    delete process.env.N8N_WEBHOOK_SECRET;
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody()));
@@ -90,7 +133,7 @@ test('submit-nps returns 405 METHOD_NOT_ALLOWED for GET requests', async (t) => 
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
 
     const response = await handler(buildRequest({}, { method: 'GET' }));
     const body = await response.json() as Record<string, unknown>;
@@ -106,7 +149,7 @@ test('submit-nps returns 204 for OPTIONS preflight', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
 
     const response = await handler(buildRequest({}, { method: 'OPTIONS' }));
 
@@ -121,7 +164,7 @@ test('submit-nps returns 400 VALIDATION_ERROR for malformed JSON body', async (t
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const request = new Request('http://localhost/api/submit-nps', {
@@ -149,7 +192,7 @@ test('submit-nps returns 400 for missing firstname', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ firstname: '' })));
@@ -166,7 +209,7 @@ test('submit-nps returns 400 for firstname over 100 characters', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ firstname: 'A'.repeat(101) })));
@@ -182,7 +225,7 @@ test('submit-nps returns 400 for invalid email', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ email: 'not-an-email' })));
@@ -198,7 +241,7 @@ test('submit-nps returns 400 for score below 0', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ score: -1 })));
@@ -214,7 +257,7 @@ test('submit-nps returns 400 for score above 10', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ score: 11 })));
@@ -230,7 +273,7 @@ test('submit-nps returns 400 for non-integer score', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ score: 7.5 })));
@@ -246,7 +289,7 @@ test('submit-nps returns 400 for non-numeric score', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ score: '9' })));
@@ -262,7 +305,7 @@ test('submit-nps returns 400 for empty reason', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ reason: '' })));
@@ -278,7 +321,7 @@ test('submit-nps returns 400 for reason over 2000 characters', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ reason: 'x'.repeat(2001) })));
@@ -294,7 +337,7 @@ test('submit-nps returns 400 for highlight over 2000 characters', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ highlight: 'x'.repeat(2001) })));
@@ -312,7 +355,7 @@ test('submit-nps returns 201 and forwards payload to webhook on success', async 
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
 
     const calls: MockWebhookCall[] = [];
     global.fetch = createMockWebhookFetch(calls, new Response('ok', { status: 200 }));
@@ -339,13 +382,35 @@ test('submit-nps returns 201 and forwards payload to webhook on success', async 
         'submittedAt deve ser gerado server-side em formato ISO 8601');
 });
 
+test('submit-nps sends X-Webhook-Secret header on outbound call', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnv();
+    });
+
+    setValidEnv();
+
+    const calls: MockWebhookCall[] = [];
+    global.fetch = createMockWebhookFetch(calls, new Response('ok', { status: 200 }));
+
+    const response = await handler(buildRequest(validBody()));
+
+    assert.equal(response.status, 201);
+    assert.equal(calls.length, 1);
+    assert.equal(
+        calls[0]!.headers['x-webhook-secret'],
+        'test-secret-abc',
+        'X-Webhook-Secret deve ser enviado para autenticar o webhook',
+    );
+});
+
 test('submit-nps accepts score 0 (boundary)', async (t) => {
     t.after(() => {
         global.fetch = originalFetch;
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ score: 0 })));
@@ -358,7 +423,7 @@ test('submit-nps accepts score 10 (boundary)', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ score: 10 })));
@@ -371,7 +436,7 @@ test('submit-nps accepts empty highlight (optional field)', async (t) => {
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const response = await handler(buildRequest(validBody({ highlight: '' })));
@@ -386,7 +451,7 @@ test('submit-nps returns 502 WEBHOOK_ERROR when upstream returns non-2xx', async
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('Bad Gateway', { status: 502 }));
 
     const response = await handler(buildRequest(validBody()));
@@ -405,7 +470,7 @@ test('submit-nps enforces rate limit after 3 requests from the same IP', async (
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     // Use a fixed unique IP to isolate this test's rate limit bucket
@@ -445,7 +510,7 @@ test('submit-nps enforces rate-limit even for invalid payloads (DoS protection)'
         restoreEnv();
     });
 
-    process.env.NPS_WEBHOOK_URL = 'https://n8n.example/webhook/nps';
+    setValidEnv();
     global.fetch = createMockWebhookFetch([], new Response('ok', { status: 200 }));
 
     const uniqueIp = `10.${Math.floor(Math.random() * 254) + 1}.${Math.floor(Math.random() * 254) + 1}.4`;


### PR DESCRIPTION
`submit-nps.ts` was calling the n8n webhook with a bare `fetch` — no `X-Webhook-Secret` header — while every other endpoint (`submit-lead`, `submit-contact`, `submit-waitlist`, `submit-quiz`) goes through `services/n8n.ts` which attaches the secret on every outbound request. This either caused all NPS submissions to silently fail with a 401/403 from n8n, or forced the n8n workflow to run without authentication and accept payloads from anyone who knows the URL.

**Route through the shared `sendNpsToN8n` helper**

Added `N8nNpsPayload` to `lib/n8n-payloads.ts` and `sendNpsToN8n` to `services/n8n.ts`, then replaced the inline `fetch` + manual `AbortController` in `api/submit-nps.ts` with a call to the new helper. The outbound payload shape is unchanged so no n8n workflow configuration is needed.

**Config guard now covers both env vars**

The handler previously only checked `NPS_WEBHOOK_URL` and would call `fetch` without a secret even when `N8N_WEBHOOK_SECRET` was absent. It now returns `SERVER_CONFIG_ERROR` (500) if either variable is missing.

**Regression coverage**

Added two new tests: one asserting `SERVER_CONFIG_ERROR` when `N8N_WEBHOOK_SECRET` is absent, and one asserting that `X-Webhook-Secret` is present on every outbound call. Updated all existing tests to set both env vars via a shared `setValidEnv()` helper.

Closes #660