### PR TITLE
feat(seo): add cross-links to melhor-idade and corporativo landings

### DIFF
--- a/pages/landings/CorporativoLanding.tsx
+++ b/pages/landings/CorporativoLanding.tsx
@@ -38,6 +38,22 @@ const CorporativoLanding: React.FC = () => {
                 <CorpPillars />
                 <CorpWhatsAppBand />
                 <CorpContactSection />
+                <nav aria-label="Outros serviços" className="bg-brand-surface py-12 border-t border-zinc-100">
+                    <div className="container mx-auto px-6 text-center">
+                        <p className="text-sm text-zinc-500 font-medium mb-4">Conheça também</p>
+                        <div className="flex flex-wrap justify-center gap-3">
+                            <a href="https://www.anhanga.tur.br/consultoria-de-viagem/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+                                Consultoria de Viagem
+                            </a>
+                            <a href="https://www.anhanga.tur.br/melhor-idade/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+                                Viagens Melhor Idade
+                            </a>
+                            <a href="https://www.anhanga.tur.br/curadoria-cruzeiros-brasil/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+                                Cruzeiros pelo Brasil
+                            </a>
+                        </div>
+                    </div>
+                </nav>
                 <CorpFooter />
             </div>
         </>

--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -219,7 +219,7 @@ const MelhorIdadeLanding: React.FC = () => {
             <a href="https://www.anhanga.tur.br/consultoria-de-viagem/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
               Consultoria de Viagem
             </a>
-            <a href="/blog/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
+            <a href="https://www.anhanga.tur.br/blog/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
               Dicas de Viagem
             </a>
           </div>

--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -212,6 +212,17 @@ const MelhorIdadeLanding: React.FC = () => {
           >
             Falar com um Consultor
           </button>
+          <div className="flex flex-wrap justify-center gap-3 mt-8 relative z-10">
+            <a href="https://www.anhanga.tur.br/curadoria-cruzeiros-brasil/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
+              Cruzeiros pelo Brasil
+            </a>
+            <a href="https://www.anhanga.tur.br/consultoria-de-viagem/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
+              Consultoria de Viagem
+            </a>
+            <a href="/blog/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
+              Dicas de Viagem
+            </a>
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary

- Add cross-links to **melhor-idade** landing page (cruzeiros, consultoria, blog)
- Add cross-links to **corporativo** landing page (consultoria, melhor-idade, cruzeiros)

**Why:** Google Search Console crawl stats (24–28 May 2026) show only 5.8% discovery crawls. These two landing pages had zero outbound internal links to sibling services, creating dead-ends for Googlebot.

## Investigation findings

- Cache immutable headers already configured (#752 — closed, already done)
- 301 redirects are from legitimate old-URL rules, no internal links affected (#753 — closed, no fix needed)
- Sitemap is auto-generated with `lastmod` dates and all routes are pre-rendered via SSR
- Google sitemap ping endpoint has been deprecated (returns 404) — workflow not added
- The 60% JS in crawl budget is render-verification resource loading, not an indexing issue (SSR prerender covers all routes)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:regression` — 445 tests pass
- [ ] Visual check: cross-links render correctly on melhor-idade and corporativo pages

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)