### PR TITLE
fix(lgpd): avisos de transparência e política de privacidade (#786 #787 #789)

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -86,7 +86,7 @@ FormattedText.displayName = 'FormattedText';
 const AIChat: React.FC = memo(() => {
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState<Message[]>([
-    { id: 'init', role: 'model', text: 'Olá! Sou seu guia Anhangá 🧭.\n\nPosso te ajudar com:\n- Roteiros exclusivos\n- Dúvidas sobre o destino\n- **Orçamento personalizado**\n\nVamos começar?' }
+    { id: 'init', role: 'model', text: 'Olá! Sou seu guia Anhangá 🧭.\n\nPosso te ajudar com:\n- Roteiros exclusivos\n- Dúvidas sobre o destino\n- **Orçamento personalizado**\n\nVamos começar?\n\n_Ao conversar comigo, você concorda com nossa [Política de Privacidade](https://www.anhanga.tur.br/politica-privacidade/)._' }
   ]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -86,7 +86,7 @@ FormattedText.displayName = 'FormattedText';
 const AIChat: React.FC = memo(() => {
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState<Message[]>([
-    { id: 'init', role: 'model', text: 'Olá! Sou seu guia Anhangá 🧭.\n\nPosso te ajudar com:\n- Roteiros exclusivos\n- Dúvidas sobre o destino\n- **Orçamento personalizado**\n\nVamos começar?\n\n_Ao conversar comigo, você concorda com nossa [Política de Privacidade](https://www.anhanga.tur.br/politica-privacidade/)._' }
+    { id: 'init', role: 'model', text: 'Olá! Sou seu guia Anhangá 🧭.\n\nPosso te ajudar com:\n- Roteiros exclusivos\n- Dúvidas sobre o destino\n- **Orçamento personalizado**\n\nVamos começar?\n\n_Ao conversar comigo, você concorda com nossa [Política de Privacidade](/politica-privacidade/)._' }
   ]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -205,17 +205,21 @@ const ContactModal: React.FC = () => {
                                 className="mt-0.5 size-4 flex-shrink-0 cursor-pointer rounded border-2 border-brand-vibrant accent-brand-vibrant"
                             />
                             <label htmlFor="contact-optIn" className="cursor-pointer text-xs leading-relaxed text-blue-700">
-                                Quero receber novidades e ofertas de viagem por e-mail.{' '}
-                                <a
-                                    href="/politica-privacidade/"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="underline hover:text-blue-900"
-                                >
-                                    Política de Privacidade
-                                </a>
+                                Quero receber novidades, ofertas e dicas de viagem da Anhangá Viagens.
                             </label>
                         </div>
+
+                        <p className="text-xs text-zinc-500 leading-relaxed">
+                            Seus dados serão registrados em nosso CRM e usados para entrar em contato via WhatsApp.{' '}
+                            <a
+                                href="/politica-privacidade/"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline hover:text-zinc-700"
+                            >
+                                Política de Privacidade
+                            </a>.
+                        </p>
 
                         {error ? (
                             <p className="text-xs font-medium text-red-500" role="alert">

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -561,11 +561,19 @@ function PreLeadScreen({ profile, onSubmit, onBack }: PreLeadScreenProps) {
                         />
                         <span className="quiz-check-box" aria-hidden="true" />
                         <span className="quiz-check-label">
-                            Topo receber novidades e ofertas da Anhangá. Posso cancelar quando quiser.
-                            Veja nossa <a href="/politica-privacidade/" target="_blank" rel="noopener noreferrer">política de privacidade</a>.
+                            Quero receber novidades, ofertas e dicas de viagem da Anhangá Viagens.
                         </span>
                     </label>
                     {errors.aceite && <span role="alert" className="quiz-err quiz-err-block">{errors.aceite}</span>}
+
+                    <p className="text-xs text-zinc-500 leading-relaxed mt-1">
+                        Ao revelar seu perfil, seus dados serão registrados em nosso CRM para atendimento
+                        comercial e entraremos em contato via WhatsApp.{' '}
+                        <a href="/politica-privacidade/" target="_blank" rel="noopener noreferrer"
+                            className="underline hover:text-zinc-700">
+                            Política de Privacidade
+                        </a>.
+                    </p>
 
                     <button type="submit" className="quiz-btn quiz-btn-primary quiz-btn-lg">
                         Revelar meu perfil

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -564,8 +564,6 @@ function PreLeadScreen({ profile, onSubmit, onBack }: PreLeadScreenProps) {
                             Quero receber novidades, ofertas e dicas de viagem da Anhangá Viagens.
                         </span>
                     </label>
-                    {errors.aceite && <span role="alert" className="quiz-err quiz-err-block">{errors.aceite}</span>}
-
                     <p className="text-xs text-zinc-500 leading-relaxed mt-1">
                         Ao revelar seu perfil, seus dados serão registrados em nosso CRM para atendimento
                         comercial e entraremos em contato via WhatsApp.{' '}

--- a/tests/e2e/contact-form.spec.ts
+++ b/tests/e2e/contact-form.spec.ts
@@ -98,6 +98,17 @@ test.describe('Contact form modal', () => {
 
     await expect(contactDialog(page)).not.toBeVisible();
   });
+
+  test('exibe aviso de transparência e link para política de privacidade', async ({ page, isMobile }) => {
+    await openHeaderContactModal(page, isMobile);
+
+    const dialog = contactDialog(page);
+    await expect(dialog.getByText(/registrados em nosso crm/i)).toBeVisible();
+    await expect(dialog.getByRole('link', { name: /política de privacidade/i })).toHaveAttribute(
+      'href',
+      '/politica-privacidade/',
+    );
+  });
 });
 
 test.describe('CallToAction inline form', () => {


### PR DESCRIPTION
## Resumo

Quatro issues de LGPD — três implementadas, uma já estava correta.

### #786 — Chatbot: aviso de privacidade na mensagem inicial
- Mensagem de abertura do `AIChat` agora inclui: _"Ao conversar comigo, você concorda com nossa [Política de Privacidade](https://www.anhanga.tur.br/politica-privacidade/)."_
- O link funciona automaticamente porque mensagens do modelo já são renderizadas via `ReactMarkdown` (linha 517) — `FormattedText` (user messages) **não foi tocado**, evitando injeção de links via output da IA.

### #787 — Quiz: aviso de tratamento de dados + texto do checkbox
- Adicionado parágrafo de transparência antes do botão "Revelar meu perfil": informa que dados vão para o CRM e que entraremos em contato via WhatsApp.
- Texto do checkbox corrigido (typo `Topo` → `Quero`) e limitado ao marketing via Mautic.
- Base legal: Art. 7º, V LGPD (pré-contrato a pedido). Lógica de envio ao Salesforce **não alterada** — decisão registrada no comentário da issue.

### #788 — instrucoes-exclusao-dados.md (sem alteração de código)
- Verificado: número `(11) 5283-3309` e prazo "15 dias corridos" já estavam corretos.
- Privacy.tsx (`PrivacySection8DireitosTitulares.tsx:23`) confirma "15 (quinze) dias corridos" — consistente. Issue pode ser fechada sem código.

### #789 — ContactModal: aviso de transparência + checkbox
- Adicionado parágrafo: _"Seus dados serão registrados em nosso CRM e usados para entrar em contato via WhatsApp."_ com link para Política de Privacidade.
- Checkbox atualizado para descrever apenas marketing (Mautic). Texto incorreto "não compartilhamos com terceiros" já havia sido removido em PR anterior.
- Base legal: Art. 7º, V LGPD — sem novo checkbox obrigatório, conforme decisão da issue.

## Testes

- [x] `pnpm test:regression` — 526 testes, 0 falhas
- [x] `tsc --noEmit` — sem erros de tipo
- [x] Novo teste E2E: `contact-form.spec.ts` — verifica aviso de transparência e link `/politica-privacidade/` no modal

## Closes

Closes #786
Closes #787
Closes #788
Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)