### PR TITLE
fix(seo): trailing slashes, blog titles, broken gov.br link

### DIFF
--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -242,7 +242,7 @@ const ContactModal: React.FC = () => {
                             <label htmlFor="contact-optIn" className="cursor-pointer text-xs leading-relaxed text-blue-700">
                                 Quero receber novidades e ofertas de viagem por e-mail.{' '}
                                 <a
-                                    href="/politica-privacidade"
+                                    href="/politica-privacidade/"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="underline hover:text-blue-900"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -114,8 +114,6 @@ const Footer: React.FC = () => {
                             <span>ANHANGA TURISMO LTDA • CNPJ/Cadastur: <a href="https://cadastur.turismo.gov.br/" target="_blank" rel="noopener noreferrer" className="hover:text-brand-yellow transition-colors underline decoration-zinc-600 underline-offset-2">37.036.732/0001-41</a></span>
                             <span className="hidden md:inline">•</span>
                             <a href="https://www.abav.com.br/" target="_blank" rel="noopener noreferrer" className="hover:text-brand-yellow transition-colors underline decoration-zinc-600 underline-offset-2">Membro ABAV</a>
-                            <span className="hidden md:inline">•</span>
-                            <a href="https://www.gov.br/turismo/pt-br" target="_blank" rel="noopener noreferrer" className="hover:text-brand-yellow transition-colors underline decoration-zinc-600 underline-offset-2">Ministério do Turismo</a>
                         </div>
                         <div className="text-[10px] text-zinc-700 font-bold uppercase tracking-widest mt-2">
                             Conteúdo da equipe Anhangá Viagens

--- a/components/cta/CtaBody.tsx
+++ b/components/cta/CtaBody.tsx
@@ -101,7 +101,7 @@ export function CtaBody() {
           />
           <label htmlFor="cta-optIn" className="text-xs text-blue-700 leading-relaxed cursor-pointer">
             Quero receber novidades por e-mail.{' '}
-            <a href="/politica-privacidade" target="_blank" rel="noopener noreferrer" className="underline">
+            <a href="/politica-privacidade/" target="_blank" rel="noopener noreferrer" className="underline">
               Política de Privacidade
             </a>
           </label>

--- a/content/blog/caribe-destinos-para-brasileiros.mdx
+++ b/content/blog/caribe-destinos-para-brasileiros.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Caribe para brasileiros: Punta Cana, Cancún ou Aruba? Entenda as diferenças"
+title: "Caribe: Punta Cana, Cancún ou Aruba? Guia para brasileiros"
 excerpt: "Praias perfeitas, all inclusive e mergulho: veja como escolher o destino certo no Caribe para o seu perfil, com tudo que você precisa saber antes de ir."
 date: "2026-04-29"
-dateModified: "2026-05-05"
+dateModified: "2026-05-28"
 author: "queila-oliveira"
 category: "Destinos"
 image: "images/blog/caribe-destinos-para-brasileiros.jpg"

--- a/content/blog/copa-do-mundo-2026-as-cidades-sede-e-o-que-cada-uma-tem-a-oferecer-alem-do-futebol.mdx
+++ b/content/blog/copa-do-mundo-2026-as-cidades-sede-e-o-que-cada-uma-tem-a-oferecer-alem-do-futebol.mdx
@@ -1,7 +1,8 @@
 ---
-title: "Copa do Mundo 2026: as cidades-sede e o que cada uma tem a oferecer além do futebol"
+title: "Copa do Mundo 2026: guia das cidades-sede além do futebol"
 excerpt: "Guia das cidades-sede da Copa 2026 nos EUA, México e Canadá, com destaques, dicas locais e roteiros para aproveitar a viagem além dos jogos."
 date: 2026-05-22
+dateModified: "2026-05-28"
 author: felipe-william
 category: Planejamento
 image: "images/blog/guadalajara.jpg"

--- a/data/blogManifest.ts
+++ b/data/blogManifest.ts
@@ -2,9 +2,10 @@ import type { PostMeta } from '../types/blog';
 
 export const BLOG_POST_MANIFEST: PostMeta[] = [
   {
-    "title": "Copa do Mundo 2026: as cidades-sede e o que cada uma tem a oferecer além do futebol",
+    "title": "Copa do Mundo 2026: guia das cidades-sede além do futebol",
     "excerpt": "Guia das cidades-sede da Copa 2026 nos EUA, México e Canadá, com destaques, dicas locais e roteiros para aproveitar a viagem além dos jogos.",
     "date": "2026-05-22",
+    "dateModified": "2026-05-28",
     "author": "felipe-william",
     "category": "Planejamento",
     "image": "https://media.anhanga.tur.br/images/blog/guadalajara.jpg",
@@ -89,10 +90,10 @@ export const BLOG_POST_MANIFEST: PostMeta[] = [
     "readingTime": "6 min de leitura"
   },
   {
-    "title": "Caribe para brasileiros: Punta Cana, Cancún ou Aruba? Entenda as diferenças",
+    "title": "Caribe: Punta Cana, Cancún ou Aruba? Guia para brasileiros",
     "excerpt": "Praias perfeitas, all inclusive e mergulho: veja como escolher o destino certo no Caribe para o seu perfil, com tudo que você precisa saber antes de ir.",
     "date": "2026-04-29",
-    "dateModified": "2026-05-05",
+    "dateModified": "2026-05-28",
     "author": "queila-oliveira",
     "category": "Destinos",
     "image": "https://media.anhanga.tur.br/images/blog/caribe-destinos-para-brasileiros.jpg",

--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -77,7 +77,7 @@ const BlogList: React.FC = () => {
                     <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
                         {filteredPosts.map((post, index) => (
                             <Link
-                                to={`/blog/${post.slug}`}
+                                to={`/blog/${post.slug}/`}
                                 key={post.slug}
                                 className={`
                                 group bg-white rounded-3xl p-5 shadow-[0_10px_20px_-5px_rgba(0,0,0,0.05)] border border-zinc-100

--- a/pages/landings/BetoCarreroLanding.tsx
+++ b/pages/landings/BetoCarreroLanding.tsx
@@ -100,7 +100,7 @@ const BetoCarreroLanding: React.FC = () => {
             <a href="https://www.anhanga.tur.br/orlando/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ver pacotes para Orlando
             </a>
-            <a href="/blog" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="/blog/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ver dicas de planejamento
             </a>
             <a href="https://www.betocarrero.com.br/" target="_blank" rel="noopener noreferrer" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -302,7 +302,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
           <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
           <div className="grid md:grid-cols-3 gap-4">
             <Link
-              to="/viagens-para-executivos"
+              to="/viagens-para-executivos/"
               className="block p-5 rounded-xl bg-brand-surface hover:bg-anhanga-blue/5 transition-colors group"
             >
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
@@ -313,7 +313,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               </div>
             </Link>
             <Link
-              to="/curadoria-cruzeiros-brasil"
+              to="/curadoria-cruzeiros-brasil/"
               className="block p-5 rounded-xl bg-brand-surface hover:bg-anhanga-blue/5 transition-colors group"
             >
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">

--- a/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
+++ b/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
@@ -318,7 +318,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
           <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
           <div className="grid md:grid-cols-3 gap-4">
             <Link
-              to="/consultoria-de-viagem"
+              to="/consultoria-de-viagem/"
               className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
             >
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
@@ -329,7 +329,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
               </div>
             </Link>
             <Link
-              to="/viagens-para-executivos"
+              to="/viagens-para-executivos/"
               className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
             >
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">

--- a/pages/landings/LollapaloozaLanding.tsx
+++ b/pages/landings/LollapaloozaLanding.tsx
@@ -119,7 +119,7 @@ const LollapaloozaLanding: React.FC = () => {
             <a href="https://www.anhanga.tur.br/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Conhecer a Anhangá Viagens
             </a>
-            <a href="/blog" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="/blog/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ler guia de festivais
             </a>
           </div>

--- a/pages/landings/OrlandoLanding.tsx
+++ b/pages/landings/OrlandoLanding.tsx
@@ -105,7 +105,7 @@ const OrlandoLanding: React.FC = () => {
             <a href="https://www.anhanga.tur.br/beto-carrero/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ver pacote Beto Carrero
             </a>
-            <a href="/blog" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="/blog/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ler dicas no blog
             </a>
             <a href="https://www.visitorlando.com/" target="_blank" rel="noopener noreferrer" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -560,7 +560,7 @@ function PreLeadScreen({ profile, onSubmit, onBack }: PreLeadScreenProps) {
                         <span className="quiz-check-box" aria-hidden="true" />
                         <span className="quiz-check-label">
                             Topo receber novidades e ofertas da Anhangá. Posso cancelar quando quiser.
-                            Veja nossa <a href="/politica-privacidade/">política de privacidade</a>.
+                            Veja nossa <a href="/politica-privacidade/" target="_blank" rel="noopener noreferrer">política de privacidade</a>.
                         </span>
                     </label>
                     {errors.aceite && <span role="status" className="quiz-err quiz-err-block">{errors.aceite}</span>}

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -560,7 +560,7 @@ function PreLeadScreen({ profile, onSubmit, onBack }: PreLeadScreenProps) {
                         <span className="quiz-check-box" aria-hidden="true" />
                         <span className="quiz-check-label">
                             Topo receber novidades e ofertas da Anhangá. Posso cancelar quando quiser.
-                            Veja nossa <a href="/politica-privacidade">política de privacidade</a>.
+                            Veja nossa <a href="/politica-privacidade/">política de privacidade</a>.
                         </span>
                     </label>
                     {errors.aceite && <span role="status" className="quiz-err quiz-err-block">{errors.aceite}</span>}

--- a/pages/landings/ViagensParaExecutivosLanding.tsx
+++ b/pages/landings/ViagensParaExecutivosLanding.tsx
@@ -290,7 +290,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
           <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
           <div className="grid md:grid-cols-3 gap-4">
             <Link
-              to="/consultoria-de-viagem"
+              to="/consultoria-de-viagem/"
               className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/5 transition-colors group"
             >
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
@@ -301,7 +301,7 @@ const ViagensParaExecutivosLanding: React.FC = () => {
               </div>
             </Link>
             <Link
-              to="/curadoria-cruzeiros-brasil"
+              to="/curadoria-cruzeiros-brasil/"
               className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/5 transition-colors group"
             >
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -126,7 +126,7 @@
     <priority>0.8</priority>
     <image:image>
       <image:loc>https://media.anhanga.tur.br/images/blog/guadalajara.jpg</image:loc>
-      <image:caption>Copa do Mundo 2026: as cidades-sede e o que cada uma tem a oferecer além do futebol</image:caption>
+      <image:caption>Copa do Mundo 2026: guia das cidades-sede além do futebol</image:caption>
     </image:image>
   </url>
   <url>
@@ -166,7 +166,7 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://media.anhanga.tur.br/images/blog/caribe-destinos-para-brasileiros.jpg</image:loc>
-      <image:caption>Caribe para brasileiros: Punta Cana, Cancún ou Aruba? Entenda as diferenças</image:caption>
+      <image:caption>Caribe: Punta Cana, Cancún ou Aruba? Guia para brasileiros</image:caption>
     </image:image>
   </url>
   <url>


### PR DESCRIPTION
## Summary
- Appended trailing slashes to 13 internal links across BlogList, landing pages, ContactModal, CtaBody, and QuizAnhanga — eliminates 308 redirect chains on Cloudflare Pages
- Shortened 2 blog titles that exceeded 70 chars (Copa do Mundo 84→57, Caribe 77→58) in `blogManifest.ts` and corresponding MDX frontmatter
- Removed dead `gov.br/turismo` link from Footer (Cadastur reference already covers regulatory compliance)

## Test plan
- [x] `pnpm build` — SSR prerender passes
- [x] `pnpm test:regression` — 443 tests pass
- [x] `grep -rn` confirms zero remaining internal links without trailing slash
- [ ] Verify no visual regressions on blog listing and footer in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)