### PR TITLE
fix(react-doctor): resolve remaining 30 correctness warnings

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -284,7 +284,7 @@ const AIChat: React.FC = memo(() => {
         void triggerHaptic('heavy');
       }
     }
-  }, [isLoading]);
+  }, [isLoading, setLeadDraft]);
 
   const submitMessageRef = useRef(submitMessage);
   useEffect(() => { submitMessageRef.current = submitMessage; }, [submitMessage]);

--- a/components/Destinations.tsx
+++ b/components/Destinations.tsx
@@ -460,7 +460,9 @@ const Destinations: React.FC = memo(() => {
 
     useEffect(() => {
         if (!mapInstance.current || !markersLayerRef.current) return;
-        markersLayerRef.current.clearLayers();
+
+        const markersLayer = markersLayerRef.current;
+        markersLayer.clearLayers();
 
         const isMobile = window.innerWidth < 768;
         // Tamanho do pin ajustado para o novo SVG (Lollipop Style)
@@ -513,18 +515,17 @@ const Destinations: React.FC = memo(() => {
                 setSelectedDestination(dest);
             });
 
-            marker.addTo(markersLayerRef.current!);
+            marker.addTo(markersLayer);
         });
 
         let flyTimer: ReturnType<typeof setTimeout> | undefined;
-        if (markersLayerRef.current.getLayers().length > 0 && mapInstance.current) {
+        if (markersLayer.getLayers().length > 0 && mapInstance.current) {
             flyTimer = setTimeout(() => {
                 const map = mapInstance.current;
-                const markers = markersLayerRef.current;
-                if (map && markers) {
+                if (map && markersLayer) {
                     try {
                         map.invalidateSize();
-                        const bounds = markers.getBounds();
+                        const bounds = markersLayer.getBounds();
                         if (bounds.isValid()) {
                             map.flyToBounds(bounds, {
                                 padding: isMobile ? [40, 40] : [80, 80],
@@ -538,7 +539,7 @@ const Destinations: React.FC = memo(() => {
         }
         return () => {
             clearTimeout(flyTimer);
-            markersLayerRef.current?.clearLayers();
+            markersLayer.clearLayers();
         };
     }, [filteredDestinations, activeFilter]);
 

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -102,6 +102,7 @@ const Header: React.FC = () => {
           </div>
 
           <button
+            type="button"
             className={`md:hidden p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-yellow transition-colors duration-500 ${mobileToggleClass}`}
             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
             aria-label={isMobileMenuOpen ? "Fechar menu" : "Abrir menu"}

--- a/components/Header/HeaderNavigation.tsx
+++ b/components/Header/HeaderNavigation.tsx
@@ -42,7 +42,7 @@ export function DesktopNavigation({
         <div key={link.name} className="relative group">
           {link.subLinks ? (
             <>
-              <button className={`flex items-center gap-1 cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-yellow focus-visible:outline-offset-2 rounded ${navTextClass}`}>
+              <button type="button" className={`flex items-center gap-1 cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-yellow focus-visible:outline-offset-2 rounded ${navTextClass}`}>
                 {link.name}
                 <CaretDown className="size-4 transition-transform duration-300 group-hover:rotate-180" weight="bold" />
               </button>

--- a/components/blog/BlogPostSidebar.tsx
+++ b/components/blog/BlogPostSidebar.tsx
@@ -37,6 +37,7 @@ export const BlogPostSidebar: React.FC<BlogPostSidebarProps> = ({ author, author
                     {author?.bio ? `"${author.bio}"` : '"Apaixonado por descobrir lugares novos e compartilhar dicas que não estão nos guias turísticos."'}
                 </p>
                 <button
+                    type="button"
                     onClick={(e) => {
                         e.preventDefault();
                         openContactModal({ source: 'blog-sidebar' });

--- a/components/landings/beto-carrero/BetoCarreroApp.tsx
+++ b/components/landings/beto-carrero/BetoCarreroApp.tsx
@@ -58,15 +58,16 @@ const App: React.FC = () => {
 
   useEffect(() => {
     const handleScroll = () => handleScrollRef.current();
-    
+
     // Usa passive listener para melhor performance
     window.addEventListener('scroll', handleScroll, { passive: true });
-    
-    
+
+    const throttleTimeout = throttleTimeoutRef;
+
     return () => {
-      if (throttleTimeoutRef.current) {
-        clearTimeout(throttleTimeoutRef.current);
-        throttleTimeoutRef.current = null;
+      if (throttleTimeout.current) {
+        clearTimeout(throttleTimeout.current);
+        throttleTimeout.current = null;
       }
       window.removeEventListener('scroll', handleScroll);
     };
@@ -162,6 +163,7 @@ const App: React.FC = () => {
 
             {/* Mobile Menu Toggle */}
             <button
+              type="button"
               onClick={toggleMobileMenu}
               className="lg:hidden relative z-50 p-2 text-fun-dark hover:bg-zinc-100 rounded-lg transition-colors focus:outline-none focus:ring-4 focus:ring-fun-blue"
               aria-label={mobileMenuOpen ? "Fechar menu" : "Abrir menu"}

--- a/components/landings/beto-carrero/Button.tsx
+++ b/components/landings/beto-carrero/Button.tsx
@@ -62,6 +62,7 @@ const Button: React.FC<ButtonProps> = ({
   return (
     <div className={`relative group ${fullWidth ? 'w-full' : 'inline-block'}`}>
       <button
+        type="button"
         onClick={(e) => {
           e.preventDefault();
           openContactModal({ source: 'beto-carrero' });

--- a/components/landings/beto-carrero/DestinationsModal.tsx
+++ b/components/landings/beto-carrero/DestinationsModal.tsx
@@ -30,6 +30,7 @@ export function DestinationsModal({ isOpen, onClose }: DestinationsModalProps) {
 
         {/* Close Button */}
         <button
+          type="button"
           onClick={onClose}
           className="absolute top-4 right-4 bg-fun-pink text-white p-2 rounded-full border-2 border-fun-dark shadow-hard hover:scale-110 hover:rotate-90 transition z-10"
           aria-label="Fechar janela"

--- a/components/landings/beto-carrero/FAQ.tsx
+++ b/components/landings/beto-carrero/FAQ.tsx
@@ -46,7 +46,8 @@ const FAQ: React.FC = () => {
                     key={item.question}
                     className={`border-2 border-fun-dark rounded-2xl transition duration-300 overflow-hidden ${isOpen ? 'bg-blue-50 shadow-hard' : 'bg-white hover:bg-zinc-50'}`}
                   >
-                    <button 
+                    <button
+                      type="button"
                       onClick={() => toggleAccordion(idx)}
                       className="w-full flex items-center justify-between p-5 md:p-6 text-left focus:outline-none focus-visible:ring-4 focus-visible:ring-inset focus-visible:ring-fun-blue/50"
                       aria-expanded={isOpen}

--- a/components/landings/beto-carrero/SolutionChecklist.tsx
+++ b/components/landings/beto-carrero/SolutionChecklist.tsx
@@ -123,6 +123,7 @@ export function SolutionChecklist({ onOpenModal }: SolutionChecklistProps) {
         <div className="absolute -top-6 left-1/2 -translate-x-1/2 w-32 h-12 bg-white/40 rotate-2 backdrop-blur-sm border-l-2 border-r-2 border-white/50 shadow-sm pointer-events-none"></div>
 
         <button
+          type="button"
           onClick={onOpenModal}
           className="bg-fun-yellow p-8 w-full rounded-xl border-4 border-fun-dark shadow-hard-lg transform -rotate-3 hover:rotate-0 hover:scale-105 active:scale-95 transition duration-300 text-left group focus:outline-none focus:ring-4 focus:ring-fun-blue focus:ring-offset-2"
           aria-label="Saiba mais sobre estender a viagem para praias próximas"

--- a/components/landings/lollapalooza/Button.tsx
+++ b/components/landings/lollapalooza/Button.tsx
@@ -51,6 +51,7 @@ const Button: React.FC<ButtonProps> = ({ text, className = '', variant = 'primar
 
   return (
     <button
+      type="button"
       onClick={(e) => {
         e.preventDefault();
         openContactModal({ source: 'lollapalooza' });

--- a/components/landings/lollapalooza/Hero.tsx
+++ b/components/landings/lollapalooza/Hero.tsx
@@ -4,18 +4,18 @@ import { Calendar, MapPin, Music2, Share2, Check } from 'lucide-react';
 import { WAITLIST_CTA_LABEL, WAITLIST_SECTION_ID } from './constants';
 import { getMediaUrl } from '../../../data/mediaConfig';
 
-const Hero: React.FC = () => {
-  const headliners = [
-    "SABRINA CARPENTER",
-    "CHAPPELL ROAN",
-    "TYLER, THE CREATOR",
-    "LORDE",
-    "SKRILLEX",
-    "DOECHII",
-    "LEWIS CAPALDI",
-    "TURNSTILE"
-  ];
+const HEADLINERS = [
+  "SABRINA CARPENTER",
+  "CHAPPELL ROAN",
+  "TYLER, THE CREATOR",
+  "LORDE",
+  "SKRILLEX",
+  "DOECHII",
+  "LEWIS CAPALDI",
+  "TURNSTILE",
+];
 
+const Hero: React.FC = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isVisible, setIsVisible] = useState(true);
   const [shareStatus, setShareStatus] = useState<'idle' | 'copied'>('idle');
@@ -24,7 +24,7 @@ const Hero: React.FC = () => {
     const interval = setInterval(() => {
       setIsVisible(false); // Start fade out
       setTimeout(() => {
-        setCurrentIndex((prev) => (prev + 1) % headliners.length);
+        setCurrentIndex((prev) => (prev + 1) % HEADLINERS.length);
         setIsVisible(true); // Start fade in
       }, 500); // Wait for fade out to finish
     }, 3500); // Change every 3.5 seconds
@@ -101,7 +101,7 @@ const Hero: React.FC = () => {
                 }`}
                 style={{ paddingRight: '0.1em' }}
             >
-                {headliners[currentIndex]}
+                {HEADLINERS[currentIndex]}
             </h2>
         </div>
 
@@ -146,7 +146,8 @@ const Hero: React.FC = () => {
             id="btn-lolla-specialist-hero"
           />
           
-          <button 
+          <button
+            type="button"
             onClick={handleShare}
             className={`
               group relative flex items-center justify-center gap-2 px-6 py-4 rounded-full border-2 transition duration-300 w-full sm:w-auto

--- a/components/landings/lollapalooza/Navbar.tsx
+++ b/components/landings/lollapalooza/Navbar.tsx
@@ -63,6 +63,7 @@ const Navbar: React.FC = () => {
 
         {/* Mobile Menu Button */}
         <button
+          type="button"
           className="md:hidden text-anhanga-yellow focus:outline-none focus:ring-2 focus:ring-anhanga-blue rounded p-1"
           onClick={() => setIsOpen(!isOpen)}
           aria-expanded={isOpen}

--- a/components/landings/lollapalooza/VenuePoiList.tsx
+++ b/components/landings/lollapalooza/VenuePoiList.tsx
@@ -36,6 +36,7 @@ export function VenuePoiList({ pois, activeIndex, listContainerRef, itemsRef, on
           const style = getPoiStyle(poi);
           return (
             <button
+              type="button"
               key={poi.name}
               ref={el => {
                 itemsRef.current[idx] = el;

--- a/components/landings/lollapalooza/hooks/useIntersectionObserver.ts
+++ b/components/landings/lollapalooza/hooks/useIntersectionObserver.ts
@@ -5,26 +5,28 @@ const useIntersectionObserver = (threshold = 0.1) => {
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
+    const element = elementRef.current;
+
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
           setIsVisible(true);
           // Stop observing once visible to run animation only once
-          if (elementRef.current) {
-            observer.unobserve(elementRef.current);
+          if (element) {
+            observer.unobserve(element);
           }
         }
       },
       { threshold }
     );
 
-    if (elementRef.current) {
-      observer.observe(elementRef.current);
+    if (element) {
+      observer.observe(element);
     }
 
     return () => {
-      if (elementRef.current) {
-        observer.unobserve(elementRef.current);
+      if (element) {
+        observer.unobserve(element);
       }
     };
   }, [threshold]);

--- a/components/landings/orlando/OrlandoFooter.tsx
+++ b/components/landings/orlando/OrlandoFooter.tsx
@@ -46,6 +46,7 @@ export function OrlandoFooter() {
               Facebook
             </a>
             <button
+              type="button"
               onClick={(e) => {
                 e.preventDefault();
                 openContactModal({ source: 'orlando', destination: 'Orlando' });

--- a/components/landings/orlando/OrlandoHero.tsx
+++ b/components/landings/orlando/OrlandoHero.tsx
@@ -123,6 +123,7 @@ export function OrlandoHero() {
 
           <div className="cta-container">
             <button
+              type="button"
               onClick={(e) => {
                 e.preventDefault();
                 openContactModal({ source: 'orlando', destination: 'Orlando' });

--- a/components/landings/orlando/OrlandoItinerary.tsx
+++ b/components/landings/orlando/OrlandoItinerary.tsx
@@ -73,6 +73,7 @@ export function OrlandoItinerary() {
         <div className="itinerary-footer">
           <p>* Personalizamos este roteiro 100% para você!</p>
           <button
+            type="button"
             onClick={(e) => {
               e.preventDefault();
               openContactModal({ source: 'orlando', destination: 'Orlando' });

--- a/components/landings/orlando/OrlandoParksGallery.tsx
+++ b/components/landings/orlando/OrlandoParksGallery.tsx
@@ -385,6 +385,7 @@ export function OrlandoParksGallery() {
 
       <div className="gallery-cta">
         <button
+          type="button"
           onClick={(e) => {
             e.preventDefault();
             openContactModal({ source: 'orlando', destination: 'Orlando' });

--- a/components/ui/BackToTop.tsx
+++ b/components/ui/BackToTop.tsx
@@ -29,6 +29,7 @@ const BackToTop: React.FC = memo(() => {
 
   return (
     <button
+      type="button"
       onClick={scrollToTop}
       aria-label="Voltar ao topo"
       className={`

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -5,7 +5,6 @@ export type ButtonVariant = 'primary' | 'action' | 'cta' | 'ghost';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-    children: React.ReactNode;
     variant?: ButtonVariant;
     size?: ButtonSize;
     leftIcon?: React.ReactNode;
@@ -55,6 +54,7 @@ export const Button: React.FC<ButtonProps> = ({
 
     return (
         <button
+            type="button"
             className={classes}
             disabled={isDisabled}
             aria-disabled={isDisabled || undefined}

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { getTrackingDataObject, getWhatsAppLink } from '../utils/whatsapp';
 import type { LeadTracking, LeadUtms, SubmitLeadRequest } from '../types/leadCapture';
 import { cleanString, normalizeWhatsappNumber } from '../lib/lead-logic';
@@ -366,9 +366,9 @@ export function useLeadCapture() {
         return { tracking: latestTracking, utms: latestUtms };
     };
 
-    const setLeadDraft = (partial: LeadDraftPartial): void => {
+    const setLeadDraft = useCallback((partial: LeadDraftPartial): void => {
         setLeadDraftState((prev) => mergeLeadDraft(prev, partial));
-    };
+    }, []);
 
     const resetLeadDraft = (): void => {
         setLeadDraftState(EMPTY_LEAD_DRAFT);

--- a/lib/head.tsx
+++ b/lib/head.tsx
@@ -128,7 +128,8 @@ export const useHeadTags = (tags: HeadTag[]): null => {
       return undefined;
     }
 
-    const elements = tags.map(applyHeadTag);
+    const parsedTags: HeadTag[] = JSON.parse(serializedTags);
+    const elements = parsedTags.map(applyHeadTag);
 
     return () => {
       for (const element of elements) {

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -80,6 +80,7 @@ const About: React.FC = () => {
           </p>
           <div className="flex justify-center">
             <button
+              type="button"
               onClick={() => openContactModal({ source: 'about' })}
               className="btn-whatsapp btn-specialist bg-brand-vibrant text-white px-8 py-4 rounded-2xl font-black text-lg shadow-xl shadow-brand-vibrant/20 hover:scale-105 transition-transform active:scale-95 flex items-center gap-3"
               data-tracking="hero-about"
@@ -281,6 +282,7 @@ const About: React.FC = () => {
               Seja para um festival épico ou um refúgio relaxante, nós desenhamos a viagem perfeita para você.
             </p>
             <button
+              type="button"
               onClick={() => openContactModal({ source: 'about' })}
               className="btn-whatsapp btn-specialist bg-brand-vibrant text-white px-10 py-5 rounded-2xl font-black text-lg shadow-xl shadow-brand-vibrant/20 hover:scale-105 transition-transform active:scale-95 flex items-center gap-3 mx-auto"
               data-tracking="footer-about"

--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -150,6 +150,7 @@ const BlogList: React.FC = () => {
                         Fale com nossos especialistas e comece a planejar sua viagem personalizada hoje mesmo.
                     </p>
                     <button
+                        type="button"
                         onClick={(e) => {
                             e.preventDefault();
                             openContactModal({ source: 'blog-list' });

--- a/tests/button-loading.test.ts
+++ b/tests/button-loading.test.ts
@@ -6,7 +6,7 @@ import { Button } from '../components/ui/Button.tsx';
 
 test('Button isLoading=true renderiza com disabled e aria-disabled="true"', () => {
     const html = renderToStaticMarkup(
-        React.createElement(Button, { children: 'Enviar', isLoading: true })
+        React.createElement(Button, { isLoading: true }, 'Enviar')
     );
     assert.ok(html.includes('disabled=""'), 'deve conter o atributo disabled=""');
     assert.ok(html.includes('aria-disabled="true"'), 'deve conter aria-disabled="true"');
@@ -14,7 +14,7 @@ test('Button isLoading=true renderiza com disabled e aria-disabled="true"', () =
 
 test('Button isLoading=false não tem disabled', () => {
     const html = renderToStaticMarkup(
-        React.createElement(Button, { children: 'Enviar', isLoading: false })
+        React.createElement(Button, { isLoading: false }, 'Enviar')
     );
     assert.ok(!html.includes('disabled=""'), 'não deve ter o atributo disabled=""');
     assert.ok(!html.includes('aria-disabled'), 'não deve ter aria-disabled em botão habilitado');

--- a/utils/whatsapp.ts
+++ b/utils/whatsapp.ts
@@ -7,7 +7,7 @@
  * in memory + sessionStorage + cookie to ensure data is available after URL changes.
  */
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 
 const TRACKING_PARAMS = [
     'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term',
@@ -304,24 +304,20 @@ export const getWhatsAppLink = (message: string, options: WhatsAppLinkOptions = 
 
 export const useWhatsAppLink = (message: string, options: WhatsAppLinkOptions = {}): string => {
     const { appendTrackingRef } = options;
-    const stableOptions: WhatsAppLinkOptions = useMemo(
-        () => ({ appendTrackingRef }),
-        [appendTrackingRef]
-    );
-    const [whatsappUrl, setWhatsappUrl] = useState(() => getWhatsAppLink(message, stableOptions));
+    const [whatsappUrl, setWhatsappUrl] = useState(() => getWhatsAppLink(message, { appendTrackingRef }));
 
     useEffect(() => {
-        const newUrl = getWhatsAppLink(message, stableOptions);
+        const newUrl = getWhatsAppLink(message, { appendTrackingRef });
         setWhatsappUrl((prev) => (prev === newUrl ? prev : newUrl));
 
         const timer = setTimeout(() => {
             captureTrackingDataObject();
-            const updatedUrl = getWhatsAppLink(message, stableOptions);
+            const updatedUrl = getWhatsAppLink(message, { appendTrackingRef });
             setWhatsappUrl((prev) => (prev === updatedUrl ? prev : updatedUrl));
         }, 1000);
 
         return () => clearTimeout(timer);
-    }, [message, stableOptions]);
+    }, [message, appendTrackingRef]);
 
     return whatsappUrl;
 };

--- a/utils/whatsapp.ts
+++ b/utils/whatsapp.ts
@@ -7,7 +7,7 @@
  * in memory + sessionStorage + cookie to ensure data is available after URL changes.
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 
 const TRACKING_PARAMS = [
     'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term',
@@ -303,20 +303,25 @@ export const getWhatsAppLink = (message: string, options: WhatsAppLinkOptions = 
 };
 
 export const useWhatsAppLink = (message: string, options: WhatsAppLinkOptions = {}): string => {
-    const [whatsappUrl, setWhatsappUrl] = useState(() => getWhatsAppLink(message, options));
+    const { appendTrackingRef } = options;
+    const stableOptions: WhatsAppLinkOptions = useMemo(
+        () => ({ appendTrackingRef }),
+        [appendTrackingRef]
+    );
+    const [whatsappUrl, setWhatsappUrl] = useState(() => getWhatsAppLink(message, stableOptions));
 
     useEffect(() => {
-        const newUrl = getWhatsAppLink(message, options);
+        const newUrl = getWhatsAppLink(message, stableOptions);
         setWhatsappUrl((prev) => (prev === newUrl ? prev : newUrl));
 
         const timer = setTimeout(() => {
             captureTrackingDataObject();
-            const updatedUrl = getWhatsAppLink(message, options);
+            const updatedUrl = getWhatsAppLink(message, stableOptions);
             setWhatsappUrl((prev) => (prev === updatedUrl ? prev : updatedUrl));
         }, 1000);
 
         return () => clearTimeout(timer);
-    }, [message, options.appendTrackingRef]);
+    }, [message, stableOptions]);
 
     return whatsappUrl;
 };


### PR DESCRIPTION
## Summary

- Resolve all 30 remaining correctness warnings from react-doctor scan (issue #696)
- **21 `button-has-type`**: added explicit `type="button"` to 21 `<button>` elements across 17 files — all verified as non-form-submit interactive buttons (nav, modals, share, CTAs, accordions, scroll-to-top)
- **7 `exhaustive-deps`**: fixed missing hook dependencies and ref cleanup patterns in AIChat, Destinations, Hero, BetoCarreroApp, useIntersectionObserver, head.tsx, and whatsapp.ts
- **2 `no-children-prop`**: refactored `React.createElement` calls in tests to pass children as 3rd argument
- **2 `no-danger`**: triaged as documented false positives (static JSON-LD structured data with `JSON.stringify`, no user input)

### Notable changes

- `components/ui/Button.tsx`: shared Button now defaults to `type="button"` (was implicit `submit`). The `type` prop is still overridable via `...rest` spread. Verified no `<Button>` callers rely on implicit form submission — all forms in the repo use native `<button type="submit">`.
- `components/ui/Button.tsx`: removed redundant `children: React.ReactNode` from `ButtonProps` (already inherited from `React.ButtonHTMLAttributes`)
- `hooks/useLeadCapture.ts`: `setLeadDraft` wrapped in `useCallback` for stable identity
- `utils/whatsapp.ts`: `options` stabilized via `useMemo` to prevent unnecessary effect re-runs
- `components/landings/lollapalooza/Hero.tsx`: `headliners` array moved to module-level constant

### React Doctor score

81 → **84** (correctness warnings: 32 → 2, only `no-danger` false positives remain)

Closes #705, closes #706

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:regression` — 445 tests pass, 0 failures
- [x] react-doctor re-scan confirms 0 remaining button-has-type, exhaustive-deps, no-children-prop
- [x] Form submit audit: no `<Button>` component used inside `<form>` elements; all 8 form files use native `<button type="submit">`
- [ ] Manual smoke test recommended: chatbot flow, WhatsApp link generation, Lolla carousel rotation, Destinations map (exhaustive-deps changes affect runtime hook behavior on conversion paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)