### PR TITLE
fix(seo): shorten remaining titles and meta descriptions

### DIFF
--- a/content/blog/america-do-norte-destinos-alem-de-nova-york.mdx
+++ b/content/blog/america-do-norte-destinos-alem-de-nova-york.mdx
@@ -1,8 +1,8 @@
 ---
-title: "América do Norte: os melhores destinos além de Nova York"
+title: "América do Norte: destinos além de Nova York"
 excerpt: "EUA, Canadá e México têm muito mais que Nova York e Disney. Veja os destinos em alta para brasileiros em 2026, com visto, custos e o que cada um tem de melhor."
 date: "2026-04-29"
-dateModified: "2026-05-05"
+dateModified: "2026-05-28"
 author: "felipe-william"
 category: "Destinos"
 image: "images/blog/america-do-norte-destinos-alem-de-nova-york.jpg"

--- a/content/blog/destinos-america-do-sul-latam.mdx
+++ b/content/blog/destinos-america-do-sul-latam.mdx
@@ -1,8 +1,8 @@
 ---
-title: "América do Sul: os destinos que mais valem a viagem saindo do Brasil"
+title: "América do Sul: destinos que valem a viagem"
 excerpt: "Argentina, Chile, Peru, Colômbia e Bolívia: o que cada destino oferece ao viajante brasileiro, com documentação, custos e como chegar de verdade."
 date: "2026-04-29"
-dateModified: "2026-05-05"
+dateModified: "2026-05-28"
 author: "felipe-william"
 category: "Destinos"
 image: "images/destinations/cartagena.jpg"

--- a/content/blog/destinos-carnaval-2026-brasil.mdx
+++ b/content/blog/destinos-carnaval-2026-brasil.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Melhores destinos para o Carnaval 2026 no Brasil"
-excerpt: "Quer curtir o Carnaval sem estourar o orçamento? Os melhores destinos no Brasil para folia ou descanso, nesta retrospectiva da edição 2026."
+excerpt: "Quer curtir o Carnaval sem estourar o orçamento? Veja os melhores destinos no Brasil para folia ou descanso nesta retrospectiva de 2026."
 date: "2026-02-11"
 dateModified: "2026-05-28"
 author: "queila-oliveira"

--- a/content/blog/destinos-carnaval-2026-brasil.mdx
+++ b/content/blog/destinos-carnaval-2026-brasil.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Melhores destinos para o Carnaval 2026 no Brasil"
-excerpt: "Quer curtir o Carnaval sem estourar o orçamento? Conheça os melhores destinos no Brasil para diferentes estilos de folia ou descanso nesta retrospectiva da edição 2026."
+excerpt: "Quer curtir o Carnaval sem estourar o orçamento? Os melhores destinos no Brasil para folia ou descanso, nesta retrospectiva da edição 2026."
 date: "2026-02-11"
-dateModified: "2026-05-05"
+dateModified: "2026-05-28"
 author: "queila-oliveira"
 category: "Carnaval"
 image: "images/blog/destinos-carnaval-2026.jpg"

--- a/content/blog/disney-tropical-americas-animal-kingdom.mdx
+++ b/content/blog/disney-tropical-americas-animal-kingdom.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Tropical Americas: nova área da Disney no Animal Kingdom"
-excerpt: "A Disney anunciou uma nova área temática no Animal Kingdom dedicada à América Latina, com atrações do Encanto e Indiana Jones. Abertura prevista para 2027. Vale começar a planejar já."
+title: "Tropical Americas: nova área no Animal Kingdom"
+excerpt: "Nova área da Disney no Animal Kingdom dedicada à América Latina, com Encanto e Indiana Jones. Abertura em 2027. Vale planejar já."
 date: "2026-05-02"
-dateModified: "2026-05-05"
+dateModified: "2026-05-28"
 author: "queila-oliveira"
 category: "Dicas de Expert"
 image: "images/blog/disney-tropical-americas-animal-kingdom.jpg"

--- a/content/blog/roteiro-europa-brasileiros-2026.mdx
+++ b/content/blog/roteiro-europa-brasileiros-2026.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Roteiro Europa 2026: ETIAS, câmbio e custos para brasileiros"
+title: "Europa 2026: ETIAS, câmbio e custos reais"
 excerpt: "O que mudou para viajar à Europa em 2026, quanto custa, quais países combinar e como montar um roteiro que realmente funciona saindo do Brasil."
 date: "2026-04-29"
-dateModified: "2026-05-05"
+dateModified: "2026-05-28"
 author: "felipe-william"
 category: "Destinos"
 image: "images/destinations/lisboa.jpg"

--- a/data/blogManifest.ts
+++ b/data/blogManifest.ts
@@ -23,10 +23,10 @@ export const BLOG_POST_MANIFEST: PostMeta[] = [
     "readingTime": "8 min de leitura"
   },
   {
-    "title": "Tropical Americas: nova área da Disney no Animal Kingdom",
-    "excerpt": "A Disney anunciou uma nova área temática no Animal Kingdom dedicada à América Latina, com atrações do Encanto e Indiana Jones. Abertura prevista para 2027. Vale começar a planejar já.",
+    "title": "Tropical Americas: nova área no Animal Kingdom",
+    "excerpt": "Nova área da Disney no Animal Kingdom dedicada à América Latina, com Encanto e Indiana Jones. Abertura em 2027. Vale planejar já.",
     "date": "2026-05-02",
-    "dateModified": "2026-05-05",
+    "dateModified": "2026-05-28",
     "author": "queila-oliveira",
     "category": "Dicas de Expert",
     "image": "https://media.anhanga.tur.br/images/blog/disney-tropical-americas-animal-kingdom.jpg",
@@ -46,10 +46,10 @@ export const BLOG_POST_MANIFEST: PostMeta[] = [
     "readingTime": "4 min de leitura"
   },
   {
-    "title": "América do Norte: os melhores destinos além de Nova York",
+    "title": "América do Norte: destinos além de Nova York",
     "excerpt": "EUA, Canadá e México têm muito mais que Nova York e Disney. Veja os destinos em alta para brasileiros em 2026, com visto, custos e o que cada um tem de melhor.",
     "date": "2026-04-29",
-    "dateModified": "2026-05-05",
+    "dateModified": "2026-05-28",
     "author": "felipe-william",
     "category": "Destinos",
     "image": "https://media.anhanga.tur.br/images/blog/america-do-norte-destinos-alem-de-nova-york.jpg",
@@ -111,10 +111,10 @@ export const BLOG_POST_MANIFEST: PostMeta[] = [
     "readingTime": "6 min de leitura"
   },
   {
-    "title": "América do Sul: os destinos que mais valem a viagem saindo do Brasil",
+    "title": "América do Sul: destinos que valem a viagem",
     "excerpt": "Argentina, Chile, Peru, Colômbia e Bolívia: o que cada destino oferece ao viajante brasileiro, com documentação, custos e como chegar de verdade.",
     "date": "2026-04-29",
-    "dateModified": "2026-05-05",
+    "dateModified": "2026-05-28",
     "author": "felipe-william",
     "category": "Destinos",
     "image": "https://media.anhanga.tur.br/images/destinations/cartagena.jpg",
@@ -155,10 +155,10 @@ export const BLOG_POST_MANIFEST: PostMeta[] = [
     "readingTime": "6 min de leitura"
   },
   {
-    "title": "Roteiro Europa 2026: ETIAS, câmbio e custos para brasileiros",
+    "title": "Europa 2026: ETIAS, câmbio e custos reais",
     "excerpt": "O que mudou para viajar à Europa em 2026, quanto custa, quais países combinar e como montar um roteiro que realmente funciona saindo do Brasil.",
     "date": "2026-04-29",
-    "dateModified": "2026-05-05",
+    "dateModified": "2026-05-28",
     "author": "felipe-william",
     "category": "Destinos",
     "image": "https://media.anhanga.tur.br/images/destinations/lisboa.jpg",
@@ -198,9 +198,9 @@ export const BLOG_POST_MANIFEST: PostMeta[] = [
   },
   {
     "title": "Melhores destinos para o Carnaval 2026 no Brasil",
-    "excerpt": "Quer curtir o Carnaval sem estourar o orçamento? Conheça os melhores destinos no Brasil para diferentes estilos de folia ou descanso nesta retrospectiva da edição 2026.",
+    "excerpt": "Quer curtir o Carnaval sem estourar o orçamento? Os melhores destinos no Brasil para folia ou descanso, nesta retrospectiva da edição 2026.",
     "date": "2026-02-11",
-    "dateModified": "2026-05-05",
+    "dateModified": "2026-05-28",
     "author": "queila-oliveira",
     "category": "Carnaval",
     "image": "https://media.anhanga.tur.br/images/blog/destinos-carnaval-2026.jpg",

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -43,7 +43,7 @@ const About: React.FC = () => {
     <div className="bg-brand-surface pt-32 pb-20">
       <SEO
         title="Sobre a Anhangá Viagens | Agência de Viagens em São Paulo"
-        description="Conheça a história da Anhangá Viagens. Agência de turismo certificada Cadastur em São Paulo, especializada em roteiros personalizados."
+        description="Conheça a história da Anhangá Viagens. Agência de turismo credenciada no Cadastur em São Paulo, especializada em roteiros personalizados."
         canonical="https://www.anhanga.tur.br/sobre/"
       />
       <OrganizationSchema />

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -43,7 +43,7 @@ const About: React.FC = () => {
     <div className="bg-brand-surface pt-32 pb-20">
       <SEO
         title="Sobre a Anhangá Viagens | Agência de Viagens em São Paulo"
-        description="Conheça a história e os valores da Anhangá Viagens. Somos uma agência de turismo certificada pela Cadastur em São Paulo, especializada em roteiros personalizados."
+        description="Conheça a história da Anhangá Viagens. Agência de turismo certificada Cadastur em São Paulo, especializada em roteiros personalizados."
         canonical="https://www.anhanga.tur.br/sobre/"
       />
       <OrganizationSchema />

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -121,7 +121,7 @@
   </url>
   <url>
     <loc>https://www.anhanga.tur.br/blog/copa-do-mundo-2026-as-cidades-sede-e-o-que-cada-uma-tem-a-oferecer-alem-do-futebol/</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-05-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -136,7 +136,7 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://media.anhanga.tur.br/images/blog/disney-tropical-americas-animal-kingdom.jpg</image:loc>
-      <image:caption>Tropical Americas: nova área da Disney no Animal Kingdom</image:caption>
+      <image:caption>Tropical Americas: nova área no Animal Kingdom</image:caption>
     </image:image>
   </url>
   <url>
@@ -146,7 +146,7 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://media.anhanga.tur.br/images/blog/america-do-norte-destinos-alem-de-nova-york.jpg</image:loc>
-      <image:caption>América do Norte: os melhores destinos além de Nova York</image:caption>
+      <image:caption>América do Norte: destinos além de Nova York</image:caption>
     </image:image>
   </url>
   <url>
@@ -161,7 +161,7 @@
   </url>
   <url>
     <loc>https://www.anhanga.tur.br/blog/caribe-destinos-para-brasileiros/</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -176,7 +176,7 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://media.anhanga.tur.br/images/destinations/cartagena.jpg</image:loc>
-      <image:caption>América do Sul: os destinos que mais valem a viagem saindo do Brasil</image:caption>
+      <image:caption>América do Sul: destinos que valem a viagem</image:caption>
     </image:image>
   </url>
   <url>
@@ -196,7 +196,7 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://media.anhanga.tur.br/images/destinations/lisboa.jpg</image:loc>
-      <image:caption>Roteiro Europa 2026: ETIAS, câmbio e custos para brasileiros</image:caption>
+      <image:caption>Europa 2026: ETIAS, câmbio e custos reais</image:caption>
     </image:image>
   </url>
   <url>


### PR DESCRIPTION
## Summary
- Shorten 4 blog `<title>` tags that exceeded 70 chars (with ` | Anhangá Viagens` suffix): América do Sul, Europa, Disney Tropical Americas, América do Norte
- Shorten 3 meta descriptions that exceeded 155 chars: Disney blog excerpt, Carnaval blog excerpt, About page
- All changes in MDX frontmatter (source of truth) + blogManifest.ts + About.tsx

## SEO Audit Items
Addresses items **#2** (remaining titles > 75 chars) and **#4** (meta descriptions > 160 chars) from `SEO/AUDIT-REPORT.md`.

## Test plan
- [x] `pnpm build` — SSR prerender success for all 19 routes
- [x] `pnpm test:regression` — 443 tests passing, 0 failures
- [ ] Verify rendered `<title>` and `<meta name="description">` in Cloudflare preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)