### PR TITLE
fix: corrige tipo pai do AggregateRating para suporte a Review Snippets

### DIFF
--- a/components/schemas/OrganizationSchema.tsx
+++ b/components/schemas/OrganizationSchema.tsx
@@ -2,72 +2,92 @@ import React from 'react';
 import { StructuredData } from './StructuredData';
 import { BRAND_LOGO_BLUE_URL } from '../../lib/media-assets';
 
-export const OrganizationSchema = () => (
-  <StructuredData
-    id="organization"
-    data={{
-      "@context": "https://schema.org",
-      "@type": ["TravelAgency", "Organization"],
-      "name": "Anhangá Viagens",
-      "alternateName": "Anhangá Turismo",
-      "url": "https://www.anhanga.tur.br/",
-      "logo": BRAND_LOGO_BLUE_URL,
-      "description": "Agência de viagens em São Paulo especializada em roteiros personalizados, turismo de transformação e pacotes exclusivos para grandes festivais, incluindo o Lollapalooza Brasil, e público 50+.",
+interface AggregateRatingProps {
+  ratingValue: number;
+  reviewCount: number;
+  bestRating?: number;
+  worstRating?: number;
+}
+
+interface OrganizationSchemaProps {
+  aggregateRating?: AggregateRatingProps;
+}
+
+export const OrganizationSchema: React.FC<OrganizationSchemaProps> = ({ aggregateRating }) => {
+  const data: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": ["TravelAgency", "Organization"],
+    "name": "Anhangá Viagens",
+    "alternateName": "Anhangá Turismo",
+    "url": "https://www.anhanga.tur.br/",
+    "logo": BRAND_LOGO_BLUE_URL,
+    "description": "Agência de viagens em São Paulo especializada em roteiros personalizados, turismo de transformação e pacotes exclusivos para grandes festivais, incluindo o Lollapalooza Brasil, e público 50+.",
+    "telephone": "+55-11-52833309",
+    "email": "contato@anhanga.tur.br",
+    "taxID": "37.036.732/0001-41",
+    "award": "Certificado Cadastur: 37.036.732/0001-41",
+    "priceRange": "R$ 3800-50000",
+    "sameAs": [
+      "https://www.instagram.com/anhangaviagens",
+      "https://www.facebook.com/profile.php?id=61585422494271"
+    ],
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Av. Dom Pedro I, 773",
+      "addressLocality": "São Paulo",
+      "addressRegion": "SP",
+      "postalCode": "01552-001",
+      "addressCountry": "BR"
+    },
+    "contactPoint": {
+      "@type": "ContactPoint",
       "telephone": "+55-11-52833309",
-      "email": "contato@anhanga.tur.br",
-      "taxID": "37.036.732/0001-41",
-      "award": "Certificado Cadastur: 37.036.732/0001-41",
-      "priceRange": "R$ 3800-50000",
-      "sameAs": [
-        "https://www.instagram.com/anhangaviagens",
-        "https://www.facebook.com/profile.php?id=61585422494271"
-      ],
-      "address": {
-        "@type": "PostalAddress",
-        "streetAddress": "Av. Dom Pedro I, 773",
-        "addressLocality": "São Paulo",
-        "addressRegion": "SP",
-        "postalCode": "01552-001",
-        "addressCountry": "BR"
+      "contactType": "Customer Support",
+      "availableLanguage": "pt-BR",
+      "areaServed": "BR"
+    },
+    "memberOf": [
+      {
+        "@type": "Organization",
+        "name": "Beto Carrero World",
+        "description": "Agente Credenciado"
       },
-      "contactPoint": {
-        "@type": "ContactPoint",
-        "telephone": "+55-11-52833309",
-        "contactType": "Customer Support",
-        "availableLanguage": "pt-BR",
-        "areaServed": "BR"
-      },
-      "memberOf": [
-        {
-          "@type": "Organization",
-          "name": "Beto Carrero World",
-          "description": "Agente Credenciado"
-        },
-        {
-          "@type": "Organization",
-          "name": "Hopi Hari",
-          "description": "Agente Credenciado"
-        }
-      ],
-      "areaServed": [
-        { "@type": "Place", "name": "Orlando, Estados Unidos" },
-        { "@type": "Place", "name": "Brasil (Festivais e Experiências)" },
-        { "@type": "Place", "name": "Caribe" },
-        { "@type": "Place", "name": "Europa" },
-        { "@type": "Place", "name": "Ásia" }
-      ],
-      "knowsAbout": [
-        "Roteiros Personalizados",
-        "Lollapalooza Brasil",
-        "Rock in Rio",
-        "The Town",
-        "Viagens para 50 Mais",
-        "Melhor Idade",
-        "Turismo de Transformação",
-        "Orlando & Disney",
-        "Beto Carrero World"
-      ],
-      "blog": "https://www.anhanga.tur.br/blog/"
-    }}
-  />
-);
+      {
+        "@type": "Organization",
+        "name": "Hopi Hari",
+        "description": "Agente Credenciado"
+      }
+    ],
+    "areaServed": [
+      { "@type": "Place", "name": "Orlando, Estados Unidos" },
+      { "@type": "Place", "name": "Brasil (Festivais e Experiências)" },
+      { "@type": "Place", "name": "Caribe" },
+      { "@type": "Place", "name": "Europa" },
+      { "@type": "Place", "name": "Ásia" }
+    ],
+    "knowsAbout": [
+      "Roteiros Personalizados",
+      "Lollapalooza Brasil",
+      "Rock in Rio",
+      "The Town",
+      "Viagens para 50 Mais",
+      "Melhor Idade",
+      "Turismo de Transformação",
+      "Orlando & Disney",
+      "Beto Carrero World"
+    ],
+    "blog": "https://www.anhanga.tur.br/blog/"
+  };
+
+  if (aggregateRating) {
+    data.aggregateRating = {
+      "@type": "AggregateRating",
+      "ratingValue": aggregateRating.ratingValue,
+      "reviewCount": aggregateRating.reviewCount,
+      "bestRating": aggregateRating.bestRating ?? 5,
+      "worstRating": aggregateRating.worstRating ?? 1
+    };
+  }
+
+  return <StructuredData id="organization" data={data} />;
+};

--- a/components/schemas/ServiceSchema.tsx
+++ b/components/schemas/ServiceSchema.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import { StructuredData } from './StructuredData';
 
-interface AggregateRatingProps {
-  ratingValue: number;
-  reviewCount: number;
-  bestRating?: number;
-  worstRating?: number;
-}
-
 interface ServiceSchemaProps {
   name: string;
   description: string;
@@ -15,7 +8,6 @@ interface ServiceSchemaProps {
   serviceType?: string;
   areaServed?: string;
   keywords?: string[];
-  aggregateRating?: AggregateRatingProps;
 }
 
 const EMPTY_KEYWORDS: string[] = [];
@@ -27,7 +19,6 @@ export const ServiceSchema: React.FC<ServiceSchemaProps> = ({
   serviceType,
   areaServed = 'Brasil',
   keywords = EMPTY_KEYWORDS,
-  aggregateRating
 }) => {
   const schemaData: Record<string, unknown> = {
     '@context': 'https://schema.org',
@@ -53,16 +44,6 @@ export const ServiceSchema: React.FC<ServiceSchemaProps> = ({
       }
     }
   };
-
-  if (aggregateRating) {
-    schemaData.aggregateRating = {
-      '@type': 'AggregateRating',
-      ratingValue: aggregateRating.ratingValue,
-      reviewCount: aggregateRating.reviewCount,
-      bestRating: aggregateRating.bestRating ?? 5,
-      worstRating: aggregateRating.worstRating ?? 1
-    };
-  }
 
   return <StructuredData id="service" data={schemaData} />;
 };

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -106,7 +106,12 @@ const Home: React.FC = () => {
         description="Agência de viagens em São Paulo. Cada roteiro começa do zero — sem pacote pronto. Orlando, Beto Carrero, Europa e muito mais. Orçamento gratuito."
         canonical="https://www.anhanga.tur.br/"
       />
-      <OrganizationSchema />
+      <OrganizationSchema
+        aggregateRating={reviewSummary ? {
+          ratingValue: reviewSummary.averageRating,
+          reviewCount: reviewSummary.totalReviews,
+        } : undefined}
+      />
       <FAQPageSchema items={FAQ_SCHEMA_ITEMS} />
       <BreadcrumbSchema
         items={[{ name: 'Home', item: 'https://www.anhanga.tur.br/' }]}
@@ -126,10 +131,6 @@ const Home: React.FC = () => {
           'turismo melhor idade',
           'pacotes de viagem SP',
         ]}
-        aggregateRating={reviewSummary ? {
-          ratingValue: reviewSummary.averageRating,
-          reviewCount: reviewSummary.totalReviews,
-        } : undefined}
       />
       <Hero />
 

--- a/tests/e2e/home_structured_data.spec.ts
+++ b/tests/e2e/home_structured_data.spec.ts
@@ -47,7 +47,17 @@ test.describe('Home structured data', () => {
     const serviceSchema = parseStructuredData(await serviceScript.first().innerHTML());
     expect(serviceSchema['@type']).toBe('Service');
     expect(serviceSchema.name).toBe('Agência de Viagens Personalizadas');
-    const rating = serviceSchema.aggregateRating as Record<string, unknown>;
+    expect(serviceSchema.aggregateRating).toBeUndefined();
+
+    // aggregateRating must be on the Organization schema (TravelAgency parent type),
+    // which Google supports for Review Snippets — Service is not a valid parent.
+    const orgScript = page.locator(
+      'script[type="application/ld+json"][data-av-head="script:ld-json:organization"]'
+    );
+    await expect(orgScript).toHaveCount(1);
+
+    const orgSchema = parseStructuredData(await orgScript.first().innerHTML());
+    const rating = orgSchema.aggregateRating as Record<string, unknown>;
     expect(rating).toBeDefined();
     expect(rating['@type']).toBe('AggregateRating');
     expect(rating['ratingValue']).toBe(5);


### PR DESCRIPTION
## Problema

O Google Search Console reportou um erro crítico de dados estruturados de **Snippets de Avaliação**:

> O tipo de objeto do campo `<parent_node>` não é válido

O `AggregateRating` estava vinculado ao tipo `Service` no JSON-LD do `ServiceSchema`. Porém, o Google **não suporta** `Service` como tipo pai para Review Snippets. Os tipos válidos incluem `LocalBusiness`, `Organization`, `TravelAgency` (subtipo de `LocalBusiness`), `Product`, entre outros.

## Solução

- Move o `aggregateRating` de `ServiceSchema` (`@type: Service`) para `OrganizationSchema` (`@type: ["TravelAgency", "Organization"]`), que são tipos pai válidos para o Google
- Remove a prop `aggregateRating` de `ServiceSchemaProps` — nenhuma landing page a usava
- Atualiza `Home.tsx` para passar o `reviewSummary` ao `OrganizationSchema`
- Atualiza o teste E2E para verificar o rating no schema da organização

## Test plan

- [ ] `pnpm typecheck` passa sem erros
- [ ] `pnpm test:regression` — 494 testes passam
- [ ] Teste E2E `home_structured_data.spec.ts` verifica `aggregateRating` no schema da organização
- [ ] Validar JSON-LD no [Google Rich Results Test](https://search.google.com/test/rich-results) após deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_015t2qF442j7EJkctXN78VLm)_