### PR TITLE
fix(seo): return 410 Gone for removed pages tracked by GSC

### DIFF
--- a/functions/blog/1.ts
+++ b/functions/blog/1.ts
@@ -1,0 +1,12 @@
+// /blog/1 (old pagination) was removed. Return 410 Gone.
+export const onRequest = () =>
+  new Response(
+    '<!DOCTYPE html><html><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida. Visite nosso <a href="/blog">blog</a>.</p></body></html>',
+    {
+      status: 410,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'X-Robots-Tag': 'noindex',
+      },
+    },
+  );

--- a/functions/blog/1.ts
+++ b/functions/blog/1.ts
@@ -1,7 +1,7 @@
 // /blog/1 (old pagination) was removed. Return 410 Gone.
 export const onRequest = () =>
   new Response(
-    '<!DOCTYPE html><html><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida. Visite nosso <a href="/blog">blog</a>.</p></body></html>',
+    '<!DOCTYPE html><html lang="pt-BR"><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida. Visite nosso <a href="/blog/">blog</a>.</p></body></html>',
     {
       status: 410,
       headers: {

--- a/functions/cookies.ts
+++ b/functions/cookies.ts
@@ -1,7 +1,7 @@
 // /cookies was removed (merged into /politica-privacidade). Return 410 Gone.
 export const onRequest = () =>
   new Response(
-    '<!DOCTYPE html><html><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida. Consulte nossa <a href="/politica-privacidade">Política de Privacidade</a>.</p></body></html>',
+    '<!DOCTYPE html><html lang="pt-BR"><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida. Consulte nossa <a href="/politica-privacidade/">Política de Privacidade</a>.</p></body></html>',
     {
       status: 410,
       headers: {

--- a/functions/cookies.ts
+++ b/functions/cookies.ts
@@ -1,0 +1,12 @@
+// /cookies was removed (merged into /politica-privacidade). Return 410 Gone.
+export const onRequest = () =>
+  new Response(
+    '<!DOCTYPE html><html><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida. Consulte nossa <a href="/politica-privacidade">Política de Privacidade</a>.</p></body></html>',
+    {
+      status: 410,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'X-Robots-Tag': 'noindex',
+      },
+    },
+  );

--- a/functions/experiencias/[[path]].ts
+++ b/functions/experiencias/[[path]].ts
@@ -1,0 +1,12 @@
+// All /experiencias/* pages were removed. Return 410 Gone so search engines deindex them.
+export const onRequest = () =>
+  new Response(
+    '<!DOCTYPE html><html><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida permanentemente.</p></body></html>',
+    {
+      status: 410,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'X-Robots-Tag': 'noindex',
+      },
+    },
+  );

--- a/functions/experiencias/[[path]].ts
+++ b/functions/experiencias/[[path]].ts
@@ -1,7 +1,7 @@
 // All /experiencias/* pages were removed. Return 410 Gone so search engines deindex them.
 export const onRequest = () =>
   new Response(
-    '<!DOCTYPE html><html><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida permanentemente.</p></body></html>',
+    '<!DOCTYPE html><html lang="pt-BR"><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida permanentemente.</p></body></html>',
     {
       status: 410,
       headers: {

--- a/functions/viagens.ts
+++ b/functions/viagens.ts
@@ -1,0 +1,12 @@
+// /viagens?q= search page was removed. Return 410 Gone.
+export const onRequest = () =>
+  new Response(
+    '<!DOCTYPE html><html><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida permanentemente.</p></body></html>',
+    {
+      status: 410,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'X-Robots-Tag': 'noindex',
+      },
+    },
+  );

--- a/functions/viagens.ts
+++ b/functions/viagens.ts
@@ -1,7 +1,7 @@
 // /viagens?q= search page was removed. Return 410 Gone.
 export const onRequest = () =>
   new Response(
-    '<!DOCTYPE html><html><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida permanentemente.</p></body></html>',
+    '<!DOCTYPE html><html lang="pt-BR"><head><meta name="robots" content="noindex"></head><body><h1>410 Gone</h1><p>Esta página foi removida permanentemente.</p></body></html>',
     {
       status: 410,
       headers: {


### PR DESCRIPTION
## Summary

- Google Search Console reports 7 dead URLs as "crawled but not indexed" because they fall through to the SPA shell (soft 404)
- Added Cloudflare Pages Functions that return proper HTTP 410 (Gone) status codes with `X-Robots-Tag: noindex` headers
- Once deployed and re-crawled, Google will permanently deindex these orphan URLs

## Affected URLs

| Function | URLs covered |
|----------|-------------|
| `functions/experiencias/[[path]].ts` | `/experiencias/expedicoes-reconexao`, `/experiencias/vivencias-interculturais`, `/experiencias/transformacao-corporativa`, `/experiencias/natureza-aventura` |
| `functions/cookies.ts` | `/cookies` |
| `functions/viagens.ts` | `/viagens?q={search_term_string}` |
| `functions/blog/1.ts` | `/blog/1` |

## Context

From the GSC coverage report (2026-05-31), 27 pages are not indexed:
- 10 are intentional (noindex, redirects, canonical alternates, robots.txt) ✅
- 17 need attention — of which 8 are "crawled but not indexed" ghost pages from a previous site version

## Test plan

- [ ] Deploy to preview and verify `curl -I https://preview.../experiencias/foo` returns 410
- [ ] Verify existing routes (`/`, `/blog`, `/orlando`, etc.) are unaffected
- [ ] After production deploy, click "Validate fix" in GSC for the "Crawled, not indexed" category

🤖 Generated with [Claude Code](https://claude.com/claude-code)