### PR TITLE
chore(privacy): replace dangerouslySetInnerHTML with WebPageSchema component

### DIFF
--- a/components/schemas/WebPageSchema.tsx
+++ b/components/schemas/WebPageSchema.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { StructuredData } from './StructuredData';
+
+interface WebPageSchemaProps {
+  name: string;
+  url: string;
+  description: string;
+  dateModified: string;
+  inLanguage?: string;
+}
+
+export const WebPageSchema: React.FC<WebPageSchemaProps> = ({
+  name,
+  url,
+  description,
+  dateModified,
+  inLanguage = 'pt-BR',
+}) => (
+  <StructuredData
+    id="webpage"
+    data={{
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      name,
+      url,
+      description,
+      dateModified,
+      inLanguage,
+    }}
+  />
+);

--- a/pages/Privacy.tsx
+++ b/pages/Privacy.tsx
@@ -2,6 +2,7 @@ import { Seo } from "@/components/Seo";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { BreadcrumbSchema } from "@/components/schemas/BreadcrumbSchema";
+import { WebPageSchema } from "@/components/schemas/WebPageSchema";
 
 const Privacy = () => {
     const metaDescription = "Política de Privacidade e Proteção de Dados da Anhangá Turismo: coleta, tratamento, armazenamento e direitos dos titulares.";
@@ -360,20 +361,11 @@ const Privacy = () => {
                 </article>
             </main>
 
-            {/* Structured Data — safe: JSON.stringify of a static object literal, no user input */}
-            <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{
-                    __html: JSON.stringify({
-                        "@context": "https://schema.org",
-                        "@type": "WebPage",
-                        name: "Política de Privacidade - Anhangá Turismo",
-                        url: canonicalUrl,
-                        description: metaDescription,
-                        dateModified: lastUpdatedIso,
-                        inLanguage: "pt-BR",
-                    }),
-                }}
+            <WebPageSchema
+                name="Política de Privacidade - Anhangá Turismo"
+                url={canonicalUrl}
+                description={metaDescription}
+                dateModified={lastUpdatedIso}
             />
 
             <Footer />


### PR DESCRIPTION
## Summary

- Creates `components/schemas/WebPageSchema.tsx` following the existing `StructuredData` pattern used by `BreadcrumbSchema`, `FAQPageSchema`, etc.
- Replaces the inline `dangerouslySetInnerHTML` block in `pages/Privacy.tsx` with the new `<WebPageSchema>` component
- JSON-LD output is identical — the component delegates to `StructuredData` which injects via `useHeadTags`

Closes #805

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:regression` passes (all tests green)
- [ ] Verify rendered JSON-LD in browser matches previous output

🤖 Generated with [Claude Code](https://claude.com/claude-code)