### PR TITLE
[codex] Reduce loaded Poppins font weights

### DIFF
--- a/Anhangá Viagens Design System/README.md
+++ b/Anhangá Viagens Design System/README.md
@@ -20,7 +20,7 @@ The working design system for **Anhangá Viagens**, a Brazilian-Portuguese conci
 
 ## 2 · Visual language (one-paragraph brief)
 
-Warm cream paper canvas (`#fffdf5`), heavy **Poppins 800/900** display type with negative tracking, and a **neobrutalist signature** of 2px dark outlines + flat offset shadows (`4px 4px 0 #0f172a`). Energy comes from a single vivid **yellow (#FFD600)** used as tape, highlights, stamps, and primary-CTA fill; the brand blue `#0056D2` lives mostly in the logo, while `sky-500 #0ea5e9` carries interactive/action states. Imagery is treated like a **scrapbook**: tilted polaroids, washi tape, rubber stamps ("Achado Anhangá"), underline scribbles, Merriweather-italic pull-quotes. Accent colors (orange/emerald/sky/blue) are used pastel-tinted to differentiate card families — never saturated.
+Warm cream paper canvas (`#fffdf5`), heavy **Poppins 900** display type with negative tracking, and a **neobrutalist signature** of 2px dark outlines + flat offset shadows (`4px 4px 0 #0f172a`). Energy comes from a single vivid **yellow (#FFD600)** used as tape, highlights, stamps, and primary-CTA fill; the brand blue `#0056D2` lives mostly in the logo, while `sky-500 #0ea5e9` carries interactive/action states. Imagery is treated like a **scrapbook**: tilted polaroids, washi tape, rubber stamps ("Achado Anhangá"), underline scribbles, Merriweather-italic pull-quotes. Accent colors (orange/emerald/sky/blue) are used pastel-tinted to differentiate card families — never saturated.
 
 **Do**
 - Commit to one bold yellow accent per screen.
@@ -58,7 +58,7 @@ Action         sky-500 #0ea5e9   sky-600 hover #0284c7
 Canvas         cream #fffdf5 (home)   sky-tinted #F4F8FF (alt sections)
 Accents        orange-100/600 · emerald-100/600 · sky-50/500 · blue-100/600
 Neutrals       Tailwind gray 50-900
-Display font   Poppins 800 · tracking -0.035em at hero scale
+Display font   Poppins 900 · tracking -0.035em at hero scale
 Body font      Poppins 400/600/700 · line-height 1.6
 Editorial font Merriweather 400/700 + italic · blog & pull-quotes
 Radius         8 · 12 · 16 · 24 · 32 · 40 · 48 · full
@@ -72,7 +72,7 @@ All of the above are available as CSS variables prefixed `--av-*` — see `color
 
 ## 5 · Signature patterns
 
-- **Hero H1** — 72–96px Poppins 800, the keyword wrapped in `.av-scribble` with the yellow gradient.
+- **Hero H1** — 72–96px Poppins 900, the keyword wrapped in `.av-scribble` with the yellow gradient.
 - **Section eyebrow** — `.av-badge` pill above every H2 (uppercase, 20% tracking).
 - **CTA (primary)** — yellow pill, 2px dark border, 4/4/0 dark shadow, arrow slides on hover.
 - **Polaroid** — white card, `-2deg` rotate, washi tape tab on top, optional rubber stamp at top-right, italic caption.

--- a/Anhangá Viagens Design System/SKILL.md
+++ b/Anhangá Viagens Design System/SKILL.md
@@ -6,7 +6,7 @@ This is the skill the design system wants you to run whenever a user asks for a 
 
 ## 1 · Before you open a file
 
-1. **Read `README.md`.** It has the voice, the Do/Don'ts, and the one-paragraph visual brief. Don't skip it — the tokens alone won't give you the handmade scrapbook mood. **Fonts loaded: Poppins 400/600/700/800 and Merriweather 400/700 regular + italic — only these.** Requesting 500 or 900 falls back and looks wrong.
+1. **Read `README.md`.** It has the voice, the Do/Don'ts, and the one-paragraph visual brief. Don't skip it — the tokens alone won't give you the handmade scrapbook mood. **Fonts loaded: Poppins 400/600/700/900 and Merriweather 400/700 regular + italic — only these.** Requesting 500 or 800 falls back to the nearest loaded weight.
 2. **Decide the surface.** Web section? Phone mockup? Print? Deck slide? Pick the right starter component (`ios_frame.jsx`, `browser_window.jsx`, `deck_stage.js`, `design_canvas.jsx`). Anhangá designs usually need a *real* phone or browser frame — the brand is strongly about craft.
 3. **Ask** (if the brief is ambiguous): what page/flow, how many variations, tone (more sonhador vs. more prático), locale (Brazilian Portuguese is default, always).
 

--- a/Anhangá Viagens Design System/colors_and_type.css
+++ b/Anhangá Viagens Design System/colors_and_type.css
@@ -4,7 +4,7 @@
    ========================================================================== */
 
 /* Fonts — loaded from Google Fonts (matches index.html <head>) */
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;800&family=Merriweather:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;900&family=Merriweather:ital,wght@0,400;0,700;1,400;1,700&display=swap');
 
 :root {
   /* ----- Brand palette (anhanga.*) ------------------------------------- */
@@ -97,9 +97,9 @@
   --av-weight-regular: 400;
   --av-weight-semi:    600;
   --av-weight-bold:    700;
-  --av-weight-xbold:   800;
-  /* Note: Poppins is loaded with 400/600/700/800 only.
-     Avoid 500 (medium) and 900 (black) — they'll fall back to the nearest weight. */
+  --av-weight-xbold:   900;
+  /* Note: Poppins is loaded with 400/600/700/900 only.
+     Avoid 500 (medium) and 800 (extrabold) — they'll fall back to the nearest weight. */
 
   --av-leading-tight:   1.1;
   --av-leading-snug:    1.25;
@@ -182,13 +182,13 @@ h1, h2, h3, h4, h5, h6 {
 
 h1 {
   font-size: clamp(3rem, 7vw, var(--av-text-8xl));
-  font-weight: var(--av-weight-xbold);   /* 800 */
+  font-weight: var(--av-weight-xbold);   /* 900 */
   letter-spacing: -0.035em;
 }
 
 h2 {
   font-size: clamp(var(--av-text-4xl), 5vw, var(--av-text-5xl));
-  font-weight: var(--av-weight-xbold);   /* 800 — loaded heaviest */
+  font-weight: var(--av-weight-xbold);   /* 900 — loaded heaviest */
   letter-spacing: -0.025em;
 }
 

--- a/Anhangá Viagens Design System/preview/brand-logo-decorations.html
+++ b/Anhangá Viagens Design System/preview/brand-logo-decorations.html
@@ -5,7 +5,7 @@
 <style>
   html, body { margin:0; padding:0; background: var(--av-cream); }
   body { padding: 28px; font-family: var(--av-font-body); display:flex; flex-direction:column; gap: 22px; }
-  .label { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .16em; color: var(--av-fg-3); }
+  .label { font-size: 10px; font-weight: 900; text-transform: uppercase; letter-spacing: .16em; color: var(--av-fg-3); }
 
   .logos {
     display:grid; grid-template-columns: 1fr 1fr; gap: 18px;
@@ -40,14 +40,14 @@
     border: 3px dashed var(--av-dark);
     display:flex; align-items:center; justify-content:center; text-align:center;
     font-family: var(--av-font-display);
-    font-weight: 800; font-size: 11px; letter-spacing: .16em; text-transform: uppercase;
+    font-weight: 900; font-size: 11px; letter-spacing: .16em; text-transform: uppercase;
     color: var(--av-dark);
     background: var(--av-yellow);
     transform: rotate(-8deg);
   }
   .scribble {
     font-family: var(--av-font-display);
-    font-weight: 800; font-size: 28px; color: var(--av-dark);
+    font-weight: 900; font-size: 28px; color: var(--av-dark);
     position: relative; padding: 0 4px;
   }
   .scribble span { position: relative; z-index: 1;}

--- a/Anhangá Viagens Design System/preview/buttons-badges.html
+++ b/Anhangá Viagens Design System/preview/buttons-badges.html
@@ -6,7 +6,7 @@
   html, body { margin:0; padding:0; background: var(--av-cream); }
   body { padding: 28px; font-family: var(--av-font-body); display:flex; flex-direction:column; gap: 20px;}
   .row { display:flex; gap: 14px; flex-wrap: wrap; align-items: center; }
-  .label { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .16em; color: var(--av-fg-3); width: 100%; }
+  .label { font-size: 10px; font-weight: 900; text-transform: uppercase; letter-spacing: .16em; color: var(--av-fg-3); width: 100%; }
 
   /* --- Primary (yellow w/ hard shadow) --- */
   .btn {
@@ -16,7 +16,7 @@
     border-radius: 9999px;
     padding: 14px 28px;
     font-family: var(--av-font-display);
-    font-weight: 800;
+    font-weight: 900;
     font-size: 15px;
     letter-spacing: .01em;
     cursor: pointer;
@@ -37,7 +37,7 @@
     border-radius: 9999px;
     padding: 6px 14px;
     font-size: 11px;
-    font-weight: 800;
+    font-weight: 900;
     letter-spacing: .18em;
     text-transform: uppercase;
     border: 2px solid var(--av-dark);

--- a/Anhangá Viagens Design System/preview/cards-content.html
+++ b/Anhangá Viagens Design System/preview/cards-content.html
@@ -24,7 +24,7 @@
     font-size: 26px; color: var(--av-orange-600);
     margin-bottom: 18px; transform: rotate(-4deg);
   }
-  .hl h3 { font-size: 22px; font-weight: 800; color: var(--av-dark); letter-spacing: -.01em;}
+  .hl h3 { font-size: 22px; font-weight: 900; color: var(--av-dark); letter-spacing: -.01em;}
   .hl p { margin-top: 8px; font-size: 14.5px; line-height: 1.55; color: var(--av-fg-2); font-weight: 400;}
   .hl .corner {
     position:absolute; top:14px; right:14px;
@@ -81,7 +81,7 @@
     border: 2px solid var(--av-dark);
     border-radius: 9999px;
     padding: 6px 12px;
-    font-size: 10px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase;
+    font-size: 10px; font-weight: 900; letter-spacing: .14em; text-transform: uppercase;
     box-shadow: 2px 2px 0 rgba(0,0,0,0.12);
     z-index: 3;
   }

--- a/Anhangá Viagens Design System/preview/cards-steps-testimonials.html
+++ b/Anhangá Viagens Design System/preview/cards-steps-testimonials.html
@@ -5,7 +5,7 @@
 <style>
   html, body { margin:0; padding:0; background: var(--av-cream); }
   body { padding: 28px; font-family: var(--av-font-body); display:flex; flex-direction:column; gap: 20px;}
-  .label { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .16em; color: var(--av-fg-3); }
+  .label { font-size: 10px; font-weight: 900; text-transform: uppercase; letter-spacing: .16em; color: var(--av-fg-3); }
 
   /* How-it-works step */
   .steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
@@ -24,10 +24,10 @@
     border: 2px solid var(--av-dark);
     display:flex; align-items:center; justify-content:center;
     font-family: var(--av-font-display);
-    font-weight: 800; font-size: 20px; color: var(--av-dark);
+    font-weight: 900; font-size: 20px; color: var(--av-dark);
     transform: rotate(-4deg);
   }
-  .step h4 { margin-top: 16px; font-size: 17px; font-weight: 800; color: var(--av-dark);}
+  .step h4 { margin-top: 16px; font-size: 17px; font-weight: 900; color: var(--av-dark);}
   .step p { margin-top: 6px; font-size: 13.5px; color: var(--av-fg-2); line-height: 1.55;}
 
   /* Testimonial */
@@ -48,11 +48,11 @@
     background: linear-gradient(135deg, #fde047, #FFD600);
     border: 2px solid var(--av-dark);
     display:flex; align-items:center; justify-content:center;
-    font-family: var(--av-font-display); font-weight: 800; color: var(--av-dark);
+    font-family: var(--av-font-display); font-weight: 900; color: var(--av-dark);
     flex-shrink: 0;
   }
   .testi .meta { flex: 1; }
-  .testi .meta b { font-weight: 800; color: var(--av-dark); font-size: 14px;}
+  .testi .meta b { font-weight: 900; color: var(--av-dark); font-size: 14px;}
   .testi .meta span { display:block; font-size: 12px; color: var(--av-fg-3); margin-top: 1px;}
   .testi .stars {
     color: #f59e0b;
@@ -78,7 +78,7 @@
     background: var(--av-yellow);
     border: 2px solid var(--av-dark);
     display:flex; align-items:center; justify-content:center;
-    font-weight: 800; color: var(--av-dark);
+    font-weight: 900; color: var(--av-dark);
   }
 </style></head>
 <body>

--- a/Anhangá Viagens Design System/preview/colors-accents.html
+++ b/Anhangá Viagens Design System/preview/colors-accents.html
@@ -7,7 +7,7 @@
   body { padding: 24px; font-family: var(--av-font-body); }
   .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
   .group { background: white; border: 1px solid var(--av-border); border-radius: 16px; padding: 14px; }
-  .family { font-size: 10px; text-transform: uppercase; letter-spacing: .12em; font-weight: 800; color: var(--av-fg-3); margin-bottom: 8px; }
+  .family { font-size: 10px; text-transform: uppercase; letter-spacing: .12em; font-weight: 900; color: var(--av-fg-3); margin-bottom: 8px; }
   .swatch-row { display: flex; gap: 6px; }
   .sw { width: 100%; height: 36px; border-radius: 8px; box-shadow: inset 0 0 0 1px rgba(15,23,42,0.05); }
   .hex { font-family: var(--av-font-mono); font-size: 10px; color: var(--av-fg-3); margin-top: 6px; }

--- a/Anhangá Viagens Design System/preview/colors-neutrals.html
+++ b/Anhangá Viagens Design System/preview/colors-neutrals.html
@@ -6,7 +6,7 @@
   html, body { margin:0; padding:0; background: var(--av-cream); }
   body { padding: 24px; font-family: var(--av-font-body); }
   .row { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; margin-bottom: 14px; }
-  .lbl { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .14em; color: var(--av-fg-3); margin-bottom: 6px; }
+  .lbl { font-size: 10px; font-weight: 900; text-transform: uppercase; letter-spacing: .14em; color: var(--av-fg-3); margin-bottom: 6px; }
   .chip { height: 72px; border-radius: 12px; display:flex; align-items:flex-end; padding: 8px 10px; font-family: var(--av-font-mono); font-size: 10px; color: rgba(0,0,0,.55); box-shadow: inset 0 0 0 1px rgba(15,23,42,0.05); }
   .chip.white { color: rgba(255,255,255,.8); }
 </style></head>

--- a/Anhangá Viagens Design System/preview/inputs.html
+++ b/Anhangá Viagens Design System/preview/inputs.html
@@ -5,7 +5,7 @@
 <style>
   html, body { margin:0; padding:0; background: var(--av-cream); }
   body { padding: 28px; font-family: var(--av-font-body); display:flex; flex-direction:column; gap: 16px;}
-  .label { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .16em; color: var(--av-fg-3); }
+  .label { font-size: 10px; font-weight: 900; text-transform: uppercase; letter-spacing: .16em; color: var(--av-fg-3); }
 
   .field { display:flex; flex-direction:column; gap:6px; max-width: 420px;}
   .field label { font-size: 13px; font-weight: 700; color: var(--av-dark);}
@@ -43,7 +43,7 @@
     background: var(--av-yellow);
     border: 2px solid var(--av-dark);
     color: var(--av-dark);
-    font-weight: 800;
+    font-weight: 900;
     border-radius: 9999px;
     padding: 10px 20px;
     font-family: var(--av-font-display);

--- a/Anhangá Viagens Design System/preview/spacing-radii-shadows.html
+++ b/Anhangá Viagens Design System/preview/spacing-radii-shadows.html
@@ -5,7 +5,7 @@
 <style>
   html, body { margin:0; padding:0; background: var(--av-cream); }
   body { padding: 28px; font-family: var(--av-font-body); display:grid; grid-template-columns: 1fr 1fr; gap: 28px; }
-  .col h5 { font-size: 11px; text-transform: uppercase; letter-spacing: .16em; font-weight: 800; color: var(--av-fg-3); margin: 0 0 14px; }
+  .col h5 { font-size: 11px; text-transform: uppercase; letter-spacing: .16em; font-weight: 900; color: var(--av-fg-3); margin: 0 0 14px; }
 
   /* Radius row */
   .radii { display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap; }
@@ -29,7 +29,7 @@
     min-height: 70px;
     border: 1px solid var(--av-border-soft);
   }
-  .s-card b { display:block; font-family: var(--av-font-body); font-weight: 800; font-size: 12px; color: var(--av-fg-1); margin-bottom: 2px; letter-spacing:.02em;}
+  .s-card b { display:block; font-family: var(--av-font-body); font-weight: 900; font-size: 12px; color: var(--av-fg-1); margin-bottom: 2px; letter-spacing:.02em;}
   .s1 { box-shadow: var(--av-shadow-hard); border: 2px solid var(--av-dark); }
   .s2 { box-shadow: var(--av-shadow-hard-yellow); border: 2px solid var(--av-dark); background: var(--av-yellow); color: var(--av-dark);}
   .s2 b { color: var(--av-dark);}

--- a/Anhangá Viagens Design System/preview/type-display.html
+++ b/Anhangá Viagens Design System/preview/type-display.html
@@ -5,13 +5,13 @@
 <style>
   html, body { margin:0; padding:0; background: var(--av-cream); }
   body { padding: 28px; font-family: var(--av-font-body); }
-  .family { font-size: 11px; text-transform: uppercase; letter-spacing: .18em; font-weight: 800; color: var(--av-fg-3); }
+  .family { font-size: 11px; text-transform: uppercase; letter-spacing: .18em; font-weight: 900; color: var(--av-fg-3); }
   .spec { font-family: var(--av-font-mono); font-size: 11px; color: var(--av-fg-3); margin-top: 4px; }
-  h1.demo { font-family: var(--av-font-display); font-weight: 800; font-size: 72px; letter-spacing: -.035em; line-height: .95; color: var(--av-dark); margin: 6px 0 0; }
+  h1.demo { font-family: var(--av-font-display); font-weight: 900; font-size: 72px; letter-spacing: -.035em; line-height: .95; color: var(--av-dark); margin: 6px 0 0; }
   h1.demo em { font-style: normal; background: linear-gradient(90deg,#fde047,#FFD600); -webkit-background-clip: text; color: transparent; padding: 0 2px; }
 </style></head>
 <body>
-  <div class="family">Poppins · 800 · Display</div>
+  <div class="family">Poppins · 900 · Display</div>
   <h1 class="demo">Sua Próxima <em>Aventura</em></h1>
-  <div class="spec">font-family: Poppins · weight 800 · 72px / 1.0 · letter-spacing −3.5% · drop-shadow-lg on image backgrounds</div>
+  <div class="spec">font-family: Poppins · weight 900 · 72px / 1.0 · letter-spacing −3.5% · drop-shadow-lg on image backgrounds</div>
 </body></html>

--- a/Anhangá Viagens Design System/preview/type-scale.html
+++ b/Anhangá Viagens Design System/preview/type-scale.html
@@ -8,19 +8,19 @@
   .row { display: grid; grid-template-columns: 140px 1fr; gap: 18px; align-items: baseline; padding: 10px 0; border-bottom: 1px dashed var(--av-border); }
   .row:last-child { border: none; }
   .meta { font-family: var(--av-font-mono); font-size: 10px; color: var(--av-fg-3); line-height: 1.3; }
-  .meta b { display:block; font-family: var(--av-font-body); color: var(--av-fg-1); font-size: 12px; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; margin-bottom: 2px;}
+  .meta b { display:block; font-family: var(--av-font-body); color: var(--av-fg-1); font-size: 12px; font-weight: 900; text-transform: uppercase; letter-spacing: .1em; margin-bottom: 2px;}
   .sample { font-family: var(--av-font-display); color: var(--av-dark); line-height: 1.15; }
-  .h2 { font-size: 48px; font-weight: 800; letter-spacing: -.025em; }
-  .h3 { font-size: 24px; font-weight: 800; letter-spacing: -.01em; }
+  .h2 { font-size: 48px; font-weight: 900; letter-spacing: -.025em; }
+  .h3 { font-size: 24px; font-weight: 900; letter-spacing: -.01em; }
   .h4 { font-size: 20px; font-weight: 700; }
   .lead { font-size: 20px; font-weight: 400; color: var(--av-fg-2); line-height: 1.5; letter-spacing: -.005em; }
   .body { font-size: 16px; font-weight: 400; color: var(--av-fg-2); line-height: 1.65; }
   .small { font-size: 14px; font-weight: 400; color: var(--av-fg-2); }
-  .eyebrow { font-size: 12px; font-weight: 800; text-transform: uppercase; letter-spacing: .2em; color: var(--av-fg-1);}
+  .eyebrow { font-size: 12px; font-weight: 900; text-transform: uppercase; letter-spacing: .2em; color: var(--av-fg-1);}
 </style></head>
 <body>
   <div class="row"><div class="meta"><b>H2 · Section</b>48 / 1.1 · 900<br>tracking −2.5%</div><div class="sample h2">Por que a Anhangá</div></div>
-  <div class="row"><div class="meta"><b>H3 · Card</b>24 / 1.25 · 800</div><div class="sample h3">Concierge Humano</div></div>
+  <div class="row"><div class="meta"><b>H3 · Card</b>24 / 1.25 · 900</div><div class="sample h3">Concierge Humano</div></div>
   <div class="row"><div class="meta"><b>H4 · Subhead</b>20 / 1.25 · 700</div><div class="sample h4">Você conta, a gente roteiriza</div></div>
   <div class="row"><div class="meta"><b>Lead</b>20 / 1.5 · 500</div><div class="sample lead">Sem script, sem pacote engessado. Só um roteiro que combina com você.</div></div>
   <div class="row"><div class="meta"><b>Body</b>16 / 1.65 · 500</div><div class="sample body">Deixe a gente cuidar dos detalhes enquanto você sonha com o próximo destino. Nosso time monta, ajusta e acompanha a viagem de ponta a ponta.</div></div>

--- a/Anhangá Viagens Design System/preview/type-supporting.html
+++ b/Anhangá Viagens Design System/preview/type-supporting.html
@@ -5,7 +5,7 @@
 <style>
   html, body { margin:0; padding:0; background: var(--av-cream); }
   body { padding: 32px; font-family: var(--av-font-body); display:flex; flex-direction:column; gap: 22px; }
-  .label { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .18em; color: var(--av-fg-3); margin-bottom: 6px; }
+  .label { font-size: 10px; font-weight: 900; text-transform: uppercase; letter-spacing: .18em; color: var(--av-fg-3); margin-bottom: 6px; }
   .quote {
     font-family: 'Merriweather', Georgia, serif;
     font-style: italic;

--- a/Anhangá Viagens Design System/standalone_src/cards-steps-testimonials.html
+++ b/Anhangá Viagens Design System/standalone_src/cards-steps-testimonials.html
@@ -14,7 +14,7 @@
 <style>
   html, body { margin:0; padding:0; background: var(--av-cream); }
   body { padding: 28px; font-family: var(--av-font-body); display:flex; flex-direction:column; gap: 20px;}
-  .label { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .16em; color: var(--av-fg-3); }
+  .label { font-size: 10px; font-weight: 900; text-transform: uppercase; letter-spacing: .16em; color: var(--av-fg-3); }
 
   /* How-it-works step */
   .steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
@@ -33,10 +33,10 @@
     border: 2px solid var(--av-dark);
     display:flex; align-items:center; justify-content:center;
     font-family: var(--av-font-display);
-    font-weight: 800; font-size: 20px; color: var(--av-dark);
+    font-weight: 900; font-size: 20px; color: var(--av-dark);
     transform: rotate(-4deg);
   }
-  .step h4 { margin-top: 16px; font-size: 17px; font-weight: 800; color: var(--av-dark);}
+  .step h4 { margin-top: 16px; font-size: 17px; font-weight: 900; color: var(--av-dark);}
   .step p { margin-top: 6px; font-size: 13.5px; color: var(--av-fg-2); line-height: 1.55;}
 
   /* Testimonial */
@@ -57,11 +57,11 @@
     background: linear-gradient(135deg, #fde047, #FFD600);
     border: 2px solid var(--av-dark);
     display:flex; align-items:center; justify-content:center;
-    font-family: var(--av-font-display); font-weight: 800; color: var(--av-dark);
+    font-family: var(--av-font-display); font-weight: 900; color: var(--av-dark);
     flex-shrink: 0;
   }
   .testi .meta { flex: 1; }
-  .testi .meta b { font-weight: 800; color: var(--av-dark); font-size: 14px;}
+  .testi .meta b { font-weight: 900; color: var(--av-dark); font-size: 14px;}
   .testi .meta span { display:block; font-size: 12px; color: var(--av-fg-3); margin-top: 1px;}
   .testi .stars {
     color: #f59e0b;
@@ -87,7 +87,7 @@
     background: var(--av-yellow);
     border: 2px solid var(--av-dark);
     display:flex; align-items:center; justify-content:center;
-    font-weight: 800; color: var(--av-dark);
+    font-weight: 900; color: var(--av-dark);
   }
 </style></head>
 <body>

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -17,7 +17,7 @@ typography:
   display:
     fontFamily: "Poppins, sans-serif"
     fontSize: "clamp(3rem, 6vw, 5rem)"
-    fontWeight: 800
+    fontWeight: 900
     lineHeight: 0.9
     letterSpacing: "-0.02em"
   headline:
@@ -156,7 +156,7 @@ Uma paleta que evoca lugares reais, não categorias de produto. Azul de oceano p
 **Character:** Poppins é o rosto da marca: geométrica, calorosa, confiante. Inter serve o corpo de texto com legibilidade máxima em telas pequenas. Merriweather guarda o blog — um registro diferente, mais lento, editorial. As duas fontes principais não competem porque operam em registros diferentes: Poppins na estrutura de identidade, Inter no fluxo de leitura.
 
 ### Hierarchy
-- **Display** (800, clamp(3rem, 6vw, 5rem), line-height 0.9, letter-spacing -0.02em): H1 do Hero. Ocupa espaço físico com intenção. Ênfase tipográfica via cor sólida `text-yellow-300`, nunca gradient text.
+- **Display** (900, clamp(3rem, 6vw, 5rem), line-height 0.9, letter-spacing -0.02em): H1 do Hero. Ocupa espaço físico com intenção. Ênfase tipográfica via cor sólida `text-yellow-300`, nunca gradient text.
 - **Headline** (700, clamp(1.5rem, 3vw, 2.5rem), line-height 1.1): Títulos de seção (H2), cabeçalhos de página. Contraste mínimo 1.25× com o nível abaixo.
 - **Title** (700, 1.25rem / 20px, line-height 1.3): Subtítulos de card, labels de destaque. Poppins bold.
 - **Body** (400–500, 1rem / 16px, line-height 1.6): Parágrafos corridos. Inter. Máximo 65–75ch de largura de coluna.

--- a/index.html
+++ b/index.html
@@ -56,12 +56,12 @@
     imagesizes="100vw"
     type="image/webp">
   <link rel="preload" as="style"
-    href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;800;900&family=Merriweather:ital,wght@0,400;0,700;1,400&display=swap">
+    href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;900&family=Merriweather:ital,wght@0,400;0,700;1,400&display=swap">
   <link rel="stylesheet" media="print" onload="this.media='all'"
-    href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;800;900&family=Merriweather:ital,wght@0,400;0,700;1,400&display=swap">
+    href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;900&family=Merriweather:ital,wght@0,400;0,700;1,400&display=swap">
   <noscript>
     <link rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;800;900&family=Merriweather:ital,wght@0,400;0,700;1,400&display=swap">
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;900&family=Merriweather:ital,wght@0,400;0,700;1,400&display=swap">
   </noscript>
 
 </head>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -47,7 +47,7 @@ export default {
             fontFamily: {
                 sans: ['Poppins', 'sans-serif'],
                 serif: ['Merriweather', 'serif'], // Fonte editorial para o blog
-                display: ['Poppins', 'sans-serif'], // Headings principais (Poppins 800)
+                display: ['Poppins', 'sans-serif'], // Headings principais (Poppins 900)
             },
             boxShadow: {
                 'glow': '0 0 20px rgba(14, 165, 233, 0.5)',

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -39,3 +39,16 @@ test('index.html lazy-loads GTM through the deferred analytics loader', () => {
   assert.ok(utmInjectIndex > -1, 'UTM tracking loader should still be present');
   assert.ok(loadGtmIndex < utmInjectIndex, 'GTM should be queued before UTM reads GA client data');
 });
+
+test('index.html loads only the required Poppins font weights', () => {
+  const fontUrls = [...indexHtml.matchAll(/href="([^"]*fonts\.googleapis\.com\/css2[^"]*)"/g)]
+    .map((match) => match[1])
+    .filter((url) => url.includes('family=Poppins'));
+
+  assert.equal(fontUrls.length, 3, 'preload, stylesheet, and noscript font URLs should stay aligned');
+
+  for (const url of fontUrls) {
+    assert.match(url, /family=Poppins:wght@400;600;700;900(?:&|$)/);
+    assert.doesNotMatch(url, /Poppins:wght@[^"]*800/);
+  }
+});

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -5,6 +5,12 @@ import path from 'node:path';
 
 const indexHtmlPath = path.resolve(process.cwd(), 'index.html');
 const indexHtml = fs.readFileSync(indexHtmlPath, 'utf8');
+const designSystemDir = fs.readdirSync(process.cwd()).find((entry) => entry.endsWith('Design System'));
+
+assert.ok(designSystemDir, 'design system directory should exist');
+
+const designSystemCssPath = path.resolve(process.cwd(), designSystemDir, 'colors_and_type.css');
+const designSystemCss = fs.readFileSync(designSystemCssPath, 'utf8');
 
 function getHeadHtml(html: string): string {
   const match = html.match(/<head\b[^>]*>([\s\S]*?)<\/head>/i);
@@ -51,4 +57,13 @@ test('index.html loads only the required Poppins font weights', () => {
     assert.match(url, /family=Poppins:wght@400;600;700;900(?:&|$)/);
     assert.doesNotMatch(url, /Poppins:wght@[^"]*800/);
   }
+});
+
+test('design system documents the production Poppins font weights', () => {
+  const importUrl = designSystemCss.match(/@import url\('([^']*fonts\.googleapis\.com\/css2[^']*)'\);/)?.[1];
+
+  assert.ok(importUrl, 'design system should import its Google Fonts stylesheet');
+  assert.match(importUrl, /family=Poppins:wght@400;600;700;900(?:&|$)/);
+  assert.doesNotMatch(importUrl, /Poppins:wght@[^']*800/);
+  assert.match(designSystemCss, /Poppins is loaded with 400\/600\/700\/900 only/);
 });


### PR DESCRIPTION
## Summary
- Remove the unused Poppins 800 weight from the render-path Google Fonts URLs in `index.html`.
- Keep the heavier 900 weight because `font-black` is used broadly across the app and issue #670 proposes consolidating the upper display weight this way.
- Align the Anhangá design-system docs/previews with the production-loaded Poppins weights.
- Add a regression test to keep the production and design-system font URLs aligned and prevent Poppins 800 from returning.

## Impact
This reduces one Poppins font file from the critical font request while keeping the documented display weight scale aligned with the actual production font request.

Closes #670.

## Test Plan
- `npx react-doctor@latest --verbose --diff`
- `pnpm exec tsx --test tests/index-third-party-scripts.test.ts`
- `pnpm test:regression`
- `pnpm typecheck`
- `git diff --check`
