### PR TITLE
fix(react-doctor): resolve architecture warnings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -28,7 +28,7 @@ const BrazilPromotionDayLanding = lazy(() => import('./pages/landings/BrazilProm
 const ConsultoriaDeViagemLanding = lazy(() => import('./pages/landings/ConsultoriaDeViagemLanding'));
 const ViagensParaExecutivosLanding = lazy(() => import('./pages/landings/ViagensParaExecutivosLanding'));
 const CuradoriaCruzeirosBrasilLanding = lazy(() => import('./pages/landings/CuradoriaCruzeirosBrasilLanding'));
-const NPS = lazy(() => import('./pages/NPS'));
+const NpsPage = lazy(() => import('./pages/NpsPage'));
 const QuizAnhangaLanding = lazy(() => import('./pages/landings/QuizAnhangaLanding'));
 
 const MainRouteFallback: React.FC = () => <section className="min-h-[40vh] bg-white" aria-hidden="true" />;
@@ -82,7 +82,7 @@ const AppLayout: React.FC<{ includeClientFeatures: boolean }> = ({ includeClient
           <Route path="/consultoria-de-viagem" element={<ConsultoriaDeViagemLanding />} />
           <Route path="/viagens-para-executivos" element={<ViagensParaExecutivosLanding />} />
           <Route path="/curadoria-cruzeiros-brasil" element={<CuradoriaCruzeirosBrasilLanding />} />
-          <Route path="/nps" element={<NPS />} />
+          <Route path="/nps" element={<NpsPage />} />
           <Route path="/quiz" element={<QuizAnhangaLanding />} />
           <Route path="/*" element={<MainSiteShell />} />
         </Routes>

--- a/components/Faq.tsx
+++ b/components/Faq.tsx
@@ -197,7 +197,7 @@ const FAQS = [
  * PERFORMANCE WIN: Prevents the entire FAQ section from re-rendering when parent state changes.
  * Individual FAQ items are already memoized, but memoizing the container avoids the outer render logic.
  */
-const FAQ = memo(() => {
+const Faq = memo(() => {
     return (
         <section
             id="faq-section"
@@ -255,6 +255,6 @@ const FAQ = memo(() => {
 });
 
 FAQItem.displayName = 'FAQItem';
-FAQ.displayName = 'FAQ';
+Faq.displayName = 'Faq';
 
-export default FAQ;
+export default Faq;

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -6,7 +6,7 @@ const DEFAULT_OG_IMAGE = DEFAULT_OG_IMAGE_URL;
 const DEFAULT_OG_IMAGE_WIDTH = '1200';
 const DEFAULT_OG_IMAGE_HEIGHT = '630';
 
-interface SEOProps {
+interface SeoProps {
   title?: string;
   description?: string;
   canonical?: string;
@@ -23,7 +23,7 @@ interface SEOProps {
   noHreflang?: boolean;
 }
 
-export const SEO: React.FC<SEOProps> = ({
+export const Seo: React.FC<SeoProps> = ({
   title = 'Anhangá Viagens | Agência de Viagens Personalizadas',
   description = 'Agência de viagens em São Paulo com roteiros personalizados, experiências no Brasil e no mundo e suporte especializado.',
   canonical,

--- a/components/landings/beto-carrero/BetoCarreroApp.tsx
+++ b/components/landings/beto-carrero/BetoCarreroApp.tsx
@@ -5,7 +5,7 @@ import Solution from './Solution';
 import Attractions from './Attractions';
 import Features from './Features';
 import Testimonials from './Testimonials';
-import FAQ from './FAQ';
+import Faq from './Faq';
 import Footer from './Footer';
 import Button from './Button';
 import { Menu, X } from 'lucide-react';
@@ -198,7 +198,7 @@ const App: React.FC = () => {
         <div id="attractions" className="scroll-mt-32 md:scroll-mt-48"><Attractions /></div>
         <Features />
         <div id="testimonials" className="scroll-mt-32 md:scroll-mt-48"><Testimonials /></div>
-        <div id="faq" className="scroll-mt-32 md:scroll-mt-48"><FAQ /></div>
+        <div id="faq" className="scroll-mt-32 md:scroll-mt-48"><Faq /></div>
       </main>
 
       <Footer />

--- a/components/landings/beto-carrero/Faq.tsx
+++ b/components/landings/beto-carrero/Faq.tsx
@@ -11,7 +11,7 @@ const items: FAQItem[] = [
   { question: "E se eu precisar cancelar?", answer: "Sem letras miúdas. Seguimos as regras da companhia aérea e do hotel, mas nossa equipe briga por você para conseguir as melhores condições de remarcação ou reembolso possíveis." },
 ];
 
-const FAQ: React.FC = () => {
+const Faq: React.FC = () => {
   const [openIndex, setOpenIndex] = useState<number | null>(0);
 
   const toggleAccordion = (index: number) => {
@@ -114,4 +114,4 @@ const FAQ: React.FC = () => {
   );
 };
 
-export default FAQ;
+export default Faq;

--- a/components/landings/brazil-promotion-day/BpdContactInfo.tsx
+++ b/components/landings/brazil-promotion-day/BpdContactInfo.tsx
@@ -41,7 +41,7 @@ export function BpdContactInfo({ whatsappUrl }: BpdContactInfoProps) {
                 Preencha o formulário e um consultor entra em contato pelo canal que você preferir, sem enrolação.
             </p>
 
-            <ul className="space-y-5 mb-10" role="list">
+            <ul className="space-y-5 mb-10">
                 {[
                     { icon: Phone, label: '(11) 5283-3309', href: 'tel:+551152833309' },
                     { icon: Envelope, label: 'contato@anhanga.tur.br', href: 'mailto:contato@anhanga.tur.br' },

--- a/components/landings/brazil-promotion-day/BpdContactInfo.tsx
+++ b/components/landings/brazil-promotion-day/BpdContactInfo.tsx
@@ -1,0 +1,91 @@
+import { m } from 'framer-motion';
+import {
+    InstagramLogo,
+    FacebookLogo,
+    WhatsappLogo,
+    MapPin,
+    Phone,
+    Envelope,
+    Sparkle,
+} from '@phosphor-icons/react';
+import { SOCIAL_LINKS, fadeUp } from './constants';
+
+interface BpdContactInfoProps {
+    whatsappUrl: string;
+}
+
+export function BpdContactInfo({ whatsappUrl }: BpdContactInfoProps) {
+    return (
+        <m.div
+            variants={fadeUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2 }}
+            custom={0}
+        >
+            <div className="inline-block relative mb-4">
+                <span className="absolute inset-0 bg-emerald-100 transform -skew-x-12 rounded-lg" />
+                <span className="relative px-3 py-1 text-emerald-600 font-black uppercase tracking-widest text-sm flex items-center gap-2">
+                    <Sparkle className="size-4" weight="fill" /> Fale com a gente
+                </span>
+            </div>
+
+            <h2 className="text-4xl md:text-5xl font-black text-brand-dark leading-tight mb-6">
+                Prefere que a gente <br />
+                <span className="text-brand-cyan">
+                    entre em contato?
+                </span>
+            </h2>
+
+            <p className="text-zinc-500 font-medium text-lg leading-relaxed mb-10 max-w-sm">
+                Preencha o formulário e um consultor entra em contato pelo canal que você preferir, sem enrolação.
+            </p>
+
+            <ul className="space-y-5 mb-10" role="list">
+                {[
+                    { icon: Phone, label: '(11) 5283-3309', href: 'tel:+551152833309' },
+                    { icon: Envelope, label: 'contato@anhanga.tur.br', href: 'mailto:contato@anhanga.tur.br' },
+                    { icon: MapPin, label: 'Av. Dom Pedro I, 773 — Vila Monumento, SP', href: null },
+                ].map(({ icon: Icon, label, href }) => (
+                    <li key={label} className="flex items-start gap-4">
+                        <div className="size-10 rounded-xl bg-blue-100 border-2 border-blue-200 flex items-center justify-center shrink-0 mt-0.5">
+                            <Icon className="size-5 text-blue-600" weight="fill" />
+                        </div>
+                        {href ? (
+                            <a href={href} className="font-semibold text-zinc-700 hover:text-brand-cyan transition-colors duration-150 pt-1.5">
+                                {label}
+                            </a>
+                        ) : (
+                            <span className="font-semibold text-zinc-700 leading-snug pt-1.5">{label}</span>
+                        )}
+                    </li>
+                ))}
+            </ul>
+
+            <div>
+                <p className="text-xs font-bold tracking-widest uppercase text-zinc-500 mb-4">
+                    Nos siga nas redes
+                </p>
+                <div className="flex gap-3">
+                    {[
+                        { href: SOCIAL_LINKS.instagram, icon: InstagramLogo, label: 'Instagram da Anhangá Viagens' },
+                        { href: SOCIAL_LINKS.facebook, icon: FacebookLogo, label: 'Facebook da Anhangá Viagens' },
+                        { href: whatsappUrl, icon: WhatsappLogo, label: 'WhatsApp da Anhangá Viagens', contact: true },
+                    ].map(({ href, icon: Icon, label, contact }) => (
+                        <a
+                            key={label}
+                            href={href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="size-11 rounded-xl bg-white border-2 border-zinc-200 flex items-center justify-center text-zinc-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-hard-yellow hover:-translate-y-1 transition duration-200"
+                            aria-label={label}
+                            {...(contact ? { 'data-contact-intent': true, 'data-tracking': 'social-whatsapp-brazil-promotion-day' } : {})}
+                        >
+                            <Icon className="size-5" weight="fill" />
+                        </a>
+                    ))}
+                </div>
+            </div>
+        </m.div>
+    );
+}

--- a/components/landings/brazil-promotion-day/BpdContactSection.tsx
+++ b/components/landings/brazil-promotion-day/BpdContactSection.tsx
@@ -1,21 +1,16 @@
 import React, { useState, useRef } from 'react';
 import { m } from 'framer-motion';
 import {
-    InstagramLogo,
-    FacebookLogo,
     WhatsappLogo,
     CheckCircle,
-    MapPin,
-    Phone,
-    Envelope,
-    Sparkle,
     AirplaneTilt,
     PaperPlaneTilt,
     SpinnerGap,
 } from '@phosphor-icons/react';
 import { useLeadCapture, createLeadEventId } from '../../../hooks/useLeadCapture';
 import { useWhatsAppLink } from '../../../utils/whatsapp';
-import { WHATSAPP_MESSAGE, SOCIAL_LINKS, fadeUp } from './constants';
+import { WHATSAPP_MESSAGE, fadeUp } from './constants';
+import { BpdContactInfo } from './BpdContactInfo';
 
 export function BpdContactSection() {
     const { submitLead, isSubmitting } = useLeadCapture();
@@ -90,79 +85,7 @@ export function BpdContactSection() {
             <div className="container mx-auto px-6 relative z-10">
                 <div className="max-w-5xl mx-auto grid md:grid-cols-2 gap-12 items-start">
 
-                    {/* Left: contact info */}
-                    <m.div
-                        variants={fadeUp}
-                        initial="hidden"
-                        whileInView="visible"
-                        viewport={{ once: true, amount: 0.2 }}
-                        custom={0}
-                    >
-                        <div className="inline-block relative mb-4">
-                            <span className="absolute inset-0 bg-emerald-100 transform -skew-x-12 rounded-lg" />
-                            <span className="relative px-3 py-1 text-emerald-600 font-black uppercase tracking-widest text-sm flex items-center gap-2">
-                                <Sparkle className="size-4" weight="fill" /> Fale com a gente
-                            </span>
-                        </div>
-
-                        <h2 className="text-4xl md:text-5xl font-black text-brand-dark leading-tight mb-6">
-                            Prefere que a gente <br />
-                            <span className="text-brand-cyan">
-                                entre em contato?
-                            </span>
-                        </h2>
-
-                        <p className="text-zinc-500 font-medium text-lg leading-relaxed mb-10 max-w-sm">
-                            Preencha o formulário e um consultor entra em contato pelo canal que você preferir, sem enrolação.
-                        </p>
-
-                        <ul className="space-y-5 mb-10" role="list">
-                            {[
-                                { icon: Phone, label: '(11) 5283-3309', href: 'tel:+551152833309' },
-                                { icon: Envelope, label: 'contato@anhanga.tur.br', href: 'mailto:contato@anhanga.tur.br' },
-                                { icon: MapPin, label: 'Av. Dom Pedro I, 773 — Vila Monumento, SP', href: null },
-                            ].map(({ icon: Icon, label, href }) => (
-                                <li key={label} className="flex items-start gap-4">
-                                    <div className="size-10 rounded-xl bg-blue-100 border-2 border-blue-200 flex items-center justify-center shrink-0 mt-0.5">
-                                        <Icon className="size-5 text-blue-600" weight="fill" />
-                                    </div>
-                                    {href ? (
-                                        <a href={href} className="font-semibold text-zinc-700 hover:text-brand-cyan transition-colors duration-150 pt-1.5">
-                                            {label}
-                                        </a>
-                                    ) : (
-                                        <span className="font-semibold text-zinc-700 leading-snug pt-1.5">{label}</span>
-                                    )}
-                                </li>
-                            ))}
-                        </ul>
-
-                        {/* Social links */}
-                        <div>
-                            <p className="text-xs font-bold tracking-widest uppercase text-zinc-500 mb-4">
-                                Nos siga nas redes
-                            </p>
-                            <div className="flex gap-3">
-                                {[
-                                    { href: SOCIAL_LINKS.instagram, icon: InstagramLogo, label: 'Instagram da Anhangá Viagens' },
-                                    { href: SOCIAL_LINKS.facebook, icon: FacebookLogo, label: 'Facebook da Anhangá Viagens' },
-                                    { href: whatsappUrl, icon: WhatsappLogo, label: 'WhatsApp da Anhangá Viagens', contact: true },
-                                ].map(({ href, icon: Icon, label, contact }) => (
-                                    <a
-                                        key={label}
-                                        href={href}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="size-11 rounded-xl bg-white border-2 border-zinc-200 flex items-center justify-center text-zinc-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-hard-yellow hover:-translate-y-1 transition duration-200"
-                                        aria-label={label}
-                                        {...(contact ? { 'data-contact-intent': true, 'data-tracking': 'social-whatsapp-brazil-promotion-day' } : {})}
-                                    >
-                                        <Icon className="size-5" weight="fill" />
-                                    </a>
-                                ))}
-                            </div>
-                        </div>
-                    </m.div>
+                    <BpdContactInfo whatsappUrl={whatsappUrl} />
 
                     {/* Right: form */}
                     <m.div
@@ -202,7 +125,6 @@ export function BpdContactSection() {
                             </div>
                         ) : (
                             <form onSubmit={handleSubmit} noValidate>
-                                {/* Form header strip */}
                                 <div className="flex justify-between items-center px-8 py-5 border-b-2 border-dashed border-zinc-100">
                                     <span className="text-brand-cyan font-black tracking-widest text-sm uppercase flex items-center gap-2">
                                         <AirplaneTilt className="size-4" weight="fill" /> Formulário de Contato

--- a/components/landings/orlando/OrlandoParksGallery.tsx
+++ b/components/landings/orlando/OrlandoParksGallery.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CSSProperties } from 'react';
 import { getMediaUrl, optimizeRemoteImageUrl } from "../../../data/mediaConfig";
 import { openContactModal } from "../../../utils/contactForm";
 
@@ -11,7 +12,7 @@ interface ParkCardData {
   alt: string;
   logo: string;
   logoAlt: string;
-  logoStyle?: React.CSSProperties;
+  logoStyle?: CSSProperties;
   logoWidth: number;
   logoHeight: number;
   description: string;

--- a/components/landings/orlando/OrlandoParksGallery.tsx
+++ b/components/landings/orlando/OrlandoParksGallery.tsx
@@ -6,6 +6,183 @@
 import { getMediaUrl, optimizeRemoteImageUrl } from "../../../data/mediaConfig";
 import { openContactModal } from "../../../utils/contactForm";
 
+interface ParkCardData {
+  image: string;
+  alt: string;
+  logo: string;
+  logoAlt: string;
+  logoStyle?: React.CSSProperties;
+  logoWidth: number;
+  logoHeight: number;
+  description: string;
+}
+
+interface ParkGroupData {
+  label: string;
+  className: string;
+  parks: ParkCardData[];
+}
+
+function ParkCard({ image, alt, logo, logoAlt, logoStyle, logoWidth, logoHeight, description }: ParkCardData) {
+  return (
+    <div className="park-card">
+      <div className="park-image-frame">
+        <img
+          src={optimizeRemoteImageUrl(image, 600, 400)}
+          alt={alt}
+          width="600"
+          height="400"
+          loading="lazy"
+        />
+      </div>
+      <img
+        className="park-logo-title"
+        style={logoStyle}
+        src={getMediaUrl(logo)}
+        alt={logoAlt}
+        width={logoWidth}
+        height={logoHeight}
+        loading="lazy"
+      />
+      <p>{description}</p>
+    </div>
+  );
+}
+
+const PARK_GROUPS: ParkGroupData[] = [
+  {
+    label: "Walt Disney World",
+    className: "disney-group",
+    parks: [
+      {
+        image: "images/orlando/parks/magic-kingdom.jpg",
+        alt: "Magic Kingdom",
+        logo: "images/orlando/logos/magic-kingdom.png",
+        logoAlt: "Magic Kingdom Logo",
+        logoWidth: 120,
+        logoHeight: 40,
+        description: "Onde a fantasia é lei. O castelo icônico, fogos inesquecíveis e a magia que define Orlando.",
+      },
+      {
+        image: "images/orlando/parks/epcot.jpg",
+        alt: "Epcot",
+        logo: "images/orlando/logos/epcot.png",
+        logoAlt: "Epcot Logo",
+        logoStyle: { maxWidth: "120px", maxHeight: "33px" },
+        logoWidth: 120,
+        logoHeight: 33,
+        description: "Volta ao mundo em um dia. Coma em Paris, beba no Japão e voe para o futuro.",
+      },
+      {
+        image: "images/orlando/parks/hollywood-studios.jpg",
+        alt: "Hollywood Studios",
+        logo: "images/orlando/logos/hollywood-studios.svg",
+        logoAlt: "Hollywood Studios Logo",
+        logoWidth: 120,
+        logoHeight: 40,
+        description: "Luz, câmera, ação! Da saga Star Wars ao quintal de Toy Story: você é o protagonista.",
+      },
+      {
+        image: "images/orlando/parks/animal-kingdom.jpg",
+        alt: "Animal Kingdom",
+        logo: "images/orlando/logos/animal-kingdom.svg",
+        logoAlt: "Animal Kingdom Logo",
+        logoWidth: 120,
+        logoHeight: 40,
+        description: "A natureza ruge. Safáris reais, montanhas flutuantes em Pandora e expedições selvagens.",
+      },
+      {
+        image: "images/orlando/parks/typhoon-lagoon.jpg",
+        alt: "Typhoon Lagoon",
+        logo: "images/orlando/logos/typhoon-lagoon.png",
+        logoAlt: "Typhoon Lagoon Logo",
+        logoWidth: 120,
+        logoHeight: 40,
+        description: "Tsunamis de diversão. Encare ondas gigantes ou relaxe no rio lento deste paraíso tropical.",
+      },
+    ],
+  },
+  {
+    label: "Universal Orlando",
+    className: "universal-group",
+    parks: [
+      {
+        image: "images/orlando/universal-studios-orlando.jpg",
+        alt: "Universal Studios Orlando",
+        logo: "images/orlando/logos/universal-studios.png",
+        logoAlt: "Universal Studios Logo",
+        logoStyle: { maxHeight: "77px", maxWidth: "280px" },
+        logoWidth: 280,
+        logoHeight: 77,
+        description: "Entre no filme. Fuja do banco de Gringotts, brinque com os Minions e viva o cinema.",
+      },
+      {
+        image: "images/orlando/parks/islands-of-adventure.jpg",
+        alt: "Islands of Adventure",
+        logo: "images/orlando/logos/islands-of-adventure.png",
+        logoAlt: "Islands of Adventure Logo",
+        logoStyle: { maxHeight: "77px", maxWidth: "280px" },
+        logoWidth: 280,
+        logoHeight: 77,
+        description: "Aventura nível hard. Voe de moto com Hagrid, escape de dinossauros e sinta a fúria do Hulk.",
+      },
+      {
+        image: "images/orlando/parks/epic-universe.jpg",
+        alt: "Epic Universe",
+        logo: "images/orlando/logos/epic-universe.png",
+        logoAlt: "Epic Universe Logo",
+        logoStyle: { maxHeight: "77px", maxWidth: "280px" },
+        logoWidth: 280,
+        logoHeight: 77,
+        description: "5 mundos, 1 destino. De Super Nintendo World a Monstros Clássicos: o portal se abriu.",
+      },
+      {
+        image: "images/orlando/parks/volcano-bay.jpg",
+        alt: "Volcano Bay",
+        logo: "images/orlando/logos/volcano-bay.png",
+        logoAlt: "Volcano Bay Logo",
+        logoStyle: { maxHeight: "77px", maxWidth: "280px" },
+        logoWidth: 280,
+        logoHeight: 77,
+        description: "Praia e adrenalina. Despenque do vulcão Krakatau ou apenas relaxe na areia. O TapuTapu cuida da fila.",
+      },
+    ],
+  },
+  {
+    label: "Outras Aventuras",
+    className: "other-group",
+    parks: [
+      {
+        image: "images/orlando/parks/seaworld.jpg",
+        alt: "SeaWorld",
+        logo: "images/orlando/logos/seaworld.png",
+        logoAlt: "SeaWorld Logo",
+        logoWidth: 120,
+        logoHeight: 40,
+        description: "Coasters insanas. Acelere na Pipeline e na Mako, depois recupere o fôlego admirando a vida marinha.",
+      },
+      {
+        image: "images/orlando/parks/discovery-cove.jpg",
+        alt: "Discovery Cove",
+        logo: "images/orlando/logos/discovery-cove.png",
+        logoAlt: "Discovery Cove Logo",
+        logoWidth: 120,
+        logoHeight: 40,
+        description: "Seu dia de VIP. All-inclusive de luxo: nade com golfinhos e esqueça do mundo lá fora.",
+      },
+      {
+        image: "images/orlando/parks/kennedy-space-center.jpg",
+        alt: "Kennedy Space Center",
+        logo: "images/orlando/logos/kennedy-space-center.svg",
+        logoAlt: "Kennedy Space Center Logo",
+        logoWidth: 120,
+        logoHeight: 40,
+        description: "3... 2... 1... Decolar! Foguetes reais da NASA, pedras lunares e a história do universo.",
+      },
+    ],
+  },
+];
+
 export function OrlandoParksGallery() {
   return (
     <section className="parks-gallery" id="parks">
@@ -14,374 +191,18 @@ export function OrlandoParksGallery() {
         <span className="highlight-blue">Imperdíveis</span>
       </h2>
 
-      {/* --- WALT DISNEY WORLD --- */}
-      <div className="complex-group disney-group">
-        <div className="complex-label">
-          <span>Walt Disney World</span>
-        </div>
-        <div className="parks-grid">
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/parks/magic-kingdom.jpg",
-                  600,
-                  400,
-                )}
-                alt="Magic Kingdom"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              src={getMediaUrl("images/orlando/logos/magic-kingdom.png")}
-              alt="Magic Kingdom Logo"
-              width="120"
-              height="40"
-              loading="lazy"
-            />
-            <p>
-              Onde a fantasia é lei. O castelo icônico, fogos inesquecíveis e
-              a magia que define Orlando.
-            </p>
+      {PARK_GROUPS.map((group) => (
+        <div key={group.label} className={`complex-group ${group.className}`}>
+          <div className="complex-label">
+            <span>{group.label}</span>
           </div>
-
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/parks/epcot.jpg",
-                  600,
-                  400,
-                )}
-                alt="Epcot"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              style={{ maxWidth: "120px", maxHeight: "33px" }}
-              src={getMediaUrl("images/orlando/logos/epcot.png")}
-              alt="Epcot Logo"
-              width="120"
-              height="33"
-              loading="lazy"
-            />
-            <p>
-              Volta ao mundo em um dia. Coma em Paris, beba no Japão e voe
-              para o futuro.
-            </p>
-          </div>
-
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/parks/hollywood-studios.jpg",
-                  600,
-                  400,
-                )}
-                alt="Hollywood Studios"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              src={getMediaUrl("images/orlando/logos/hollywood-studios.svg")}
-              alt="Hollywood Studios Logo"
-              width="120"
-              height="40"
-              loading="lazy"
-            />
-            <p>
-              Luz, câmera, ação! Da saga Star Wars ao quintal de Toy Story:
-              você é o protagonista.
-            </p>
-          </div>
-
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/parks/animal-kingdom.jpg",
-                  600,
-                  400,
-                )}
-                alt="Animal Kingdom"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              src={getMediaUrl("images/orlando/logos/animal-kingdom.svg")}
-              alt="Animal Kingdom Logo"
-              width="120"
-              height="40"
-              loading="lazy"
-            />
-            <p>
-              A natureza ruge. Safáris reais, montanhas flutuantes em Pandora
-              e expedições selvagens.
-            </p>
-          </div>
-
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/parks/typhoon-lagoon.jpg",
-                  600,
-                  400,
-                )}
-                alt="Typhoon Lagoon"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              src={getMediaUrl("images/orlando/logos/typhoon-lagoon.png")}
-              alt="Typhoon Lagoon Logo"
-              width="120"
-              height="40"
-              loading="lazy"
-            />
-            <p>
-              Tsunamis de diversão. Encare ondas gigantes ou relaxe no rio
-              lento deste paraíso tropical.
-            </p>
+          <div className="parks-grid">
+            {group.parks.map((park) => (
+              <ParkCard key={park.alt} {...park} />
+            ))}
           </div>
         </div>
-      </div>
-
-      {/* --- UNIVERSAL ORLANDO --- */}
-      <div className="complex-group universal-group">
-        <div className="complex-label">
-          <span>Universal Orlando</span>
-        </div>
-        <div className="parks-grid">
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/universal-studios-orlando.jpg",
-                  600,
-                  400,
-                )}
-                alt="Universal Studios Orlando"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              style={{ maxHeight: "77px", maxWidth: "280px" }}
-              src={getMediaUrl("images/orlando/logos/universal-studios.png")}
-              alt="Universal Studios Logo"
-              width="280"
-              height="77"
-              loading="lazy"
-            />
-            <p>
-              Entre no filme. Fuja do banco de Gringotts, brinque com os
-              Minions e viva o cinema.
-            </p>
-          </div>
-
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/parks/islands-of-adventure.jpg",
-                  600,
-                  400,
-                )}
-                alt="Islands of Adventure"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              style={{ maxHeight: "77px", maxWidth: "280px" }}
-              src={getMediaUrl(
-                "images/orlando/logos/islands-of-adventure.png",
-              )}
-              alt="Islands of Adventure Logo"
-              width="280"
-              height="77"
-              loading="lazy"
-            />
-            <p>
-              Aventura nível hard. Voe de moto com Hagrid, escape de
-              dinossauros e sinta a fúria do Hulk.
-            </p>
-          </div>
-
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/parks/epic-universe.jpg",
-                  600,
-                  400,
-                )}
-                alt="Epic Universe"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              style={{ maxHeight: "77px", maxWidth: "280px" }}
-              src={getMediaUrl("images/orlando/logos/epic-universe.png")}
-              alt="Epic Universe Logo"
-              width="280"
-              height="77"
-              loading="lazy"
-            />
-            <p>
-              5 mundos, 1 destino. De Super Nintendo World a Monstros
-              Clássicos: o portal se abriu.
-            </p>
-          </div>
-
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/parks/volcano-bay.jpg",
-                  600,
-                  400,
-                )}
-                alt="Volcano Bay"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              style={{ maxHeight: "77px", maxWidth: "280px" }}
-              src={getMediaUrl("images/orlando/logos/volcano-bay.png")}
-              alt="Volcano Bay Logo"
-              width="280"
-              height="77"
-              loading="lazy"
-            />
-            <p>
-              Praia e adrenalina. Despenque do vulcão Krakatau ou apenas
-              relaxe na areia. O TapuTapu cuida da fila.
-            </p>
-          </div>
-        </div>
-      </div>
-
-      {/* --- OUTRAS AVENTURAS --- */}
-      <div className="complex-group other-group">
-        <div className="complex-label">
-          <span>Outras Aventuras</span>
-        </div>
-        <div className="parks-grid">
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/parks/seaworld.jpg",
-                  600,
-                  400,
-                )}
-                alt="SeaWorld"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              src={getMediaUrl("images/orlando/logos/seaworld.png")}
-              alt="SeaWorld Logo"
-              width="120"
-              height="40"
-              loading="lazy"
-            />
-            <p>
-              Coasters insanas. Acelere na Pipeline e na Mako, depois recupere
-              o fôlego admirando a vida marinha.
-            </p>
-          </div>
-
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/parks/discovery-cove.jpg",
-                  600,
-                  400,
-                )}
-                alt="Discovery Cove"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              src={getMediaUrl("images/orlando/logos/discovery-cove.png")}
-              alt="Discovery Cove Logo"
-              width="120"
-              height="40"
-              loading="lazy"
-            />
-            <p>
-              Seu dia de VIP. All-inclusive de luxo: nade com golfinhos e
-              esqueça do mundo lá fora.
-            </p>
-          </div>
-
-          <div className="park-card">
-            <div className="park-image-frame">
-              <img
-                src={optimizeRemoteImageUrl(
-                  "images/orlando/parks/kennedy-space-center.jpg",
-                  600,
-                  400,
-                )}
-                alt="Kennedy Space Center"
-                width="600"
-                height="400"
-                loading="lazy"
-              />
-            </div>
-            <img
-              className="park-logo-title"
-              src={getMediaUrl(
-                "images/orlando/logos/kennedy-space-center.svg",
-              )}
-              alt="Kennedy Space Center Logo"
-              width="120"
-              height="40"
-              loading="lazy"
-            />
-            <p>
-              3... 2... 1... Decolar! Foguetes reais da NASA, pedras lunares e
-              a história do universo.
-            </p>
-          </div>
-        </div>
-      </div>
+      ))}
 
       <div className="gallery-cta">
         <button

--- a/components/nps/NpsThankOther.tsx
+++ b/components/nps/NpsThankOther.tsx
@@ -8,7 +8,7 @@ export function NpsThankOther({ firstname }: NpsThankOtherProps) {
   return (
     <div className="nps-thank-card animate-fade-in-up text-center py-8">
       <div
-        className="mx-auto mb-6 flex items-center justify-center rounded-full w-16 h-16 bg-anhanga-blue border-2 border-anhanga-dark shadow-[4px_4px_0_#003B8E]"
+        className="mx-auto mb-6 flex items-center justify-center rounded-full size-16 bg-anhanga-blue border-2 border-anhanga-dark shadow-[4px_4px_0_#003B8E]"
         aria-hidden="true"
       >
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">

--- a/components/nps/NpsThankPromoter.tsx
+++ b/components/nps/NpsThankPromoter.tsx
@@ -8,7 +8,7 @@ export function NpsThankPromoter({ firstname }: NpsThankPromoterProps) {
   return (
     <div className="nps-thank-card animate-fade-in-up text-center py-8">
       <div
-        className="mx-auto mb-6 flex items-center justify-center rounded-full w-16 h-16 bg-anhanga-yellow border-2 border-anhanga-dark shadow-hard"
+        className="mx-auto mb-6 flex items-center justify-center rounded-full size-16 bg-anhanga-yellow border-2 border-anhanga-dark shadow-hard"
         aria-hidden="true"
       >
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#0f172a" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">

--- a/data/faqData.ts
+++ b/data/faqData.ts
@@ -1,10 +1,4 @@
-/**
- * Plain-text FAQ items for FAQPageSchema structured data.
- * Mirrors the questions from components/Faq.tsx but with string answers
- * so they can be serialised into JSON-LD without JSX or HTML markup.
- *
- * Keep in sync with FAQ.tsx whenever questions or answers change.
- */
+// Keep in sync with Faq.tsx whenever questions or answers change.
 
 export interface FAQSchemaItem {
   question: string;

--- a/data/faqData.ts
+++ b/data/faqData.ts
@@ -1,6 +1,6 @@
 /**
  * Plain-text FAQ items for FAQPageSchema structured data.
- * Mirrors the questions from components/FAQ.tsx but with string answers
+ * Mirrors the questions from components/Faq.tsx but with string answers
  * so they can be serialised into JSON-LD without JSX or HTML markup.
  *
  * Keep in sync with FAQ.tsx whenever questions or answers change.

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { m, Variants } from 'framer-motion';
-import { SEO } from '../components/SEO';
+import { Seo } from '../components/Seo';
 import { OrganizationSchema } from '../components/schemas/OrganizationSchema';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { LazyImage } from '../components/ui/LazyImage';
@@ -41,7 +41,7 @@ const About: React.FC = () => {
 
   return (
     <div className="bg-brand-surface pt-32 pb-20">
-      <SEO
+      <Seo
         title="Sobre a Anhangá Viagens | Agência de Viagens em São Paulo"
         description="Conheça a história da Anhangá Viagens. Agência de turismo credenciada no Cadastur em São Paulo, especializada em roteiros personalizados."
         canonical="https://www.anhanga.tur.br/sobre/"

--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -7,7 +7,7 @@ import { SocialShare } from '../components/SocialShare';
 import { getBlogPostUrl, getBlogHomeUrl, formatDate } from '../utils/blog';
 import { optimizeRemoteImageUrl } from '../data/mediaConfig';
 import { getCategoryColor } from '../utils/categoryColors';
-import { SEO } from '../components/SEO';
+import { Seo } from '../components/Seo';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { openContactModal } from '../utils/contactForm';
 
@@ -33,7 +33,7 @@ const BlogList: React.FC = () => {
 
     return (
         <>
-            <SEO
+            <Seo
                 title="Blog de Viagens e Dicas Práticas"
                 description="Roteiros práticos, dicas de insider e destinos que valem cada centavo. Planejamento de viagem do jeito que deveria ser. Leia no blog da Anhangá!"
                 canonical={getBlogHomeUrl()}

--- a/pages/BlogPost.tsx
+++ b/pages/BlogPost.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 
-import { SEO } from '../components/SEO';
+import { Seo } from '../components/Seo';
 import { ArticleSchema } from '../components/schemas/ArticleSchema';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { PersonSchema } from '../components/schemas/PersonSchema';
@@ -92,7 +92,7 @@ const BlogPost: React.FC = () => {
 
     return (
         <article className="min-h-screen bg-brand-surface">
-            <SEO
+            <Seo
                 title={post.title}
                 description={post.excerpt}
                 image={post.image}

--- a/pages/BlogRedirect.tsx
+++ b/pages/BlogRedirect.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { getBlogHomeUrl, getBlogPostUrl } from '../utils/blog';
-import { SEO } from '../components/SEO';
+import { Seo } from '../components/Seo';
 
 const BlogRedirect: React.FC = () => {
   const { slug } = useParams<{ slug?: string }>();
@@ -15,7 +15,7 @@ const BlogRedirect: React.FC = () => {
 
   return (
     <>
-      <SEO
+      <Seo
         title="Redirecionando para o blog"
         description="O blog da Anhangá foi movido para um novo endereço."
         canonical={destination}

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -9,7 +9,7 @@ import { ServiceSchema } from '../components/schemas/ServiceSchema';
 import { FAQ_SCHEMA_ITEMS } from '../data/faqData';
 // aggregateRating was removed from ServiceSchema to comply with Google's visibility guidelines; individual reviews now use microdata.
 
-import { SEO } from '../components/SEO';
+import { Seo } from '../components/Seo';
 
 const Highlights = lazy(() => import('../components/Highlights'));
 const Categories = lazy(() => import('../components/Categories'));
@@ -17,7 +17,7 @@ const Destinations = lazy(() => import('../components/Destinations'));
 const HowItWorks = lazy(() => import('../components/HowItWorks'));
 const Testimonials = lazy(() => import('../components/Testimonials'));
 const Blog = lazy(() => import('../components/Blog'));
-const FAQ = lazy(() => import('../components/FAQ'));
+const Faq = lazy(() => import('../components/Faq'));
 const CallToAction = lazy(() => import('../components/CallToAction'));
 
 const Home: React.FC = () => {
@@ -97,7 +97,7 @@ const Home: React.FC = () => {
 
   return (
     <>
-      <SEO
+      <Seo
         title="Agência de Viagens em São Paulo | Roteiros Sob Medida"
         description="Agência de viagens em São Paulo. Cada roteiro começa do zero — sem pacote pronto. Orlando, Beto Carrero, Europa e muito mais. Orçamento gratuito."
         canonical="https://www.anhanga.tur.br/"
@@ -154,7 +154,7 @@ const Home: React.FC = () => {
             <HowItWorks />
           </Suspense>
           <Suspense fallback={<section id="faq" className="min-h-[600px] bg-brand-surface" />}>
-            <FAQ />
+            <Faq />
           </Suspense>
           <Suspense fallback={<section id="depoimentos" className="min-h-[500px] bg-brand-surface" />}>
             <Testimonials />

--- a/pages/NotFound.tsx
+++ b/pages/NotFound.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { MapPin, Home as HomeIcon, Compass, BookOpen, ArrowLeft } from 'lucide-react';
-import { SEO } from '../components/SEO';
+import { Seo } from '../components/Seo';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { getBlogHomeUrl } from '../utils/blog';
 
@@ -10,7 +10,7 @@ const SITE_URL = 'https://www.anhanga.tur.br';
 const NotFound: React.FC = () => {
   return (
     <>
-      <SEO
+      <Seo
         title="Página não encontrada"
         description="A página que você procura não foi encontrada. Explore nossos roteiros personalizados e planeje sua próxima aventura."
         robots="noindex, follow"

--- a/pages/NpsPage.tsx
+++ b/pages/NpsPage.tsx
@@ -1,3 +1,4 @@
+import type { FormEvent } from 'react';
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { BRAND_LOGO_WHITE_URL } from '../lib/media-assets';
@@ -79,7 +80,7 @@ export default function NpsPage() {
     return () => { document.title = prev; };
   }, []);
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (score === null) return;
 

--- a/pages/NpsPage.tsx
+++ b/pages/NpsPage.tsx
@@ -5,7 +5,7 @@ import { NpsTextarea } from '../components/nps/NpsTextarea';
 import { NpsScoreSelector } from '../components/nps/NpsScoreSelector';
 import { NpsThankPromoter } from '../components/nps/NpsThankPromoter';
 import { NpsThankOther } from '../components/nps/NpsThankOther';
-import { SEO } from '../components/SEO';
+import { Seo } from '../components/Seo';
 
 type PageState = 'form' | 'thank-promoter' | 'thank-other';
 
@@ -60,7 +60,7 @@ const PAGE_STYLES = `
   }
 `;
 
-export default function NPS() {
+export default function NpsPage() {
   const [params] = useSearchParams();
   const firstname = params.get('firstname')?.trim() ?? '';
   const email = params.get('email')?.trim() ?? '';
@@ -118,7 +118,7 @@ export default function NPS() {
 
   return (
     <>
-      <SEO
+      <Seo
         title="Avaliação de Viagem"
         description="Pagina operacional para clientes avaliarem a experiencia com a Anhanga Viagens."
         canonical="https://www.anhanga.tur.br/nps/"
@@ -221,7 +221,7 @@ export default function NPS() {
                 >
                   {submitting ? (
                     <span className="inline-flex items-center gap-2">
-                      <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                      <svg className="animate-spin size-4" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                       </svg>

--- a/pages/Privacy.tsx
+++ b/pages/Privacy.tsx
@@ -1,4 +1,4 @@
-import { SEO } from "@/components/SEO";
+import { Seo } from "@/components/Seo";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { BreadcrumbSchema } from "@/components/schemas/BreadcrumbSchema";
@@ -11,7 +11,7 @@ const Privacy = () => {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <SEO
+            <Seo
                 title="Política de Privacidade | Anhangá Viagens"
                 description={metaDescription}
                 canonical={canonicalUrl}

--- a/pages/SiteMap.tsx
+++ b/pages/SiteMap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { SEO } from '../components/SEO';
+import { Seo } from '../components/Seo';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { getAllPosts } from '../lib/mdx';
 import { getBlogHomeUrl, getBlogPostUrl } from '../utils/blog';
@@ -22,7 +22,7 @@ const SiteMap: React.FC = () => {
 
   return (
     <>
-      <SEO
+      <Seo
         title="Mapa do Site | Anhangá Viagens"
         description="Navegue pelas principais páginas da Anhangá Viagens, incluindo landings, blog e páginas institucionais."
         canonical="https://www.anhanga.tur.br/mapa-do-site/"

--- a/pages/Terms.tsx
+++ b/pages/Terms.tsx
@@ -1,4 +1,4 @@
-import { SEO } from "@/components/SEO";
+import { Seo } from "@/components/Seo";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { BreadcrumbSchema } from "@/components/schemas/BreadcrumbSchema";
@@ -11,7 +11,7 @@ const Terms = () => {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <SEO
+            <Seo
                 title="Termos e Condições de Uso | Anhangá Viagens"
                 description={metaDescription}
                 canonical={canonicalUrl}

--- a/pages/landings/BetoCarreroLanding.tsx
+++ b/pages/landings/BetoCarreroLanding.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import BetoCarreroApp from '../../components/landings/beto-carrero/BetoCarreroApp';
-import { SEO } from '../../components/SEO';
+import { Seo } from '../../components/Seo';
 import { LandingFAQ } from '../../components/LandingFAQ';
 import { BreadcrumbSchema } from '../../components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '../../components/schemas/FAQPageSchema';
@@ -30,7 +30,7 @@ const BETO_FAQ_ITEMS = [
 const BetoCarreroLanding: React.FC = () => {
   return (
     <>
-      <SEO
+      <Seo
         title="Pacote Beto Carrero: Família e Diversão 2026"
         description="Garanta seu pacote para o Beto Carrero com hotel, passagens e ingressos. Planejamento completo para famílias com o suporte da Anhangá Viagens."
         canonical="https://www.anhanga.tur.br/beto-carrero/"

--- a/pages/landings/BrazilPromotionDayLanding.tsx
+++ b/pages/landings/BrazilPromotionDayLanding.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { SEO } from '../../components/SEO';
+import { Seo } from '../../components/Seo';
 import { BreadcrumbSchema } from '../../components/schemas/BreadcrumbSchema';
 import { BpdNav } from '../../components/landings/brazil-promotion-day/BpdNav';
 import { BpdHero } from '../../components/landings/brazil-promotion-day/BpdHero';
@@ -22,7 +22,7 @@ const BrazilPromotionDayLanding: React.FC = () => {
 
     return (
         <>
-            <SEO
+            <Seo
                 title="Anhangá Viagens na Brazil Promotion Day | Roteiros Personalizados"
                 description="Conheça a Anhangá Viagens na Brazil Promotion Day. Agência de viagens em SP com roteiros exclusivos feitos do zero, sem pacote pronto."
                 canonical="https://www.anhanga.tur.br/brazil-promotion-day/"

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { SEO } from '@/components/SEO';
+import { Seo } from '@/components/Seo';
 import { LandingFAQ } from '@/components/LandingFAQ';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
@@ -81,7 +81,7 @@ const PILLARS = [
 const ConsultoriaDeViagemLanding: React.FC = () => {
   return (
     <div className="bg-brand-surface min-h-screen font-sans">
-      <SEO
+      <Seo
         title="Consultoria de Viagem Sob Medida em SP — Anhangá Viagens"
         description="Planeje sua viagem com consultores humanos. Sem pacote pronto, sem improviso. Roteiro personalizado com suporte antes, durante e depois."
         canonical="https://www.anhanga.tur.br/consultoria-de-viagem/"

--- a/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
+++ b/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { SEO } from '@/components/SEO';
+import { Seo } from '@/components/Seo';
 import { LandingFAQ } from '@/components/LandingFAQ';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
@@ -89,7 +89,7 @@ const HOW_IT_WORKS = [
 const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
   return (
     <div className="bg-anhanga-light min-h-screen font-sans">
-      <SEO
+      <Seo
         title="Curadoria de Cruzeiros no Brasil — Anhangá Viagens"
         description="Escolha navio, cabine e roteiro certos para o seu perfil. Curadoria consultiva para quem quer fazer o cruzeiro certo na primeira vez."
         canonical="https://www.anhanga.tur.br/curadoria-cruzeiros-brasil/"

--- a/pages/landings/LollapaloozaLanding.tsx
+++ b/pages/landings/LollapaloozaLanding.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SEO } from '../../components/SEO';
+import { Seo } from '../../components/Seo';
 import { LandingFAQ } from '../../components/LandingFAQ';
 import LollapaloozaApp from '../../components/landings/lollapalooza/LollapaloozaApp';
 import { openContactModal } from '../../utils/contactForm';
@@ -32,7 +32,7 @@ const LOLLAPALOOZA_FAQ_ITEMS = [
 const LollapaloozaLanding: React.FC = () => {
   return (
     <>
-      <SEO
+      <Seo
         title="Lollapalooza 2026 Esgotado | Lista de Espera 2027"
         description="A campanha do Lollapalooza 2026 foi encerrada com sucesso. Entre na lista de espera 2027 para receber prioridade quando os próximos pacotes abrirem."
         canonical="https://www.anhanga.tur.br/lollapalooza/"

--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { SEO } from '../../components/SEO';
+import { Seo } from '../../components/Seo';
 import { LandingFAQ } from '../../components/LandingFAQ';
 import { BreadcrumbSchema } from '../../components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '../../components/schemas/FAQPageSchema';
@@ -31,7 +31,7 @@ const MELHOR_IDADE_FAQ_ITEMS = [
 const MelhorIdadeLanding: React.FC = () => {
   return (
     <div className="bg-brand-surface min-h-screen font-sans">
-      <SEO
+      <Seo
         title="Turismo 50+: Viagens Seguras e Personalizadas"
         description="Experiências de viagem exclusivas para o público 50+. Roteiros com conforto, segurança e atendimento humano. Planeje sua próxima aventura com a Anhangá."
         canonical="https://www.anhanga.tur.br/melhor-idade/"

--- a/pages/landings/OrlandoLanding.tsx
+++ b/pages/landings/OrlandoLanding.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { SEO } from '../../components/SEO';
+import { Seo } from '../../components/Seo';
 import { LandingFAQ } from '../../components/LandingFAQ';
 import OrlandoApp from '../../components/landings/orlando/OrlandoApp';
 import { BreadcrumbSchema } from '../../components/schemas/BreadcrumbSchema';
@@ -35,7 +35,7 @@ const ORLANDO_FAQ_ITEMS = [
 const OrlandoLanding: React.FC = () => {
   return (
     <>
-      <SEO
+      <Seo
         title="Pacotes para Orlando: Disney e Universal 2026"
         description="Planeje sua viagem para Orlando com roteiro personalizado, ingressos e hospedagem. Atendimento especializado por agência de viagens em São Paulo."
         canonical="https://www.anhanga.tur.br/orlando/"

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { SEO } from '../../components/SEO';
+import { Seo } from '../../components/Seo';
 import { BreadcrumbSchema } from '../../components/schemas/BreadcrumbSchema';
 import { useQuizCapture } from '../../hooks/useQuizCapture';
 import { getWhatsAppLink } from '../../utils/whatsapp';
@@ -1037,7 +1037,7 @@ export default function QuizAnhangaLanding() {
 
     return (
         <>
-            <SEO
+            <Seo
                 title="Quiz de Destinos | Descubra seu próximo rolê — Anhangá Viagens"
                 description="6 perguntas rápidas para descobrir seu perfil de viajante e os destinos que mais combinam com você. Gratuito e sem compromisso."
                 canonical="https://www.anhanga.tur.br/quiz/"

--- a/pages/landings/ViagensParaExecutivosLanding.tsx
+++ b/pages/landings/ViagensParaExecutivosLanding.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { SEO } from '@/components/SEO';
+import { Seo } from '@/components/Seo';
 import { LandingFAQ } from '@/components/LandingFAQ';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
@@ -80,7 +80,7 @@ const HOW_IT_WORKS = [
 const ViagensParaExecutivosLanding: React.FC = () => {
   return (
     <div className="bg-white min-h-screen font-sans">
-      <SEO
+      <Seo
         title="Viagens Para Executivos e Profissionais — Anhangá Viagens"
         description="Planejamento de viagem com precisão para quem não tem tempo a perder. Atendimento consultivo, roteiro sob medida e suporte real."
         canonical="https://www.anhanga.tur.br/viagens-para-executivos/"

--- a/tests/static-media-assets.test.ts
+++ b/tests/static-media-assets.test.ts
@@ -237,7 +237,7 @@ test('remaining runtime media dependencies should use managed Cloudflare assets'
     readRepoFile('data/testimonialsData.ts'),
     readRepoFile('pages/landings/orlando.css'),
     readRepoFile('components/landings/lollapalooza/Hero.tsx'),
-    readRepoFile('components/SEO.tsx'),
+    readRepoFile('components/Seo.tsx'),
     readRepoFile('data/blogData.ts'),
     readRepoFile('components/Header/Header.tsx'),
     readRepoFile('components/Footer.tsx'),
@@ -273,7 +273,7 @@ test('remaining runtime media dependencies should use managed Cloudflare assets'
   assert.match(lollapaloozaHero, /videos\/lollapalooza\/hero\/crowd-background\.mp4/);
 
   for (const [label, content] of [
-    ['components/SEO.tsx', seo],
+    ['components/Seo.tsx', seo],
     ['data/blogData.ts', blogData],
     ['components/Header/Header.tsx', header],
     ['components/Footer.tsx', footer],


### PR DESCRIPTION
## Summary

Resolves **27 of 29** architecture warnings from the React Doctor scan (#722), including all sub-issues (#723, #724, #725).

### Changes

- **jsx-pascal-case (22 fixes):** Renamed `SEO` → `Seo`, `FAQ` → `Faq`, `NPS` → `NpsPage` across component definitions, file names, and all consumer imports
- **design-no-redundant-size-axes (3 fixes):** `w-16 h-16` → `size-16`, `h-4 w-4` → `size-4` in NPS components
- **no-giant-component (2 fixes):** Refactored `OrlandoParksGallery` (400→221 lines) by extracting park data into an array + `ParkCard` subcomponent; split `BpdContactSection` (330→252 lines) by extracting `BpdContactInfo`
- **Justified false positives (2 remaining):**
  - `LineupSection.tsx` `-space-x-4`: intentional negative spacing for overlapping avatar circles — `gap` does not support negative values
  - `Privacy.tsx` 377 lines: static legal content with no logic, state, or repetition to factor out — splitting adds no maintainability benefit

### Validation

- `pnpm typecheck` — passed
- `pnpm test:regression` — 445 tests, 0 failures
- `pnpm build` — production build successful
- React Doctor re-scan — only the 2 justified false positives remain

Closes #722, #723, #724, #725

## Test plan

- [x] TypeScript compiles without errors
- [x] All 445 regression tests pass
- [x] Production build succeeds
- [x] React Doctor re-scan confirms only justified delta remains
- [ ] Visual spot-check of renamed components in browser (Home FAQ, Beto Carrero FAQ, NPS page, Orlando parks gallery, BPD contact form)

🤖 Generated with [Claude Code](https://claude.com/claude-code)