### PR TITLE
fix(security): safe-fail rate limiting on edge runtime

### DIFF
--- a/api/generate.ts
+++ b/api/generate.ts
@@ -185,6 +185,14 @@ async function getRateLimitState(
         return { rateLimit };
     }
 
+    if (rateLimit.serviceUnavailable) {
+        logger.error('RATE_LIMIT', { clientIP, stage: 'service_unavailable' });
+        return buildJsonResponse({
+            code: 'SERVICE_UNAVAILABLE',
+            error: 'Serviço temporariamente indisponível. Tente novamente em instantes.',
+        }, 503, corsHeaders);
+    }
+
     logger.warn('RATE_LIMIT', {
         clientIP,
         retryAfterSeconds: Math.ceil(rateLimit.resetIn / 1000),

--- a/api/purchase-dispatch.ts
+++ b/api/purchase-dispatch.ts
@@ -322,6 +322,14 @@ async function enforceRateLimit(request: Request, requestId: string): Promise<Re
     return null;
   }
 
+  if (rateLimit.serviceUnavailable) {
+    emitConversionLog('error', requestId, 'service_unavailable', { clientIP });
+    return buildJsonResponse(
+      { ok: false, requestId, error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
+      503,
+    );
+  }
+
   emitConversionLog('warn', requestId, 'rate_limited', {
     clientIP,
     remaining: rateLimit.remaining,

--- a/api/submit-contact.ts
+++ b/api/submit-contact.ts
@@ -68,6 +68,14 @@ async function getRateLimitResponse(
 
     if (rateLimitResult.allowed) return null;
 
+    if (rateLimitResult.serviceUnavailable) {
+        return buildJsonResponse(
+            { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
+            503,
+            corsHeaders,
+        );
+    }
+
     return buildJsonResponse(
         {
             ok: false,

--- a/api/submit-lead.ts
+++ b/api/submit-lead.ts
@@ -121,6 +121,15 @@ async function getRateLimitResponse(
 
     if (rateLimit.allowed) return null;
 
+    if (rateLimit.serviceUnavailable) {
+        emitLeadLog('error', requestId, 'service_unavailable', { clientIP });
+        return buildJsonResponse(
+            { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
+            503,
+            corsHeaders,
+        );
+    }
+
     emitLeadLog('warn', requestId, 'rate_limited', {
         clientIP,
         remaining: rateLimit.remaining,

--- a/api/submit-nps.ts
+++ b/api/submit-nps.ts
@@ -90,6 +90,16 @@ export default async function handler(request: Request): Promise<Response> {
   });
 
   if (!rateLimit.allowed) {
+    if (rateLimit.serviceUnavailable) {
+      logger.error('SUBMIT_NPS', { requestId, stage: 'service_unavailable', clientIP });
+      return buildJsonResponse(
+        { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
+        503,
+        corsHeaders,
+        requestId,
+      );
+    }
+
     logger.warn('SUBMIT_NPS', {
       requestId,
       stage: 'rate_limited',

--- a/api/submit-quiz.ts
+++ b/api/submit-quiz.ts
@@ -129,6 +129,15 @@ export default async function handler(request: Request): Promise<Response> {
     });
 
     if (!rateLimitResult.allowed) {
+        if (rateLimitResult.serviceUnavailable) {
+            emitQuizLog('error', requestId, 'service_unavailable', { clientIp });
+            return buildJsonResponse(
+                { ok: false, requestId, error: 'Serviço temporariamente indisponível. Tente novamente em instantes.', code: 'SERVICE_UNAVAILABLE' },
+                503,
+                corsHeaders,
+            );
+        }
+
         const retryAfterSec = Math.ceil(rateLimitResult.resetIn / 1000);
         emitQuizLog('warn', requestId, 'rate_limited', {
             clientIp,

--- a/api/submit-waitlist.ts
+++ b/api/submit-waitlist.ts
@@ -134,6 +134,14 @@ async function getRateLimitResponse(
 
     if (rateLimit.allowed) return null;
 
+    if (rateLimit.serviceUnavailable) {
+        return buildJsonResponse(
+            { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
+            503,
+            corsHeaders,
+        );
+    }
+
     return buildJsonResponse(
         {
             ok: false,

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -55,7 +55,12 @@ export function getClientIP(request: Request): string {
     const forwardedFor = getTrimmedHeader(request, 'x-forwarded-for');
     if (forwardedFor) {
         const ips = forwardedFor.split(',').map(ip => ip.trim()).filter(Boolean);
-        return ips[ips.length - 1] || 'unknown';
+        // XFF is only reached in local dev or on platforms that don't set
+        // cf-connecting-ip / x-vercel-forwarded-for. In those contexts,
+        // the leftmost IP is the original client (RFC 7239). Spoofing via a
+        // client-controlled XFF value is irrelevant in local dev and not a
+        // concern on Cloudflare/Vercel because those headers take priority above.
+        return ips[0] || 'unknown';
     }
 
     return 'unknown';

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -4,6 +4,8 @@ export interface RateLimitResult {
   allowed: boolean;
   remaining: number;
   resetIn: number; // in milliseconds
+  /** True when denial is due to infrastructure unavailability, not quota exhaustion. */
+  serviceUnavailable?: true;
 }
 
 interface RateLimitEntry {
@@ -26,14 +28,17 @@ const IN_MEMORY_MAX_ENTRIES = 2500;
 // True when running inside a managed serverless edge runtime where module-level
 // state resets per request. Both Vercel (VERCEL_ENV) and Cloudflare Pages
 // (CF_PAGES) are detected; local development has neither variable set.
-const IS_EDGE_RUNTIME = Boolean(process.env.VERCEL_ENV || process.env.CF_PAGES);
+// Implemented as a function so tests can control env vars at call time.
+function isEdgeRuntime(): boolean {
+  return Boolean(process.env.VERCEL_ENV || process.env.CF_PAGES);
+}
 
 async function getRedisClient(): Promise<RedisLike | null> {
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
 
   if (!url || !token) {
-    if (IS_EDGE_RUNTIME) {
+    if (isEdgeRuntime()) {
       // Each serverless edge invocation (Vercel or Cloudflare) gets a fresh V8
       // isolate — the in-memory Map above resets on every request and provides
       // no real protection. Configure Upstash Redis to enable shared rate
@@ -71,6 +76,16 @@ export async function checkRateLimit(
   const { limit, windowMs, prefix } = options;
   const redis = await getRedisClient();
 
+  // On edge runtimes the in-memory store resets every request (isolated V8
+  // context), so it provides zero real protection. Deny rather than allow when
+  // Redis is unavailable — this is the safe-fail default. The tradeoff is that
+  // a Redis outage will block all traffic on affected endpoints; this is
+  // preferable to silently bypassing rate limits entirely.
+  if (!redis && isEdgeRuntime()) {
+    logger.error('RateLimit: Redis unavailable on edge runtime. Denying request to prevent rate limit bypass.', { prefix, clientIP });
+    return { allowed: false, remaining: 0, resetIn: windowMs, serviceUnavailable: true };
+  }
+
   if (redis) {
     try {
       const key = `${prefix}:${clientIP}`;
@@ -97,12 +112,17 @@ export async function checkRateLimit(
         resetIn,
       };
     } catch (error) {
+      if (isEdgeRuntime()) {
+        // Redis failure on edge: in-memory fallback is non-functional. Deny to
+        // prevent the bypass rather than silently allowing all requests through.
+        logger.error('RateLimit: Redis error on edge runtime. Denying request.', { error, prefix, clientIP });
+        return { allowed: false, remaining: 0, resetIn: windowMs, serviceUnavailable: true };
+      }
       logger.error('RateLimit: Redis error, falling back to in-memory', error);
-      // Fallback to in-memory if Redis fails
     }
   }
 
-  // In-memory fallback
+  // In-memory fallback (local development only — isEdgeRuntime() is false here).
   return checkInMemoryRateLimit(clientIP, options);
 }
 

--- a/tests/lib-rate-limit.test.ts
+++ b/tests/lib-rate-limit.test.ts
@@ -123,6 +123,74 @@ test('in-memory fallback works correctly without Redis configured', async (t) =>
     assert.equal(r3.allowed, false);
 });
 
+// --- Edge runtime safe-fail tests ---
+
+/** Sets CF_PAGES for the duration of a test to simulate edge runtime. */
+function useEdgeRuntime(t: { after: (fn: () => void) => void }): void {
+    const saved = process.env.CF_PAGES;
+    process.env.CF_PAGES = '1';
+    t.after(() => {
+        if (saved === undefined) delete process.env.CF_PAGES;
+        else process.env.CF_PAGES = saved;
+    });
+}
+
+test('edge runtime: denies when Redis is not configured (safe-fail)', async (t) => {
+    useEdgeRuntime(t);
+    useInMemoryFallback(t);
+
+    const result = await checkRateLimit(`edge-${uid()}`, {
+        limit: 100,
+        windowMs: 60_000,
+        prefix: `test-rl-edge-no-redis-${uid()}`,
+    });
+
+    assert.equal(result.allowed, false, 'should deny when Redis is absent on edge runtime');
+    assert.equal(result.remaining, 0);
+    assert.ok(result.resetIn > 0);
+});
+
+test('edge runtime: in-memory fallback is not used (safe-fail preserves deny across calls)', async (t) => {
+    useEdgeRuntime(t);
+    useInMemoryFallback(t);
+
+    const ip = `edge-multi-${uid()}`;
+    const prefix = `test-rl-edge-multi-${uid()}`;
+
+    // Multiple requests should all be denied, not counted against in-memory store
+    for (let i = 0; i < 3; i++) {
+        const result = await checkRateLimit(ip, { limit: 100, windowMs: 60_000, prefix });
+        assert.equal(result.allowed, false, `request ${i + 1} should be denied on edge without Redis`);
+    }
+});
+
+test('local dev: in-memory fallback still works when edge runtime is not detected', async (t) => {
+    // Ensure neither CF_PAGES nor VERCEL_ENV is set (local dev scenario)
+    const savedCf = process.env.CF_PAGES;
+    const savedVercel = process.env.VERCEL_ENV;
+    delete process.env.CF_PAGES;
+    delete process.env.VERCEL_ENV;
+    t.after(() => {
+        if (savedCf === undefined) delete process.env.CF_PAGES;
+        else process.env.CF_PAGES = savedCf;
+        if (savedVercel === undefined) delete process.env.VERCEL_ENV;
+        else process.env.VERCEL_ENV = savedVercel;
+    });
+    useInMemoryFallback(t);
+
+    const ip = `local-${uid()}`;
+    const prefix = `test-rl-local-dev-${uid()}`;
+
+    const r1 = await checkRateLimit(ip, { limit: 2, windowMs: 60_000, prefix });
+    assert.equal(r1.allowed, true, 'first request should be allowed in local dev');
+
+    const r2 = await checkRateLimit(ip, { limit: 2, windowMs: 60_000, prefix });
+    assert.equal(r2.allowed, true);
+
+    const r3 = await checkRateLimit(ip, { limit: 2, windowMs: 60_000, prefix });
+    assert.equal(r3.allowed, false, 'request over limit should be blocked in local dev');
+});
+
 test('in-memory store GC runs when size exceeds 2000 and cleans expired entries', async (t) => {
     useInMemoryFallback(t);
 

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -15,12 +15,34 @@ test('getClientIP uses Cloudflare connecting IP before spoofable headers', () =>
     assert.equal(getClientIP(request), '203.0.113.10');
 });
 
-test('getClientIP uses the proxy-appended X-Forwarded-For value as generic fallback', () => {
+test('getClientIP uses the leftmost (original client) IP from X-Forwarded-For', () => {
     const request = new Request('https://example.com/api/generate', {
         headers: {
-            'x-forwarded-for': '10.0.0.42, 198.51.100.30',
+            'x-forwarded-for': '203.0.113.42, 198.51.100.30',
         },
     });
 
-    assert.equal(getClientIP(request), '198.51.100.30');
+    // Leftmost is the original client per RFC 7239; rightmost is the last proxy.
+    assert.equal(getClientIP(request), '203.0.113.42');
+});
+
+test('getClientIP X-Forwarded-For with single IP returns that IP', () => {
+    const request = new Request('https://example.com/api/generate', {
+        headers: {
+            'x-forwarded-for': '203.0.113.55',
+        },
+    });
+
+    assert.equal(getClientIP(request), '203.0.113.55');
+});
+
+test('getClientIP X-Forwarded-For is consistent with x-vercel-forwarded-for (both take first IP)', () => {
+    const vercelRequest = new Request('https://example.com/api/generate', {
+        headers: { 'x-vercel-forwarded-for': '203.0.113.10, 10.0.0.1' },
+    });
+    const xffRequest = new Request('https://example.com/api/generate', {
+        headers: { 'x-forwarded-for': '203.0.113.10, 10.0.0.1' },
+    });
+
+    assert.equal(getClientIP(vercelRequest), getClientIP(xffRequest));
 });

--- a/types/contactCapture.ts
+++ b/types/contactCapture.ts
@@ -27,7 +27,8 @@ export type SubmitContactErrorCode =
     | 'SERVER_CONFIG_ERROR'
     | 'N8N_WEBHOOK_ERROR'
     | 'METHOD_NOT_ALLOWED'
-    | 'INTERNAL_ERROR';
+    | 'INTERNAL_ERROR'
+    | 'SERVICE_UNAVAILABLE';
 
 export interface SubmitContactSuccess {
     ok: true;

--- a/types/leadCapture.ts
+++ b/types/leadCapture.ts
@@ -50,7 +50,8 @@ export type SubmitLeadErrorCode =
     | 'SERVER_CONFIG_ERROR'
     | 'N8N_WEBHOOK_ERROR'
     | 'METHOD_NOT_ALLOWED'
-    | 'RATE_LIMIT_EXCEEDED';
+    | 'RATE_LIMIT_EXCEEDED'
+    | 'SERVICE_UNAVAILABLE';
 
 export interface SubmitLeadError {
     ok: false;

--- a/types/quiz.ts
+++ b/types/quiz.ts
@@ -28,7 +28,8 @@ export type SubmitQuizErrorCode =
     | 'N8N_WEBHOOK_ERROR'
     | 'INTERNAL_ERROR'
     | 'METHOD_NOT_ALLOWED'
-    | 'RATE_LIMIT_EXCEEDED';
+    | 'RATE_LIMIT_EXCEEDED'
+    | 'SERVICE_UNAVAILABLE';
 
 export interface SubmitQuizError {
     ok: false;

--- a/types/waitlist.ts
+++ b/types/waitlist.ts
@@ -21,7 +21,8 @@ export type SubmitWaitlistErrorCode =
     | 'N8N_WEBHOOK_ERROR'
     | 'INTERNAL_ERROR'
     | 'METHOD_NOT_ALLOWED'
-    | 'RATE_LIMIT_EXCEEDED';
+    | 'RATE_LIMIT_EXCEEDED'
+    | 'SERVICE_UNAVAILABLE';
 
 export interface SubmitWaitlistError {
     ok: false;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,6 +11,7 @@ mode = "off"
 mode = "smart"
 
 [vars]
+CF_PAGES = "1"
 NODE_VERSION = "24"
 AI_GATEWAY_ENABLED = "true"
 CLOUDFLARE_AI_GATEWAY_ID = "av-site"
@@ -32,6 +33,7 @@ HUBSPOT_DEAL_STAGE_ID = "appointmentscheduled"
 HUBSPOT_DEAL_BANT_PROPERTY = "bant_summary"
 
 [env.production.vars]
+CF_PAGES = "1"
 NODE_VERSION = "24"
 AI_GATEWAY_ENABLED = "true"
 CLOUDFLARE_AI_GATEWAY_ID = "av-site"


### PR DESCRIPTION
## Summary

- **VULN-001 (Critical):** Rate limiting era não-funcional em produção (Cloudflare Pages / Vercel Edge) sem Redis configurado. Em edge runtimes, cada requisição executa em um contexto V8 isolado — o `inMemoryStore` resetava a cada invocação, dando `allowed: true` para sempre. Agora, quando Redis está indisponível em edge, a requisição é negada explicitamente em vez de cair no fallback inócuo.

- **Regressão XFF (VERIFY-001):** O PR #661 inverteu acidentalmente o comportamento do fallback `x-forwarded-for`, passando a retornar o IP mais à direita (`ips[ips.length - 1]`) em vez do IP de origem do cliente (`ips[0]`). O código anterior tinha o comentário `"Standard practice: use the first one (original client)"`. Revertido e alinhado com o comportamento de `x-vercel-forwarded-for` (ambos agora usam `ips[0]`, conforme RFC 7239).

- **Binding CF_PAGES em runtime (code review #1):** `CF_PAGES` é uma variável de ambiente de build do Cloudflare CI — não é injetada em `process.env` dentro de uma Pages Function em tempo de execução. O wrapper existente (`Object.assign(process.env, env)`) só injeta o que está em `context.env`, que vem dos bindings do `wrangler.toml [vars]`. Adicionado `CF_PAGES = "1"` em `[vars]` e `[env.production.vars]` para que `isEdgeRuntime()` retorne `true` corretamente em produção.

## Arquivos alterados

| Arquivo | Mudança |
|---------|---------|
| `lib/rate-limit.ts` | `IS_EDGE_RUNTIME` const → `isEdgeRuntime()` função; deny em edge sem Redis; deny em edge com falha de Redis |
| `lib/network.ts` | XFF fallback: `ips[last]` → `ips[0]` (RFC 7239) |
| `wrangler.toml` | `CF_PAGES = "1"` em `[vars]` e `[env.production.vars]` |
| `tests/lib-rate-limit.test.ts` | +3 testes: deny edge sem Redis, deny persistente, in-memory local dev |
| `tests/network.test.ts` | Teste corrigido + 2 novos (single IP, consistência XFF vs x-vercel-forwarded-for) |

## Test plan

- [ ] CI `build-and-test` passa (437 testes, 0 falhas verificado localmente)
- [ ] Confirmar que `UPSTASH_REDIS_REST_URL` e `UPSTASH_REDIS_REST_TOKEN` estão configurados no Cloudflare Pages dashboard (secrets, não vars — não aparecem no wrangler.toml)
- [ ] Após merge, monitorar logs do Cloudflare para entradas `RateLimit:` confirmando que Redis está sendo atingido

🤖 Generated with [Claude Code](https://claude.ai/claude-code)