### PR TITLE
feat(quiz): newsletter opt-in + Salesforce lead submission

### DIFF
--- a/hooks/useQuizCapture.ts
+++ b/hooks/useQuizCapture.ts
@@ -84,7 +84,7 @@ export function useQuizCapture() {
     const [trackingState, setTrackingState] = useState(() => captureTrackingState());
 
     const submitQuiz = async (
-        input: Pick<SubmitQuizRequest, 'firstName' | 'lastName' | 'email' | 'whatsapp' | 'profileKey' | 'profileName' | 'bantSummary' | 'destinos' | 'skipped'>,
+        input: Pick<SubmitQuizRequest, 'firstName' | 'lastName' | 'email' | 'whatsapp' | 'profileKey' | 'profileName' | 'bantSummary' | 'destinos' | 'skipped' | 'newsletterOptIn'>,
     ): Promise<SubmitQuizResult> => {
         setError(null);
         setIsSubmitting(true);
@@ -102,6 +102,20 @@ export function useQuizCapture() {
             utms: latest.utms,
             tracking: latest.tracking,
         };
+
+        // Fire-and-forget — SF failure never blocks the quiz result
+        void fetch('/api/submit-lead-sf', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                firstName: payload.firstName,
+                lastName: payload.lastName,
+                email: payload.email,
+                whatsapp: payload.whatsapp,
+                leadSource: 'Web',
+                description: `${payload.bantSummary} | Newsletter: ${payload.newsletterOptIn ? 'Sim' : 'Não'}`,
+            }),
+        }).catch(() => undefined);
 
         try {
             const response = await fetch('/api/submit-quiz', {

--- a/hooks/useQuizCapture.ts
+++ b/hooks/useQuizCapture.ts
@@ -109,7 +109,7 @@ export function useQuizCapture() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 firstName: payload.firstName,
-                lastName: payload.lastName,
+                lastName: payload.lastName || '-',
                 email: payload.email,
                 whatsapp: payload.whatsapp,
                 leadSource: 'Web',

--- a/lib/n8n-payloads.ts
+++ b/lib/n8n-payloads.ts
@@ -208,6 +208,7 @@ export interface N8nQuizPayload {
         sourcePage: string;
         destinos: string[];
         skipped: boolean;
+        newsletterOptIn: boolean;
     };
     utms: SubmitQuizRequest['utms'];
     tracking: SubmitQuizRequest['tracking'];
@@ -231,6 +232,7 @@ export function buildN8nQuizPayload(payload: SubmitQuizRequest, requestId: strin
             sourcePage: payload.sourcePage,
             destinos: payload.destinos ?? [],
             skipped: payload.skipped ?? false,
+            newsletterOptIn: payload.newsletterOptIn ?? false,
         },
         utms: payload.utms,
         tracking: payload.tracking,

--- a/lib/quiz-logic.ts
+++ b/lib/quiz-logic.ts
@@ -42,6 +42,7 @@ export function validateQuizPayload(
     const utms = normalizeUtms(raw.utms);
     const tracking = normalizeTracking(raw.tracking, utms);
     const skipped = raw.skipped === true;
+    const newsletterOptIn = raw.newsletterOptIn === true;
 
     return {
         valid: true,
@@ -56,6 +57,7 @@ export function validateQuizPayload(
             sourcePage,
             destinos,
             skipped,
+            newsletterOptIn,
             utms,
             tracking,
         },

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -479,7 +479,6 @@ function PreLeadScreen({ profile, onSubmit, onBack }: PreLeadScreenProps) {
         if (!form.nome.trim()) errs.nome = 'Conta pra gente seu nome';
         if (!form.sobrenome.trim()) errs.sobrenome = 'E o sobrenome?';
         if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(form.email)) errs.email = 'E-mail inválido';
-        if (!form.aceite) errs.aceite = 'Precisa do aceite pra continuar';
         if (Object.keys(errs).length) { setErrors(errs); return; }
         onSubmit(form);
     }
@@ -1046,6 +1045,7 @@ export default function QuizAnhangaLanding() {
             bantSummary,
             destinos: answers.destino ?? [],
             skipped,
+            newsletterOptIn: form.aceite,
         });
 
         if (!result.ok) {

--- a/tests/submit-quiz.test.ts
+++ b/tests/submit-quiz.test.ts
@@ -88,6 +88,36 @@ test('buildN8nQuizPayload — inclui lastName no payload do n8n', () => {
     assert.equal(n8n.quiz.lastName, 'Silva');
 });
 
+test('validateQuizPayload — newsletterOptIn true é preservado', () => {
+    const result = validateQuizPayload({ ...BASE_PAYLOAD, newsletterOptIn: true });
+    assert.ok(result.valid);
+    assert.equal(result.data.newsletterOptIn, true);
+});
+
+test('validateQuizPayload — newsletterOptIn ausente resulta em false', () => {
+    const result = validateQuizPayload({ ...BASE_PAYLOAD });
+    assert.ok(result.valid);
+    assert.equal(result.data.newsletterOptIn, false);
+});
+
+test('validateQuizPayload — newsletterOptIn com valor não-boolean resulta em false', () => {
+    const result = validateQuizPayload({ ...BASE_PAYLOAD, newsletterOptIn: 'sim' });
+    assert.ok(result.valid);
+    assert.equal(result.data.newsletterOptIn, false);
+});
+
+test('buildN8nQuizPayload — inclui newsletterOptIn no payload do n8n', () => {
+    const payload = { ...BASE_PAYLOAD, newsletterOptIn: true, tracking: undefined };
+    const n8n = buildN8nQuizPayload(payload, 'req-nl-1');
+    assert.equal(n8n.quiz.newsletterOptIn, true);
+});
+
+test('buildN8nQuizPayload — newsletterOptIn ausente resulta em false no payload n8n', () => {
+    const payload = { ...BASE_PAYLOAD, tracking: undefined };
+    const n8n = buildN8nQuizPayload(payload, 'req-nl-2');
+    assert.equal(n8n.quiz.newsletterOptIn, false);
+});
+
 test('validateQuizPayload — sanitiza destinos contra XSS', () => {
     const payload = {
         ...BASE_PAYLOAD,

--- a/types/quiz.ts
+++ b/types/quiz.ts
@@ -11,6 +11,7 @@ export interface SubmitQuizRequest {
     sourcePage: string;
     destinos?: string[];
     skipped?: boolean;
+    newsletterOptIn?: boolean;
     utms: LeadUtms;
     tracking?: LeadTracking;
 }


### PR DESCRIPTION
## Resumo

- **LGPD fix:** remove validação obrigatória do aceite no formulário do quiz — opt-in de newsletter passa a ser voluntário
- **Newsletter opt-in:** propaga o campo `newsletterOptIn` por toda a cadeia (tipos → validação → hook → payload n8n), para que o workflow do n8n possa segmentar assinantes por perfil no HubSpot
- **Salesforce:** dispara chamada fire-and-forget para `/api/submit-lead-sf` ao submeter o quiz — falha no SF nunca bloqueia o resultado para o usuário; preferência de newsletter aparece no campo `description` do lead

## Arquivos alterados

| Arquivo | Mudança |
|---|---|
| `types/quiz.ts` | `newsletterOptIn?: boolean` em `SubmitQuizRequest` |
| `lib/quiz-logic.ts` | Lê e valida `newsletterOptIn` do payload bruto |
| `lib/n8n-payloads.ts` | Inclui `newsletterOptIn` em `N8nQuizPayload` e no builder |
| `hooks/useQuizCapture.ts` | Fire-and-forget para `/api/submit-lead-sf` + `newsletterOptIn` no pick type |
| `pages/landings/QuizAnhangaLanding.tsx` | Remove validação obrigatória do aceite |
| `tests/submit-quiz.test.ts` | 5 novos testes de regressão para `newsletterOptIn` |

## Plano de teste

- [ ] Preencher quiz sem marcar o aceite — deve exibir o perfil normalmente
- [ ] Preencher quiz marcando o aceite — verificar no n8n que `newsletterOptIn: true` chega no payload
- [ ] Verificar no Salesforce que o lead é criado com `description` contendo `| Newsletter: Sim`
- [ ] Simular falha no SF (desabilitar env var temporariamente) — confirmar que o quiz ainda completa com sucesso
- [ ] `pnpm test:regression` — zero falhas

## Notas

O aceite de newsletter no Salesforce é armazenado no campo `description` livre (ex: `Quiz Anhangá · Perfil: Bon Vivant · ... | Newsletter: Sim`). Não requer campo customizado no admin do SF. Se no futuro quiserem um campo dedicado, basta criar `newsletter_opt_in__c` no Salesforce Setup e adicionar o field ID ao `services/salesforce.ts`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)