### PR TITLE
refactor(state-effects): resolve React Doctor state/effect warnings

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -115,7 +115,6 @@ const AIChat: React.FC = memo(() => {
   const navigate = useNavigate();
   const isOrlandoPage = location.pathname.startsWith('/orlando');
 
-  const [liveAnnouncement, setLiveAnnouncement] = useState('');
   const prevMessagesCount = useRef(messages.length);
 
   // PERFORMANCE: Pre-calculate the index of the last model message to avoid O(N^2)
@@ -127,18 +126,18 @@ const AIChat: React.FC = memo(() => {
     return -1;
   }, [messages]);
 
-  useEffect(() => {
-    if (messages.length > prevMessagesCount.current) {
-      const newModelMessages = messages
-        .slice(prevMessagesCount.current)
-        .filter(m => m.role === 'model' && !m.isAction);
-
-      if (newModelMessages.length > 0) {
-        const fullText = newModelMessages.map(m => m.text).join(' ');
-        setLiveAnnouncement(fullText.replace(/\*\*|\*|- /g, ''));
-      }
+  // Derive the screen-reader announcement from the latest model messages added this render.
+  const liveAnnouncement = useMemo(() => {
+    if (messages.length <= prevMessagesCount.current) {
+      prevMessagesCount.current = messages.length;
+      return '';
     }
+    const newModelMessages = messages
+      .slice(prevMessagesCount.current)
+      .filter(m => m.role === 'model' && !m.isAction);
     prevMessagesCount.current = messages.length;
+    if (newModelMessages.length === 0) return '';
+    return newModelMessages.map(m => m.text).join(' ').replace(/\*\*|\*|- /g, '');
   }, [messages]);
 
   useEffect(() => {

--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -127,17 +127,19 @@ const AIChat: React.FC = memo(() => {
   }, [messages]);
 
   // Derive the screen-reader announcement from the latest model messages added this render.
+  // Read the ref snapshot before useMemo so the memo body stays pure.
+  const prevCount = prevMessagesCount.current;
   const liveAnnouncement = useMemo(() => {
-    if (messages.length <= prevMessagesCount.current) {
-      prevMessagesCount.current = messages.length;
-      return '';
-    }
+    if (messages.length <= prevCount) return '';
     const newModelMessages = messages
-      .slice(prevMessagesCount.current)
+      .slice(prevCount)
       .filter(m => m.role === 'model' && !m.isAction);
-    prevMessagesCount.current = messages.length;
     if (newModelMessages.length === 0) return '';
     return newModelMessages.map(m => m.text).join(' ').replace(/\*\*|\*|- /g, '');
+  }, [messages, prevCount]);
+
+  useEffect(() => {
+    prevMessagesCount.current = messages.length;
   }, [messages]);
 
   useEffect(() => {

--- a/components/cta/CtaBody.tsx
+++ b/components/cta/CtaBody.tsx
@@ -1,21 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { WhatsappLogo, SpinnerGap, CheckCircle } from '@phosphor-icons/react';
 import { useContactForm } from '../../hooks/useContactForm';
 
-type FormState = 'closed' | 'open' | 'submitted';
-
 export function CtaBody() {
-  const [formState, setFormState] = useState<FormState>('closed');
+  const [formOpen, setFormOpen] = useState(false);
   const { fields, setField, isValid, isSubmitting, error, submitted, submit } =
     useContactForm({ source: 'cta-homepage' });
 
-  useEffect(() => {
-    if (submitted && formState === 'open') {
-      setFormState('submitted');
-    }
-  }, [formState, submitted]);
-
-  if (formState === 'submitted') {
+  if (submitted && formOpen) {
     return (
       <output className="flex flex-col gap-3" aria-live="polite">
         <p className="flex items-center gap-2 text-green-600 text-sm font-bold">
@@ -26,7 +18,7 @@ export function CtaBody() {
     );
   }
 
-  if (formState === 'open') {
+  if (formOpen) {
     return (
       <form
         onSubmit={(event) => {
@@ -151,7 +143,7 @@ export function CtaBody() {
       </div>
       <button
         type="button"
-        onClick={() => setFormState('open')}
+        onClick={() => setFormOpen(true)}
         className="btn-specialist flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-8 py-4 rounded-xl shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition self-start"
         data-tracking="cta-home-footer"
       >

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -359,16 +359,15 @@ function QuestionScreen({ q, qIndex, total, value, onChange, onNext, onBack }: Q
     const [pendingId, setPendingId] = useState<string | null>(null);
     const advanceTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    // reset pending when question changes and clear any pending timer
+    // Timer cleanup on unmount (state resets via key={q.id} on the render site)
     useEffect(() => {
-        setPendingId(null);
         const timerRef = advanceTimerRef;
         return () => {
             if (timerRef.current !== null) {
                 clearTimeout(timerRef.current);
             }
         };
-    }, [q.id]);
+    }, []);
 
     function toggle(optId: string) {
         if (q.multi) {
@@ -903,6 +902,7 @@ function StageContent({
         const q = QUIZ_QUESTIONS[stage.index];
         return (
             <QuestionScreen
+                key={q.id}
                 q={q}
                 qIndex={stage.index}
                 total={QUIZ_QUESTIONS.length}


### PR DESCRIPTION
## Summary

- **CtaBody**: eliminado efeito cascading + tipo `FormState`; o estado de sucesso agora é derivado diretamente de `submitted && formOpen` durante render
- **AIChat**: `liveAnnouncement` convertido de `useState`+`useEffect` para `useMemo` derivado, preservando a semântica do `aria-live` para screen readers
- **QuizAnhangaLanding**: adicionado `key={q.id}` no render site do `QuestionScreen` para que o React resete o estado automaticamente na troca de pergunta; efeito simplificado para cleanup-only

### Warnings corrigidos (6 de 23)
| Regra | Arquivo | Fix |
|---|---|---|
| `no-event-handler` | CtaBody:13 | Efeito removido |
| `no-chain-state-updates` | CtaBody:14 | Efeito removido |
| `no-derived-state` | AIChat:135 | `useMemo` |
| `no-event-handler` | AIChat:128 | Eliminado com remoção do efeito de liveAnnouncement |
| `no-reset-all-state-on-prop-change` | QuizAnhangaLanding:363 | `key={q.id}` |
| `no-adjust-state-on-prop-change` | QuizAnhangaLanding:364 | `key={q.id}` |

### Warnings documentados como intencionais (17)
| Categoria | Count | Justificativa |
|---|---|---|
| `no-initialize-state` | 6 | Padrão de hidratação SSG — valores browser-only (`window`, `sessionStorage`, cookies) inicializados após mount via efeito para evitar mismatch em prerender |
| `prefer-useReducer` | 4 | Baixo valor / alto risco de regressão para converter 4 componentes a useReducer |
| `no-event-handler` | 2 | Operações DOM pós-render (scroll-to-bottom, focus management) que precisam do timing do useEffect |
| `no-cascading-set-state` | 2 | Deep-link + tracking flows com updates sequenciais necessários |
| `no-adjust-state-on-prop-change` | 1 | IntersectionObserver re-setup quando threshold muda |
| `no-event-handler` (ContactModal) | 1 | Listener de custom event global (`window.addEventListener`) |
| `no-cascading-set-state` (whatsapp) | 1 | Re-captura de tracking com delay intencional |

## Test plan

- [x] `pnpm typecheck` — passa
- [x] `pnpm test:regression` — todos os testes passam (0 failures)
- [x] React Doctor re-scan: 23 → 17 warnings (6 corrigidos, 17 documentados)
- [ ] Testar CtaBody: abrir formulário → preencher → submeter → confirmar tela de sucesso
- [ ] Testar Quiz: navegar entre perguntas → confirmar auto-avanço com feedback visual
- [ ] Testar AIChat: enviar mensagem → confirmar anúncio via screen reader (VoiceOver)

Closes #716, #717, #718, #719, #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)