### PR TITLE
feat(corporativo): integração Salesforce Web-to-Lead

### DIFF
--- a/api/submit-lead-sf.ts
+++ b/api/submit-lead-sf.ts
@@ -1,0 +1,153 @@
+import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
+import { checkRateLimit } from '../lib/rate-limit';
+import { cleanString, normalizeWhatsappNumber, maskEmail } from '../lib/lead-logic';
+import { logger } from '../lib/logger';
+import { postWebToLead } from '../services/salesforce';
+import type { SalesforceLeadFields } from '../services/salesforce';
+
+export const config = {
+    runtime: 'edge',
+};
+
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS = 5;
+
+interface SfLeadBody {
+    firstName: string;
+    lastName: string;
+    email: string;
+    whatsapp: string;
+    empresa?: string;
+    cargo?: string;
+}
+
+function buildJsonResponse(
+    body: Record<string, unknown>,
+    status: number,
+    corsHeaders: Record<string, string>,
+): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+}
+
+function validateSfLeadBody(raw: unknown): { valid: true; data: SalesforceLeadFields } | { valid: false; error: string } {
+    if (!raw || typeof raw !== 'object') {
+        return { valid: false, error: 'Corpo da requisição inválido.' };
+    }
+
+    const body = raw as Record<string, unknown>;
+
+    const firstName = cleanString(body.firstName);
+    const lastName = cleanString(body.lastName);
+    const email = cleanString(body.email).toLowerCase();
+    const phone = normalizeWhatsappNumber(body.whatsapp);
+    const company = cleanString(body.empresa) || 'Não informado';
+    const title = cleanString(body.cargo) || '';
+
+    if (!firstName || !lastName || !email) {
+        return { valid: false, error: 'Campos obrigatórios ausentes.' };
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+        return { valid: false, error: 'Email inválido.' };
+    }
+
+    if (!phone) {
+        return { valid: false, error: 'Número de telefone inválido.' };
+    }
+
+    return {
+        valid: true,
+        data: {
+            firstName,
+            lastName,
+            email,
+            phone,
+            company,
+            title,
+            leadSource: 'Corporativo',
+        },
+    };
+}
+
+export default async function handler(request: Request): Promise<Response> {
+    const requestId = createRequestId();
+    const corsHeaders = buildCorsHeaders();
+
+    if (request.method === 'OPTIONS') {
+        return new Response(null, { status: 204, headers: corsHeaders });
+    }
+
+    if (request.method !== 'POST') {
+        return buildJsonResponse({ ok: false, requestId, error: 'Method not allowed' }, 405, corsHeaders);
+    }
+
+    const clientIP = getClientIP(request);
+    const rateLimit = await checkRateLimit(clientIP, {
+        limit: RATE_LIMIT_MAX_REQUESTS,
+        windowMs: RATE_LIMIT_WINDOW_MS,
+        prefix: 'ratelimit:submit-lead-sf',
+    });
+
+    if (!rateLimit.allowed) {
+        if (rateLimit.serviceUnavailable) {
+            return buildJsonResponse({ ok: false, requestId, error: 'Serviço temporariamente indisponível.' }, 503, corsHeaders);
+        }
+        return buildJsonResponse(
+            { ok: false, requestId, error: 'Muitas tentativas. Tente novamente em breve.' },
+            429,
+            { ...corsHeaders, 'Retry-After': String(Math.ceil(rateLimit.resetIn / 1000)) },
+        );
+    }
+
+    let rawBody: unknown;
+    try {
+        rawBody = await request.json();
+    } catch {
+        return buildJsonResponse({ ok: false, requestId, error: 'JSON inválido.' }, 400, corsHeaders);
+    }
+
+    const validation = validateSfLeadBody(rawBody);
+    if (!validation.valid) {
+        return buildJsonResponse({ ok: false, requestId, error: validation.error }, 400, corsHeaders);
+    }
+
+    const fields = validation.data;
+
+    logger.info('SUBMIT_LEAD_SF', {
+        requestId,
+        stage: 'sending',
+        email: maskEmail(fields.email),
+        company: fields.company,
+    });
+
+    try {
+        const result = await postWebToLead(fields);
+
+        if (!result.ok) {
+            logger.error('SUBMIT_LEAD_SF', { requestId, stage: 'sf_rejected' });
+            return buildJsonResponse({ ok: false, requestId, error: 'Falha ao enviar para Salesforce.' }, 502, corsHeaders);
+        }
+
+        logger.info('SUBMIT_LEAD_SF', { requestId, stage: 'success' });
+        return buildJsonResponse({ ok: true, requestId }, 201, corsHeaders);
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        const isTimeout = (error instanceof Error || (error && typeof error === 'object' && 'name' in error)) && (error as { name: string }).name === 'AbortError';
+
+        logger.error('SUBMIT_LEAD_SF', {
+            requestId,
+            stage: isTimeout ? 'timeout' : 'error',
+            detail: message.slice(0, 200),
+        });
+
+        return buildJsonResponse(
+            { ok: false, requestId, error: 'Erro ao processar envio para Salesforce.' },
+            isTimeout ? 504 : 500,
+            corsHeaders,
+        );
+    }
+}

--- a/components/landings/corporativo/CorpContactSection.tsx
+++ b/components/landings/corporativo/CorpContactSection.tsx
@@ -39,6 +39,21 @@ export function CorpContactSection() {
         };
     }
 
+    function submitToSalesforce() {
+        fetch('/api/submit-lead-sf', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                firstName: form.firstName,
+                lastName: form.lastName,
+                email: form.email,
+                whatsapp: form.whatsapp,
+                empresa: form.empresa,
+                cargo: form.cargo,
+            }),
+        }).catch(() => {});
+    }
+
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
         if (isLocallySubmitting.current) return;
@@ -74,6 +89,7 @@ export function CorpContactSection() {
             );
 
             if (result.ok) {
+                submitToSalesforce();
                 setSubmitState('success');
             } else {
                 setSubmitState('error');

--- a/services/salesforce.ts
+++ b/services/salesforce.ts
@@ -1,0 +1,51 @@
+const SF_WEB_TO_LEAD_URL = 'https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8&orgId=00Das00000EnTnB';
+const SF_ORG_ID = '00Das00000EnTnB';
+const SF_RET_URL = 'https://www.anhanga.tur.br/corporativo';
+const SF_REQUEST_TIMEOUT_MS = 5000;
+
+export interface SalesforceLeadFields {
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone: string;
+    company: string;
+    title: string;
+    leadSource: string;
+}
+
+export async function postWebToLead(fields: SalesforceLeadFields): Promise<{ ok: boolean }> {
+    const params = new URLSearchParams();
+    params.set('oid', SF_ORG_ID);
+    params.set('retURL', SF_RET_URL);
+    params.set('first_name', fields.firstName);
+    params.set('last_name', fields.lastName);
+    params.set('email', fields.email);
+    params.set('phone', fields.phone);
+    params.set('company', fields.company);
+    params.set('title', fields.title);
+    params.set('lead_source', fields.leadSource);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), SF_REQUEST_TIMEOUT_MS);
+
+    try {
+        const response = await fetch(SF_WEB_TO_LEAD_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params.toString(),
+            signal: controller.signal,
+            redirect: 'manual',
+        });
+
+        return { ok: response.status < 400 };
+    } catch (error: unknown) {
+        if (controller.signal.aborted) {
+            const abortError = new Error('Salesforce request timed out');
+            abortError.name = 'AbortError';
+            throw abortError;
+        }
+        throw error;
+    } finally {
+        clearTimeout(timeout);
+    }
+}

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -34,6 +34,7 @@ test.describe('Corporativo Landing Page', () => {
   test('should capture corporate lead and trigger dataLayer events', async ({ page }) => {
     const landing = new CorporativoPage(page);
     let submitPayload: SubmitLeadRequest | null = null;
+    let sfPayload: Record<string, unknown> | null = null;
 
     await page.route('**/api/submit-lead', async route => {
       submitPayload = route.request().postDataJSON();
@@ -41,6 +42,15 @@ test.describe('Corporativo Landing Page', () => {
         status: 201,
         contentType: 'application/json',
         body: JSON.stringify({ ok: true, requestId: 'corp-123' }),
+      });
+    });
+
+    await page.route('**/api/submit-lead-sf', async route => {
+      sfPayload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, requestId: 'sf-123' }),
       });
     });
 
@@ -71,6 +81,16 @@ test.describe('Corporativo Landing Page', () => {
     expect(payload.bantSummary).toContain('Empresa Teste LTDA');
     expect(payload.bantSummary).toContain('Sócia');
 
+    await expect.poll(() => sfPayload).toBeTruthy();
+    expect(sfPayload).toMatchObject({
+      firstName: 'Maria',
+      lastName: 'Santos',
+      email: 'maria@empresa.com.br',
+      whatsapp: '(11) 98831-4487',
+      empresa: 'Empresa Teste LTDA',
+      cargo: 'Sócia',
+    });
+
     const formSubmissionEvent = await page.evaluate(() =>
       (window.dataLayer || []).find(e => e.event === 'form_submission')
     );
@@ -95,6 +115,14 @@ test.describe('Corporativo Landing Page', () => {
         status: 201,
         contentType: 'application/json',
         body: JSON.stringify({ ok: true, requestId: 'corp-no-leak' }),
+      });
+    });
+
+    await page.route('**/api/submit-lead-sf', async route => {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, requestId: 'sf-no-leak' }),
       });
     });
 

--- a/tests/submit-lead-sf.test.ts
+++ b/tests/submit-lead-sf.test.ts
@@ -1,0 +1,154 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from '../api/submit-lead-sf.ts';
+
+const originalFetch = global.fetch;
+
+function buildRequest(body: Record<string, unknown>, init?: { method?: string }): Request {
+    const ipSuffix = Math.floor(Math.random() * 200) + 1;
+    const method = init?.method || 'POST';
+
+    return new Request('http://localhost/api/submit-lead-sf', {
+        method,
+        headers: {
+            'Content-Type': 'application/json',
+            'x-real-ip': `127.0.0.${ipSuffix}`,
+        },
+        body: method === 'OPTIONS' ? undefined : JSON.stringify(body),
+    });
+}
+
+function validPayload() {
+    return {
+        firstName: 'João',
+        lastName: 'Silva',
+        email: 'joao@empresa.com.br',
+        whatsapp: '11999998888',
+        empresa: 'Acme Corp',
+        cargo: 'Diretor',
+    };
+}
+
+test('submit-lead-sf: OPTIONS returns 204', async () => {
+    const res = await handler(new Request('http://localhost/api/submit-lead-sf', { method: 'OPTIONS' }));
+    assert.equal(res.status, 204);
+});
+
+test('submit-lead-sf: GET returns 405', async () => {
+    const res = await handler(new Request('http://localhost/api/submit-lead-sf', { method: 'GET' }));
+    assert.equal(res.status, 405);
+});
+
+test('submit-lead-sf: invalid JSON returns 400', async () => {
+    const ipSuffix = Math.floor(Math.random() * 200) + 1;
+    const req = new Request('http://localhost/api/submit-lead-sf', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-real-ip': `127.0.0.${ipSuffix}`,
+        },
+        body: 'not json',
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 400);
+    const data = await res.json();
+    assert.equal(data.ok, false);
+});
+
+test('submit-lead-sf: missing required fields returns 400', async () => {
+    const res = await handler(buildRequest({ firstName: 'João' }));
+    assert.equal(res.status, 400);
+    const data = await res.json();
+    assert.equal(data.ok, false);
+});
+
+test('submit-lead-sf: invalid email returns 400', async () => {
+    const payload = validPayload();
+    payload.email = 'not-an-email';
+    const res = await handler(buildRequest(payload));
+    assert.equal(res.status, 400);
+    const data = await res.json();
+    assert.match(data.error, /email/i);
+});
+
+test('submit-lead-sf: invalid phone returns 400', async () => {
+    const payload = validPayload();
+    payload.whatsapp = '123';
+    const res = await handler(buildRequest(payload));
+    assert.equal(res.status, 400);
+    const data = await res.json();
+    assert.match(data.error, /telefone/i);
+});
+
+test('submit-lead-sf: valid payload sends to Salesforce and returns 201', async () => {
+    let capturedUrl = '';
+    let capturedBody = '';
+
+    global.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        capturedUrl = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+        capturedBody = typeof init?.body === 'string' ? init.body : '';
+        return new Response('', { status: 200 });
+    };
+
+    try {
+        const res = await handler(buildRequest(validPayload()));
+        assert.equal(res.status, 201);
+        const data = await res.json();
+        assert.equal(data.ok, true);
+
+        assert.ok(capturedUrl.includes('webto.salesforce.com'), 'Should POST to Salesforce');
+        assert.ok(capturedBody.includes('first_name=Jo%C3%A3o'), 'Should include first_name');
+        assert.ok(capturedBody.includes('last_name=Silva'), 'Should include last_name');
+        assert.ok(capturedBody.includes('company=Acme+Corp'), 'Should include company');
+        assert.ok(capturedBody.includes('title=Diretor'), 'Should include title');
+        assert.ok(capturedBody.includes('lead_source=Corporativo'), 'Should set lead_source to Corporativo');
+        assert.ok(capturedBody.includes('oid=00Das00000EnTnB'), 'Should include org ID');
+    } finally {
+        global.fetch = originalFetch;
+    }
+});
+
+test('submit-lead-sf: empty empresa defaults to "Não informado"', async () => {
+    let capturedBody = '';
+
+    global.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = typeof init?.body === 'string' ? init.body : '';
+        return new Response('', { status: 200 });
+    };
+
+    try {
+        const payload = validPayload();
+        payload.empresa = '';
+        const res = await handler(buildRequest(payload));
+        assert.equal(res.status, 201);
+        assert.ok(capturedBody.includes('company=N%C3%A3o+informado'), 'Empty empresa should default');
+    } finally {
+        global.fetch = originalFetch;
+    }
+});
+
+test('submit-lead-sf: Salesforce error returns 502', async () => {
+    global.fetch = async () => new Response('error', { status: 500 });
+
+    try {
+        const res = await handler(buildRequest(validPayload()));
+        assert.equal(res.status, 502);
+        const data = await res.json();
+        assert.equal(data.ok, false);
+    } finally {
+        global.fetch = originalFetch;
+    }
+});
+
+test('submit-lead-sf: network error returns 500', async () => {
+    global.fetch = async () => { throw new Error('Network failure'); };
+
+    try {
+        const res = await handler(buildRequest(validPayload()));
+        assert.equal(res.status, 500);
+        const data = await res.json();
+        assert.equal(data.ok, false);
+    } finally {
+        global.fetch = originalFetch;
+    }
+});

--- a/tests/submit-lead-sf.test.ts
+++ b/tests/submit-lead-sf.test.ts
@@ -96,7 +96,8 @@ test('submit-lead-sf: valid payload sends to Salesforce and returns 201', async 
         const data = await res.json();
         assert.equal(data.ok, true);
 
-        assert.ok(capturedUrl.includes('webto.salesforce.com'), 'Should POST to Salesforce');
+        const parsedUrl = new URL(capturedUrl);
+        assert.equal(parsedUrl.hostname, 'webto.salesforce.com', 'Should POST to Salesforce');
         assert.ok(capturedBody.includes('first_name=Jo%C3%A3o'), 'Should include first_name');
         assert.ok(capturedBody.includes('last_name=Silva'), 'Should include last_name');
         assert.ok(capturedBody.includes('company=Acme+Corp'), 'Should include company');


### PR DESCRIPTION
## Summary

- Cria endpoint `api/submit-lead-sf.ts` que faz POST server-side para o Salesforce Web-to-Lead (sem necessidade de API key)
- Cria serviço `services/salesforce.ts` com `postWebToLead()` — URLSearchParams + timeout + redirect manual
- Após sucesso do envio ao n8n, o formulário corporativo dispara fire-and-forget para o novo endpoint
- Lead chega no Salesforce com `Origem do lead = Corporativo`, mapeando empresa → company e cargo → title

## Test plan

- [x] 10 testes unitários para o endpoint (`tests/submit-lead-sf.test.ts`)
- [x] Testes E2E atualizados com mock da nova rota (`tests/e2e/corporativo.spec.ts`)
- [x] Suite completa de regressão (475 testes passando)
- [x] TypeScript typecheck sem erros
- [ ] Verificar que o lead aparece no Salesforce após deploy (criar lead de teste via `/corporativo`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)