### PR TITLE
fix(e2e): block HubSpot tracking domains to prevent CRM pollution

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,9 +18,20 @@ export default defineConfig({
     baseURL: BASE_URL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    // Block Mautic tracking during tests — prevents anonymous contacts from being created in production Mautic
+    // Block third-party tracking during tests — prevents test data from polluting production CRMs
     launchOptions: {
-      args: ['--host-resolver-rules=MAP mkt.anhanga.tur.br ~NOTFOUND'],
+      args: [
+        '--host-resolver-rules='
+        + 'MAP mkt.anhanga.tur.br ~NOTFOUND, '
+        + 'MAP *.hubspot.com ~NOTFOUND, '
+        + 'MAP *.hsforms.com ~NOTFOUND, '
+        + 'MAP *.hsforms.net ~NOTFOUND, '
+        + 'MAP *.hscollectedforms.net ~NOTFOUND, '
+        + 'MAP *.hs-scripts.com ~NOTFOUND, '
+        + 'MAP *.hs-analytics.net ~NOTFOUND, '
+        + 'MAP *.hs-banner.com ~NOTFOUND, '
+        + 'MAP *.usemessages.com ~NOTFOUND',
+      ],
     },
   },
 

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -85,7 +85,7 @@ test.describe('Corporativo Landing Page', () => {
 
     page.on('requestfinished', (req) => {
       const url = req.url();
-      if (/hubspot|hsforms|hscollectedforms|hs-scripts|hs-analytics/i.test(url)) {
+      if (/hubspot|hsforms|hscollectedforms|hs-scripts|hs-analytics|hs-banner|usemessages/i.test(url)) {
         hubspotRequests.push(url);
       }
     });
@@ -112,8 +112,7 @@ test.describe('Corporativo Landing Page', () => {
     await landing.submit();
     await landing.expectSuccess();
 
-    // Allow time for any async tracking to attempt
-    await page.waitForTimeout(2000);
+    await page.waitForTimeout(500);
 
     expect(hubspotRequests).toEqual([]);
   });

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -80,6 +80,44 @@ test.describe('Corporativo Landing Page', () => {
     });
   });
 
+  test('should not leak form data to HubSpot tracking', async ({ page }) => {
+    const hubspotRequests: string[] = [];
+
+    page.on('requestfinished', (req) => {
+      const url = req.url();
+      if (/hubspot|hsforms|hscollectedforms|hs-scripts|hs-analytics/i.test(url)) {
+        hubspotRequests.push(url);
+      }
+    });
+
+    await page.route('**/api/submit-lead', async route => {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, requestId: 'corp-no-leak' }),
+      });
+    });
+
+    const landing = new CorporativoPage(page);
+    await landing.goto();
+    await landing.fillForm({
+      firstName: 'Teste',
+      lastName: 'Regressão',
+      email: 'regressao@teste.com.br',
+      whatsapp: '(11) 99999-0000',
+      empresa: 'Empresa Fictícia',
+      cargo: 'QA',
+    });
+
+    await landing.submit();
+    await landing.expectSuccess();
+
+    // Allow time for any async tracking to attempt
+    await page.waitForTimeout(2000);
+
+    expect(hubspotRequests).toEqual([]);
+  });
+
   test('should handle navigation to #contato anchor', async ({ page, isMobile }) => {
     const landing = new CorporativoPage(page);
     await landing.goto();


### PR DESCRIPTION
## Summary

- Expands Chromium `--host-resolver-rules` in `playwright.config.ts` to block all HubSpot tracking domains (with wildcards) during E2E tests, preventing test form data from creating real contacts in production HubSpot
- Adds regression test in `corporativo.spec.ts` verifying no HubSpot requests succeed during form submission

## Root Cause

HubSpot's "Collected Forms" feature (loaded via `js.hs-scripts.com`) automatically captures any DOM form submission and POSTs data directly to `*.hsforms.com` — completely bypassing Playwright's `page.route()` mocks on `/api/submit-lead`. This is the same class of bug previously fixed for Mautic tracking (`mkt.anhanga.tur.br`).

## Test plan

- [x] All 5 corporativo E2E tests pass (Chromium)
- [x] New regression test `should not leak form data to HubSpot tracking` asserts zero successful HubSpot requests after form submit
- [x] TypeScript typecheck passes
- [x] Build succeeds

## Notes

The DNS block via `host-resolver-rules` is Chromium-only, which covers CI (Chromium + Mobile Chrome). Local cross-browser runs (webkit/firefox) are not affected by this flag — a `context.route()` fixture would be needed for full cross-browser coverage if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)