### PR TITLE
fix(polyfill): Object.hasOwn polyfill for Chrome < 93

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,3 +1,4 @@
+import './polyfills';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './src/index.css';

--- a/polyfills.ts
+++ b/polyfills.ts
@@ -1,6 +1,12 @@
 // Object.hasOwn — not available in Chrome < 93 (Sentry NODE-1)
 // Reference captured once at install time to guard against prototype pollution.
+// defineProperty used to match native non-enumerable descriptor.
 if (!Object.hasOwn) {
   const hop = Object.prototype.hasOwnProperty;
-  Object.hasOwn = (obj: object, prop: PropertyKey) => hop.call(obj, prop);
+  Object.defineProperty(Object, 'hasOwn', {
+    value: (obj: object, prop: PropertyKey) => hop.call(obj, prop),
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  });
 }

--- a/polyfills.ts
+++ b/polyfills.ts
@@ -1,0 +1,6 @@
+// Object.hasOwn — not available in Chrome < 93 (Sentry NODE-1)
+// Reference captured once at install time to guard against prototype pollution.
+if (!Object.hasOwn) {
+  const hop = Object.prototype.hasOwnProperty;
+  Object.hasOwn = (obj: object, prop: PropertyKey) => hop.call(obj, prop);
+}

--- a/tests/polyfills.test.ts
+++ b/tests/polyfills.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 // Regression test for Sentry NODE-1: Object.hasOwn not available on Chrome < 93.
 // Simulates an environment without native Object.hasOwn by temporarily removing it,
-// then re-importing the polyfill to verify it installs a working implementation.
+// then re-running the polyfill logic to verify it installs a working implementation.
 
 test('polyfill installs Object.hasOwn when missing', () => {
   const native = Object.hasOwn;
@@ -14,10 +14,16 @@ test('polyfill installs Object.hasOwn when missing', () => {
     // Re-run the polyfill logic inline (mirrors polyfills.ts exactly)
     if (!Object.hasOwn) {
       const hop = Object.prototype.hasOwnProperty;
-      Object.hasOwn = (obj: object, prop: PropertyKey) => hop.call(obj, prop);
+      Object.defineProperty(Object, 'hasOwn', {
+        value: (obj: object, prop: PropertyKey) => hop.call(obj, prop),
+        writable: true,
+        configurable: true,
+        enumerable: false,
+      });
     }
 
     assert.equal(typeof Object.hasOwn, 'function', 'polyfill must install a function');
+    assert.equal(Object.propertyIsEnumerable('hasOwn'), false, 'polyfill must be non-enumerable');
     assert.equal(Object.hasOwn({ a: 1 }, 'a'), true);
     assert.equal(Object.hasOwn({ a: 1 }, 'b'), false);
     assert.equal(Object.hasOwn(Object.create({ inherited: true }), 'inherited'), false);
@@ -32,7 +38,12 @@ test('polyfill is a no-op when Object.hasOwn already exists', () => {
   // Re-run the guard — should not overwrite
   if (!Object.hasOwn) {
     const hop = Object.prototype.hasOwnProperty;
-    Object.hasOwn = (obj: object, prop: PropertyKey) => hop.call(obj, prop);
+    Object.defineProperty(Object, 'hasOwn', {
+      value: (obj: object, prop: PropertyKey) => hop.call(obj, prop),
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
   }
 
   assert.equal(Object.hasOwn, before, 'native implementation must not be replaced');
@@ -45,11 +56,15 @@ test('polyfill uses captured hasOwnProperty reference, not live prototype lookup
     Object.hasOwn = undefined;
 
     const hop = Object.prototype.hasOwnProperty;
-    Object.hasOwn = (obj: object, prop: PropertyKey) => hop.call(obj, prop);
+    Object.defineProperty(Object, 'hasOwn', {
+      value: (obj: object, prop: PropertyKey) => hop.call(obj, prop),
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
 
     // Poison the prototype after install — polyfill must be unaffected
     const original = Object.prototype.hasOwnProperty;
-    // @ts-expect-error — intentional pollution for test
     Object.prototype.hasOwnProperty = () => true;
     try {
       // The polyfill captured `hop` before the poison, so result must still be correct

--- a/tests/polyfills.test.ts
+++ b/tests/polyfills.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Regression test for Sentry NODE-1: Object.hasOwn not available on Chrome < 93.
+// Simulates an environment without native Object.hasOwn by temporarily removing it,
+// then re-importing the polyfill to verify it installs a working implementation.
+
+test('polyfill installs Object.hasOwn when missing', () => {
+  const native = Object.hasOwn;
+  try {
+    // @ts-expect-error — simulating old browser
+    Object.hasOwn = undefined;
+
+    // Re-run the polyfill logic inline (mirrors polyfills.ts exactly)
+    if (!Object.hasOwn) {
+      const hop = Object.prototype.hasOwnProperty;
+      Object.hasOwn = (obj: object, prop: PropertyKey) => hop.call(obj, prop);
+    }
+
+    assert.equal(typeof Object.hasOwn, 'function', 'polyfill must install a function');
+    assert.equal(Object.hasOwn({ a: 1 }, 'a'), true);
+    assert.equal(Object.hasOwn({ a: 1 }, 'b'), false);
+    assert.equal(Object.hasOwn(Object.create({ inherited: true }), 'inherited'), false);
+  } finally {
+    Object.hasOwn = native;
+  }
+});
+
+test('polyfill is a no-op when Object.hasOwn already exists', () => {
+  const before = Object.hasOwn;
+
+  // Re-run the guard — should not overwrite
+  if (!Object.hasOwn) {
+    const hop = Object.prototype.hasOwnProperty;
+    Object.hasOwn = (obj: object, prop: PropertyKey) => hop.call(obj, prop);
+  }
+
+  assert.equal(Object.hasOwn, before, 'native implementation must not be replaced');
+});
+
+test('polyfill uses captured hasOwnProperty reference, not live prototype lookup', () => {
+  const native = Object.hasOwn;
+  try {
+    // @ts-expect-error — simulating old browser
+    Object.hasOwn = undefined;
+
+    const hop = Object.prototype.hasOwnProperty;
+    Object.hasOwn = (obj: object, prop: PropertyKey) => hop.call(obj, prop);
+
+    // Poison the prototype after install — polyfill must be unaffected
+    const original = Object.prototype.hasOwnProperty;
+    // @ts-expect-error — intentional pollution for test
+    Object.prototype.hasOwnProperty = () => true;
+    try {
+      // The polyfill captured `hop` before the poison, so result must still be correct
+      assert.equal(Object.hasOwn({ a: 1 }, 'b'), false, 'must use captured reference, not poisoned one');
+    } finally {
+      Object.prototype.hasOwnProperty = original;
+    }
+  } finally {
+    Object.hasOwn = native;
+  }
+});


### PR DESCRIPTION
## Problema

Sentry **NODE-1**: `TypeError: Object.hasOwn is not a function` em produção.

`Object.hasOwn` foi introduzido no Chrome 93 (agosto 2021). Um usuário em Chrome 79 / Windows causou o erro ao acessar `react-markdown`, que usa `Object.hasOwn` internamente na função `post()`.

## Solução

- **`polyfills.ts`** — arquivo dedicado com o polyfill; captura a referência a `hasOwnProperty` uma vez na instalação para evitar prototype pollution (ex: scripts GTM/HubSpot que rodam na mesma página)
- **`index.tsx`** — `import './polyfills'` movido para ser o **primeiro** import do entry point; com Vite/Rollup, isso garante que o módulo é avaliado antes de qualquer outro na árvore de dependências
- **`tests/polyfills.test.ts`** — 3 testes de regressão: instala quando ausente, não sobrescreve o nativo, usa referência capturada (não o prototype ao vivo)

## Notas técnicas

O polyfill inline anterior estava posicionado *entre* imports no código fonte. Embora funcionasse hoje (porque react-markdown chama `Object.hasOwn` apenas em tempo de render, não na inicialização do módulo), era frágil: qualquer atualização do react-markdown que adicionasse uma chamada em nível de módulo quebraria Chrome 79–92 silenciosamente.

## Test plan

- [x] `pnpm test:regression` — 440 testes, 0 falhas
- [x] `tests/polyfills.test.ts` cobre os 3 cenários de risco identificados na code review
- [ ] Verificar no Sentry após deploy que NODE-1 fica resolvido

Fixes NODE-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)