### PR TITLE
fix(reviews): handle async Outscraper API + populate real data

### DIFF
--- a/data/googleReviews.json
+++ b/data/googleReviews.json
@@ -1,7 +1,24 @@
 {
-  "placeId": "",
-  "averageRating": 0,
-  "totalReviews": 0,
-  "lastFetched": "",
-  "reviews": []
+  "placeId": "ChIJ65P6-_G9oycRruws5FfoRDs",
+  "averageRating": 5,
+  "totalReviews": 2,
+  "lastFetched": "2026-06-01T01:17:32.849Z",
+  "reviews": [
+    {
+      "id": "Ci9DQUlRQUNvZENodHljRjlvT25JMVpVeFFORWR6VWxrdFVrcHpWSE5xY2xGQ00yYxAB",
+      "authorName": "Daryw Mena",
+      "rating": 5,
+      "text": "Gostaria de tornar público a experiência incrível que vivi do início ao fim com essa agência. Desde o primeiro contato, senti um acolhimento e atendimento diferente e especial. Atenciosos e preocupados com os detalhes, eles fizeram toda a diferença no atendimento e na entrega da viagem. Foi tudo perfeito! Foram dias incríveis e recebi todo o suporte necessário. Valeu cada centavo. Não viajo mais sem vocês! Parabéns, sucesso, vida longa e até a próxima viagem!!",
+      "date": "2025-08-08",
+      "photoUrl": ""
+    },
+    {
+      "id": "Ci9DQUlRQUNvZENodHljRjlvT2pGRlVHUkJiazFNT0ZKMGJta3laVXREY3pKMVJsRRAB",
+      "authorName": "william cardoso da silva",
+      "rating": 5,
+      "text": "Roteiro especializado , suporte humanizado , valor justo .",
+      "date": "2025-08-06",
+      "photoUrl": ""
+    }
+  ]
 }

--- a/scripts/fetch-google-reviews.ts
+++ b/scripts/fetch-google-reviews.ts
@@ -129,6 +129,37 @@ function loadConfig(): EnvConfig {
   };
 }
 
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLL_ATTEMPTS = 60;
+
+async function pollForResults(
+  resultsUrl: string,
+  apiKey: string
+): Promise<Record<string, unknown>> {
+  for (let attempt = 1; attempt <= MAX_POLL_ATTEMPTS; attempt++) {
+    console.log(`Polling for results (attempt ${attempt}/${MAX_POLL_ATTEMPTS})...`);
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+    const res = await fetch(resultsUrl, {
+      headers: { 'X-API-KEY': apiKey },
+    });
+
+    if (!res.ok) throw new Error(`Poll error: ${res.status} ${res.statusText}`);
+
+    const json = await res.json() as Record<string, unknown>;
+
+    if (json['status'] === 'Success' || Array.isArray(json['data'])) {
+      return json;
+    }
+
+    if (json['status'] !== 'Pending') {
+      throw new Error(`Outscraper job failed with status: ${json['status']}`);
+    }
+  }
+
+  throw new Error(`Outscraper job timed out after ${MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS / 1000}s`);
+}
+
 async function fetchFromOutscraper(apiKey: string, placeId: string): Promise<{
   reviews: Record<string, unknown>[];
   averageRating: number;
@@ -148,9 +179,23 @@ async function fetchFromOutscraper(apiKey: string, placeId: string): Promise<{
     throw new Error(`Outscraper API error: ${response.status} ${response.statusText}`);
   }
 
-  const json = await response.json() as { data: Record<string, unknown>[][] };
-  const place = json.data?.[0]?.[0];
-  if (!place) throw new Error('No place data in Outscraper response');
+  let json = await response.json() as Record<string, unknown>;
+
+  if (json['status'] === 'Pending' && typeof json['results_location'] === 'string') {
+    console.log('Job queued, waiting for results...');
+    json = await pollForResults(json['results_location'] as string, apiKey);
+  }
+
+  let place: Record<string, unknown> | undefined;
+
+  if (Array.isArray(json['data'])) {
+    const first = (json['data'] as unknown[])[0];
+    place = Array.isArray(first) ? first[0] as Record<string, unknown> : first as Record<string, unknown>;
+  }
+
+  if (!place) {
+    throw new Error('No place data in Outscraper response');
+  }
 
   const reviewsRaw = (place['reviews_data'] ?? []) as Record<string, unknown>[];
   const averageRating = Number(place['rating'] ?? 0);

--- a/scripts/fetch-google-reviews.ts
+++ b/scripts/fetch-google-reviews.ts
@@ -132,6 +132,10 @@ function loadConfig(): EnvConfig {
 const POLL_INTERVAL_MS = 5000;
 const MAX_POLL_ATTEMPTS = 60;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 async function pollForResults(
   resultsUrl: string,
   apiKey: string
@@ -140,20 +144,34 @@ async function pollForResults(
     console.log(`Polling for results (attempt ${attempt}/${MAX_POLL_ATTEMPTS})...`);
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
 
-    const res = await fetch(resultsUrl, {
-      headers: { 'X-API-KEY': apiKey },
-    });
+    try {
+      const res = await fetch(resultsUrl, {
+        headers: { 'X-API-KEY': apiKey },
+      });
 
-    if (!res.ok) throw new Error(`Poll error: ${res.status} ${res.statusText}`);
+      if (!res.ok) {
+        console.warn(`Poll attempt ${attempt} failed: ${res.status} ${res.statusText}`);
+        continue;
+      }
 
-    const json = await res.json() as Record<string, unknown>;
+      const rawJson: unknown = await res.json();
+      if (!isRecord(rawJson)) {
+        console.warn(`Poll attempt ${attempt} returned invalid JSON`);
+        continue;
+      }
 
-    if (json['status'] === 'Success' || Array.isArray(json['data'])) {
-      return json;
-    }
+      if (rawJson['status'] === 'Success' || Array.isArray(rawJson['data'])) {
+        return rawJson;
+      }
 
-    if (json['status'] !== 'Pending') {
-      throw new Error(`Outscraper job failed with status: ${json['status']}`);
+      if (rawJson['status'] !== 'Pending') {
+        throw new Error(`Outscraper job failed with status: ${rawJson['status']}`);
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('Outscraper job failed')) {
+        throw err;
+      }
+      console.warn(`Transient error during poll attempt ${attempt}:`, err);
     }
   }
 
@@ -179,25 +197,34 @@ async function fetchFromOutscraper(apiKey: string, placeId: string): Promise<{
     throw new Error(`Outscraper API error: ${response.status} ${response.statusText}`);
   }
 
-  let json = await response.json() as Record<string, unknown>;
+  const rawJson: unknown = await response.json();
+  if (!isRecord(rawJson)) {
+    throw new Error('Invalid JSON response from Outscraper');
+  }
+  let json = rawJson;
 
-  if (json['status'] === 'Pending' && typeof json['results_location'] === 'string') {
+  const resultsLocation = json['results_location'];
+  if (json['status'] === 'Pending' && typeof resultsLocation === 'string') {
     console.log('Job queued, waiting for results...');
-    json = await pollForResults(json['results_location'] as string, apiKey);
+    json = await pollForResults(resultsLocation, apiKey);
   }
 
   let place: Record<string, unknown> | undefined;
 
   if (Array.isArray(json['data'])) {
     const first = (json['data'] as unknown[])[0];
-    place = Array.isArray(first) ? first[0] as Record<string, unknown> : first as Record<string, unknown>;
+    if (isRecord(first)) {
+      place = first;
+    } else if (Array.isArray(first) && isRecord(first[0])) {
+      place = first[0];
+    }
   }
 
   if (!place) {
     throw new Error('No place data in Outscraper response');
   }
 
-  const reviewsRaw = (place['reviews_data'] ?? []) as Record<string, unknown>[];
+  const reviewsRaw = Array.isArray(place['reviews_data']) ? place['reviews_data'] as Record<string, unknown>[] : [];
   const averageRating = Number(place['rating'] ?? 0);
   const totalReviews = Number(place['reviews'] ?? 0);
 


### PR DESCRIPTION
## Summary
- Outscraper reviews-v3 API returns async jobs (`status: "Pending"`) with a `results_location` URL instead of inline data
- Added polling loop (5s intervals, max 5 minutes) to wait for job completion
- Populated `googleReviews.json` with 2 real reviews from Google My Business (both 5-star)

## Test plan
- [ ] `pnpm reviews:fetch` with valid API key — fetches, polls, and writes real reviews
- [ ] `npx tsx --test tests/fetch-google-reviews.test.ts` — 7/7 pass
- [ ] Site shows real reviews in Mural do Amor section

🤖 Generated with [Claude Code](https://claude.com/claude-code)