### PR TITLE
chore(tracking): migrate GTM to Stape sGTM first-party loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,8 +67,8 @@
 </head>
 
 <body>
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T2KGS86G" height="0" width="0"
+  <!-- Google Tag Manager (noscript) — Stape Custom Loader (first-party) -->
+  <noscript><iframe src="https://load.sst.anhanga.tur.br/ns.html?id=GTM-T2KGS86G" height="0" width="0"
       style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
   <div id="root"></div>
@@ -100,7 +100,7 @@
           'gtm.start': new Date().getTime(),
           event: 'gtm.js'
         });
-        injectScript('https://www.googletagmanager.com/gtm.js?id=GTM-T2KGS86G');
+        injectScript('https://load.sst.anhanga.tur.br/60oxrlttgl.js?56lu7e=BQNJMzg%2FVTteLDMnVEQ%2FSRpaRlpdVBwBUQYaHA0cHw5CEwEGQhAK');
       };
 
       var loadMautic = function () {

--- a/index.html
+++ b/index.html
@@ -40,6 +40,12 @@
   <link rel="preconnect" href="https://media.anhanga.tur.br" crossorigin>
   <link rel="dns-prefetch" href="https://media.anhanga.tur.br">
 
+  <!-- Stape sGTM — warm DNS/TLS before deferred loader fires -->
+  <link rel="preconnect" href="https://load.sst.anhanga.tur.br" crossorigin>
+  <link rel="dns-prefetch" href="https://load.sst.anhanga.tur.br">
+  <link rel="preconnect" href="https://sst.anhanga.tur.br" crossorigin>
+  <link rel="dns-prefetch" href="https://sst.anhanga.tur.br">
+
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -40,7 +40,7 @@ test('index.html lazy-loads GTM through the deferred analytics loader', () => {
 
   assert.match(indexHtml, /var\s+gtmLoaded\s*=\s*false/i);
   assert.match(indexHtml, /'gtm\.start'\s*:\s*new Date\(\)\.getTime\(\)/i);
-  assert.match(indexHtml, /https:\/\/www\.googletagmanager\.com\/gtm\.js\?id=GTM-T2KGS86G/i);
+  assert.match(indexHtml, /https:\/\/load\.sst\.anhanga\.tur\.br\//i);
   assert.ok(loadGtmIndex > -1, 'GTM loader should be called from the analytics trigger');
   assert.ok(utmInjectIndex > -1, 'UTM tracking loader should still be present');
   assert.ok(loadGtmIndex < utmInjectIndex, 'GTM should be queued before UTM reads GA client data');


### PR DESCRIPTION
## Summary

- Replaces `googletagmanager.com` with Stape Custom Loader (`load.sst.anhanga.tur.br`) for both the GTM script and the noscript iframe
- GTM scripts are now served from a first-party domain, improving tracking resilience against ad blockers and Safari ITP cookie restrictions
- Preserves the existing deferred loading pattern (scroll/click/idle trigger) for mobile TBT protection

## Context

Part of the Stape sGTM migration:
1. **Stape free tier** hosts the sGTM container at `sst.anhanga.tur.br`
2. **Meta CAPI** tag in sGTM sends conversion events server-side with `fbp`/`fbc` cookies (first-party)
3. **GA4 transport stream** (`G-QDBT5PM4KP`) routes browser data through sGTM to Meta CAPI
4. **This PR** makes the GTM loader itself first-party (anti-adblock)

## Remaining steps (no code changes needed)

- [x] Disable n8n workflow "Meta CAPI - Lead Events" (sGTM replaces it)
- [x] Reactivate n8n workflow "HubSpot Closed Won → Purchase Dispatch" (offline conversions)
- [ ] Test a real lead event in Meta Events Manager
- [ ] Remove Test Event Code (TEST4728) from sGTM tag after validation

## Test plan

- [ ] After deploy, open site with DevTools → Network → filter `sst.anhanga` → confirm GTM script loads from `load.sst.anhanga.tur.br`
- [ ] Confirm NO requests to `googletagmanager.com`
- [ ] Enable uBlock Origin → confirm tracking still loads (first-party domain not blocked)
- [ ] Check Meta Events Manager → Test Events → confirm events still arrive with status "Processado"

🤖 Generated with [Claude Code](https://claude.com/claude-code)