### PR TITLE
Fix React Doctor performance warnings

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -21,7 +21,10 @@ interface Message {
   id: string;
   role: 'user' | 'model';
   text: string;
-  chips?: string[];
+  chips?: Array<{
+    id: string;
+    label: string;
+  }>;
   isAction?: boolean;
   actionData?: {
     destination: string;
@@ -245,7 +248,10 @@ const AIChat: React.FC = memo(() => {
         id: crypto.randomUUID(),
         role: 'model',
         text: response.text || '',
-        chips: response.chips
+        chips: response.chips?.map((label) => ({
+          id: crypto.randomUUID(),
+          label,
+        }))
       });
     }
 
@@ -549,13 +555,13 @@ const AIChat: React.FC = memo(() => {
                 {/* Action Chips */}
                 {isLastModelMsg && msg.chips && msg.chips.length > 0 && (
                   <div className="flex flex-wrap gap-2 pl-12 mt-1">
-                    {msg.chips.map((chip, chipIdx) => (
+                    {msg.chips.map((chip) => (
                       <button
-                        key={chipIdx}
-                        onClick={() => submitMessage(chip)}
+                        key={chip.id}
+                        onClick={() => submitMessage(chip.label)}
                         className="text-[12px] font-semibold text-zinc-600 bg-white border border-zinc-200 px-4 py-2 rounded-xl shadow-sm hover:shadow hover:border-brand-vibrant/30 hover:text-brand-vibrant hover:-translate-y-0.5 transition text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant/50"
                       >
-                        {chip}
+                        {chip.label}
                       </button>
                     ))}
                   </div>

--- a/components/landings/beto-carrero/BetoCarreroApp.tsx
+++ b/components/landings/beto-carrero/BetoCarreroApp.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Hero from './Hero';
 import Problem from './Problem';
 import Solution from './Solution';
@@ -21,6 +21,31 @@ const App: React.FC = () => {
   const throttleTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const showStickyRef = useRef(false);
   const isScrolledRef = useRef(false);
+  const handleScrollRef = useRef<() => void>(() => {
+    // Throttle: só executa a cada 16ms (~60fps)
+    if (throttleTimeoutRef.current) return;
+
+    throttleTimeoutRef.current = setTimeout(() => {
+      throttleTimeoutRef.current = null;
+      const scrollY = window.scrollY;
+
+
+      // Só atualiza estado se realmente mudou para evitar re-renders desnecessários
+      const newShowSticky = scrollY > 600;
+      const newIsScrolled = scrollY > 20;
+
+      // Verifica se o estado realmente precisa mudar usando refs
+      if (newShowSticky !== showStickyRef.current) {
+        setShowSticky(newShowSticky);
+        showStickyRef.current = newShowSticky;
+      }
+
+      if (newIsScrolled !== isScrolledRef.current) {
+        setIsScrolled(newIsScrolled);
+        isScrolledRef.current = newIsScrolled;
+      }
+    }, 16);
+  });
 
   // Atualiza refs quando estado muda para usar valores atuais no handler
   useEffect(() => {
@@ -31,33 +56,8 @@ const App: React.FC = () => {
     isScrolledRef.current = isScrolled;
   }, [isScrolled]);
 
-  const handleScroll = useCallback(() => {
-    // Throttle: só executa a cada 16ms (~60fps)
-    if (throttleTimeoutRef.current) return;
-    
-    throttleTimeoutRef.current = setTimeout(() => {
-      throttleTimeoutRef.current = null;
-      const scrollY = window.scrollY;
-      
-
-      // Só atualiza estado se realmente mudou para evitar re-renders desnecessários
-      const newShowSticky = scrollY > 600;
-      const newIsScrolled = scrollY > 20;
-      
-      // Verifica se o estado realmente precisa mudar usando refs
-      if (newShowSticky !== showStickyRef.current) {
-        setShowSticky(newShowSticky);
-        showStickyRef.current = newShowSticky;
-      }
-      
-      if (newIsScrolled !== isScrolledRef.current) {
-        setIsScrolled(newIsScrolled);
-        isScrolledRef.current = newIsScrolled;
-      }
-    }, 16);
-  }, []);
-
   useEffect(() => {
+    const handleScroll = () => handleScrollRef.current();
     
     // Usa passive listener para melhor performance
     window.addEventListener('scroll', handleScroll, { passive: true });
@@ -70,7 +70,7 @@ const App: React.FC = () => {
       }
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [handleScroll]);
+  }, []);
 
   const navLinks = [
     { name: 'O Perrengue', href: '#problem' },

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -54,7 +54,13 @@ export function getClientIP(request: Request): string {
 
     const forwardedFor = getTrimmedHeader(request, 'x-forwarded-for');
     if (forwardedFor) {
-        const ips = forwardedFor.split(',').map(ip => ip.trim()).filter(Boolean);
+        const ips: string[] = [];
+        for (const ip of forwardedFor.split(',')) {
+            const trimmed = ip.trim();
+            if (trimmed) {
+                ips.push(trimmed);
+            }
+        }
         // XFF is only reached in local dev or on platforms that don't set
         // cf-connecting-ip / x-vercel-forwarded-for. In those contexts,
         // the leftmost IP is the original client (RFC 7239). Spoofing via a

--- a/services/hubspot.ts
+++ b/services/hubspot.ts
@@ -57,7 +57,9 @@ async function assertHubSpotResponseOk(response: Response, errorCode: string): P
 }
 
 async function parseHubSpotJsonResponse<T>(response: Response, errorCode: string, fallback?: T): Promise<T> {
-    await assertHubSpotResponseOk(response, errorCode);
+    if (!response.ok) {
+        await assertHubSpotResponseOk(response, errorCode);
+    }
 
     if (fallback !== undefined) {
         return (await response.json().catch(() => fallback)) as T;


### PR DESCRIPTION
## Summary
- Resolve four React Doctor performance findings from #721 with code changes: stable AI chat chip keys, Beto Carrero scroll listener ref handling, XFF normalization in a single loop, and HubSpot JSON parsing that avoids the success-path await.
- Keep `api/auth/callback.ts` and `utils/whatsapp.ts` on `string.indexOf` + `slice`; React Doctor reports these as `array.indexOf()` but the code is string parsing, so changing them to `split`/`join` would be a regression.
- Avoid broad cleanup of unrelated React Doctor warnings that remain outside this issue.

## Validation
- npx -y react-doctor@latest --json --yes: remaining #721 matches are the two documented `string.indexOf` false positives; errors 0
- pnpm exec tsx --test tests/auth-callback-security.test.ts tests/network.test.ts tests/chatbot-regressions.test.ts
- pnpm typecheck
- Previously run before review follow-up: pnpm test:regression: 443 passed; pnpm build; git diff --check

Closes #721