### PR TITLE
refactor(corporativo): extrair subcomponentes e adotar useReducer no CorpContactForm

### DIFF
--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -1,15 +1,11 @@
-import React, { useState, useRef } from 'react';
+import React from 'react';
 import { m } from 'framer-motion';
-import {
-    WhatsappLogo,
-    CheckCircle,
-    AirplaneTilt,
-    PaperPlaneTilt,
-    SpinnerGap,
-    Check,
-} from '@phosphor-icons/react';
+import { AirplaneTilt, PaperPlaneTilt, SpinnerGap } from '@phosphor-icons/react';
 import { useLeadCapture, createLeadEventId } from '@/hooks/useLeadCapture';
-import { normalizeWhatsappNumber } from '@/lib/lead-logic';
+import { useCorpFormReducer, validateCorpForm } from './useCorpFormReducer';
+import { CorpFormFields } from './CorpFormFields';
+import { CorpLgpdConsent } from './CorpLgpdConsent';
+import { CorpSuccessState } from './CorpSuccessState';
 import { fadeUp } from './constants';
 
 interface CorpContactFormProps {
@@ -18,80 +14,46 @@ interface CorpContactFormProps {
 
 export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
     const { submitLead, isSubmitting } = useLeadCapture();
-
-    const [form, setForm] = useState({
-        firstName: '',
-        lastName: '',
-        email: '',
-        whatsapp: '',
-        empresa: '',
-        cargo: '',
-    });
-    const [submitState, setSubmitState] = useState<'idle' | 'success' | 'error'>('idle');
-    const [errorMessage, setErrorMessage] = useState('');
-    const [acceptedLGPD, setAcceptedLGPD] = useState(false);
-    const isLocallySubmitting = useRef(false);
-
-    const lgpdError = submitState === 'error' && !acceptedLGPD ? 'Aceite obrigatório' : '';
-
-    function handleField(field: keyof typeof form) {
-        return (e: React.ChangeEvent<HTMLInputElement>) => {
-            setForm((prev) => ({ ...prev, [field]: e.target.value }));
-        };
-    }
+    const { state, dispatch, isSubmittingRef, handleField, toggleLgpd } = useCorpFormReducer();
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
-        if (isLocallySubmitting.current) return;
-        if (!form.firstName.trim() || !form.lastName.trim() || !form.email.trim() || !form.whatsapp.trim()) {
-            setSubmitState('error');
-            setErrorMessage('Preencha todos os campos obrigatórios');
+        if (isSubmittingRef.current) return;
+
+        const validation = validateCorpForm(state.form, state.acceptedLGPD);
+        if (!validation.ok) {
+            dispatch({ type: 'submit-error', message: validation.message, field: validation.field });
             return;
         }
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (!emailRegex.test(form.email.trim())) {
-            setSubmitState('error');
-            setErrorMessage('Insira um e-mail corporativo válido');
-            return;
-        }
-        if (!normalizeWhatsappNumber(form.whatsapp)) {
-            setSubmitState('error');
-            setErrorMessage('Insira um número de WhatsApp válido');
-            return;
-        }
-        if (!acceptedLGPD) {
-            setSubmitState('error');
-            setErrorMessage('Você deve aceitar os termos para continuar.');
-            return;
-        }
-        isLocallySubmitting.current = true;
-        setErrorMessage('');
+
+        isSubmittingRef.current = true;
+        dispatch({ type: 'submit-start' });
 
         try {
             const eventId = createLeadEventId();
-            const empresa = form.empresa.trim() || 'Não informado';
-            const cargo = form.cargo.trim() || 'Não informado';
+            const empresa = state.form.empresa.trim() || 'Não informado';
+            const cargo = state.form.cargo.trim() || 'Não informado';
 
             const sfPromise = fetch('/api/submit-lead-sf', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    firstName: form.firstName,
-                    lastName: form.lastName,
-                    email: form.email,
-                    whatsapp: form.whatsapp,
-                    empresa: form.empresa,
-                    cargo: form.cargo,
+                    firstName: state.form.firstName,
+                    lastName: state.form.lastName,
+                    email: state.form.email,
+                    whatsapp: state.form.whatsapp,
+                    empresa: state.form.empresa,
+                    cargo: state.form.cargo,
                     leadSource: 'Corporativo',
                 }),
             }).catch(() => {});
 
             const n8nPromise = submitLead(
                 {
-                    firstName: form.firstName,
-                    lastName: form.lastName,
-                    email: form.email,
-                    whatsapp: form.whatsapp,
+                    firstName: state.form.firstName,
+                    lastName: state.form.lastName,
+                    email: state.form.email,
+                    whatsapp: state.form.whatsapp,
                     destination: 'Corporativo',
                     bantSummary: `Lead corporativo captado via landing /corporativo. Empresa: ${empresa}. Cargo: ${cargo}.`,
                 },
@@ -101,18 +63,23 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
             const [, n8nResult] = await Promise.all([sfPromise, n8nPromise]);
 
             if (n8nResult.ok) {
-                setSubmitState('success');
+                dispatch({ type: 'submit-success' });
             } else {
-                setSubmitState('error');
-                setErrorMessage('error' in n8nResult ? n8nResult.error : 'Ocorreu um erro ao enviar. Tente novamente.');
-                isLocallySubmitting.current = false;
+                dispatch({
+                    type: 'submit-error',
+                    message: 'error' in n8nResult ? n8nResult.error : 'Ocorreu um erro ao enviar. Tente novamente.',
+                });
+                isSubmittingRef.current = false;
             }
-        } catch (err) {
-            setSubmitState('error');
-            setErrorMessage('Ocorreu um erro inesperado. Tente novamente.');
-            isLocallySubmitting.current = false;
+        } catch {
+            dispatch({ type: 'submit-error', message: 'Ocorreu um erro inesperado. Tente novamente.' });
+            isSubmittingRef.current = false;
         }
     }
+
+    const showError = state.phase === 'error' && state.message;
+    const lgpdError = state.phase === 'error' && !state.acceptedLGPD;
+    const busy = state.phase === 'submitting' || isSubmitting;
 
     return (
         <m.div
@@ -123,33 +90,8 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
             custom={1}
             className="bg-white rounded-[2rem] border-2 border-zinc-100 shadow-[0_30px_60px_-15px_rgba(0,0,0,0.15)] overflow-hidden"
         >
-            {submitState === 'success' ? (
-                <output className="flex flex-col items-center text-center p-8 sm:p-12" aria-live="polite">
-                    <m.div
-                        initial={{ scale: 0.5, opacity: 0 }}
-                        animate={{ scale: 1, opacity: 1 }}
-                        transition={{ type: 'spring', stiffness: 400, damping: 20 }}
-                    >
-                        <CheckCircle className="size-16 text-emerald-500 mb-4" weight="fill" />
-                    </m.div>
-                    <h3 className="text-2xl font-black text-brand-dark mb-3">
-                        Mensagem recebida!
-                    </h3>
-                    <p className="text-zinc-500 max-w-xs leading-relaxed mb-8">
-                        Um consultor da Anhangá vai entrar em contato em breve. Fique de olho no WhatsApp ou e-mail.
-                    </p>
-                    <a
-                        href={whatsappUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
-                        data-contact-intent
-                        data-tracking="success-corporativo"
-                    >
-                        <WhatsappLogo className="size-4" weight="fill" />
-                        Ou fale agora no WhatsApp
-                    </a>
-                </output>
+            {state.phase === 'success' ? (
+                <CorpSuccessState whatsappUrl={whatsappUrl} />
             ) : (
                 <form onSubmit={handleSubmit} noValidate>
                     <div className="flex justify-between items-center px-6 sm:px-8 py-5 border-b-2 border-dashed border-zinc-100 gap-4">
@@ -160,153 +102,27 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                     </div>
 
                     <div className="p-6 sm:p-8 space-y-5">
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label htmlFor="firstName" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
-                                    Nome <span className="text-brand-cyan">*</span>
-                                </label>
-                                <input
-                                    id="firstName"
-                                    type="text"
-                                    placeholder="João"
-                                    autoComplete="given-name"
-                                    value={form.firstName}
-                                    onChange={handleField('firstName')}
-                                    required
-                                    className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400"
-                                />
-                            </div>
-                            <div>
-                                <label htmlFor="lastName" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
-                                    Sobrenome <span className="text-brand-cyan">*</span>
-                                </label>
-                                <input
-                                    id="lastName"
-                                    type="text"
-                                    placeholder="Silva"
-                                    autoComplete="family-name"
-                                    value={form.lastName}
-                                    onChange={handleField('lastName')}
-                                    required
-                                    className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400"
-                                />
-                            </div>
-                        </div>
+                        <CorpFormFields form={state.form} onField={handleField} />
 
-                        <div>
-                            <label htmlFor="email" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
-                                E-mail corporativo <span className="text-brand-cyan">*</span>
-                            </label>
-                            <input
-                                id="email"
-                                type="email"
-                                placeholder="joao@suaempresa.com.br"
-                                autoComplete="email"
-                                value={form.email}
-                                onChange={handleField('email')}
-                                required
-                                className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400"
-                            />
-                        </div>
+                        <CorpLgpdConsent
+                            checked={state.acceptedLGPD}
+                            onChange={toggleLgpd}
+                            error={lgpdError}
+                        />
 
-                        <div>
-                            <label htmlFor="whatsapp" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
-                                WhatsApp <span className="text-brand-cyan">*</span>
-                            </label>
-                            <input
-                                id="whatsapp"
-                                type="tel"
-                                placeholder="(11) 99999-9999"
-                                autoComplete="tel"
-                                value={form.whatsapp}
-                                onChange={handleField('whatsapp')}
-                                required
-                                className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400"
-                            />
-                        </div>
-
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label htmlFor="empresa" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
-                                    Empresa
-                                </label>
-                                <input
-                                    id="empresa"
-                                    type="text"
-                                    placeholder="Sua empresa"
-                                    autoComplete="organization"
-                                    value={form.empresa}
-                                    onChange={handleField('empresa')}
-                                    className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400"
-                                />
-                            </div>
-                            <div>
-                                <label htmlFor="cargo" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
-                                    Cargo / Função
-                                </label>
-                                <input
-                                    id="cargo"
-                                    type="text"
-                                    placeholder="Ex: Sócio, RH, Assistente"
-                                    autoComplete="organization-title"
-                                    value={form.cargo}
-                                    onChange={handleField('cargo')}
-                                    className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400"
-                                />
-                            </div>
-                        </div>
-
-                        <div className="flex flex-col gap-1">
-                            <label htmlFor="lgpd-corp" className="flex items-start gap-3 cursor-pointer group">
-                                <span className="relative flex items-center mt-0.5">
-                                    <input
-                                        id="lgpd-corp"
-                                        type="checkbox"
-                                        checked={acceptedLGPD}
-                                        onChange={(e) => {
-                                            setAcceptedLGPD(e.target.checked);
-                                            if (e.target.checked && errorMessage === 'Você deve aceitar os termos para continuar.') {
-                                                setErrorMessage('');
-                                                setSubmitState('idle');
-                                            }
-                                        }}
-                                        className="peer size-4 cursor-pointer appearance-none rounded border-2 border-zinc-300 bg-white checked:bg-brand-cyan checked:border-brand-cyan transition focus-visible:ring-2 focus-visible:ring-brand-cyan/40"
-                                    />
-                                    <Check className="absolute size-3 text-white opacity-0 peer-checked:opacity-100 left-0.5 pointer-events-none transition-opacity" weight="bold" />
-                                </span>
-                                <span className="text-xs text-zinc-500 leading-tight">
-                                    Aceito receber comunicações e autorizo o tratamento dos meus dados conforme a{' '}
-                                    <a
-                                        href="https://www.anhanga.tur.br/politica-privacidade/"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="underline hover:text-brand-cyan"
-                                    >
-                                        Política de Privacidade
-                                    </a>
-                                    .
-                                </span>
-                            </label>
-                            {lgpdError && (
-                                <span className="text-[10px] text-red-500 font-bold ml-7 uppercase">
-                                    {lgpdError}
-                                </span>
-                            )}
-                        </div>
-
-                        {submitState === 'error' && errorMessage && (
+                        {showError && (
                             <p className="text-red-500 text-xs font-medium" role="alert">
-                                {errorMessage}
+                                {state.message}
                             </p>
                         )}
 
                         <button
                             type="submit"
-                            disabled={isSubmitting}
+                            disabled={busy}
                             className="w-full flex items-center justify-center gap-3 bg-brand-dark text-white py-4 rounded-xl font-bold text-base shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition disabled:opacity-60 disabled:pointer-events-none"
                             data-tracking="submit-form-corporativo"
                         >
-                            {isSubmitting ? (
+                            {busy ? (
                                 <>
                                     <SpinnerGap className="size-5 animate-spin" weight="bold" />
                                     Enviando…

--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -67,7 +67,7 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
             } else {
                 dispatch({
                     type: 'submit-error',
-                    message: 'error' in n8nResult ? n8nResult.error : 'Ocorreu um erro ao enviar. Tente novamente.',
+                    message: n8nResult.error || 'Ocorreu um erro ao enviar. Tente novamente.',
                 });
                 isSubmittingRef.current = false;
             }

--- a/components/landings/corporativo/CorpFormFields.tsx
+++ b/components/landings/corporativo/CorpFormFields.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import type { FormFields } from './useCorpFormReducer';
+
+interface CorpFormFieldsProps {
+    form: FormFields;
+    onField: (field: keyof FormFields) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const INPUT_CLASS =
+    'w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-400';
+
+export function CorpFormFields({ form, onField }: CorpFormFieldsProps) {
+    return (
+        <>
+            <div className="grid grid-cols-2 gap-4">
+                <div>
+                    <label htmlFor="firstName" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
+                        Nome <span className="text-brand-cyan">*</span>
+                    </label>
+                    <input
+                        id="firstName"
+                        type="text"
+                        placeholder="João"
+                        autoComplete="given-name"
+                        value={form.firstName}
+                        onChange={onField('firstName')}
+                        required
+                        className={INPUT_CLASS}
+                    />
+                </div>
+                <div>
+                    <label htmlFor="lastName" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
+                        Sobrenome <span className="text-brand-cyan">*</span>
+                    </label>
+                    <input
+                        id="lastName"
+                        type="text"
+                        placeholder="Silva"
+                        autoComplete="family-name"
+                        value={form.lastName}
+                        onChange={onField('lastName')}
+                        required
+                        className={INPUT_CLASS}
+                    />
+                </div>
+            </div>
+
+            <div>
+                <label htmlFor="email" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
+                    E-mail corporativo <span className="text-brand-cyan">*</span>
+                </label>
+                <input
+                    id="email"
+                    type="email"
+                    placeholder="joao@suaempresa.com.br"
+                    autoComplete="email"
+                    value={form.email}
+                    onChange={onField('email')}
+                    required
+                    className={INPUT_CLASS}
+                />
+            </div>
+
+            <div>
+                <label htmlFor="whatsapp" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
+                    WhatsApp <span className="text-brand-cyan">*</span>
+                </label>
+                <input
+                    id="whatsapp"
+                    type="tel"
+                    placeholder="(11) 99999-9999"
+                    autoComplete="tel"
+                    value={form.whatsapp}
+                    onChange={onField('whatsapp')}
+                    required
+                    className={INPUT_CLASS}
+                />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+                <div>
+                    <label htmlFor="empresa" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
+                        Empresa
+                    </label>
+                    <input
+                        id="empresa"
+                        type="text"
+                        placeholder="Sua empresa"
+                        autoComplete="organization"
+                        value={form.empresa}
+                        onChange={onField('empresa')}
+                        className={INPUT_CLASS}
+                    />
+                </div>
+                <div>
+                    <label htmlFor="cargo" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
+                        Cargo / Função
+                    </label>
+                    <input
+                        id="cargo"
+                        type="text"
+                        placeholder="Ex: Sócio, RH, Assistente"
+                        autoComplete="organization-title"
+                        value={form.cargo}
+                        onChange={onField('cargo')}
+                        className={INPUT_CLASS}
+                    />
+                </div>
+            </div>
+        </>
+    );
+}

--- a/components/landings/corporativo/CorpLgpdConsent.tsx
+++ b/components/landings/corporativo/CorpLgpdConsent.tsx
@@ -1,0 +1,43 @@
+import { Check } from '@phosphor-icons/react';
+
+interface CorpLgpdConsentProps {
+    checked: boolean;
+    onChange: (value: boolean) => void;
+    error: boolean;
+}
+
+export function CorpLgpdConsent({ checked, onChange, error }: CorpLgpdConsentProps) {
+    return (
+        <div className="flex flex-col gap-1">
+            <label htmlFor="lgpd-corp" className="flex items-start gap-3 cursor-pointer group">
+                <span className="relative flex items-center mt-0.5">
+                    <input
+                        id="lgpd-corp"
+                        type="checkbox"
+                        checked={checked}
+                        onChange={(e) => onChange(e.target.checked)}
+                        className="peer size-4 cursor-pointer appearance-none rounded border-2 border-zinc-300 bg-white checked:bg-brand-cyan checked:border-brand-cyan transition focus-visible:ring-2 focus-visible:ring-brand-cyan/40"
+                    />
+                    <Check className="absolute size-3 text-white opacity-0 peer-checked:opacity-100 left-0.5 pointer-events-none transition-opacity" weight="bold" />
+                </span>
+                <span className="text-xs text-zinc-500 leading-tight">
+                    Aceito receber comunicações e autorizo o tratamento dos meus dados conforme a{' '}
+                    <a
+                        href="https://www.anhanga.tur.br/politica-privacidade/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline hover:text-brand-cyan"
+                    >
+                        Política de Privacidade
+                    </a>
+                    .
+                </span>
+            </label>
+            {error && (
+                <span className="text-[10px] text-red-500 font-bold ml-7 uppercase">
+                    Aceite obrigatório
+                </span>
+            )}
+        </div>
+    );
+}

--- a/components/landings/corporativo/CorpSuccessState.tsx
+++ b/components/landings/corporativo/CorpSuccessState.tsx
@@ -1,0 +1,37 @@
+import { m } from 'framer-motion';
+import { WhatsappLogo, CheckCircle } from '@phosphor-icons/react';
+
+interface CorpSuccessStateProps {
+    whatsappUrl: string;
+}
+
+export function CorpSuccessState({ whatsappUrl }: CorpSuccessStateProps) {
+    return (
+        <output className="flex flex-col items-center text-center p-8 sm:p-12" aria-live="polite">
+            <m.div
+                initial={{ scale: 0.5, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                transition={{ type: 'spring', stiffness: 400, damping: 20 }}
+            >
+                <CheckCircle className="size-16 text-emerald-500 mb-4" weight="fill" />
+            </m.div>
+            <h3 className="text-2xl font-black text-brand-dark mb-3">
+                Mensagem recebida!
+            </h3>
+            <p className="text-zinc-500 max-w-xs leading-relaxed mb-8">
+                Um consultor da Anhangá vai entrar em contato em breve. Fique de olho no WhatsApp ou e-mail.
+            </p>
+            <a
+                href={whatsappUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
+                data-contact-intent
+                data-tracking="success-corporativo"
+            >
+                <WhatsappLogo className="size-4" weight="fill" />
+                Ou fale agora no WhatsApp
+            </a>
+        </output>
+    );
+}

--- a/components/landings/corporativo/useCorpFormReducer.ts
+++ b/components/landings/corporativo/useCorpFormReducer.ts
@@ -1,0 +1,121 @@
+import { useReducer, useRef, useCallback } from 'react';
+import { normalizeWhatsappNumber } from '@/lib/lead-logic';
+
+export type FormFields = {
+    firstName: string;
+    lastName: string;
+    email: string;
+    whatsapp: string;
+    empresa: string;
+    cargo: string;
+};
+
+export type ErrorField = 'required' | 'email' | 'whatsapp' | 'lgpd';
+
+type IdleState = { phase: 'idle'; form: FormFields; acceptedLGPD: boolean };
+type SubmittingState = { phase: 'submitting'; form: FormFields; acceptedLGPD: boolean };
+type ErrorState = { phase: 'error'; form: FormFields; acceptedLGPD: boolean; message: string; field?: ErrorField };
+type SuccessState = { phase: 'success'; form: FormFields; acceptedLGPD: boolean };
+
+export type CorpFormState = IdleState | SubmittingState | ErrorState | SuccessState;
+
+type Action =
+    | { type: 'change-field'; field: keyof FormFields; value: string }
+    | { type: 'toggle-lgpd'; value: boolean }
+    | { type: 'submit-start' }
+    | { type: 'submit-error'; message: string; field?: ErrorField }
+    | { type: 'submit-success' };
+
+const INITIAL_FORM: FormFields = {
+    firstName: '',
+    lastName: '',
+    email: '',
+    whatsapp: '',
+    empresa: '',
+    cargo: '',
+};
+
+const INITIAL_STATE: CorpFormState = {
+    phase: 'idle',
+    form: INITIAL_FORM,
+    acceptedLGPD: false,
+};
+
+function corpFormReducer(state: CorpFormState, action: Action): CorpFormState {
+    switch (action.type) {
+        case 'change-field':
+            if (state.phase === 'submitting' || state.phase === 'success') return state;
+            return {
+                ...state,
+                form: { ...state.form, [action.field]: action.value },
+            } as CorpFormState;
+
+        case 'toggle-lgpd':
+            if (state.phase === 'submitting' || state.phase === 'success') return state;
+            if (state.phase === 'error' && state.field === 'lgpd' && action.value) {
+                return { phase: 'idle', form: state.form, acceptedLGPD: true };
+            }
+            return { ...state, acceptedLGPD: action.value } as CorpFormState;
+
+        case 'submit-start':
+            if (state.phase === 'submitting') return state;
+            return { phase: 'submitting', form: state.form, acceptedLGPD: state.acceptedLGPD };
+
+        case 'submit-error':
+            return {
+                phase: 'error',
+                form: state.form,
+                acceptedLGPD: state.acceptedLGPD,
+                message: action.message,
+                field: action.field,
+            };
+
+        case 'submit-success':
+            return { phase: 'success', form: state.form, acceptedLGPD: state.acceptedLGPD };
+
+        default:
+            return state;
+    }
+}
+
+type ValidationResult =
+    | { ok: true }
+    | { ok: false; message: string; field: ErrorField };
+
+export function validateCorpForm(form: FormFields, acceptedLGPD: boolean): ValidationResult {
+    if (!form.firstName.trim() || !form.lastName.trim() || !form.email.trim() || !form.whatsapp.trim()) {
+        return { ok: false, message: 'Preencha todos os campos obrigatórios', field: 'required' };
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(form.email.trim())) {
+        return { ok: false, message: 'Insira um e-mail corporativo válido', field: 'email' };
+    }
+    if (!normalizeWhatsappNumber(form.whatsapp)) {
+        return { ok: false, message: 'Insira um número de WhatsApp válido', field: 'whatsapp' };
+    }
+    if (!acceptedLGPD) {
+        return { ok: false, message: 'Você deve aceitar os termos para continuar.', field: 'lgpd' };
+    }
+    return { ok: true };
+}
+
+export function useCorpFormReducer() {
+    const [state, dispatch] = useReducer(corpFormReducer, INITIAL_STATE);
+    // Synchronous re-entry guard — dispatch is async-batched, so phase
+    // may not yet reflect 'submitting' within the same handler tick.
+    const isSubmittingRef = useRef(false);
+
+    const handleField = useCallback(
+        (field: keyof FormFields) =>
+            (e: React.ChangeEvent<HTMLInputElement>) =>
+                dispatch({ type: 'change-field', field, value: e.target.value }),
+        [],
+    );
+
+    const toggleLgpd = useCallback(
+        (value: boolean) => dispatch({ type: 'toggle-lgpd', value }),
+        [],
+    );
+
+    return { state, dispatch, isSubmittingRef, handleField, toggleLgpd };
+}

--- a/tests/corp-form-reducer.test.ts
+++ b/tests/corp-form-reducer.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateCorpForm } from '../components/landings/corporativo/useCorpFormReducer';
+import type { FormFields } from '../components/landings/corporativo/useCorpFormReducer';
+
+const VALID_FORM: FormFields = {
+    firstName: 'Maria',
+    lastName: 'Santos',
+    email: 'maria@empresa.com.br',
+    whatsapp: '(11) 98831-4487',
+    empresa: 'Empresa Teste',
+    cargo: 'Sócia',
+};
+
+describe('validateCorpForm', () => {
+    it('should pass with all required fields and LGPD accepted', () => {
+        const result = validateCorpForm(VALID_FORM, true);
+        assert.deepStrictEqual(result, { ok: true });
+    });
+
+    it('should fail when required text fields are empty', () => {
+        const result = validateCorpForm({ ...VALID_FORM, firstName: '' }, true);
+        assert.equal(result.ok, false);
+        if (!result.ok) {
+            assert.equal(result.field, 'required');
+            assert.equal(result.message, 'Preencha todos os campos obrigatórios');
+        }
+    });
+
+    it('should fail for whitespace-only required fields', () => {
+        const result = validateCorpForm({ ...VALID_FORM, email: '   ' }, true);
+        assert.equal(result.ok, false);
+        if (!result.ok) {
+            assert.equal(result.field, 'required');
+        }
+    });
+
+    it('should fail for invalid email format', () => {
+        const result = validateCorpForm({ ...VALID_FORM, email: 'not-an-email' }, true);
+        assert.equal(result.ok, false);
+        if (!result.ok) {
+            assert.equal(result.field, 'email');
+            assert.equal(result.message, 'Insira um e-mail corporativo válido');
+        }
+    });
+
+    it('should fail for invalid WhatsApp number', () => {
+        const result = validateCorpForm({ ...VALID_FORM, whatsapp: '123' }, true);
+        assert.equal(result.ok, false);
+        if (!result.ok) {
+            assert.equal(result.field, 'whatsapp');
+            assert.equal(result.message, 'Insira um número de WhatsApp válido');
+        }
+    });
+
+    it('should fail when LGPD is not accepted', () => {
+        const result = validateCorpForm(VALID_FORM, false);
+        assert.equal(result.ok, false);
+        if (!result.ok) {
+            assert.equal(result.field, 'lgpd');
+            assert.equal(result.message, 'Você deve aceitar os termos para continuar.');
+        }
+    });
+
+    it('should check required fields before email format', () => {
+        const result = validateCorpForm({ ...VALID_FORM, firstName: '', email: 'bad' }, true);
+        assert.equal(result.ok, false);
+        if (!result.ok) {
+            assert.equal(result.field, 'required');
+        }
+    });
+
+    it('should check email format before WhatsApp', () => {
+        const result = validateCorpForm({ ...VALID_FORM, email: 'bad', whatsapp: '123' }, true);
+        assert.equal(result.ok, false);
+        if (!result.ok) {
+            assert.equal(result.field, 'email');
+        }
+    });
+
+    it('should check WhatsApp before LGPD', () => {
+        const result = validateCorpForm({ ...VALID_FORM, whatsapp: '123' }, false);
+        assert.equal(result.ok, false);
+        if (!result.ok) {
+            assert.equal(result.field, 'whatsapp');
+        }
+    });
+
+    it('should accept form without optional empresa and cargo', () => {
+        const result = validateCorpForm({ ...VALID_FORM, empresa: '', cargo: '' }, true);
+        assert.deepStrictEqual(result, { ok: true });
+    });
+});


### PR DESCRIPTION
## Summary

Resolve os dois warnings do React Doctor em `CorpContactForm.tsx` (#796):

- **`no-giant-component`** — componente de 326 linhas decomposto em 4 subcomponentes + 1 hook
- **`prefer-useReducer`** — 4 `useState` + 1 `useRef` consolidados em um reducer com transições explícitas

### Arquivos criados

| Arquivo | Responsabilidade |
|---|---|
| `useCorpFormReducer.ts` | Reducer, tipos, validação pura, hook |
| `CorpFormFields.tsx` | 6 campos de input (apresentação pura) |
| `CorpLgpdConsent.tsx` | Checkbox LGPD + hint de erro |
| `CorpSuccessState.tsx` | Estado de sucesso com CTA WhatsApp |

### O que mudou no orquestrador

`CorpContactForm.tsx`: **326 → 142 linhas**. Agora só orquestra estado, submit e montagem dos subcomponentes.

### O que NÃO mudou

- IDs, `data-*` attributes, `role="alert"`, seletores usados pelo Page Object E2E
- Strings de erro (mesmos textos, mesma ordem de validação)
- Payloads para `/api/submit-lead` e `/api/submit-lead-sf`
- Evento `dataLayer` (`form_submission` / `corporate_lead`)
- Guarda de duplo-submit (ref síncrono mantido)

## Verification

- [x] `pnpm typecheck` — verde
- [x] `pnpm test:regression` — 504/504 (inclui 10 novos testes do reducer)
- [x] E2E `corporativo.spec.ts` — 12/12 (chromium + Mobile Chrome)
- [x] React Doctor `--diff` — **100/100**, zero warnings

## Test plan

- [ ] Verificar que o formulário corporativo funciona end-to-end em staging
- [ ] Confirmar que payloads chegam corretos no n8n e Salesforce
- [ ] CI `build-and-test` verde

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)