### PR TITLE
fix(reviews): use Cloudflare API for R2 uploads + populate real data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,9 +122,10 @@ GITHUB_CLIENT_SECRET=seu_github_oauth_client_secret
 NPS_WEBHOOK_URL=https://seu-n8n.com/webhook/nps-pos-viagem
 
 # =============================================================================
-# OPTIONAL - Google Reviews (Outscraper + Cloudflare R2 via wrangler)
+# OPTIONAL - Google Reviews (Outscraper + Cloudflare R2 API)
 # =============================================================================
 # OUTSCRAPER_API_KEY=your_outscraper_api_key
 # GOOGLE_PLACE_ID=your_google_place_id
 # R2_BUCKET_NAME=your_bucket_name
 # R2_CDN_BASE_URL=https://media.anhanga.tur.br
+# CLOUDFLARE_API_TOKEN=your_r2_edit_token  # Token with R2 Storage: Edit permission

--- a/.env.example
+++ b/.env.example
@@ -129,3 +129,4 @@ NPS_WEBHOOK_URL=https://seu-n8n.com/webhook/nps-pos-viagem
 # R2_BUCKET_NAME=your_bucket_name
 # R2_CDN_BASE_URL=https://media.anhanga.tur.br
 # CLOUDFLARE_API_TOKEN=your_r2_edit_token  # Token with R2 Storage: Edit permission
+# CLOUDFLARE_ACCOUNT_ID=your_cloudflare_account_id  # Also used by AI Gateway above

--- a/data/googleReviews.json
+++ b/data/googleReviews.json
@@ -2,7 +2,7 @@
   "placeId": "ChIJ65P6-_G9oycRruws5FfoRDs",
   "averageRating": 5,
   "totalReviews": 2,
-  "lastFetched": "2026-06-01T01:27:30.579Z",
+  "lastFetched": "2026-06-01T03:10:39.643Z",
   "reviews": [
     {
       "id": "Ci9DQUlRQUNvZENodHljRjlvT25JMVpVeFFORWR6VWxrdFVrcHpWSE5xY2xGQ00yYxAB",

--- a/scripts/fetch-google-reviews.ts
+++ b/scripts/fetch-google-reviews.ts
@@ -70,14 +70,9 @@ const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 async function uploadPhotoToR2(
   reviewId: string,
   sourceUrl: string,
-  bucketName: string,
+  _bucketName: string,
   cdnBaseUrl: string
 ): Promise<string> {
-  const { execFileSync } = await import('node:child_process');
-  const { writeFileSync, unlinkSync, mkdirSync } = await import('node:fs');
-  const { tmpdir } = await import('node:os');
-  const { join } = await import('node:path');
-
   if (!SAFE_ID_RE.test(reviewId)) {
     throw new Error(`Invalid review ID: ${reviewId}`);
   }
@@ -88,21 +83,27 @@ async function uploadPhotoToR2(
   const buffer = Buffer.from(await response.arrayBuffer());
   const key = `reviews/${reviewId}.jpg`;
 
-  const tmpDir = join(tmpdir(), 'review-photos');
-  mkdirSync(tmpDir, { recursive: true });
-  const tmpFile = join(tmpDir, `${reviewId}.jpg`);
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  const bucketName = process.env.R2_BUCKET_NAME;
 
-  writeFileSync(tmpFile, buffer);
-  try {
-    execFileSync('npx', [
-      'wrangler', 'r2', 'object', 'put',
-      `${bucketName}/${key}`,
-      `--file=${tmpFile}`,
-      '--content-type=image/jpeg',
-      '--remote',
-    ], { stdio: 'pipe' });
-  } finally {
-    try { unlinkSync(tmpFile); } catch {}
+  if (!accountId || !apiToken || !bucketName) {
+    throw new Error('Missing CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN, or R2_BUCKET_NAME for R2 upload');
+  }
+
+  const uploadUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucketName}/objects/${key}`;
+  const putRes = await fetch(uploadUrl, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `Bearer ${apiToken}`,
+      'Content-Type': 'image/jpeg',
+    },
+    body: buffer,
+  });
+
+  if (!putRes.ok) {
+    const errBody = await putRes.text();
+    throw new Error(`R2 upload failed (${putRes.status}): ${errBody.slice(0, 200)}`);
   }
 
   return `${cdnBaseUrl}/${key}`;
@@ -265,8 +266,9 @@ async function main() {
       try {
         photoUrl = await uploadPhotoToR2(review.id, review.photoUrl, config.r2BucketName!, config.r2CdnBaseUrl!);
         if (photoUrl) photosUploaded++;
-      } catch {
-        console.warn(`Failed to upload photo for review ${review.id}`);
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        console.warn(`Failed to upload photo for review ${review.id}: ${detail}`);
       }
     }
     finalReviews.push({

--- a/scripts/fetch-google-reviews.ts
+++ b/scripts/fetch-google-reviews.ts
@@ -70,7 +70,7 @@ const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 async function uploadPhotoToR2(
   reviewId: string,
   sourceUrl: string,
-  _bucketName: string,
+  bucketName: string,
   cdnBaseUrl: string
 ): Promise<string> {
   if (!SAFE_ID_RE.test(reviewId)) {
@@ -85,10 +85,9 @@ async function uploadPhotoToR2(
 
   const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
   const apiToken = process.env.CLOUDFLARE_API_TOKEN;
-  const bucketName = process.env.R2_BUCKET_NAME;
 
-  if (!accountId || !apiToken || !bucketName) {
-    throw new Error('Missing CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN, or R2_BUCKET_NAME for R2 upload');
+  if (!accountId || !apiToken) {
+    throw new Error('Missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_API_TOKEN for R2 upload');
   }
 
   const uploadUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucketName}/objects/${key}`;


### PR DESCRIPTION
## Summary
- Replaced `wrangler r2 object put` with direct Cloudflare API calls via `fetch`
- wrangler CLI required Node >= 22, which isn't always available; the API works on any Node version
- Photos are now uploaded to the remote R2 bucket and accessible via `media.anhanga.tur.br`
- `googleReviews.json` populated with 2 real reviews including CDN photo URLs
- Updated `.env.example` with `CLOUDFLARE_API_TOKEN` documentation
- Updated E2E test to assert `aggregateRating` presence (reviews are now visible on page)

## Test plan
- [x] `pnpm reviews:fetch` — fetches, polls, uploads 2 photos, writes JSON
- [x] `curl -sI https://media.anhanga.tur.br/reviews/<id>.jpg` returns 200
- [x] Unit tests pass (7/7)
- [x] TypeScript compiles clean
- [ ] E2E tests pass (structured data + testimonials)
- [ ] Site shows real photos in Mural do Amor

🤖 Generated with [Claude Code](https://claude.com/claude-code)