### PR TITLE
fix(rate-limit): use @upstash/redis/cloudflare on CF Workers

### DIFF
--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -112,13 +112,14 @@ export async function checkRateLimit(
         resetIn,
       };
     } catch (error) {
+      const errInfo = error instanceof Error
+        ? { name: error.name, message: error.message, stack: error.stack }
+        : { value: String(error) };
       if (isEdgeRuntime()) {
-        // Redis failure on edge: in-memory fallback is non-functional. Deny to
-        // prevent the bypass rather than silently allowing all requests through.
-        logger.error('RateLimit: Redis error on edge runtime. Denying request.', { error, prefix, clientIP });
+        logger.error('RateLimit: Redis error on edge runtime. Denying request.', { error: errInfo, prefix, clientIP });
         return { allowed: false, remaining: 0, resetIn: windowMs, serviceUnavailable: true };
       }
-      logger.error('RateLimit: Redis error, falling back to in-memory', error);
+      logger.error('RateLimit: Redis error, falling back to in-memory', { error: errInfo });
     }
   }
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -117,14 +117,21 @@ export async function checkRateLimit(
         resetIn,
       };
     } catch (error) {
-      const errInfo = error instanceof Error
-        ? { name: error.name, message: error.message, stack: error.stack }
-        : { value: String(error) };
+      const err = error instanceof Error ? error : new Error(String(error));
+      // Error properties are non-enumerable and serialize to {} in CF Workers
+      // JSON logs. Define toJSON so the runtime can serialize them while
+      // keeping the original Error instance intact for Sentry stack traces.
+      if (!('toJSON' in err)) {
+        Object.defineProperty(err, 'toJSON', {
+          value: () => ({ name: err.name, message: err.message, stack: err.stack }),
+          configurable: true,
+        });
+      }
       if (isEdgeRuntime()) {
-        logger.error('RateLimit: Redis error on edge runtime. Denying request.', { error: errInfo, prefix, clientIP });
+        logger.error('RateLimit: Redis error on edge runtime. Denying request.', { error: err, prefix, clientIP });
         return { allowed: false, remaining: 0, resetIn: windowMs, serviceUnavailable: true };
       }
-      logger.error('RateLimit: Redis error, falling back to in-memory', { error: errInfo });
+      logger.error('RateLimit: Redis error, falling back to in-memory', err);
     }
   }
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -53,8 +53,13 @@ async function getRedisClient(): Promise<RedisLike | null> {
   }
 
   try {
-    const { Redis } = await import('@upstash/redis');
-    return new Redis({ url, token });
+    // CF Workers do not support the `cache` field on fetch RequestInit.
+    // The default entry point (`@upstash/redis`) passes `cache: 'no-store'`,
+    // which throws at runtime. The `/cloudflare` entry omits it.
+    const mod = process.env.CF_PAGES
+      ? await import('@upstash/redis/cloudflare')
+      : await import('@upstash/redis');
+    return new mod.Redis({ url, token });
   } catch {
     logger.warn('RateLimit: @upstash/redis not available, using in-memory fallback');
     return null;


### PR DESCRIPTION
## Summary
- **Root cause:** `@upstash/redis` default entry point passes `cache: 'no-store'` in `fetch()` calls, but CF Workers runtime does not support the `cache` field on `RequestInit` — throws `"The 'cache' field on 'RequestInitializerDict' is not implemented."`
- **Fix:** Use `@upstash/redis/cloudflare` entry point when `CF_PAGES` env var is set. This entry point omits the unsupported `cache` field while sharing the same core Redis pipeline logic.
- **Bonus:** Improved Error object serialization in catch blocks so Redis failures are visible in CF Workers JSON logs (Error properties are non-enumerable and serialize to `{}` with `JSON.stringify`).

## Impact
All three rate-limited production endpoints were returning 503 `SERVICE_UNAVAILABLE`:
- `/api/submit-contact` (contact form)
- `/api/submit-lead` (chatbot lead capture)
- `/api/generate` (AI chatbot)

## Test plan
- [x] Deploy to CF Pages production
- [x] `curl -X POST https://www.anhanga.tur.br/api/submit-contact` returns `{"ok":true}`
- [x] `/api/submit-lead` and `/api/generate` pass rate limiting (return 400 validation errors, not 503)
- [x] TypeScript typecheck passes
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)