### PR TITLE
fix(terms): correct Instagram handle to @anhangaviagens

### DIFF
--- a/pages/Terms.tsx
+++ b/pages/Terms.tsx
@@ -250,7 +250,7 @@ const Terms = () => {
                             <h3 className="font-merriweather font-semibold">14.2 Canais de Comunicação</h3>
                             <p><strong>E-mail Geral:</strong> privacidade@anhanga.tur.br<br />
                                 <strong>WhatsApp Business:</strong> +55 (11) 5283-3309<br />
-                                <strong>Instagram:</strong> <a href="https://instagram.com/anhangatur" target="_blank" rel="noopener noreferrer" className="text-primary underline">@anhangatur</a><br />
+                                <strong>Instagram:</strong> <a href="https://instagram.com/anhangaviagens" target="_blank" rel="noopener noreferrer" className="text-primary underline">@anhangaviagens</a><br />
                                 <strong>Website:</strong> <a href="https://www.anhanga.tur.br/" target="_blank" rel="noopener noreferrer" className="text-primary underline">https://www.anhanga.tur.br/</a></p>
                             <h3 className="font-merriweather font-semibold">14.3 Atendimento</h3>
                             <p>Nossos canais funcionam em horário comercial, com compromisso de resposta em até 5 dias úteis para questões relacionadas a estes Termos.</p>


### PR DESCRIPTION
## Summary

- Fixed the Instagram link in `pages/Terms.tsx` (line 253) from `@anhangatur` to `@anhangaviagens`
- Updated both the URL (`https://instagram.com/anhangaviagens`) and the display text (`@anhangaviagens`)
- Aligns with the canonical handle used across the codebase (`Footer.tsx`, `OrganizationSchema.tsx`, `components/landings/shared/constants.ts`)

## Test plan

- [ ] Verify the Instagram link on the Terms page points to the correct profile
- [ ] Confirm no other files reference the old `anhangatur` handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)