### PR TITLE
fix(lgpd): adicionar checkbox de consentimento ao formulário corporativo

### DIFF
--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -30,8 +30,9 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
     const [submitState, setSubmitState] = useState<'idle' | 'success' | 'error'>('idle');
     const [errorMessage, setErrorMessage] = useState('');
     const [acceptedLGPD, setAcceptedLGPD] = useState(false);
-    const [lgpdError, setLgpdError] = useState('');
     const isLocallySubmitting = useRef(false);
+
+    const lgpdError = submitState === 'error' && !acceptedLGPD ? 'Aceite obrigatório' : '';
 
     function handleField(field: keyof typeof form) {
         return (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -61,10 +62,8 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
         if (!acceptedLGPD) {
             setSubmitState('error');
             setErrorMessage('Você deve aceitar os termos para continuar.');
-            setLgpdError('Aceite obrigatório');
             return;
         }
-        setLgpdError('');
         isLocallySubmitting.current = true;
         setErrorMessage('');
 
@@ -264,10 +263,7 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                                         id="lgpd-corp"
                                         type="checkbox"
                                         checked={acceptedLGPD}
-                                        onChange={(e) => {
-                                            setAcceptedLGPD(e.target.checked);
-                                            if (e.target.checked) setLgpdError('');
-                                        }}
+                                        onChange={(e) => setAcceptedLGPD(e.target.checked)}
                                         className="peer size-4 cursor-pointer appearance-none rounded border-2 border-zinc-300 bg-white checked:bg-brand-cyan checked:border-brand-cyan transition focus-visible:ring-2 focus-visible:ring-brand-cyan/40"
                                     />
                                     <Check className="absolute size-3 text-white opacity-0 peer-checked:opacity-100 left-0.5 pointer-events-none transition-opacity" weight="bold" />

--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -6,6 +6,7 @@ import {
     AirplaneTilt,
     PaperPlaneTilt,
     SpinnerGap,
+    Check,
 } from '@phosphor-icons/react';
 import { useLeadCapture, createLeadEventId } from '@/hooks/useLeadCapture';
 import { normalizeWhatsappNumber } from '@/lib/lead-logic';
@@ -28,6 +29,8 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
     });
     const [submitState, setSubmitState] = useState<'idle' | 'success' | 'error'>('idle');
     const [errorMessage, setErrorMessage] = useState('');
+    const [acceptedLGPD, setAcceptedLGPD] = useState(false);
+    const [lgpdError, setLgpdError] = useState('');
     const isLocallySubmitting = useRef(false);
 
     function handleField(field: keyof typeof form) {
@@ -55,6 +58,13 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
             setErrorMessage('Insira um número de WhatsApp válido');
             return;
         }
+        if (!acceptedLGPD) {
+            setSubmitState('error');
+            setErrorMessage('Você deve aceitar os termos para continuar.');
+            setLgpdError('Aceite obrigatório');
+            return;
+        }
+        setLgpdError('');
         isLocallySubmitting.current = true;
         setErrorMessage('');
 
@@ -247,6 +257,41 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                             </div>
                         </div>
 
+                        <div className="flex flex-col gap-1">
+                            <label htmlFor="lgpd-corp" className="flex items-start gap-3 cursor-pointer group">
+                                <span className="relative flex items-center mt-0.5">
+                                    <input
+                                        id="lgpd-corp"
+                                        type="checkbox"
+                                        checked={acceptedLGPD}
+                                        onChange={(e) => {
+                                            setAcceptedLGPD(e.target.checked);
+                                            if (e.target.checked) setLgpdError('');
+                                        }}
+                                        className="peer size-4 cursor-pointer appearance-none rounded border-2 border-zinc-300 bg-white checked:bg-brand-cyan checked:border-brand-cyan transition focus-visible:ring-2 focus-visible:ring-brand-cyan/40"
+                                    />
+                                    <Check className="absolute size-3 text-white opacity-0 peer-checked:opacity-100 left-0.5 pointer-events-none transition-opacity" weight="bold" />
+                                </span>
+                                <span className="text-xs text-zinc-500 leading-tight">
+                                    Aceito receber comunicações e autorizo o tratamento dos meus dados conforme a{' '}
+                                    <a
+                                        href="/politica-privacidade/"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="underline hover:text-brand-cyan"
+                                    >
+                                        Política de Privacidade
+                                    </a>
+                                    .
+                                </span>
+                            </label>
+                            {lgpdError && (
+                                <span className="text-[10px] text-red-500 font-bold ml-7 uppercase">
+                                    {lgpdError}
+                                </span>
+                            )}
+                        </div>
+
                         {submitState === 'error' && errorMessage && (
                             <p className="text-red-500 text-xs font-medium" role="alert">
                                 {errorMessage}
@@ -271,10 +316,6 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                                 </>
                             )}
                         </button>
-
-                        <p className="text-xs text-zinc-400 text-center leading-relaxed">
-                            Seus dados são usados apenas para entrar em contato. Não compartilhamos com terceiros.
-                        </p>
                     </div>
                 </form>
             )}

--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -263,7 +263,13 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                                         id="lgpd-corp"
                                         type="checkbox"
                                         checked={acceptedLGPD}
-                                        onChange={(e) => setAcceptedLGPD(e.target.checked)}
+                                        onChange={(e) => {
+                                            setAcceptedLGPD(e.target.checked);
+                                            if (e.target.checked && errorMessage === 'Você deve aceitar os termos para continuar.') {
+                                                setErrorMessage('');
+                                                setSubmitState('idle');
+                                            }
+                                        }}
                                         className="peer size-4 cursor-pointer appearance-none rounded border-2 border-zinc-300 bg-white checked:bg-brand-cyan checked:border-brand-cyan transition focus-visible:ring-2 focus-visible:ring-brand-cyan/40"
                                     />
                                     <Check className="absolute size-3 text-white opacity-0 peer-checked:opacity-100 left-0.5 pointer-events-none transition-opacity" weight="bold" />
@@ -271,7 +277,7 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                                 <span className="text-xs text-zinc-500 leading-tight">
                                     Aceito receber comunicações e autorizo o tratamento dos meus dados conforme a{' '}
                                     <a
-                                        href="/politica-privacidade/"
+                                        href="https://www.anhanga.tur.br/politica-privacidade/"
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="underline hover:text-brand-cyan"

--- a/docs/superpowers/plans/2026-06-03-cookie-consent-cmp.md
+++ b/docs/superpowers/plans/2026-06-03-cookie-consent-cmp.md
@@ -1,0 +1,1004 @@
+# Cookie Consent Banner (CMP) — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implementar banner de consentimento LGPD que bloqueia Mautic e HubSpot até aceite do usuário, integra Google Consent Mode v2, e oferece revogação a qualquer momento.
+
+**Architecture:** `lib/consent.ts` gerencia estado puro em localStorage e dispara CustomEvents. `index.html` lê localStorage antes do React montar para gatekeear scripts de terceiros e configura Consent Mode v2. `CookieConsentBanner.tsx` monta em `AppLayout` ao lado de `ClientFeatures` e escuta eventos para reaparecer. Footers de todas as páginas expõem `triggerResetBanner()`.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS, `node:test` (unitários), Playwright (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-06-03-cookie-consent-cmp-design.md`
+
+---
+
+## Chunk 1: `lib/consent.ts` + testes unitários
+
+### Files
+- Create: `lib/consent.ts`
+- Create: `tests/consent.test.ts`
+
+---
+
+### Task 1: Escrever os testes unitários que vão falhar
+
+**Files:**
+- Create: `tests/consent.test.ts`
+
+- [ ] **1.0 Confirmar que o projeto é ESM (pré-requisito para top-level await)**
+
+```bash
+grep '"type"' package.json
+```
+
+Esperado: `"type": "module"`. Se não aparecer, o `await import(...)` abaixo não funcionará — reportar ao usuário antes de continuar.
+
+- [ ] **1.1 Criar `tests/consent.test.ts` com mocks e todos os casos**
+
+```typescript
+import test, { beforeEach, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+// --- Mocks de browser APIs ---
+const eventsFired: string[] = [];
+let store: Record<string, string> = {};
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { store = {}; },
+  },
+  configurable: true,
+  writable: true,
+});
+
+Object.defineProperty(globalThis, 'dispatchEvent', {
+  value: (event: Event) => { eventsFired.push(event.type); return true; },
+  configurable: true,
+  writable: true,
+});
+
+// Importar APÓS configurar os mocks (execução de módulo ocorre no import)
+const { getConsent, setConsent, triggerResetBanner } = await import('../lib/consent.ts');
+
+// --- Helpers ---
+function clearAll() {
+  store = {};
+  eventsFired.length = 0;
+}
+
+// --- Testes ---
+describe('getConsent()', () => {
+  beforeEach(clearAll);
+
+  test('retorna null quando chave ausente', () => {
+    assert.strictEqual(getConsent(), null);
+  });
+
+  test('retorna "marketing" quando valor gravado é "marketing"', () => {
+    store['anhanga_cookie_consent'] = 'marketing';
+    assert.strictEqual(getConsent(), 'marketing');
+  });
+
+  test('retorna "essential" quando valor gravado é "essential"', () => {
+    store['anhanga_cookie_consent'] = 'essential';
+    assert.strictEqual(getConsent(), 'essential');
+  });
+
+  test('retorna null para valor inválido', () => {
+    store['anhanga_cookie_consent'] = 'foo';
+    assert.strictEqual(getConsent(), null);
+  });
+});
+
+describe('setConsent("marketing")', () => {
+  beforeEach(clearAll);
+
+  test('grava "marketing" no localStorage', () => {
+    setConsent('marketing');
+    assert.strictEqual(store['anhanga_cookie_consent'], 'marketing');
+  });
+
+  test('grava metadados com choice, timestamp e version', () => {
+    setConsent('marketing');
+    const meta = JSON.parse(store['anhanga_cookie_consent_meta'] ?? '{}');
+    assert.strictEqual(meta.choice, 'marketing');
+    assert.strictEqual(meta.version, '1');
+    assert.ok(meta.timestamp, 'timestamp deve estar presente');
+    assert.doesNotThrow(() => new Date(meta.timestamp));
+  });
+
+  test('dispara anhanga:marketing-consent', () => {
+    setConsent('marketing');
+    assert.ok(eventsFired.includes('anhanga:marketing-consent'));
+  });
+
+  test('não dispara anhanga:revoke-consent', () => {
+    setConsent('marketing');
+    assert.ok(!eventsFired.includes('anhanga:revoke-consent'));
+  });
+});
+
+describe('setConsent("essential") — primeira escolha (anterior era null)', () => {
+  beforeEach(clearAll);
+
+  test('grava "essential" no localStorage', () => {
+    setConsent('essential');
+    assert.strictEqual(store['anhanga_cookie_consent'], 'essential');
+  });
+
+  test('não dispara nenhum evento de consentimento', () => {
+    setConsent('essential');
+    assert.ok(!eventsFired.includes('anhanga:marketing-consent'));
+    assert.ok(!eventsFired.includes('anhanga:revoke-consent'));
+  });
+});
+
+describe('setConsent("essential") — revogação (anterior era "marketing")', () => {
+  beforeEach(() => {
+    clearAll();
+    store['anhanga_cookie_consent'] = 'marketing';
+  });
+
+  test('grava "essential" no localStorage', () => {
+    setConsent('essential');
+    assert.strictEqual(store['anhanga_cookie_consent'], 'essential');
+  });
+
+  test('dispara anhanga:revoke-consent', () => {
+    setConsent('essential');
+    assert.ok(eventsFired.includes('anhanga:revoke-consent'));
+  });
+
+  test('não dispara anhanga:marketing-consent', () => {
+    setConsent('essential');
+    assert.ok(!eventsFired.includes('anhanga:marketing-consent'));
+  });
+});
+
+describe('triggerResetBanner()', () => {
+  beforeEach(clearAll);
+
+  test('dispara anhanga:reset-consent', () => {
+    triggerResetBanner();
+    assert.ok(eventsFired.includes('anhanga:reset-consent'));
+  });
+
+  test('não altera o localStorage', () => {
+    store['anhanga_cookie_consent'] = 'marketing';
+    triggerResetBanner();
+    assert.strictEqual(store['anhanga_cookie_consent'], 'marketing');
+  });
+});
+
+describe('degradação silenciosa — localStorage indisponível', () => {
+  test('getConsent() não lança exceção', () => {
+    const original = globalThis.localStorage;
+    Object.defineProperty(globalThis, 'localStorage', {
+      get() { throw new Error('blocked'); },
+      configurable: true,
+    });
+    assert.doesNotThrow(() => getConsent());
+    Object.defineProperty(globalThis, 'localStorage', { value: original, configurable: true });
+  });
+
+  test('setConsent() não lança exceção', () => {
+    const original = globalThis.localStorage;
+    Object.defineProperty(globalThis, 'localStorage', {
+      get() { throw new Error('blocked'); },
+      configurable: true,
+    });
+    assert.doesNotThrow(() => setConsent('marketing'));
+    Object.defineProperty(globalThis, 'localStorage', { value: original, configurable: true });
+  });
+});
+```
+
+- [ ] **1.2 Verificar que os testes falham (arquivo alvo não existe)**
+
+```bash
+pnpm test:regression 2>&1 | grep "consent"
+```
+
+Esperado: erro `Cannot find module '../lib/consent.ts'` ou similar.
+
+---
+
+### Task 2: Implementar `lib/consent.ts`
+
+**Files:**
+- Create: `lib/consent.ts`
+
+- [ ] **2.1 Criar `lib/consent.ts`**
+
+```typescript
+const CHOICE_KEY = 'anhanga_cookie_consent';
+const META_KEY = 'anhanga_cookie_consent_meta';
+const SCHEMA_VERSION = '1';
+
+export type ConsentChoice = 'marketing' | 'essential';
+
+export function getConsent(): ConsentChoice | null {
+  try {
+    const v = localStorage.getItem(CHOICE_KEY);
+    return v === 'marketing' || v === 'essential' ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setConsent(choice: ConsentChoice): void {
+  try {
+    const previous = localStorage.getItem(CHOICE_KEY);
+    localStorage.setItem(CHOICE_KEY, choice);
+    localStorage.setItem(
+      META_KEY,
+      JSON.stringify({ choice, timestamp: new Date().toISOString(), version: SCHEMA_VERSION })
+    );
+    if (choice === 'marketing') {
+      dispatch(new CustomEvent('anhanga:marketing-consent'));
+    } else if (previous === 'marketing') {
+      dispatch(new Event('anhanga:revoke-consent'));
+    }
+  } catch {
+    // localStorage indisponível (modo privado, storage cheio)
+  }
+}
+
+export function triggerResetBanner(): void {
+  // NÃO toca o localStorage — preserva valor anterior para detecção de transição em setConsent()
+  dispatch(new Event('anhanga:reset-consent'));
+}
+
+function dispatch(event: Event): void {
+  if (typeof window !== 'undefined') window.dispatchEvent(event);
+  else if (typeof globalThis.dispatchEvent === 'function') globalThis.dispatchEvent(event);
+}
+```
+
+- [ ] **2.2 Rodar testes e verificar que passam**
+
+```bash
+pnpm test:regression 2>&1 | grep -A 2 "consent"
+```
+
+Esperado: todos os casos passam, zero falhas.
+
+- [ ] **2.3 Commit**
+
+```bash
+git add lib/consent.ts tests/consent.test.ts
+git commit -m "feat(cmp): add lib/consent.ts with unit tests"
+```
+
+---
+
+## Chunk 2: `index.html` — Consent Mode v2 + gates
+
+### Files
+- Modify: `index.html`
+- Modify: `tests/index-third-party-scripts.test.ts`
+
+---
+
+### Task 3: Adicionar bloco Consent Mode v2 no `index.html`
+
+**Files:**
+- Modify: `index.html`
+
+O bloco `<script>window.dataLayer = window.dataLayer || [];</script>` já existe. Adicionar o bloco de consent IMEDIATAMENTE APÓS ele e ANTES do `<script type="module" src="/index.tsx">`.
+
+- [ ] **3.1 Inserir bloco gtag consent defaults**
+
+Localizar no `index.html`:
+```html
+  <script>window.dataLayer = window.dataLayer || [];</script>
+  <script type="module" src="/index.tsx"></script>
+```
+
+Substituir por:
+```html
+  <script>window.dataLayer = window.dataLayer || [];</script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    var _consentInit = (function () { try { return localStorage.getItem('anhanga_cookie_consent'); } catch (e) { return null; } })();
+    gtag('consent', 'default', {
+      analytics_storage: 'granted',
+      ad_storage: _consentInit === 'marketing' ? 'granted' : 'denied',
+      ad_personalization: _consentInit === 'marketing' ? 'granted' : 'denied',
+      ad_user_data: _consentInit === 'marketing' ? 'granted' : 'denied',
+      wait_for_update: 2000
+    });
+  </script>
+  <script type="module" src="/index.tsx"></script>
+```
+
+> **Importante:** `function gtag()` deve ficar no escopo **global** (fora de qualquer IIFE). Isso garante que os listeners `anhanga:marketing-consent` e `anhanga:revoke-consent`, definidos dentro da IIFE de scripts lazy, consigam chamar `gtag()` via `typeof gtag === 'function'` sem erro de escopo.
+
+---
+
+### Task 4: Adicionar `_consentChoice` e gates na IIFE existente
+
+**Files:**
+- Modify: `index.html`
+
+A IIFE começa com `(function () {` e logo tem `var analyticsLoaded = false;`. Fazer duas modificações:
+
+- [ ] **4.1 Adicionar leitura de `_consentChoice` no topo da IIFE**
+
+Localizar o início da IIFE:
+```js
+    (function () {
+      var analyticsLoaded = false;
+```
+
+Substituir por:
+```js
+    (function () {
+      var _consentChoice = (function () { try { return localStorage.getItem('anhanga_cookie_consent'); } catch (e) { return null; } })();
+      var analyticsLoaded = false;
+```
+
+- [ ] **4.2 Adicionar gate em `loadMautic`**
+
+Localizar:
+```js
+      var loadMautic = function () {
+        if (mauticLoaded) return;
+```
+
+Substituir por:
+```js
+      var loadMautic = function () {
+        if (_consentChoice !== 'marketing') return;
+        if (mauticLoaded) return;
+```
+
+- [ ] **4.3 Adicionar gate em `loadHubspot`**
+
+Localizar:
+```js
+      var loadHubspot = function () {
+        if (hubspotLoaded) return;
+```
+
+Substituir por:
+```js
+      var loadHubspot = function () {
+        if (_consentChoice !== 'marketing') return;
+        if (hubspotLoaded) return;
+```
+
+- [ ] **4.4 Adicionar listeners `anhanga:marketing-consent` e `anhanga:revoke-consent` no final da IIFE, antes do `})()`**
+
+Localizar o fechamento da IIFE `    })();` e adicionar os listeners ANTES dele:
+
+```js
+      window.addEventListener('anhanga:marketing-consent', function () {
+        _consentChoice = 'marketing';
+        loadMautic();
+        loadHubspot();
+        if (typeof gtag === 'function') {
+          gtag('consent', 'update', { ad_storage: 'granted', ad_personalization: 'granted', ad_user_data: 'granted' });
+        }
+      }, { once: true });
+
+      window.addEventListener('anhanga:revoke-consent', function () {
+        _consentChoice = 'essential';
+        if (typeof gtag === 'function') {
+          gtag('consent', 'update', { ad_storage: 'denied', ad_personalization: 'denied', ad_user_data: 'denied' });
+        }
+        window.location.reload();
+      }, { once: true });
+```
+
+---
+
+### Task 5: Atualizar `tests/index-third-party-scripts.test.ts`
+
+**Files:**
+- Modify: `tests/index-third-party-scripts.test.ts`
+
+- [ ] **5.1 Adicionar asserções de conformidade LGPD no final do arquivo**
+
+Anexar ao final de `tests/index-third-party-scripts.test.ts`:
+
+```typescript
+test('index.html configura gtag consent defaults antes da IIFE de scripts lazy', () => {
+  const consentBlockIndex = indexHtml.indexOf("gtag('consent', 'default'");
+  const iifeIndex = indexHtml.indexOf('var analyticsLoaded');
+
+  assert.ok(consentBlockIndex > -1, 'bloco gtag consent default deve existir');
+  assert.ok(iifeIndex > -1, 'IIFE de scripts lazy deve existir');
+  assert.ok(consentBlockIndex < iifeIndex, 'consent default deve vir antes da IIFE');
+
+  assert.match(indexHtml, /analytics_storage:\s*'granted'/, 'analytics_storage deve ser granted por padrão (legítimo interesse)');
+  assert.match(indexHtml, /ad_storage:.*'denied'/, 'ad_storage deve ser denied por padrão');
+  assert.match(indexHtml, /wait_for_update:\s*2000/, 'wait_for_update deve ser 2000ms');
+});
+
+test('loadMautic tem gate de consentimento LGPD', () => {
+  const loadMauticMatch = indexHtml.match(/var loadMautic\s*=\s*function\s*\(\)\s*\{([\s\S]*?)};/);
+  assert.ok(loadMauticMatch, 'loadMautic deve estar definida');
+  const body = loadMauticMatch[1];
+  assert.match(body, /_consentChoice\s*!==\s*'marketing'/, 'loadMautic deve ter gate de consentimento');
+});
+
+test('loadHubspot tem gate de consentimento LGPD', () => {
+  const loadHubspotMatch = indexHtml.match(/var loadHubspot\s*=\s*function\s*\(\)\s*\{([\s\S]*?)};/);
+  assert.ok(loadHubspotMatch, 'loadHubspot deve estar definida');
+  const body = loadHubspotMatch[1];
+  assert.match(body, /_consentChoice\s*!==\s*'marketing'/, 'loadHubspot deve ter gate de consentimento');
+});
+
+test('index.html tem listener anhanga:marketing-consent', () => {
+  assert.match(indexHtml, /anhanga:marketing-consent/, 'listener de aceite deve estar presente');
+});
+
+test('index.html tem listener anhanga:revoke-consent com reload', () => {
+  assert.match(indexHtml, /anhanga:revoke-consent/, 'listener de revogação deve estar presente');
+  const revokeIdx = indexHtml.indexOf('anhanga:revoke-consent');
+  const reloadIdx = indexHtml.indexOf('window.location.reload()', revokeIdx);
+  assert.ok(reloadIdx > revokeIdx, 'reload deve ocorrer após revoke-consent');
+});
+```
+
+- [ ] **5.2 Rodar testes**
+
+```bash
+pnpm test:regression 2>&1 | grep -E "(consent|Mautic|Hubspot|LGPD|pass|fail)" -i
+```
+
+Esperado: todos passam.
+
+- [ ] **5.3 Commit**
+
+```bash
+git add index.html tests/index-third-party-scripts.test.ts
+git commit -m "feat(cmp): add Consent Mode v2 and marketing script gates to index.html"
+```
+
+---
+
+## Chunk 3: React — Banner + App.tsx + Footers
+
+### Files
+- Create: `components/CookieConsentBanner.tsx`
+- Modify: `App.tsx`
+- Modify: `components/Footer.tsx`
+- Modify: `components/landings/shared/LandingFooter.tsx`
+- Modify: `components/landings/beto-carrero/Footer.tsx`
+- Modify: `components/landings/lollapalooza/Footer.tsx`
+- Modify: `components/landings/corporativo/CorpFooter.tsx`
+
+---
+
+### Task 6: Criar `CookieConsentBanner.tsx`
+
+**Files:**
+- Create: `components/CookieConsentBanner.tsx`
+
+- [ ] **6.1 Criar o componente**
+
+```tsx
+import { useEffect, useState } from 'react';
+import { getConsent, setConsent } from '@/lib/consent';
+
+const CookieConsentBanner: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (getConsent() === null) setVisible(true);
+
+    const handleReset = () => setVisible(true);
+    window.addEventListener('anhanga:reset-consent', handleReset);
+    return () => window.removeEventListener('anhanga:reset-consent', handleReset);
+  }, []);
+
+  if (!visible) return null;
+
+  const handleAccept = () => {
+    setConsent('marketing');
+    setVisible(false);
+  };
+
+  const handleDecline = () => {
+    setConsent('essential');
+    setVisible(false);
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="false"
+      aria-label="Preferências de cookies"
+      className="fixed bottom-0 left-0 right-0 z-50 bg-brand-dark border-t border-white/10 shadow-lg"
+    >
+      <div className="container mx-auto px-6 py-4 flex flex-col sm:flex-row items-center justify-between gap-4">
+        <p className="text-sm text-zinc-300 leading-relaxed max-w-2xl">
+          Usamos cookies de marketing (Mautic e HubSpot) para comunicações personalizadas.
+          Analytics continua ativo por interesse legítimo —{' '}
+          <a
+            href="/politica-privacidade#cookies"
+            className="underline underline-offset-2 hover:text-brand-yellow transition-colors"
+          >
+            saiba como se opor em nossa Política de Privacidade
+          </a>
+          .
+        </p>
+        <div className="flex gap-3 shrink-0">
+          <button
+            onClick={handleDecline}
+            className="px-4 py-2 text-sm font-medium text-zinc-300 border border-white/20 rounded-lg hover:border-white/40 hover:text-white transition-colors"
+          >
+            Recusar
+          </button>
+          <button
+            onClick={handleAccept}
+            className="px-4 py-2 text-sm font-medium text-zinc-300 border border-white/20 rounded-lg hover:border-white/40 hover:text-white transition-colors"
+          >
+            Aceitar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CookieConsentBanner;
+```
+
+> **LGPD:** Ambos os botões têm classes Tailwind idênticas — sem nenhuma distinção de cor. Não alterar isso.
+
+---
+
+### Task 7: Montar o banner em `App.tsx`
+
+**Files:**
+- Modify: `App.tsx`
+
+O banner deve ficar no `AppLayout`, ao lado de `ClientFeatures`, para aparecer em **todas** as páginas incluindo landings.
+
+- [ ] **7.1 Adicionar import no topo do `App.tsx`**
+
+```tsx
+import CookieConsentBanner from './components/CookieConsentBanner';
+```
+
+- [ ] **7.2 Adicionar o banner em `AppLayout`**
+
+Localizar no `AppLayout`:
+```tsx
+      {includeClientFeatures ? (
+        <ClientFeatures />
+      ) : null}
+```
+
+Substituir por:
+```tsx
+      {includeClientFeatures ? (
+        <ClientFeatures />
+      ) : null}
+      <ClientOnly>
+        <CookieConsentBanner />
+      </ClientOnly>
+```
+
+> **Por que fora do `if`:** o banner deve aparecer em **todas** as páginas independente de `includeClientFeatures`. Colocar dentro do bloco condicional esconderia o banner em contextos de teste/SSR que passam `includeClientFeatures={false}`.
+
+---
+
+### Task 8: Adicionar "Gerenciar cookies" no `Footer.tsx`
+
+**Files:**
+- Modify: `components/Footer.tsx`
+
+- [ ] **8.1 Adicionar import de `triggerResetBanner`**
+
+No topo de `components/Footer.tsx`, adicionar:
+```tsx
+import { triggerResetBanner } from '@/lib/consent';
+```
+
+- [ ] **8.2 Adicionar link na seção de copyright**
+
+Localizar no footer o div com `text-[10px] text-zinc-400 font-bold uppercase`:
+```tsx
+                        <div className="text-[10px] text-zinc-400 font-bold uppercase tracking-widest mt-2">
+                            Conteúdo da equipe Anhangá Viagens
+                            {runtimeMetadata ? ` • Última atualização: ${runtimeMetadata.lastUpdatedLabel}` : null}
+                        </div>
+```
+
+Adicionar APÓS esse div:
+```tsx
+                        <div className="text-[10px] text-zinc-400 mt-1">
+                            <button
+                                onClick={triggerResetBanner}
+                                className="underline underline-offset-2 hover:text-brand-yellow transition-colors"
+                            >
+                                Gerenciar cookies
+                            </button>
+                        </div>
+```
+
+---
+
+### Task 9: Adicionar "Gerenciar cookies" nos footers de landing pages
+
+**Files:**
+- Modify: `components/landings/shared/LandingFooter.tsx`
+- Modify: `components/landings/beto-carrero/Footer.tsx`
+- Modify: `components/landings/lollapalooza/Footer.tsx`
+- Modify: `components/landings/corporativo/CorpFooter.tsx`
+
+Padrão a aplicar em cada footer: importar `triggerResetBanner` e adicionar o botão "Gerenciar cookies" ao lado dos outros links/textos de rodapé.
+
+- [ ] **9.1 `components/landings/shared/LandingFooter.tsx`**
+
+Adicionar import:
+```tsx
+import { triggerResetBanner } from '@/lib/consent';
+```
+
+Localizar o elemento `<a href="https://www.anhanga.tur.br/"...>` (o link "Ir para o site principal") e adicionar após ele:
+```tsx
+                <button
+                    onClick={triggerResetBanner}
+                    className="text-xs text-white/50 hover:text-white transition-colors duration-150 font-medium underline underline-offset-2"
+                >
+                    Gerenciar cookies
+                </button>
+```
+
+- [ ] **9.2 `components/landings/beto-carrero/Footer.tsx`**
+
+Adicionar import:
+```tsx
+import { triggerResetBanner } from '@/lib/consent';
+```
+
+Localizar a seção de copyright/CNPJ no footer e adicionar antes do fechamento:
+```tsx
+        <button
+          onClick={triggerResetBanner}
+          className="text-xs opacity-60 hover:opacity-100 transition-opacity underline underline-offset-2 mt-2"
+        >
+          Gerenciar cookies
+        </button>
+```
+
+- [ ] **9.3 `components/landings/lollapalooza/Footer.tsx`**
+
+Adicionar import:
+```tsx
+import { triggerResetBanner } from '@/lib/consent';
+```
+
+Localizar no final do bloco `border-t border-zinc-800 pt-8`:
+```tsx
+          <p className="mt-4 text-xs opacity-50">
+            Nota: Este site comercializa pacotes de viagem...
+          </p>
+        </div>
+```
+
+Adicionar após o `<p className="mt-4 text-xs opacity-50">`:
+```tsx
+          <p className="mt-3 text-xs opacity-50">
+            <button
+              onClick={triggerResetBanner}
+              className="underline underline-offset-2 hover:opacity-100 transition-opacity"
+            >
+              Gerenciar cookies
+            </button>
+          </p>
+```
+
+- [ ] **9.4 `components/landings/corporativo/CorpFooter.tsx`**
+
+`CorpFooter` é um re-export de `LandingFooter`:
+```ts
+export { LandingFooter as CorpFooter } from '../shared/LandingFooter';
+```
+
+O link "Gerenciar cookies" já está incluído pela task 9.1. Nenhuma ação necessária aqui.
+
+- [ ] **9.5 Verificar build sem erros de TypeScript**
+
+```bash
+pnpm typecheck
+```
+
+Esperado: zero erros.
+
+- [ ] **9.6 Commit**
+
+```bash
+git add components/CookieConsentBanner.tsx App.tsx components/Footer.tsx \
+  components/landings/shared/LandingFooter.tsx \
+  components/landings/beto-carrero/Footer.tsx \
+  components/landings/lollapalooza/Footer.tsx \
+  components/landings/corporativo/CorpFooter.tsx
+git commit -m "feat(cmp): add CookieConsentBanner and Gerenciar cookies links"
+```
+
+---
+
+## Chunk 4: Testes E2E + atualização do RIPD
+
+### Files
+- Create: `tests/e2e/cookie-consent.spec.ts`
+- Modify: `docs/ripd-legitimo-interesse.md`
+
+---
+
+### Task 10: Escrever testes Playwright
+
+**Files:**
+- Create: `tests/e2e/cookie-consent.spec.ts`
+
+- [ ] **10.1 Criar `tests/e2e/cookie-consent.spec.ts`**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+const CHOICE_KEY = 'anhanga_cookie_consent';
+
+test.describe('Cookie Consent Banner (CMP)', () => {
+
+  test.beforeEach(async ({ page }) => {
+    // Garantir estado limpo: sem localStorage de consentimento
+    await page.goto('/');
+    await page.evaluate((key) => localStorage.removeItem(key), CHOICE_KEY);
+  });
+
+  // --- Visibilidade ---
+
+  test('banner aparece na primeira visita', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('dialog', { name: 'Preferências de cookies' })).toBeVisible();
+  });
+
+  test('banner tem botões "Aceitar" e "Recusar" com peso visual idêntico', async ({ page }) => {
+    await page.goto('/');
+    const accept = page.getByRole('button', { name: 'Aceitar' });
+    const decline = page.getByRole('button', { name: 'Recusar' });
+
+    await expect(accept).toBeVisible();
+    await expect(decline).toBeVisible();
+
+    // Ambos devem ter a mesma classe de border (sem cor primária exclusiva em um deles)
+    const acceptClass = await accept.getAttribute('class') ?? '';
+    const declineClass = await decline.getAttribute('class') ?? '';
+    expect(acceptClass).toEqual(declineClass);
+  });
+
+  // --- Aceitar ---
+
+  test('clicar "Aceitar" fecha o banner e salva "marketing" no localStorage', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Aceitar' }).click();
+    await expect(page.getByRole('dialog', { name: 'Preferências de cookies' })).not.toBeVisible();
+
+    const value = await page.evaluate((key) => localStorage.getItem(key), CHOICE_KEY);
+    expect(value).toBe('marketing');
+  });
+
+  test('após aceitar, recarregar não mostra o banner', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Aceitar' }).click();
+    await page.reload();
+    await expect(page.getByRole('dialog', { name: 'Preferências de cookies' })).not.toBeVisible();
+  });
+
+  test('após aceitar, metadados são gravados com timestamp e version', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Aceitar' }).click();
+
+    const meta = await page.evaluate(() => {
+      const raw = localStorage.getItem('anhanga_cookie_consent_meta');
+      return raw ? JSON.parse(raw) : null;
+    });
+    expect(meta).not.toBeNull();
+    expect(meta.version).toBe('1');
+    expect(meta.choice).toBe('marketing');
+    expect(() => new Date(meta.timestamp)).not.toThrow();
+  });
+
+  // --- Recusar ---
+
+  test('clicar "Recusar" fecha o banner e salva "essential" no localStorage', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Recusar' }).click();
+    await expect(page.getByRole('dialog', { name: 'Preferências de cookies' })).not.toBeVisible();
+
+    const value = await page.evaluate((key) => localStorage.getItem(key), CHOICE_KEY);
+    expect(value).toBe('essential');
+  });
+
+  test('após recusar, recarregar não mostra o banner', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Recusar' }).click();
+    await page.reload();
+    await expect(page.getByRole('dialog', { name: 'Preferências de cookies' })).not.toBeVisible();
+  });
+
+  test('recusar não bloqueia GTM/analytics (legítimo interesse)', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Recusar' }).click();
+
+    const hasDataLayer = await page.evaluate(() => Array.isArray(window.dataLayer));
+    expect(hasDataLayer).toBe(true);
+  });
+
+  test('recusar impede carregamento do Mautic', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Recusar' }).click();
+
+    // Aguardar possíveis triggers de scroll/idle
+    await page.waitForTimeout(500);
+    const hasMautic = await page.evaluate(() => typeof window.MauticTrackingObject !== 'undefined');
+    expect(hasMautic).toBe(false);
+  });
+
+  // --- Link de Política de Privacidade ---
+
+  test('link "Política de Privacidade" aponta para /politica-privacidade#cookies', async ({ page }) => {
+    await page.goto('/');
+    const link = page.getByRole('dialog').getByRole('link');
+    const href = await link.getAttribute('href');
+    expect(href).toBe('/politica-privacidade#cookies');
+  });
+
+  // --- Gerenciar cookies (revogação) ---
+
+  test('"Gerenciar cookies" na footer reabre o banner sem limpar localStorage', async ({ page }) => {
+    // Aceitar primeiro
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Aceitar' }).click();
+
+    // Clicar em Gerenciar cookies
+    await page.getByRole('button', { name: 'Gerenciar cookies' }).click();
+
+    // Banner deve reaparecer
+    await expect(page.getByRole('dialog', { name: 'Preferências de cookies' })).toBeVisible();
+
+    // localStorage ainda tem 'marketing' (não foi limpo)
+    const value = await page.evaluate((key) => localStorage.getItem(key), CHOICE_KEY);
+    expect(value).toBe('marketing');
+  });
+
+  test('revogação: aceitar → gerenciar → recusar dispara reload e bloqueia Mautic', async ({ page }) => {
+    // Aceitar
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Aceitar' }).click();
+
+    // Clicar em Gerenciar cookies
+    await page.getByRole('button', { name: 'Gerenciar cookies' }).click();
+
+    // Aguardar banner reaparecer
+    await expect(page.getByRole('dialog', { name: 'Preferências de cookies' })).toBeVisible();
+
+    // Revogar — aguarda o reload que o listener dispara
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+      page.getByRole('button', { name: 'Recusar' }).click(),
+    ]);
+
+    // Após o reload, localStorage deve ser 'essential'
+    const value = await page.evaluate((key) => localStorage.getItem(key), CHOICE_KEY);
+    expect(value).toBe('essential');
+
+    // Mautic não deve ter carregado
+    const hasMautic = await page.evaluate(() => typeof window.MauticTrackingObject !== 'undefined');
+    expect(hasMautic).toBe(false);
+
+    // Banner não deve reaparecer
+    await expect(page.getByRole('dialog', { name: 'Preferências de cookies' })).not.toBeVisible();
+  });
+
+  // --- Aceitar com Mautic ---
+
+  test('aceitar carrega Mautic', async ({ page }) => {
+    // Interceptar o script do Mautic para confirmar que foi solicitado
+    let mauticRequested = false;
+    await page.route('**/mtc.js', async (route) => {
+      mauticRequested = true;
+      await route.fulfill({ status: 200, body: 'window.MauticTrackingObject="mt";' });
+    });
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Aceitar' }).click();
+
+    // Dar tempo para scripts lazy carregarem
+    await page.waitForTimeout(300);
+
+    expect(mauticRequested).toBe(true);
+  });
+});
+```
+
+- [ ] **10.2 Iniciar o dev server e rodar os testes E2E**
+
+```bash
+# Terminal 1
+pnpm dev
+
+# Terminal 2
+pnpm test:e2e tests/e2e/cookie-consent.spec.ts
+```
+
+Esperado: todos os testes passam. Se algum falhar por timing, ajustar `waitForTimeout` pontualmente.
+
+---
+
+### Task 11: Atualizar `docs/ripd-legitimo-interesse.md`
+
+**Files:**
+- Modify: `docs/ripd-legitimo-interesse.md`
+
+- [ ] **11.1 Atualizar §3.5 — tabela de riscos da Atividade 2**
+
+Localizar a linha da tabela:
+```markdown
+| Coleta de click IDs antes do consentimento (client-side) | Alta (antes da issue #782) | Médio | Condicionar `initializeTracking()` ao consentimento via banner; repasse de conversões já é server-side via Stape |
+```
+
+Substituir por:
+```markdown
+| Coleta de click IDs antes do consentimento (client-side) | Baixa (pós issue #782) | Baixo | `initializeTracking()` opera sob legítimo interesse (RIPD Atividade 2); repasse de conversões é integralmente server-side via Stape sGTM, sem cookie de terceiros no browser; titular pode exercer direito de oposição via `privacidade@anhanga.tur.br` |
+```
+
+- [ ] **11.2 Atualizar §3.6 — salvaguardas pendentes da Atividade 2**
+
+Localizar:
+```markdown
+- [ ] **Pendente (issue #782):** bloquear `initializeTracking()` antes do consentimento do usuário
+```
+
+Substituir por:
+```markdown
+- [x] **Implementado (issue #782):** `initializeTracking()` opera sob legítimo interesse; banner de cookies bloqueia Mautic e HubSpot; direito de oposição ao tratamento por interesse legítimo disponível via `privacidade@anhanga.tur.br` e documentado em `/politica-privacidade#cookies`
+```
+
+- [ ] **11.3 Atualizar o histórico de versões no final do RIPD**
+
+Adicionar linha na tabela de versões:
+```markdown
+| 1.2 | 2026-06-03 | Revisão pós issue #782: atualização de §3.5 e §3.6 da Atividade 2; `initializeTracking()` mantido sob legítimo interesse; canal de oposição documentado |
+```
+
+- [ ] **11.4 Rodar todos os testes de regressão para garantir que nada quebrou**
+
+```bash
+pnpm test:regression
+```
+
+Esperado: zero falhas.
+
+- [ ] **11.5 Commit final**
+
+```bash
+git add tests/e2e/cookie-consent.spec.ts docs/ripd-legitimo-interesse.md
+git commit -m "feat(cmp): add E2E tests and update RIPD v1.2 (issue #782)"
+```
+
+---
+
+## Checklist final de QA manual
+
+Antes de abrir o PR, verificar manualmente no browser (`pnpm dev`):
+
+- [ ] Banner aparece na homepage em aba anônima (sem localStorage)
+- [ ] Botões "Aceitar" e "Recusar" têm aparência visual idêntica
+- [ ] Clicar "Aceitar" → banner some → recarregar → banner não reaparece
+- [ ] Clicar "Recusar" → banner some → recarregar → banner não reaparece
+- [ ] "Gerenciar cookies" na footer → banner reaparece
+- [ ] "Gerenciar cookies" → "Recusar" → página recarrega → Mautic não carrega (verificar DevTools → Network)
+- [ ] Banner aparece também em `/beto-carrero`, `/lollapalooza`, `/corporativo`
+- [ ] Link "Política de Privacidade" no banner leva para `/politica-privacidade#cookies`
+- [ ] Console sem erros de JS

--- a/docs/superpowers/specs/2026-06-03-cookie-consent-cmp-design.md
+++ b/docs/superpowers/specs/2026-06-03-cookie-consent-cmp-design.md
@@ -22,7 +22,7 @@ GA4 (via sGTM Stape) e o rastreamento UTM/click IDs (`initializeTracking()`) sã
 
 O RIPD v1.1 lista como pendência da issue #782 "bloquear `initializeTracking()` antes do consentimento". Esta implementação **revisa essa pendência**: a decisão de produto é que analytics e UTM são tratados por legítimo interesse e não serão gatekeados pelo banner. O RIPD v1.1 deverá ser atualizado na mesma PR para:
 
-1. Remover "bloquear `initializeTracking()`" das pendências das Atividades 1 e 2.
+1. Remover "bloquear `initializeTracking()`" das pendências da **Atividade 2** (único local onde o item existe — §3.6, linha do RIPD).
 2. Substituir a salvaguarda "opt-out via banner de cookies" pela descrição real: **direito de oposição ao legítimo interesse exercido via `privacidade@anhanga.tur.br` ou pelo opt-out do GA4 documentado em `/politica-privacidade#cookies`**.
 
 ---
@@ -38,7 +38,7 @@ O RIPD v1.1 lista como pendência da issue #782 "bloquear `initializeTracking()`
 | Peso visual dos botões | Idêntico | Resolução ANPD 15/2024 proíbe dark patterns |
 | Persistência | `localStorage` chave `anhanga_cookie_consent` (choice) + `anhanga_cookie_consent_meta` (JSON com timestamp e versão) | Chave simples para o script inline no `index.html`; metadados separados para auditabilidade (Art. 8º, §1º) |
 | Revogação na sessão | `gtag('consent', 'update', {...denied})` + `window.location.reload()` | Garante que scripts já carregados sejam descarregados; cumpre Art. 8º, §5º com efeito imediato |
-| Canal de revogação UI | `window.dispatchEvent(new Event('anhanga:reset-consent'))` disparado pelo Footer; banner escuta e reaparece | Evita prop-drilling através dos níveis de rota do `AppLayout` |
+| Canal de revogação UI | Footer chama `triggerResetBanner()` → dispara `anhanga:reset-consent` sem tocar localStorage; banner escuta e reaparece | Preserva valor anterior para detecção de transição em `setConsent()`; evita prop-drilling |
 | Footers com "Gerenciar cookies" | `Footer.tsx` (site principal) + footers de landing pages (`/beto-carrero`, `/lollapalooza`, etc.) | Revogação disponível em todas as páginas onde o banner aparece |
 
 ---
@@ -59,7 +59,7 @@ O RIPD v1.1 lista como pendência da issue #782 "bloquear `initializeTracking()`
 | Arquivo | Mudança |
 |---|---|
 | `index.html` | Bloco `gtag('consent', 'default', {...})` antes da IIFE de carregamento lazy. Leitura de localStorage no topo da IIFE. Gate em `loadMautic`/`loadHubspot`. Listeners `anhanga:marketing-consent` e `anhanga:revoke-consent`. |
-| `App.tsx` | `<CookieConsentBanner />` dentro de `AppLayout`, fora das rotas. |
+| `App.tsx` | `<CookieConsentBanner />` adicionado em `AppLayout` ao nível de `<ClientFeatures />` (não dentro de `MainSiteShell`), para que renderize em todas as páginas incluindo landing pages. |
 | `components/Footer.tsx` | Link "Gerenciar cookies" que dispara `anhanga:reset-consent`. |
 | Footers de landing pages | Mesmo link "Gerenciar cookies" — todas as landings com footer próprio. |
 | `docs/ripd-legitimo-interesse.md` | Atualizar pendências das Atividades 1 e 2 conforme descrito na Seção 1. |
@@ -78,11 +78,18 @@ export function getConsent(): ConsentChoice | null
 // Grava 'anhanga_cookie_consent' = choice (string simples, lida pelo index.html).
 // Grava 'anhanga_cookie_consent_meta' = JSON { choice, timestamp: ISO8601, version: '1' } (auditoria Art. 8º §1º).
 // Se choice === 'marketing': dispara window.dispatchEvent(new CustomEvent('anhanga:marketing-consent')).
+// Se choice === 'essential' E o valor anterior era 'marketing' (revogação):
+//   dispara window.dispatchEvent(new Event('anhanga:revoke-consent')).
+//   O listener no index.html faz gtag denied + window.location.reload().
+// Se choice === 'essential' E o valor anterior era null (primeira escolha):
+//   nenhum evento adicional — nenhum script foi carregado, sem necessidade de reload.
 export function setConsent(choice: ConsentChoice): void
 
-// Remove ambas as chaves do localStorage.
-// Dispara window.dispatchEvent(new Event('anhanga:reset-consent')) para que o banner reaça.
-export function resetConsent(): void
+// Dispara apenas window.dispatchEvent(new Event('anhanga:reset-consent')).
+// NÃO limpa o localStorage — mantém o valor anterior ('marketing' | 'essential')
+// para que setConsent() detecte a transição corretamente quando o usuário fizer nova escolha.
+// Usado pelo Footer para reabrir o banner sem perder o estado.
+export function triggerResetBanner(): void
 ```
 
 Todas as funções degradam silenciosamente se `localStorage` não estiver disponível (modo privado, storage cheio).
@@ -148,15 +155,24 @@ React monta → CookieConsentBanner → 'essential' → renderiza null
 ### Revogação (usuário que havia aceito clica "Gerenciar cookies")
 
 ```
-Footer dispara window.dispatchEvent(new Event('anhanga:reset-consent'))
+Footer chama triggerResetBanner()
+  → dispatchEvent('anhanga:reset-consent')
+  → localStorage permanece 'marketing'  ← estado preservado para detectar transição
   → CookieConsentBanner escuta o evento → exibe banner novamente
 
 Usuário clica "Recusar"
   → setConsent('essential')
-  → localStorage ← 'essential'
-  → gtag('consent', 'update', { ad_storage: 'denied', ad_personalization: 'denied', ad_user_data: 'denied' })
+  → lê valor anterior do localStorage → 'marketing'  ← transição detectada
+  → localStorage ← 'essential' + metadados
+  → dispatchEvent('anhanga:revoke-consent')
+  → index.html listener → gtag('consent', 'update', { ad_storage: 'denied', ... })
   → window.location.reload()
-    → no reload: localStorage = 'essential' → Mautic/HubSpot bloqueados desde o início da nova sessão
+    → no reload: localStorage = 'essential' → Mautic/HubSpot bloqueados desde o início
+
+Usuário clica "Aceitar" (mudou de ideia)
+  → setConsent('marketing')
+  → valor anterior já era 'marketing' → nenhuma mudança de estado → nenhum reload
+  → banner some
 ```
 
 ---
@@ -173,7 +189,7 @@ Usuário clica "Recusar"
 
 ### Revogação (footers)
 
-Link "Gerenciar cookies" na linha de copyright de **todos os footers** (site principal e landing pages). Ao clicar: `resetConsent()` + `window.dispatchEvent(new Event('anhanga:reset-consent'))`. O banner escuta o evento e volta a exibir sem prop-drilling.
+Link "Gerenciar cookies" na linha de copyright de **todos os footers** (site principal e landing pages). Ao clicar: `triggerResetBanner()` — dispara `anhanga:reset-consent` **sem limpar o localStorage**, preservando o valor anterior para que `setConsent()` detecte a transição corretamente. O banner escuta o evento e volta a exibir sem prop-drilling.
 
 ---
 
@@ -255,7 +271,7 @@ window.addEventListener('anhanga:revoke-consent', function() {
 }, { once: true });
 ```
 
-> **Nota:** `setConsent('essential')` em lib/consent.ts dispara `anhanga:revoke-consent` apenas quando estava anteriormente em `'marketing'` (i.e., no fluxo de revogação). No fluxo de primeira escolha "Recusar", nenhum reload é necessário pois nenhum script foi carregado.
+> **Nota:** `setConsent('essential')` dispara `anhanga:revoke-consent` apenas quando o valor anterior no localStorage era `'marketing'` (transição de revogação). No fluxo de primeira escolha "Recusar" (valor anterior = `null`), nenhum evento de revogação é disparado e nenhum reload ocorre, pois nenhum script de marketing foi carregado.
 
 ---
 
@@ -270,9 +286,9 @@ window.addEventListener('anhanga:revoke-consent', function() {
 | `getConsent()` com `'essential'` | Retorna `'essential'` |
 | `getConsent()` com valor inválido | Retorna `null` |
 | `setConsent('marketing')` | Escreve localStorage + dispara `anhanga:marketing-consent` + grava metadados com timestamp e version |
-| `setConsent('essential')` | Escreve localStorage + **não** dispara `anhanga:marketing-consent` |
-| `resetConsent()` | Remove ambas as chaves do localStorage + dispara `anhanga:reset-consent` |
-| `getConsent()` após `resetConsent()` | Retorna `null` |
+| `setConsent('essential')` quando anterior é `null` | Escreve localStorage + não dispara nenhum evento extra |
+| `setConsent('essential')` quando anterior é `'marketing'` | Escreve localStorage + dispara `anhanga:revoke-consent` |
+| `triggerResetBanner()` | Dispara `anhanga:reset-consent`; localStorage **não é alterado** |
 | localStorage indisponível (throw simulado) | Não lança exceção |
 
 ### `tests/e2e/cookie-consent.spec.ts` (Playwright)
@@ -287,8 +303,8 @@ window.addEventListener('anhanga:revoke-consent', function() {
 | Recarregar após recusa | Banner não reaparece |
 | Recusar → analytics continua ativo | GTM ainda carregou; `window.dataLayer` existe (legítimo interesse não bloqueado) |
 | Link "Política de Privacidade" | Navega para `/politica-privacidade#cookies` |
-| "Gerenciar cookies" na footer | Banner reaparece + localStorage limpo |
-| Revogação: aceitar → gerenciar → recusar | `window.location.reload()` disparado; após reload Mautic não carrega |
+| "Gerenciar cookies" na footer | Banner reaparece + localStorage **mantém** valor anterior |
+| Revogação: aceitar → gerenciar → recusar | `anhanga:revoke-consent` disparado + `window.location.reload()`; após reload Mautic não carrega |
 | Aceitar → Mautic carrega | `window.MauticTrackingObject` definido |
 | Recusar → Mautic não carrega | `window.MauticTrackingObject` indefinido |
 

--- a/docs/superpowers/specs/2026-06-03-cookie-consent-cmp-design.md
+++ b/docs/superpowers/specs/2026-06-03-cookie-consent-cmp-design.md
@@ -16,7 +16,14 @@ O site não possui mecanismo de consentimento prévio para cookies de marketing,
 - **HubSpot tracking passivo** (`js.hs-scripts.com/50895604.js`) — rastreamento passivo de visitantes
 - **Tags de remarketing via GTM** — publicidade direcionada
 
-GA4 (via sGTM Stape) e o rastreamento UTM/click IDs (`initializeTracking()`) são classificados como **legítimo interesse** no RIPD v1.1 e não requerem opt-in, mas o titular tem direito de oposição.
+GA4 (via sGTM Stape) e o rastreamento UTM/click IDs (`initializeTracking()`) são classificados como **legítimo interesse** no RIPD v1.1 e não requerem opt-in, mas o titular tem direito de oposição (Art. 18).
+
+### Relação com o RIPD v1.1
+
+O RIPD v1.1 lista como pendência da issue #782 "bloquear `initializeTracking()` antes do consentimento". Esta implementação **revisa essa pendência**: a decisão de produto é que analytics e UTM são tratados por legítimo interesse e não serão gatekeados pelo banner. O RIPD v1.1 deverá ser atualizado na mesma PR para:
+
+1. Remover "bloquear `initializeTracking()`" das pendências das Atividades 1 e 2.
+2. Substituir a salvaguarda "opt-out via banner de cookies" pela descrição real: **direito de oposição ao legítimo interesse exercido via `privacidade@anhanga.tur.br` ou pelo opt-out do GA4 documentado em `/politica-privacidade#cookies`**.
 
 ---
 
@@ -24,13 +31,15 @@ GA4 (via sGTM Stape) e o rastreamento UTM/click IDs (`initializeTracking()`) sã
 
 | Decisão | Escolha | Justificativa |
 |---|---|---|
-| `initializeTracking()` | Não alterar | Legítimo interesse (RIPD Atividade 2) — não precisa de gate de consentimento |
-| Consent Mode v2 | Integrar | Preserva dados modelados do GA4 antes do aceite; `analytics_storage: 'granted'` por padrão |
-| Granularidade do banner | 2 botões (sem "Personalizar") | Apenas 1 categoria requer consentimento; granularidade desnecessária |
-| Labels dos botões | "Aceitar" / "Recusar" | Evitar a palavra "marketing" nos botões para reduzir aversão; informação está no texto do banner |
-| Peso visual dos botões | Idêntico | Resolução ANPD 15/2024 proíbe dark patterns (botão de aceite destacado) |
-| Persistência | `localStorage` chave `anhanga_cookie_consent` | Padrão do projeto; sem cookie para persistir consentimento |
-| Revogação | Link "Gerenciar cookies" na footer | Art. 8º, §5º — revogação gratuita e facilitada a qualquer momento |
+| `initializeTracking()` | Não alterar | Legítimo interesse (RIPD Atividade 2) — sem gate de consentimento |
+| Consent Mode v2 | Integrar | Preserva dados modelados do GA4; `analytics_storage: 'granted'` por padrão |
+| Granularidade do banner | 2 botões (sem "Personalizar") | Apenas 1 categoria requer consentimento |
+| Labels dos botões | "Aceitar" / "Recusar" | Evitar "marketing" nos botões para reduzir aversão; informação está no texto |
+| Peso visual dos botões | Idêntico | Resolução ANPD 15/2024 proíbe dark patterns |
+| Persistência | `localStorage` chave `anhanga_cookie_consent` (choice) + `anhanga_cookie_consent_meta` (JSON com timestamp e versão) | Chave simples para o script inline no `index.html`; metadados separados para auditabilidade (Art. 8º, §1º) |
+| Revogação na sessão | `gtag('consent', 'update', {...denied})` + `window.location.reload()` | Garante que scripts já carregados sejam descarregados; cumpre Art. 8º, §5º com efeito imediato |
+| Canal de revogação UI | `window.dispatchEvent(new Event('anhanga:reset-consent'))` disparado pelo Footer; banner escuta e reaparece | Evita prop-drilling através dos níveis de rota do `AppLayout` |
+| Footers com "Gerenciar cookies" | `Footer.tsx` (site principal) + footers de landing pages (`/beto-carrero`, `/lollapalooza`, etc.) | Revogação disponível em todas as páginas onde o banner aparece |
 
 ---
 
@@ -40,7 +49,7 @@ GA4 (via sGTM Stape) e o rastreamento UTM/click IDs (`initializeTracking()`) sã
 
 | Arquivo | Responsabilidade |
 |---|---|
-| `lib/consent.ts` | Lógica pura: ler/escrever localStorage, disparar `anhanga:marketing-consent`. Sem React, sem efeitos no import. |
+| `lib/consent.ts` | Lógica pura: ler/escrever localStorage, disparar eventos. Sem React, sem efeitos no import. |
 | `components/CookieConsentBanner.tsx` | UI do banner. Monta em `AppLayout`. Renderiza `null` se consentimento já registrado. |
 | `tests/consent.test.ts` | Testes unitários de `lib/consent.ts` via `node:test`. |
 | `tests/e2e/cookie-consent.spec.ts` | Playwright: primeira visita, persistência, revogação, carga condicional de Mautic/HubSpot. |
@@ -49,9 +58,11 @@ GA4 (via sGTM Stape) e o rastreamento UTM/click IDs (`initializeTracking()`) sã
 
 | Arquivo | Mudança |
 |---|---|
-| `index.html` | `gtag('consent', 'default', {...})` antes do GTM. Verificação de localStorage no topo do script inline. `loadMautic`/`loadHubspot` com gate de consentimento. Listener `anhanga:marketing-consent`. |
-| `App.tsx` | `<CookieConsentBanner />` dentro de `AppLayout`, fora das rotas (aparece em todas as páginas). |
-| `components/Footer.tsx` | Link "Gerenciar cookies" que chama `resetConsent()` e força re-mount do banner. |
+| `index.html` | Bloco `gtag('consent', 'default', {...})` antes da IIFE de carregamento lazy. Leitura de localStorage no topo da IIFE. Gate em `loadMautic`/`loadHubspot`. Listeners `anhanga:marketing-consent` e `anhanga:revoke-consent`. |
+| `App.tsx` | `<CookieConsentBanner />` dentro de `AppLayout`, fora das rotas. |
+| `components/Footer.tsx` | Link "Gerenciar cookies" que dispara `anhanga:reset-consent`. |
+| Footers de landing pages | Mesmo link "Gerenciar cookies" — todas as landings com footer próprio. |
+| `docs/ripd-legitimo-interesse.md` | Atualizar pendências das Atividades 1 e 2 conforme descrito na Seção 1. |
 
 ---
 
@@ -63,10 +74,14 @@ type ConsentChoice = 'marketing' | 'essential';
 // Lê a escolha do localStorage. Retorna null se ausente ou valor inválido.
 export function getConsent(): ConsentChoice | null
 
-// Persiste a escolha. Se 'marketing', dispara window.dispatchEvent('anhanga:marketing-consent').
+// Persiste a escolha no localStorage.
+// Grava 'anhanga_cookie_consent' = choice (string simples, lida pelo index.html).
+// Grava 'anhanga_cookie_consent_meta' = JSON { choice, timestamp: ISO8601, version: '1' } (auditoria Art. 8º §1º).
+// Se choice === 'marketing': dispara window.dispatchEvent(new CustomEvent('anhanga:marketing-consent')).
 export function setConsent(choice: ConsentChoice): void
 
-// Remove a chave do localStorage (para revogação via "Gerenciar cookies").
+// Remove ambas as chaves do localStorage.
+// Dispara window.dispatchEvent(new Event('anhanga:reset-consent')) para que o banner reaça.
 export function resetConsent(): void
 ```
 
@@ -94,7 +109,7 @@ React monta → CookieConsentBanner lê localStorage → null → exibe banner
 
 Usuário clica "Aceitar"
   → setConsent('marketing')
-  → localStorage ← 'marketing'
+  → localStorage ← 'marketing' + metadados { timestamp, version }
   → dispatchEvent('anhanga:marketing-consent')
   → index.html listener → loadMautic() + loadHubspot()
   → gtag('consent', 'update', { ad_storage: 'granted', ad_personalization: 'granted', ad_user_data: 'granted' })
@@ -102,9 +117,9 @@ Usuário clica "Aceitar"
 
 Usuário clica "Recusar"
   → setConsent('essential')
-  → localStorage ← 'essential'
-  → nenhum evento disparado
-  → Mautic e HubSpot nunca carregam
+  → localStorage ← 'essential' + metadados { timestamp, version }
+  → nenhum evento de marketing disparado
+  → Mautic e HubSpot nunca carregam na sessão
   → banner some
 ```
 
@@ -125,9 +140,23 @@ React monta → CookieConsentBanner → 'marketing' → renderiza null
 index.html carrega
   → lê localStorage → 'essential'
   → gtag('consent', 'default', { analytics_storage: 'granted', ad_storage: 'denied', ... })
-  → loadMautic() / loadHubspot() → 'essential' → no-op
+  → loadMautic() / loadHubspot() → gate bloqueia → no-op
 
 React monta → CookieConsentBanner → 'essential' → renderiza null
+```
+
+### Revogação (usuário que havia aceito clica "Gerenciar cookies")
+
+```
+Footer dispara window.dispatchEvent(new Event('anhanga:reset-consent'))
+  → CookieConsentBanner escuta o evento → exibe banner novamente
+
+Usuário clica "Recusar"
+  → setConsent('essential')
+  → localStorage ← 'essential'
+  → gtag('consent', 'update', { ad_storage: 'denied', ad_personalization: 'denied', ad_user_data: 'denied' })
+  → window.location.reload()
+    → no reload: localStorage = 'essential' → Mautic/HubSpot bloqueados desde o início da nova sessão
 ```
 
 ---
@@ -135,24 +164,22 @@ React monta → CookieConsentBanner → 'essential' → renderiza null
 ## 6. Design do componente `CookieConsentBanner`
 
 - **Posição:** `fixed bottom-0 left-0 right-0` — aparece sobre o conteúdo sem bloquear scroll
-- **Renderização:** `null` se `getConsent() !== null`; estado `visible` controlado por `useEffect` no mount
+- **Estado:** `visible: boolean`, iniciado como `false`; `useEffect` no mount define `true` se `getConsent() === null`; também escuta `anhanga:reset-consent` para voltar a `true`
 - **Texto obrigatório (LGPD transparência):**
-  > *"Usamos cookies de marketing (Mautic e HubSpot) para comunicações personalizadas. Analytics continua ativo por interesse legítimo. [Política de Privacidade →](/politica-privacidade#cookies)"*
+  > *"Usamos cookies de marketing (Mautic e HubSpot) para comunicações personalizadas. Analytics continua ativo por interesse legítimo — saiba como se opor em nossa [Política de Privacidade](/politica-privacidade#cookies)."*
 - **Botões:** "Aceitar" e "Recusar" com peso visual idêntico — sem cor de destaque exclusiva em nenhum dos dois
 - **Sem auto-fechamento:** o usuário deve escolher ativamente
 - **`role="dialog"` `aria-modal="false"` `aria-label="Preferências de cookies"`** para acessibilidade
 
-### Revogação (footer)
+### Revogação (footers)
 
-Link "Gerenciar cookies" na linha de copyright do `Footer.tsx`. Ao clicar:
-1. Chama `resetConsent()`
-2. Força re-render do banner via `key` prop em `AppLayout` (incrementa contador no estado de `AppLayout`)
+Link "Gerenciar cookies" na linha de copyright de **todos os footers** (site principal e landing pages). Ao clicar: `resetConsent()` + `window.dispatchEvent(new Event('anhanga:reset-consent'))`. O banner escuta o evento e volta a exibir sem prop-drilling.
 
 ---
 
 ## 7. Mudanças em `index.html`
 
-### Antes do bloco GTM existente — adicionar:
+### Bloco a adicionar antes da IIFE de carregamento lazy de scripts:
 
 ```html
 <script>
@@ -171,7 +198,7 @@ Link "Gerenciar cookies" na linha de copyright do `Footer.tsx`. Ao clicar:
 </script>
 ```
 
-### No script inline existente — adicionar no topo da IIFE:
+### Na IIFE existente — adicionar no topo:
 
 ```js
 var _consentChoice = (function() {
@@ -193,7 +220,7 @@ var loadHubspot = function() {
 };
 ```
 
-### Listener para aceite em tempo real (primeira visita):
+### Listener para aceite em primeira visita:
 
 ```js
 window.addEventListener('anhanga:marketing-consent', function() {
@@ -210,6 +237,26 @@ window.addEventListener('anhanga:marketing-consent', function() {
 }, { once: true });
 ```
 
+### Listener para revogação em sessão:
+
+```js
+window.addEventListener('anhanga:revoke-consent', function() {
+  _consentChoice = 'essential';
+  if (typeof gtag === 'function') {
+    gtag('consent', 'update', {
+      ad_storage: 'denied',
+      ad_personalization: 'denied',
+      ad_user_data: 'denied'
+    });
+  }
+  // Scripts já injetados no DOM não podem ser descarregados dinamicamente.
+  // O reload garante estado limpo na próxima carga.
+  window.location.reload();
+}, { once: true });
+```
+
+> **Nota:** `setConsent('essential')` em lib/consent.ts dispara `anhanga:revoke-consent` apenas quando estava anteriormente em `'marketing'` (i.e., no fluxo de revogação). No fluxo de primeira escolha "Recusar", nenhum reload é necessário pois nenhum script foi carregado.
+
 ---
 
 ## 8. Plano de testes
@@ -222,9 +269,9 @@ window.addEventListener('anhanga:marketing-consent', function() {
 | `getConsent()` com `'marketing'` | Retorna `'marketing'` |
 | `getConsent()` com `'essential'` | Retorna `'essential'` |
 | `getConsent()` com valor inválido | Retorna `null` |
-| `setConsent('marketing')` | Escreve localStorage + dispara `anhanga:marketing-consent` |
-| `setConsent('essential')` | Escreve localStorage + **não** dispara evento |
-| `resetConsent()` | Remove chave do localStorage |
+| `setConsent('marketing')` | Escreve localStorage + dispara `anhanga:marketing-consent` + grava metadados com timestamp e version |
+| `setConsent('essential')` | Escreve localStorage + **não** dispara `anhanga:marketing-consent` |
+| `resetConsent()` | Remove ambas as chaves do localStorage + dispara `anhanga:reset-consent` |
 | `getConsent()` após `resetConsent()` | Retorna `null` |
 | localStorage indisponível (throw simulado) | Não lança exceção |
 
@@ -234,12 +281,14 @@ window.addEventListener('anhanga:marketing-consent', function() {
 |---|---|
 | Primeira visita | Banner visível antes de qualquer interação |
 | Peso visual dos botões | Nenhum botão tem cor primária que o outro não tenha |
-| Clicar "Aceitar" | Banner some + localStorage `=== 'marketing'` |
+| Clicar "Aceitar" | Banner some + localStorage `=== 'marketing'` + metadados gravados |
 | Clicar "Recusar" | Banner some + localStorage `=== 'essential'` |
 | Recarregar após aceite | Banner não reaparece |
 | Recarregar após recusa | Banner não reaparece |
+| Recusar → analytics continua ativo | GTM ainda carregou; `window.dataLayer` existe (legítimo interesse não bloqueado) |
 | Link "Política de Privacidade" | Navega para `/politica-privacidade#cookies` |
 | "Gerenciar cookies" na footer | Banner reaparece + localStorage limpo |
+| Revogação: aceitar → gerenciar → recusar | `window.location.reload()` disparado; após reload Mautic não carrega |
 | Aceitar → Mautic carrega | `window.MauticTrackingObject` definido |
 | Recusar → Mautic não carrega | `window.MauticTrackingObject` indefinido |
 
@@ -254,11 +303,14 @@ Adicionar asserção: `loadMautic` e `loadHubspot` são no-ops quando localStora
 - [x] Base legal documentada (RIPD v1.1 + consentimento para marketing)
 - [x] Consentimento livre, informado e inequívoco (Art. 8º)
 - [x] Finalidade determinada — Mautic e HubSpot nomeados no banner (Art. 8º, §4º)
-- [x] Revogação gratuita e facilitada — link "Gerenciar cookies" na footer (Art. 8º, §5º)
+- [x] Ônus da prova no controlador — metadados gravados com timestamp e versão (Art. 8º, §1º)
+- [x] Revogação gratuita e facilitada com efeito imediato via reload (Art. 8º, §5º)
 - [x] Sem dark patterns — botões com peso visual idêntico (Resolução ANPD 15/2024)
-- [x] Transparência sobre legítimo interesse — mencionado no texto do banner (Art. 6º, VI)
+- [x] Transparência sobre legítimo interesse — mencionado no texto do banner com link de oposição (Art. 6º, VI)
+- [x] Direito de oposição ao legítimo interesse — canal declarado na Política de Privacidade (`/politica-privacidade#cookies`) e via `privacidade@anhanga.tur.br` (Art. 18)
 - [x] Consent Mode v2 com `analytics_storage: 'granted'` por padrão (legítimo interesse)
 - [x] Scripts bloqueados antes do aceite — gate no `index.html` antes do React montar
+- [x] RIPD v1.1 atualizado na mesma PR para refletir decisão sobre `initializeTracking()` e canal real de oposição
 
 ---
 

--- a/docs/superpowers/specs/2026-06-03-cookie-consent-cmp-design.md
+++ b/docs/superpowers/specs/2026-06-03-cookie-consent-cmp-design.md
@@ -1,0 +1,269 @@
+# Design: Banner de Consentimento de Cookies (CMP)
+
+**Data:** 2026-06-03
+**Issue:** [#782](https://github.com/felipewilliam2/AV-SITE/issues/782)
+**Status:** Aprovado — aguardando implementação
+**Base legal:** LGPD Art. 7º, I (consentimento — marketing) e Art. 7º, IX (legítimo interesse — analytics/UTM)
+**Referência regulatória:** Resolução CD/ANPD nº 15/2024; RIPD v1.1 (`docs/ripd-legitimo-interesse.md`)
+
+---
+
+## 1. Contexto e problema
+
+O site não possui mecanismo de consentimento prévio para cookies de marketing, em violação do Art. 7º, I da LGPD. Três scripts de terceiros carregam sem opt-in do titular:
+
+- **Mautic** (`mkt.anhanga.tur.br/mtc.js`) — automação de marketing comportamental
+- **HubSpot tracking passivo** (`js.hs-scripts.com/50895604.js`) — rastreamento passivo de visitantes
+- **Tags de remarketing via GTM** — publicidade direcionada
+
+GA4 (via sGTM Stape) e o rastreamento UTM/click IDs (`initializeTracking()`) são classificados como **legítimo interesse** no RIPD v1.1 e não requerem opt-in, mas o titular tem direito de oposição.
+
+---
+
+## 2. Decisões de design
+
+| Decisão | Escolha | Justificativa |
+|---|---|---|
+| `initializeTracking()` | Não alterar | Legítimo interesse (RIPD Atividade 2) — não precisa de gate de consentimento |
+| Consent Mode v2 | Integrar | Preserva dados modelados do GA4 antes do aceite; `analytics_storage: 'granted'` por padrão |
+| Granularidade do banner | 2 botões (sem "Personalizar") | Apenas 1 categoria requer consentimento; granularidade desnecessária |
+| Labels dos botões | "Aceitar" / "Recusar" | Evitar a palavra "marketing" nos botões para reduzir aversão; informação está no texto do banner |
+| Peso visual dos botões | Idêntico | Resolução ANPD 15/2024 proíbe dark patterns (botão de aceite destacado) |
+| Persistência | `localStorage` chave `anhanga_cookie_consent` | Padrão do projeto; sem cookie para persistir consentimento |
+| Revogação | Link "Gerenciar cookies" na footer | Art. 8º, §5º — revogação gratuita e facilitada a qualquer momento |
+
+---
+
+## 3. Arquitetura
+
+### 3.1 Arquivos novos
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `lib/consent.ts` | Lógica pura: ler/escrever localStorage, disparar `anhanga:marketing-consent`. Sem React, sem efeitos no import. |
+| `components/CookieConsentBanner.tsx` | UI do banner. Monta em `AppLayout`. Renderiza `null` se consentimento já registrado. |
+| `tests/consent.test.ts` | Testes unitários de `lib/consent.ts` via `node:test`. |
+| `tests/e2e/cookie-consent.spec.ts` | Playwright: primeira visita, persistência, revogação, carga condicional de Mautic/HubSpot. |
+
+### 3.2 Arquivos modificados
+
+| Arquivo | Mudança |
+|---|---|
+| `index.html` | `gtag('consent', 'default', {...})` antes do GTM. Verificação de localStorage no topo do script inline. `loadMautic`/`loadHubspot` com gate de consentimento. Listener `anhanga:marketing-consent`. |
+| `App.tsx` | `<CookieConsentBanner />` dentro de `AppLayout`, fora das rotas (aparece em todas as páginas). |
+| `components/Footer.tsx` | Link "Gerenciar cookies" que chama `resetConsent()` e força re-mount do banner. |
+
+---
+
+## 4. API de `lib/consent.ts`
+
+```typescript
+type ConsentChoice = 'marketing' | 'essential';
+
+// Lê a escolha do localStorage. Retorna null se ausente ou valor inválido.
+export function getConsent(): ConsentChoice | null
+
+// Persiste a escolha. Se 'marketing', dispara window.dispatchEvent('anhanga:marketing-consent').
+export function setConsent(choice: ConsentChoice): void
+
+// Remove a chave do localStorage (para revogação via "Gerenciar cookies").
+export function resetConsent(): void
+```
+
+Todas as funções degradam silenciosamente se `localStorage` não estiver disponível (modo privado, storage cheio).
+
+---
+
+## 5. Fluxo de dados
+
+### Primeira visita
+
+```
+index.html carrega
+  → gtag('consent', 'default', {
+        analytics_storage: 'granted',   ← legítimo interesse
+        ad_storage: 'denied',
+        ad_personalization: 'denied',
+        ad_user_data: 'denied'
+      })
+  → GTM carrega
+  → loadMautic() / loadHubspot() verificam localStorage → ausente → no-op
+  → initializeTracking() roda normalmente (legítimo interesse)
+
+React monta → CookieConsentBanner lê localStorage → null → exibe banner
+
+Usuário clica "Aceitar"
+  → setConsent('marketing')
+  → localStorage ← 'marketing'
+  → dispatchEvent('anhanga:marketing-consent')
+  → index.html listener → loadMautic() + loadHubspot()
+  → gtag('consent', 'update', { ad_storage: 'granted', ad_personalization: 'granted', ad_user_data: 'granted' })
+  → banner some
+
+Usuário clica "Recusar"
+  → setConsent('essential')
+  → localStorage ← 'essential'
+  → nenhum evento disparado
+  → Mautic e HubSpot nunca carregam
+  → banner some
+```
+
+### Visita de retorno — aceitou marketing
+
+```
+index.html carrega
+  → lê localStorage → 'marketing'
+  → gtag('consent', 'default', { analytics_storage: 'granted', ad_storage: 'granted', ... })
+  → loadMautic() / loadHubspot() passam no gate → carregam nos triggers normais
+
+React monta → CookieConsentBanner → 'marketing' → renderiza null
+```
+
+### Visita de retorno — recusou
+
+```
+index.html carrega
+  → lê localStorage → 'essential'
+  → gtag('consent', 'default', { analytics_storage: 'granted', ad_storage: 'denied', ... })
+  → loadMautic() / loadHubspot() → 'essential' → no-op
+
+React monta → CookieConsentBanner → 'essential' → renderiza null
+```
+
+---
+
+## 6. Design do componente `CookieConsentBanner`
+
+- **Posição:** `fixed bottom-0 left-0 right-0` — aparece sobre o conteúdo sem bloquear scroll
+- **Renderização:** `null` se `getConsent() !== null`; estado `visible` controlado por `useEffect` no mount
+- **Texto obrigatório (LGPD transparência):**
+  > *"Usamos cookies de marketing (Mautic e HubSpot) para comunicações personalizadas. Analytics continua ativo por interesse legítimo. [Política de Privacidade →](/politica-privacidade#cookies)"*
+- **Botões:** "Aceitar" e "Recusar" com peso visual idêntico — sem cor de destaque exclusiva em nenhum dos dois
+- **Sem auto-fechamento:** o usuário deve escolher ativamente
+- **`role="dialog"` `aria-modal="false"` `aria-label="Preferências de cookies"`** para acessibilidade
+
+### Revogação (footer)
+
+Link "Gerenciar cookies" na linha de copyright do `Footer.tsx`. Ao clicar:
+1. Chama `resetConsent()`
+2. Força re-render do banner via `key` prop em `AppLayout` (incrementa contador no estado de `AppLayout`)
+
+---
+
+## 7. Mudanças em `index.html`
+
+### Antes do bloco GTM existente — adicionar:
+
+```html
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  var _consentChoice = (function() {
+    try { return localStorage.getItem('anhanga_cookie_consent'); } catch(e) { return null; }
+  })();
+  gtag('consent', 'default', {
+    analytics_storage: 'granted',
+    ad_storage: _consentChoice === 'marketing' ? 'granted' : 'denied',
+    ad_personalization: _consentChoice === 'marketing' ? 'granted' : 'denied',
+    ad_user_data: _consentChoice === 'marketing' ? 'granted' : 'denied',
+    wait_for_update: 2000
+  });
+</script>
+```
+
+### No script inline existente — adicionar no topo da IIFE:
+
+```js
+var _consentChoice = (function() {
+  try { return localStorage.getItem('anhanga_cookie_consent'); } catch(e) { return null; }
+})();
+```
+
+### `loadMautic` e `loadHubspot` — adicionar gate:
+
+```js
+var loadMautic = function() {
+  if (_consentChoice !== 'marketing') return;  // gate LGPD
+  // ... código existente
+};
+
+var loadHubspot = function() {
+  if (_consentChoice !== 'marketing') return;  // gate LGPD
+  // ... código existente
+};
+```
+
+### Listener para aceite em tempo real (primeira visita):
+
+```js
+window.addEventListener('anhanga:marketing-consent', function() {
+  _consentChoice = 'marketing';
+  loadMautic();
+  loadHubspot();
+  if (typeof gtag === 'function') {
+    gtag('consent', 'update', {
+      ad_storage: 'granted',
+      ad_personalization: 'granted',
+      ad_user_data: 'granted'
+    });
+  }
+}, { once: true });
+```
+
+---
+
+## 8. Plano de testes
+
+### `tests/consent.test.ts` (node:test)
+
+| Teste | Comportamento |
+|---|---|
+| `getConsent()` sem chave | Retorna `null` |
+| `getConsent()` com `'marketing'` | Retorna `'marketing'` |
+| `getConsent()` com `'essential'` | Retorna `'essential'` |
+| `getConsent()` com valor inválido | Retorna `null` |
+| `setConsent('marketing')` | Escreve localStorage + dispara `anhanga:marketing-consent` |
+| `setConsent('essential')` | Escreve localStorage + **não** dispara evento |
+| `resetConsent()` | Remove chave do localStorage |
+| `getConsent()` após `resetConsent()` | Retorna `null` |
+| localStorage indisponível (throw simulado) | Não lança exceção |
+
+### `tests/e2e/cookie-consent.spec.ts` (Playwright)
+
+| Teste | O que verifica |
+|---|---|
+| Primeira visita | Banner visível antes de qualquer interação |
+| Peso visual dos botões | Nenhum botão tem cor primária que o outro não tenha |
+| Clicar "Aceitar" | Banner some + localStorage `=== 'marketing'` |
+| Clicar "Recusar" | Banner some + localStorage `=== 'essential'` |
+| Recarregar após aceite | Banner não reaparece |
+| Recarregar após recusa | Banner não reaparece |
+| Link "Política de Privacidade" | Navega para `/politica-privacidade#cookies` |
+| "Gerenciar cookies" na footer | Banner reaparece + localStorage limpo |
+| Aceitar → Mautic carrega | `window.MauticTrackingObject` definido |
+| Recusar → Mautic não carrega | `window.MauticTrackingObject` indefinido |
+
+### `tests/index-third-party-scripts.test.ts` (atualizar)
+
+Adicionar asserção: `loadMautic` e `loadHubspot` são no-ops quando localStorage está ausente ou é `'essential'`.
+
+---
+
+## 9. Conformidade LGPD — checklist
+
+- [x] Base legal documentada (RIPD v1.1 + consentimento para marketing)
+- [x] Consentimento livre, informado e inequívoco (Art. 8º)
+- [x] Finalidade determinada — Mautic e HubSpot nomeados no banner (Art. 8º, §4º)
+- [x] Revogação gratuita e facilitada — link "Gerenciar cookies" na footer (Art. 8º, §5º)
+- [x] Sem dark patterns — botões com peso visual idêntico (Resolução ANPD 15/2024)
+- [x] Transparência sobre legítimo interesse — mencionado no texto do banner (Art. 6º, VI)
+- [x] Consent Mode v2 com `analytics_storage: 'granted'` por padrão (legítimo interesse)
+- [x] Scripts bloqueados antes do aceite — gate no `index.html` antes do React montar
+
+---
+
+## 10. Fora do escopo
+
+- `utils/whatsapp.ts` — `initializeTracking()` não é alterado (legítimo interesse)
+- Granularidade por categoria no banner — desnecessária com uma única categoria de consentimento
+- SaaS CMP externo — descartado (custo, controle, alinhamento ao design system)

--- a/docs/superpowers/specs/2026-06-03-cookie-consent-cmp-design.md
+++ b/docs/superpowers/specs/2026-06-03-cookie-consent-cmp-design.md
@@ -22,8 +22,8 @@ GA4 (via sGTM Stape) e o rastreamento UTM/click IDs (`initializeTracking()`) sã
 
 O RIPD v1.1 lista como pendência da issue #782 "bloquear `initializeTracking()` antes do consentimento". Esta implementação **revisa essa pendência**: a decisão de produto é que analytics e UTM são tratados por legítimo interesse e não serão gatekeados pelo banner. O RIPD v1.1 deverá ser atualizado na mesma PR para:
 
-1. Remover "bloquear `initializeTracking()`" das pendências da **Atividade 2** (único local onde o item existe — §3.6, linha do RIPD).
-2. Substituir a salvaguarda "opt-out via banner de cookies" pela descrição real: **direito de oposição ao legítimo interesse exercido via `privacidade@anhanga.tur.br` ou pelo opt-out do GA4 documentado em `/politica-privacidade#cookies`**.
+1. Em **§3.6** (salvaguardas pendentes da Atividade 2): remover "bloquear `initializeTracking()` antes do consentimento do usuário" e substituir pela salvaguarda real — **direito de oposição ao legítimo interesse exercido via `privacidade@anhanga.tur.br` ou pelo opt-out do GA4 documentado em `/politica-privacidade#cookies`**.
+2. Em **§3.5** (tabela de riscos da Atividade 2, linha de risco "Coleta de click IDs antes do consentimento"): substituir a mitigação "Condicionar `initializeTracking()` ao consentimento via banner" pela salvaguarda real — `initializeTracking()` opera sob legítimo interesse; repasse de conversões é integralmente server-side via Stape sGTM, sem cookie de terceiros no browser do usuário.
 
 ---
 
@@ -62,7 +62,7 @@ O RIPD v1.1 lista como pendência da issue #782 "bloquear `initializeTracking()`
 | `App.tsx` | `<CookieConsentBanner />` adicionado em `AppLayout` ao nível de `<ClientFeatures />` (não dentro de `MainSiteShell`), para que renderize em todas as páginas incluindo landing pages. |
 | `components/Footer.tsx` | Link "Gerenciar cookies" que dispara `anhanga:reset-consent`. |
 | Footers de landing pages | Mesmo link "Gerenciar cookies" — todas as landings com footer próprio. |
-| `docs/ripd-legitimo-interesse.md` | Atualizar pendências das Atividades 1 e 2 conforme descrito na Seção 1. |
+| `docs/ripd-legitimo-interesse.md` | Atualizar Atividade 2 conforme descrito na Seção 1. |
 
 ---
 

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -31,6 +31,38 @@ test.describe('Corporativo Landing Page', () => {
     await landing.expectError('Preencha todos os campos obrigatórios');
   });
 
+  test('should block submit when LGPD consent is not accepted', async ({ page }) => {
+    const corpRequests: string[] = [];
+    page.on('requestfinished', (req) => {
+      const url = req.url();
+      if (/\/api\/submit-lead(-sf)?$/.test(url)) {
+        corpRequests.push(url);
+      }
+    });
+
+    const landing = new CorporativoPage(page);
+    await landing.goto();
+
+    await landing.fillForm({
+      firstName: 'Sem',
+      lastName: 'Consentimento',
+      email: 'sem@consentimento.com.br',
+      whatsapp: '(11) 98831-4487',
+      empresa: 'Sem Consent LTDA',
+      cargo: 'Tester',
+      acceptLGPD: false,
+    });
+
+    await expect(landing.lgpdCheckbox).not.toBeChecked();
+
+    await landing.submit();
+
+    await landing.expectError('Você deve aceitar os termos para continuar.');
+
+    await page.waitForTimeout(300);
+    expect(corpRequests).toEqual([]);
+  });
+
   test('should capture corporate lead and trigger dataLayer events', async ({ page }) => {
     const landing = new CorporativoPage(page);
     let submitPayload: SubmitLeadRequest | null = null;

--- a/tests/e2e/pages/CorporativoPage.ts
+++ b/tests/e2e/pages/CorporativoPage.ts
@@ -8,6 +8,7 @@ export class CorporativoPage {
   readonly whatsappInput: Locator;
   readonly empresaInput: Locator;
   readonly cargoInput: Locator;
+  readonly lgpdCheckbox: Locator;
   readonly submitBtn: Locator;
   readonly successHeading: Locator;
   readonly errorAlert: Locator;
@@ -22,6 +23,7 @@ export class CorporativoPage {
     this.whatsappInput = page.locator('#whatsapp');
     this.empresaInput = page.locator('#empresa');
     this.cargoInput = page.locator('#cargo');
+    this.lgpdCheckbox = page.locator('#lgpd-corp');
     this.submitBtn = page.locator('button[type="submit"]');
     this.successHeading = page.locator('h3:has-text("Mensagem recebida!")');
     this.errorAlert = page.locator('p[role="alert"]');
@@ -40,6 +42,7 @@ export class CorporativoPage {
     whatsapp?: string;
     empresa?: string;
     cargo?: string;
+    acceptLGPD?: boolean;
   }) {
     if (data.firstName) await this.firstNameInput.fill(data.firstName);
     if (data.lastName) await this.lastNameInput.fill(data.lastName);
@@ -47,6 +50,7 @@ export class CorporativoPage {
     if (data.whatsapp) await this.whatsappInput.fill(data.whatsapp);
     if (data.empresa) await this.empresaInput.fill(data.empresa);
     if (data.cargo) await this.cargoInput.fill(data.cargo);
+    if (data.acceptLGPD !== false) await this.lgpdCheckbox.check();
   }
 
   async submit() {


### PR DESCRIPTION
## Summary
- Adiciona checkbox de consentimento LGPD (Art. 8º) ao formulário de `/corporativo`, bloqueando submit enquanto não estiver marcado
- Remove o texto impreciso "Seus dados são usados apenas para entrar em contato. Não compartilhamos com terceiros." — o fluxo real envia para n8n e Salesforce
- Link "Política de Privacidade" aponta para `/politica-privacidade/` e abre em nova aba

Closes #783

## Mudanças
- `components/landings/corporativo/CorpContactForm.tsx`
  - Estado `acceptedLGPD` + `lgpdError`
  - Validação no `handleSubmit` antes de qualquer chamada outbound
  - Checkbox seguindo o padrão visual de `ChatLeadForm.tsx`
- `tests/e2e/pages/CorporativoPage.ts`
  - Locator `lgpdCheckbox` exposto
  - `fillForm` aceita `acceptLGPD` e marca o checkbox por padrão
- `tests/e2e/corporativo.spec.ts`
  - Novo teste `should block submit when LGPD consent is not accepted` confirma que nenhuma requisição para `/api/submit-lead*` ocorre sem opt-in

## Test plan
- [x] `pnpm typecheck` — sem erros
- [x] `pnpm test:regression` — 494/494 passaram
- [x] `pnpm exec playwright test corporativo.spec.ts --project=chromium` — 6/6 passaram (inclui novo teste de bloqueio)
- [ ] Verificar visualmente o checkbox em `/corporativo#contato` (foco visível, mobile, link abrindo `politica-privacidade` em nova aba)

🤖 Generated with [Claude Code](https://claude.com/claude-code)