### PR TITLE
refactor(a11y): migrate 4 modals to native <dialog>

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -157,19 +157,6 @@ const AIChat: React.FC = memo(() => {
     }
   }, [isOpen]);
 
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    const handleCancel = (e: Event) => {
-      e.preventDefault();
-      closeChatDrawer();
-    };
-
-    dialog.addEventListener('cancel', handleCancel);
-    return () => dialog.removeEventListener('cancel', handleCancel);
-  }, []);
-
   const openChatDrawer = (enableHaptics: boolean = true) => {
     triggerRef.current = document.activeElement as HTMLElement | null;
     if (enableHaptics) {
@@ -184,6 +171,29 @@ const AIChat: React.FC = memo(() => {
     }
     setIsOpen(false);
   };
+
+  const closeChatDrawerRef = useRef(closeChatDrawer);
+  useEffect(() => { closeChatDrawerRef.current = closeChatDrawer; });
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleCancel = (e: Event) => {
+      e.preventDefault();
+      closeChatDrawerRef.current();
+    };
+    const handleClick = (e: MouseEvent) => {
+      if (e.target === dialog) closeChatDrawerRef.current();
+    };
+
+    dialog.addEventListener('cancel', handleCancel);
+    dialog.addEventListener('click', handleClick);
+    return () => {
+      dialog.removeEventListener('cancel', handleCancel);
+      dialog.removeEventListener('click', handleClick);
+    };
+  }, []);
 
   const handlePrepareLeadSubmitPayload = (payload: LeadFinalizePayload, eventId: string): SubmitLeadRequest => {
     setLeadDraft({ ...payload });
@@ -421,7 +431,6 @@ const AIChat: React.FC = memo(() => {
         ref={dialogRef}
         className="ai-chat-drawer fixed top-0 right-0 h-full w-full sm:w-[450px] z-[9999] m-0 ml-auto p-0 bg-white flex-col shadow-[-10px_0_40px_rgba(0,0,0,0.1)] sm:rounded-l-[2rem] overflow-hidden outline-none max-h-full max-w-full"
         aria-labelledby="ai-chat-title"
-        onClick={(e) => { if (e.target === dialogRef.current) closeChatDrawer(); }}
       >
         {/* Header - Scrapbook Softness */}
         <div className="bg-white/80 backdrop-blur-md px-6 py-5 border-b border-zinc-100 flex justify-between items-center shrink-0 z-10">

--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -83,15 +83,6 @@ FormattedText.displayName = 'FormattedText';
  * 2. Pre-calculates the last model message index once per update (O(N))
  *    instead of within the render loop (O(N^2)).
  */
-const FOCUSABLE_SELECTOR = [
-  'a[href]',
-  'button:not([disabled])',
-  'input:not([disabled])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  '[tabindex]:not([tabindex="-1"])',
-].join(',');
-
 const AIChat: React.FC = memo(() => {
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState<Message[]>([
@@ -101,7 +92,7 @@ const AIChat: React.FC = memo(() => {
   const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const drawerRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
   const messagesRef = useRef<Message[]>(messages);
   const {
@@ -155,11 +146,29 @@ const AIChat: React.FC = memo(() => {
   }, [messages, isOpen, isLoading]);
 
   useEffect(() => {
-    if (isOpen) {
-      // Focus the drawer panel itself to ensure screen readers announce it immediately
-      drawerRef.current?.focus();
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (isOpen && !dialog.open) {
+      dialog.showModal();
+    } else if (!isOpen && dialog.open) {
+      dialog.close();
+      triggerRef.current?.focus();
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleCancel = (e: Event) => {
+      e.preventDefault();
+      closeChatDrawer();
+    };
+
+    dialog.addEventListener('cancel', handleCancel);
+    return () => dialog.removeEventListener('cancel', handleCancel);
+  }, []);
 
   const openChatDrawer = (enableHaptics: boolean = true) => {
     triggerRef.current = document.activeElement as HTMLElement | null;
@@ -174,7 +183,6 @@ const AIChat: React.FC = memo(() => {
       void triggerHaptic('light');
     }
     setIsOpen(false);
-    triggerRef.current?.focus();
   };
 
   const handlePrepareLeadSubmitPayload = (payload: LeadFinalizePayload, eventId: string): SubmitLeadRequest => {
@@ -305,42 +313,6 @@ const AIChat: React.FC = memo(() => {
     }
   };
 
-  // Focus Trapping Logic
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        closeChatDrawer();
-        return;
-      }
-
-      if (event.key !== 'Tab' || !drawerRef.current) return;
-
-      const focusable = Array.from(
-        drawerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-      ).filter((element) => element.offsetParent !== null);
-      if (focusable.length === 0) return;
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-        return;
-      }
-
-      if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen]);
-
   useEffect(() => {
     const handleToggle = (event: Event) => {
       const customEvent = event as CustomEvent;
@@ -444,25 +416,12 @@ const AIChat: React.FC = memo(() => {
         </div>
       </button>
 
-      {/* Backdrop Overlay */}
-      <button
-        type="button"
-        tabIndex={-1}
-        aria-hidden="true"
-        className={`fixed inset-0 z-[9998] transition-opacity duration-300 ease-in-out bg-brand-dark/20 backdrop-blur-sm border-0 p-0 cursor-default ${isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
-          }`}
-        onClick={() => closeChatDrawer()}
-      />
-
-      {/* Drawer Panel - Soft Scrapbook Geometry */}
-      <div
-        ref={drawerRef}
-        tabIndex={-1}
-        className={`fixed top-0 right-0 h-full w-full sm:w-[450px] z-[9999] bg-white flex flex-col shadow-[-10px_0_40px_rgba(0,0,0,0.1)] transition-all duration-500 ease-[cubic-bezier(0.19,1,0.22,1)] sm:rounded-l-[2rem] overflow-hidden outline-none ${isOpen ? 'translate-x-0 visible opacity-100' : 'translate-x-full invisible opacity-0'
-          }`}
-        role="dialog"
-        aria-modal="true"
+      {/* Drawer Dialog - Soft Scrapbook Geometry */}
+      <dialog
+        ref={dialogRef}
+        className="ai-chat-drawer fixed top-0 right-0 h-full w-full sm:w-[450px] z-[9999] m-0 ml-auto p-0 bg-white flex-col shadow-[-10px_0_40px_rgba(0,0,0,0.1)] sm:rounded-l-[2rem] overflow-hidden outline-none max-h-full max-w-full"
         aria-labelledby="ai-chat-title"
+        onClick={(e) => { if (e.target === dialogRef.current) closeChatDrawer(); }}
       >
         {/* Header - Scrapbook Softness */}
         <div className="bg-white/80 backdrop-blur-md px-6 py-5 border-b border-zinc-100 flex justify-between items-center shrink-0 z-10">
@@ -618,7 +577,7 @@ const AIChat: React.FC = memo(() => {
             Nossa IA pode cometer erros. Confirme os dados no WhatsApp.
           </p>
         </div>
-      </div>
+      </dialog>
     </>
   );
 });

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -60,23 +60,23 @@ const ContactModal: React.FC = () => {
             e.preventDefault();
             closeRef.current();
         };
+        const handleClick = (e: MouseEvent) => {
+            if (e.target === dialog) closeRef.current();
+        };
 
         dialog.addEventListener('cancel', handleCancel);
-        return () => dialog.removeEventListener('cancel', handleCancel);
+        dialog.addEventListener('click', handleClick);
+        return () => {
+            dialog.removeEventListener('cancel', handleCancel);
+            dialog.removeEventListener('click', handleClick);
+        };
     }, []);
-
-    const handleBackdropClick = (e: React.MouseEvent<HTMLDialogElement>) => {
-        if (e.target === dialogRef.current) {
-            close();
-        }
-    };
 
     return (
         <dialog
             ref={dialogRef}
             className="fixed inset-0 z-50 m-auto p-4 bg-transparent backdrop:bg-black/60 backdrop:backdrop-blur-sm max-w-md w-full"
             aria-labelledby={titleId}
-            onClick={handleBackdropClick}
         >
             <div className="relative z-10 w-full overflow-hidden rounded-2xl bg-white shadow-[0_24px_60px_rgba(0,0,0,0.3)]">
                 <div className="flex items-start justify-between p-6 pb-4">

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -3,23 +3,13 @@ import { CheckCircle, X } from '@phosphor-icons/react';
 import { useContactForm } from '../hooks/useContactForm';
 import type { ContactModalOptions } from '../utils/contactForm';
 
-const FOCUSABLE_SELECTOR = [
-    'a[href]',
-    'button:not([disabled])',
-    'input:not([disabled])',
-    'select:not([disabled])',
-    'textarea:not([disabled])',
-    '[tabindex]:not([tabindex="-1"])',
-].join(',');
-
 const ContactModal: React.FC = () => {
     const [isOpen, setIsOpen] = useState(false);
     const [options, setOptions] = useState<ContactModalOptions>({});
     const titleId = useId();
-    const dialogRef = useRef<HTMLDivElement>(null);
+    const dialogRef = useRef<HTMLDialogElement>(null);
     const firstFieldRef = useRef<HTMLInputElement>(null);
     const closeButtonRef = useRef<HTMLButtonElement>(null);
-    const triggerRef = useRef<HTMLElement | null>(null);
     const previousBodyOverflow = useRef<string>('');
 
     const { fields, setField, isValid, isSubmitting, error, submitted, submit, reset } =
@@ -28,7 +18,6 @@ const ContactModal: React.FC = () => {
     const close = useCallback(() => {
         setIsOpen(false);
         reset();
-        triggerRef.current?.focus();
     }, [reset]);
 
     const closeRef = useRef(close);
@@ -36,7 +25,6 @@ const ContactModal: React.FC = () => {
 
     useEffect(() => {
         const handleOpen = (event: Event) => {
-            triggerRef.current = document.activeElement as HTMLElement | null;
             setOptions((event as CustomEvent<ContactModalOptions>).detail ?? {});
             setIsOpen(true);
         };
@@ -46,77 +34,51 @@ const ContactModal: React.FC = () => {
     }, []);
 
     useEffect(() => {
+        const dialog = dialogRef.current;
+        if (!dialog) return;
+
+        if (isOpen && !dialog.open) {
+            previousBodyOverflow.current = document.body.style.overflow;
+            document.body.style.overflow = 'hidden';
+            dialog.showModal();
+            firstFieldRef.current?.focus();
+        } else if (!isOpen && dialog.open) {
+            dialog.close();
+            document.body.style.overflow = previousBodyOverflow.current;
+        }
+    }, [isOpen]);
+
+    useEffect(() => {
         if (submitted) closeButtonRef.current?.focus();
     }, [submitted]);
 
     useEffect(() => {
-        if (!isOpen) return;
+        const dialog = dialogRef.current;
+        if (!dialog) return;
 
-        firstFieldRef.current?.focus();
-        previousBodyOverflow.current = document.body.style.overflow;
-        document.body.style.overflow = 'hidden';
-
-        return () => {
-            document.body.style.overflow = previousBodyOverflow.current;
-        };
-    }, [isOpen]);
-
-    useEffect(() => {
-        if (!isOpen) return;
-
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                closeRef.current();
-                return;
-            }
-
-            if (event.key !== 'Tab' || !dialogRef.current) return;
-
-            const focusable = Array.from(
-                dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-            ).filter((element) => element.offsetParent !== null);
-            if (focusable.length === 0) return;
-
-            const first = focusable[0];
-            const last = focusable[focusable.length - 1];
-
-            if (event.shiftKey && document.activeElement === first) {
-                event.preventDefault();
-                last.focus();
-                return;
-            }
-
-            if (!event.shiftKey && document.activeElement === last) {
-                event.preventDefault();
-                first.focus();
-            }
+        const handleCancel = (e: Event) => {
+            e.preventDefault();
+            closeRef.current();
         };
 
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [isOpen]);
+        dialog.addEventListener('cancel', handleCancel);
+        return () => dialog.removeEventListener('cancel', handleCancel);
+    }, []);
 
-    if (!isOpen) return null;
+    const handleBackdropClick = (e: React.MouseEvent<HTMLDialogElement>) => {
+        if (e.target === dialogRef.current) {
+            close();
+        }
+    };
 
     return (
-        <div
-            className="fixed inset-0 z-50 flex items-center justify-center p-4"
-            role="presentation"
+        <dialog
+            ref={dialogRef}
+            className="fixed inset-0 z-50 m-auto p-4 bg-transparent backdrop:bg-black/60 backdrop:backdrop-blur-sm max-w-md w-full"
+            aria-labelledby={titleId}
+            onClick={handleBackdropClick}
         >
-            <button
-                type="button"
-                className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-                onClick={close}
-                aria-label="Fechar formulário"
-            />
-
-            <div
-                ref={dialogRef}
-                role="dialog"
-                aria-modal="true"
-                aria-labelledby={titleId}
-                className="relative z-10 w-full max-w-md overflow-hidden rounded-2xl bg-white shadow-[0_24px_60px_rgba(0,0,0,0.3)]"
-            >
+            <div className="relative z-10 w-full overflow-hidden rounded-2xl bg-white shadow-[0_24px_60px_rgba(0,0,0,0.3)]">
                 <div className="flex items-start justify-between p-6 pb-4">
                     <div>
                         <p className="mb-1 text-xs font-black uppercase tracking-widest text-brand-vibrant">
@@ -277,7 +239,7 @@ const ContactModal: React.FC = () => {
                     </form>
                 )}
             </div>
-        </div>
+        </dialog>
     );
 };
 

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -82,7 +82,7 @@ const ContactModal: React.FC = () => {
             className="fixed inset-0 z-50 m-auto p-4 bg-transparent backdrop:bg-black/60 backdrop:backdrop-blur-sm max-w-md w-full"
             aria-labelledby={titleId}
         >
-            <div className="relative z-10 w-full overflow-hidden rounded-2xl bg-white shadow-[0_24px_60px_rgba(0,0,0,0.3)]">
+            {isOpen && <div className="relative z-10 w-full overflow-hidden rounded-2xl bg-white shadow-[0_24px_60px_rgba(0,0,0,0.3)]">
                 <div className="flex items-start justify-between p-6 pb-4">
                     <div>
                         <p className="mb-1 text-xs font-black uppercase tracking-widest text-brand-vibrant">
@@ -242,7 +242,7 @@ const ContactModal: React.FC = () => {
                         </div>
                     </form>
                 )}
-            </div>
+            </div>}
         </dialog>
     );
 };

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -46,6 +46,10 @@ const ContactModal: React.FC = () => {
             dialog.close();
             document.body.style.overflow = previousBodyOverflow.current;
         }
+
+        return () => {
+            document.body.style.overflow = previousBodyOverflow.current;
+        };
     }, [isOpen]);
 
     useEffect(() => {

--- a/components/Destinations.tsx
+++ b/components/Destinations.tsx
@@ -366,8 +366,16 @@ const Destinations: React.FC = memo(() => {
             closeModal();
         };
 
+        const handleClick = (e: MouseEvent) => {
+            if (e.target === dialog) closeModal();
+        };
+
         dialog.addEventListener('cancel', handleCancel);
-        return () => dialog.removeEventListener('cancel', handleCancel);
+        dialog.addEventListener('click', handleClick);
+        return () => {
+            dialog.removeEventListener('cancel', handleCancel);
+            dialog.removeEventListener('click', handleClick);
+        };
     }, [closeModal]);
 
     // Map Init
@@ -681,7 +689,6 @@ const Destinations: React.FC = memo(() => {
                 ref={destinationModalRef}
                 className="fixed inset-0 z-[9999] m-auto p-4 bg-transparent backdrop:bg-zinc-900/60 backdrop:backdrop-blur-sm max-w-4xl w-full"
                 aria-labelledby="dest-modal-title"
-                onClick={(e) => { if (e.target === destinationModalRef.current) closeModal(); }}
             >
                 {selectedDestination && (
                     <div

--- a/components/Destinations.tsx
+++ b/components/Destinations.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useMemo, memo } from 'react';
+import React, { useEffect, useRef, useState, useMemo, memo, useCallback } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { MapPin, X, Calendar, ArrowRight, Star, Compass, MousePointerClick, Share2, Image as ImageIcon, Loader2, Plus, Minus, Share } from 'lucide-react';
@@ -330,55 +330,45 @@ const CONTINENT_COLORS: Record<string, string> = {
  * This is particularly important because this component initializes a Leaflet map and
  * iterates over a large set of destination markers and cards.
  */
-const FOCUSABLE_SELECTOR = 'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
-
 const Destinations: React.FC = memo(() => {
     const mapRef = useRef<HTMLDivElement>(null);
     const mapInstance = useRef<L.Map | null>(null);
     const markersLayerRef = useRef<L.FeatureGroup | null>(null);
-    const destinationModalRef = useRef<HTMLDivElement>(null);
-    const previousFocusRef = useRef<HTMLElement | null>(null);
+    const destinationModalRef = useRef<HTMLDialogElement>(null);
 
     const [activeFilter, setActiveFilter] = useState('Todos');
     const [selectedDestination, setSelectedDestination] = useState<Destination | null>(null);
-
 
     const filteredDestinations = useMemo(() => {
         if (activeFilter === 'Todos') return DESTINATIONS;
         return DESTINATIONS.filter(d => d.continent === activeFilter);
     }, [activeFilter]);
 
+    const closeModal = useCallback(() => setSelectedDestination(null), []);
 
-
-    // Modal focus trap + restoration
     useEffect(() => {
-        if (!selectedDestination) return;
-        previousFocusRef.current = document.activeElement as HTMLElement;
-        const modal = destinationModalRef.current;
-        if (!modal) return;
-        const visibleFocusable = () => Array.from(modal.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(el => el.offsetParent !== null);
-        visibleFocusable()[0]?.focus();
+        const dialog = destinationModalRef.current;
+        if (!dialog) return;
 
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') { setSelectedDestination(null); return; }
-            if (e.key !== 'Tab') return;
-            const focusable = visibleFocusable();
-            if (focusable.length === 0) return;
-            const first = focusable[0];
-            const last = focusable[focusable.length - 1];
-            if (e.shiftKey) {
-                if (document.activeElement === first) { e.preventDefault(); last.focus(); }
-            } else {
-                if (document.activeElement === last) { e.preventDefault(); first.focus(); }
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-            previousFocusRef.current?.focus();
-        };
+        if (selectedDestination && !dialog.open) {
+            dialog.showModal();
+        } else if (!selectedDestination && dialog.open) {
+            dialog.close();
+        }
     }, [selectedDestination]);
+
+    useEffect(() => {
+        const dialog = destinationModalRef.current;
+        if (!dialog) return;
+
+        const handleCancel = (e: Event) => {
+            e.preventDefault();
+            closeModal();
+        };
+
+        dialog.addEventListener('cancel', handleCancel);
+        return () => dialog.removeEventListener('cancel', handleCancel);
+    }, [closeModal]);
 
     // Map Init
     useEffect(() => {
@@ -687,19 +677,15 @@ const Destinations: React.FC = memo(() => {
             </div>
 
             {/* Modal - Scrapbook Page Style */}
-            {selectedDestination && (
-                <div
-                    role="presentation"
-                    className="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-zinc-900/60 backdrop-blur-sm"
-                    onClick={() => setSelectedDestination(null)}
-                >
+            <dialog
+                ref={destinationModalRef}
+                className="fixed inset-0 z-[9999] m-auto p-4 bg-transparent backdrop:bg-zinc-900/60 backdrop:backdrop-blur-sm max-w-4xl w-full"
+                aria-labelledby="dest-modal-title"
+                onClick={(e) => { if (e.target === destinationModalRef.current) closeModal(); }}
+            >
+                {selectedDestination && (
                     <div
-                        ref={destinationModalRef}
-                        role="dialog"
-                        aria-modal="true"
-                        aria-labelledby="dest-modal-title"
-                        className="bg-brand-surface w-full max-w-4xl rounded-[2.5rem] shadow-2xl overflow-hidden relative flex flex-col md:flex-row max-h-[90vh] border-8 border-white transform rotate-1"
-                        onClick={e => e.stopPropagation()}
+                        className="bg-brand-surface w-full rounded-[2.5rem] shadow-2xl overflow-hidden relative flex flex-col md:flex-row max-h-[90vh] border-8 border-white transform rotate-1"
                     >
 
                         {/* Washi Tape Decor */}
@@ -707,7 +693,7 @@ const Destinations: React.FC = memo(() => {
 
                         <button
                             type="button"
-                            onClick={() => setSelectedDestination(null)}
+                            onClick={closeModal}
                             className="absolute top-4 right-4 z-30 bg-white border-2 border-zinc-100 p-2 rounded-full shadow-md hover:scale-110 transition-transform text-zinc-800"
                             aria-label="Fechar detalhes do destino"
                         >
@@ -758,7 +744,7 @@ const Destinations: React.FC = memo(() => {
                                 {selectedDestination.landingPage && (
                                     <Link
                                         to={selectedDestination.landingPage}
-                                        onClick={() => setSelectedDestination(null)}
+                                        onClick={closeModal}
                                         className="w-full bg-white border-2 border-brand-dark text-brand-dark py-4 rounded-xl font-black text-lg hover:bg-zinc-50 transition shadow-[4px_4px_0px_#0f172a] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2"
                                     >
                                         Ver detalhes do pacote <ArrowRight className="size-5" />
@@ -772,7 +758,7 @@ const Destinations: React.FC = memo(() => {
                                             source: 'destinations-modal',
                                             destination: selectedDestination.city,
                                         });
-                                        setSelectedDestination(null);
+                                        closeModal();
                                     }}
                                     className={`btn-whatsapp btn-specialist w-full bg-brand-dark text-white py-4 rounded-xl font-black text-lg hover:bg-brand-vibrant transition shadow-[4px_4px_0px_#94a3b8] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2`}
                                     data-tracking={`modal-destinations-${selectedDestination.city.toLowerCase()}`}
@@ -782,8 +768,8 @@ const Destinations: React.FC = memo(() => {
                             </div>
                         </div>
                     </div>
-                </div>
-            )}
+                )}
+            </dialog>
         </section>
     );
 });

--- a/components/landings/beto-carrero/DestinationsModal.tsx
+++ b/components/landings/beto-carrero/DestinationsModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { Sun, Fish, Building2, X } from 'lucide-react';
 import Button from './Button';
 
@@ -7,25 +8,47 @@ interface DestinationsModalProps {
 }
 
 export function DestinationsModal({ isOpen, onClose }: DestinationsModalProps) {
-  if (!isOpen) return null;
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (isOpen && !dialog.open) {
+      dialog.showModal();
+    } else if (!isOpen && dialog.open) {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleCancel = (e: Event) => {
+      e.preventDefault();
+      onClose();
+    };
+
+    dialog.addEventListener('cancel', handleCancel);
+    return () => dialog.removeEventListener('cancel', handleCancel);
+  }, [onClose]);
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDialogElement>) => {
+    if (e.target === dialogRef.current) {
+      onClose();
+    }
+  };
 
   return (
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center p-4 animate-[fadeIn_0.2s_ease-out]"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-[100] m-auto p-4 bg-transparent backdrop:bg-fun-dark/80 backdrop:backdrop-blur-sm animate-[fadeIn_0.2s_ease-out] max-w-lg w-full"
+      aria-label="Destinos Extras"
+      onClick={handleBackdropClick}
     >
-      {/* Backdrop */}
-      <button
-        type="button"
-        tabIndex={-1}
-        aria-hidden="true"
-        className="absolute inset-0 bg-fun-dark/80 backdrop-blur-sm transition-opacity w-full h-full border-0 p-0 cursor-default"
-        onClick={onClose}
-      />
-
       {/* Modal Content */}
-      <div className="relative bg-white w-full max-w-lg rounded-3xl border-4 border-fun-dark shadow-hard-lg p-6 md:p-8 animate-[scaleIn_0.3s_cubic-bezier(0.16,1,0.3,1)] overflow-hidden">
+      <div className="relative bg-white w-full rounded-3xl border-4 border-fun-dark shadow-hard-lg p-6 md:p-8 animate-[scaleIn_0.3s_cubic-bezier(0.16,1,0.3,1)] overflow-hidden">
 
         {/* Close Button */}
         <button
@@ -100,6 +123,6 @@ export function DestinationsModal({ isOpen, onClose }: DestinationsModalProps) {
         </div>
 
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/components/landings/beto-carrero/DestinationsModal.tsx
+++ b/components/landings/beto-carrero/DestinationsModal.tsx
@@ -29,23 +29,23 @@ export function DestinationsModal({ isOpen, onClose }: DestinationsModalProps) {
       e.preventDefault();
       onClose();
     };
+    const handleClick = (e: MouseEvent) => {
+      if (e.target === dialog) onClose();
+    };
 
     dialog.addEventListener('cancel', handleCancel);
-    return () => dialog.removeEventListener('cancel', handleCancel);
+    dialog.addEventListener('click', handleClick);
+    return () => {
+      dialog.removeEventListener('cancel', handleCancel);
+      dialog.removeEventListener('click', handleClick);
+    };
   }, [onClose]);
-
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDialogElement>) => {
-    if (e.target === dialogRef.current) {
-      onClose();
-    }
-  };
 
   return (
     <dialog
       ref={dialogRef}
       className="fixed inset-0 z-[100] m-auto p-4 bg-transparent backdrop:bg-fun-dark/80 backdrop:backdrop-blur-sm animate-[fadeIn_0.2s_ease-out] max-w-lg w-full"
       aria-label="Destinos Extras"
-      onClick={handleBackdropClick}
     >
       {/* Modal Content */}
       <div className="relative bg-white w-full rounded-3xl border-4 border-fun-dark shadow-hard-lg p-6 md:p-8 animate-[scaleIn_0.3s_cubic-bezier(0.16,1,0.3,1)] overflow-hidden">

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,52 @@
     }
 }
 
+/* AIChat drawer: animate open/close via @starting-style (Chrome 117+, FF 129+, Safari 17.5+) */
+.ai-chat-drawer {
+    transition:
+        transform 500ms cubic-bezier(0.19, 1, 0.22, 1),
+        opacity 500ms cubic-bezier(0.19, 1, 0.22, 1),
+        overlay 500ms cubic-bezier(0.19, 1, 0.22, 1) allow-discrete,
+        display 500ms cubic-bezier(0.19, 1, 0.22, 1) allow-discrete;
+    transform: translateX(100%);
+    opacity: 0;
+}
+
+.ai-chat-drawer[open] {
+    display: flex;
+    transform: translateX(0);
+    opacity: 1;
+}
+
+@starting-style {
+    .ai-chat-drawer[open] {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+}
+
+.ai-chat-drawer::backdrop {
+    transition:
+        background-color 300ms ease-in-out,
+        backdrop-filter 300ms ease-in-out,
+        overlay 300ms ease-in-out allow-discrete,
+        display 300ms ease-in-out allow-discrete;
+    background-color: rgb(15 23 42 / 0);
+    backdrop-filter: blur(0);
+}
+
+.ai-chat-drawer[open]::backdrop {
+    background-color: rgb(15 23 42 / 0.2);
+    backdrop-filter: blur(4px);
+}
+
+@starting-style {
+    .ai-chat-drawer[open]::backdrop {
+        background-color: rgb(15 23 42 / 0);
+        backdrop-filter: blur(0);
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
         animation-duration: 0.01ms !important;

--- a/tests/e2e/pages/AIChat.ts
+++ b/tests/e2e/pages/AIChat.ts
@@ -12,7 +12,7 @@ export class AIChat {
 
   constructor(page: Page) {
     this.page = page;
-    this.chatDialog = page.locator('div[role="dialog"][aria-labelledby="ai-chat-title"]');
+    this.chatDialog = page.locator('dialog[aria-labelledby="ai-chat-title"]');
     this.inputField = page.locator('textarea[placeholder="Digite sua dúvida aqui..."]');
     this.sendBtn = page.locator('button[aria-label="Enviar mensagem"]');
     this.closeBtn = page.locator('button[aria-label="Fechar gaveta"]');
@@ -22,9 +22,8 @@ export class AIChat {
   }
 
   async open() {
-    // The drawer hides via translateX (not display:none), so chatDialog.isVisible()
-    // returns true even when closed. Instead, check the open button: it becomes
-    // opacity-0 (invisible to Playwright) when the drawer is open.
+    // The drawer uses a <dialog> that animates via translateX. Check the open button
+    // visibility (it becomes opacity-0 when the drawer is open) as the reliable signal.
     if (await this.openBtn.isVisible()) {
       await this.openBtn.click();
       // Wait for the drawer slide-in animation (500ms) to complete by confirming


### PR DESCRIPTION
## Summary

- Migrates all 4 modals from `role="dialog"` on `<div>` to native `<dialog>` element with `showModal()`/`close()`
- **DestinationsModal** (Beto Carrero): backdrop via `::backdrop`, `cancel` event for Escape
- **ContactModal**: removes ~30 lines of `FOCUSABLE_SELECTOR` + Tab cycling + Escape handler; keeps body scroll-lock for Safari
- **Destinations modal**: removes focus trap effect + `previousFocusRef`
- **AIChat drawer**: uses `@starting-style` + `transition-behavior: allow-discrete` for smooth slide-in/out animation; removes `isClosing` state machine
- Updates `AIChat.ts` Playwright page object selector (`div[role="dialog"]` → `dialog`)
- Net result: **-25 lines** — less code, better a11y

## Gains
- Native focus trap (no manual Tab cycling)
- Native Escape dismiss (no `keydown` listeners)
- Top-layer rendering (no z-index stacking issues)
- Correct accessibility tree (no `role`/`aria-modal` attributes needed)
- Native `::backdrop` pseudo-element

## Browser support
- `@starting-style` for AIChat animations: Chrome 117+, Firefox 129+, Safari 17.5+
- `<dialog>` element: supported in all modern browsers

## Test plan
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm build` — successful production build
- [x] `pnpm test:regression` — 445/445 tests passing
- [x] Visual test: AIChat drawer (mobile + desktop) — slide-in/slide-out confirmed via frame sampling
- [x] Visual test: ContactModal — opens with backdrop, focus on first field
- [x] Visual test: Destinations modal — opens with washi tape decor, close works
- [x] Visual test: DestinationsModal (Beto Carrero) — opens with backdrop blur
- [x] Console errors: zero across all pages
- [ ] `pnpm test:e2e` — E2E suite (CI)
- [ ] Safari manual test (scroll-lock, `@starting-style` animation)

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)