### PR TITLE
fix(reviews): fix direct-run detection for tsx runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:update-snapshots": "playwright test tests/e2e/visual.spec.ts --update-snapshots",
     "test:size": "bundlesize --config bundlesize.config.json",
     "prepare": "node scripts/install-hooks.mjs",
-    "reviews:fetch": "tsx scripts/fetch-google-reviews.ts",
+    "reviews:fetch": "tsx --env-file=.env --env-file=.env.local scripts/fetch-google-reviews.ts",
     "update:dates": "node scripts/update-post-dates.mjs --all",
     "doctor": "react-doctor"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:update-snapshots": "playwright test tests/e2e/visual.spec.ts --update-snapshots",
     "test:size": "bundlesize --config bundlesize.config.json",
     "prepare": "node scripts/install-hooks.mjs",
-    "reviews:fetch": "tsx --env-file=.env --env-file=.env.local scripts/fetch-google-reviews.ts",
+    "reviews:fetch": "tsx scripts/fetch-google-reviews.ts",
     "update:dates": "node scripts/update-post-dates.mjs --all",
     "doctor": "react-doctor"
   },

--- a/scripts/fetch-google-reviews.ts
+++ b/scripts/fetch-google-reviews.ts
@@ -1,9 +1,10 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { cleanString } from '../lib/lead-logic';
 import type { GoogleReview, GoogleReviewsData, ReviewAnnotations, ReviewsBlocklist } from '../types/reviews';
 
-for (const file of ['.env', '.env.local']) {
+for (const file of ['.env.local', '.env']) {
   const path = resolve(process.cwd(), file);
   if (existsSync(path) && typeof process.loadEnvFile === 'function') {
     process.loadEnvFile(path);
@@ -226,9 +227,7 @@ async function main() {
   }, null, 2));
 }
 
-const scriptPath = new URL(import.meta.url).pathname;
-const isDirectRun = scriptPath.endsWith('/fetch-google-reviews.ts') &&
-  !process.argv[1]?.includes('.test.');
+const isDirectRun = !!process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
 
 if (isDirectRun) {
   main().catch((err) => {

--- a/scripts/fetch-google-reviews.ts
+++ b/scripts/fetch-google-reviews.ts
@@ -226,7 +226,9 @@ async function main() {
   }, null, 2));
 }
 
-const isDirectRun = import.meta.url === `file://${process.argv[1]}`;
+const scriptPath = new URL(import.meta.url).pathname;
+const isDirectRun = scriptPath.endsWith('/fetch-google-reviews.ts') &&
+  !process.argv[1]?.includes('.test.');
 
 if (isDirectRun) {
   main().catch((err) => {


### PR DESCRIPTION
## Summary
- `import.meta.url` returns an absolute `file://` URL while `process.argv[1]` is the relative path passed to `tsx`, so the strict equality check never matched
- `main()` never executed — the script silently did nothing
- Now uses pathname check with test file exclusion

## Test plan
- [ ] `pnpm reviews:fetch` with valid `OUTSCRAPER_API_KEY` in `.env.local` — should print progress and write `data/googleReviews.json`
- [ ] `npx tsx --test tests/fetch-google-reviews.test.ts` — all 7 tests pass, `main()` does not fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)