### PR TITLE
test(media-url): regression para contrato LCP preload/srcset (#673)

### DIFF
--- a/tests/media-url.test.ts
+++ b/tests/media-url.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import {
     buildCloudflareImageUrl,
@@ -224,20 +225,18 @@ test('optimizeImageUrl should propagate format=webp into the Cloudflare transfor
 // Regression for issue #673: preload widths in index.html must match the URLs
 // that Hero.tsx generates for its posterSrcSet. If the preset snap logic changes
 // or Hero.tsx requests different dimensions, the preload URLs must be updated too.
+// Reads index.html dynamically so a drift in either side is caught.
 test('hero poster srcset URLs at each breakpoint match the preload hints in index.html', () => {
     const POSTER_PATH = '/images/hero/rio-poster.jpg';
     const BASE        = 'https://media.anhanga.tur.br';
 
-    assert.equal(
-        buildCloudflareImageUrl(POSTER_PATH, BASE, selectImagePreset(960, 540), 'webp'),
-        'https://media.anhanga.tur.br/cdn-cgi/image/format=webp,quality=85,metadata=none,fit=cover,width=960,height=540/images/hero/rio-poster.jpg',
-    );
-    assert.equal(
-        buildCloudflareImageUrl(POSTER_PATH, BASE, selectImagePreset(1200, 675), 'webp'),
-        'https://media.anhanga.tur.br/cdn-cgi/image/format=webp,quality=85,metadata=none,fit=cover,width=1200,height=675/images/hero/rio-poster.jpg',
-    );
-    assert.equal(
-        buildCloudflareImageUrl(POSTER_PATH, BASE, selectImagePreset(1280, 720), 'webp'),
-        'https://media.anhanga.tur.br/cdn-cgi/image/format=webp,quality=85,metadata=none,fit=cover,width=1280,height=720/images/hero/rio-poster.jpg',
-    );
+    const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+
+    const url960  = buildCloudflareImageUrl(POSTER_PATH, BASE, selectImagePreset(960, 540), 'webp');
+    const url1200 = buildCloudflareImageUrl(POSTER_PATH, BASE, selectImagePreset(1200, 675), 'webp');
+    const url1280 = buildCloudflareImageUrl(POSTER_PATH, BASE, selectImagePreset(1280, 720), 'webp');
+
+    assert.ok(html.includes(url960),  `index.html must contain the 960w preload URL: ${url960}`);
+    assert.ok(html.includes(url1200), `index.html must contain the 1200w preload URL: ${url1200}`);
+    assert.ok(html.includes(url1280), `index.html must contain the 1280w preload URL: ${url1280}`);
 });

--- a/tests/media-url.test.ts
+++ b/tests/media-url.test.ts
@@ -53,6 +53,13 @@ test('selectImagePreset should snap landscape requests to fixed cover presets', 
         fit: 'cover',
     });
 
+    assert.deepEqual(selectImagePreset(1200, 675), {
+        id: 'content',
+        width: 1200,
+        height: 675,
+        fit: 'cover',
+    });
+
     assert.deepEqual(selectImagePreset(1280, 720), {
         id: 'hero',
         width: 1280,
@@ -211,5 +218,26 @@ test('optimizeImageUrl should propagate format=webp into the Cloudflare transfor
             format: 'webp',
         }),
         'https://media.anhanga.tur.br/cdn-cgi/image/format=webp,quality=85,metadata=none,fit=scale-down,width=800/images/home/hero.jpg',
+    );
+});
+
+// Regression for issue #673: preload widths in index.html must match the URLs
+// that Hero.tsx generates for its posterSrcSet. If the preset snap logic changes
+// or Hero.tsx requests different dimensions, the preload URLs must be updated too.
+test('hero poster srcset URLs at each breakpoint match the preload hints in index.html', () => {
+    const POSTER_PATH = '/images/hero/rio-poster.jpg';
+    const BASE        = 'https://media.anhanga.tur.br';
+
+    assert.equal(
+        buildCloudflareImageUrl(POSTER_PATH, BASE, selectImagePreset(960, 540), 'webp'),
+        'https://media.anhanga.tur.br/cdn-cgi/image/format=webp,quality=85,metadata=none,fit=cover,width=960,height=540/images/hero/rio-poster.jpg',
+    );
+    assert.equal(
+        buildCloudflareImageUrl(POSTER_PATH, BASE, selectImagePreset(1200, 675), 'webp'),
+        'https://media.anhanga.tur.br/cdn-cgi/image/format=webp,quality=85,metadata=none,fit=cover,width=1200,height=675/images/hero/rio-poster.jpg',
+    );
+    assert.equal(
+        buildCloudflareImageUrl(POSTER_PATH, BASE, selectImagePreset(1280, 720), 'webp'),
+        'https://media.anhanga.tur.br/cdn-cgi/image/format=webp,quality=85,metadata=none,fit=cover,width=1280,height=720/images/hero/rio-poster.jpg',
     );
 });


### PR DESCRIPTION
## Resumo

- Adiciona `selectImagePreset(1200, 675)` ao teste de landscapes — único preset hero que estava sem cobertura
- Adiciona teste de contrato que verifica que `buildCloudflareImageUrl` com as três dimensões do srcset do Hero (960/1200/1280) e formato `webp` produz URLs idênticas aos hints de preload hardcodados em `index.html`

A correção do alinhamento em si foi feita no PR #671. Este PR fecha o ciclo adicionando o guard de regressão: se alguém mudar o snap de presets ou as URLs do `index.html` sem sincronizar o outro lado, o teste vai falhar.

## Arquivos alterados

- `tests/media-url.test.ts` — +28 linhas (2 novos asserts + 1 novo teste)

## Plano de testes

- [x] `pnpm test:regression` — 441 testes, 0 falhas

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)