### PR TITLE
content: posts de blog junho 2026 (férias de julho + seguro viagem)

### DIFF
--- a/content/blog/ferias-julho-2026-destinos.mdx
+++ b/content/blog/ferias-julho-2026-destinos.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Férias de Julho 2026: 10 Destinos Para Reservar nos Próximos 15 Dias"
-excerpt: "Julho está a três semanas. Esses 10 destinos nacionais e internacionais ainda têm disponibilidade, fazem sentido para o período e cabem em diferentes perfis e orçamentos."
+excerpt: "Julho está a três semanas. Veja 10 destinos nacionais e internacionais com disponibilidade, que fazem sentido para o período e cabem em diferentes orçamentos."
 date: "2026-06-04"
 author: "queila-oliveira"
 category: "Destinos"
@@ -8,7 +8,7 @@ image: "images/blog/ferias-julho-2026.jpg"
 featured: true
 showChatCTA: true
 chatCTADestination: "Férias de Julho"
-tags: ["ferias-julho", "destinos", "viagem-nacional", "viagem-internacional", "planejamento"]
+tags: ["ferias-julho", "destinos", "viagem-nacional", "viagem-internacional", "planejamento", "sul", "sudeste", "orlando", "eua", "chile", "argentina", "mexico", "portugal", "europa", "caribe", "america-do-sul"]
 seoTitle: "Férias de Julho 2026: 10 Destinos Para Reservar Agora"
 seoDescription: "Julho está chegando e você ainda não reservou? Veja 10 destinos nacionais e internacionais com disponibilidade, preços estimados e o mínimo de planejamento para cada um."
 ---
@@ -103,7 +103,7 @@ Buenos Aires em julho é frio (5°C a 15°C), mas é quando a cidade fica mais p
 
 **O que resolver rápido:** passaporte ou RG, passagem aérea (voos diretos de 2h30 a partir de SP/RJ/Curitiba). Buenos Aires tem hospedagem abundante, mas reserve em Palermo ou San Telmo para a melhor experiência de bairro.
 
-**Investimento estimado (casal, 5 noites):** R$ 5.000 a R$ 9.000 (aéreo + hotel boutique + alimentação + passeios).
+**Investimento estimado (casal, 5 noites):** R$ 5.000 a R$ 9.000 (aéreo + hotel charmoso + alimentação + passeios).
 
 **Para quem:** casais, viajantes culturais, quem gosta de gastronomia e não se importa com frio.
 
@@ -182,4 +182,4 @@ Orlando não é cidade-sede de nenhum jogo da Copa. Os parques da Disney e Unive
 
 ### Vale a pena contratar uma agência para férias de julho de última hora?
 
-Sim, especialmente quando o prazo é curto. Uma agência boutique como a Anhangá consegue acessar disponibilidade que não aparece nos sites de busca, negociar tarifas de grupo com operadoras, e resolver toda a logística (voo + hotel + passeios + seguro) em uma conversa só. Quando você tem 15 dias, a economia de tempo vale tanto quanto a economia de dinheiro.
+Sim, especialmente quando o prazo é curto. Uma agência especializada como a Anhangá consegue acessar disponibilidade que não aparece nos sites de busca, negociar tarifas de grupo com operadoras, e resolver toda a logística (voo + hotel + passeios + seguro) em uma conversa só. Quando você tem 15 dias, a economia de tempo vale tanto quanto a economia de dinheiro.

--- a/content/blog/ferias-julho-2026-destinos.mdx
+++ b/content/blog/ferias-julho-2026-destinos.mdx
@@ -1,0 +1,185 @@
+---
+title: "Férias de Julho 2026: 10 Destinos Para Reservar nos Próximos 15 Dias"
+excerpt: "Julho está a três semanas. Esses 10 destinos nacionais e internacionais ainda têm disponibilidade, fazem sentido para o período e cabem em diferentes perfis e orçamentos."
+date: "2026-06-04"
+author: "queila-oliveira"
+category: "Destinos"
+image: "images/blog/ferias-julho-2026.jpg"
+featured: true
+showChatCTA: true
+chatCTADestination: "Férias de Julho"
+tags: ["ferias-julho", "destinos", "viagem-nacional", "viagem-internacional", "planejamento"]
+seoTitle: "Férias de Julho 2026: 10 Destinos Para Reservar Agora"
+seoDescription: "Julho está chegando e você ainda não reservou? Veja 10 destinos nacionais e internacionais com disponibilidade, preços estimados e o mínimo de planejamento para cada um."
+---
+
+Faltam menos de quatro semanas para julho. Se você está lendo isso e ainda não reservou nada, não está sozinho. A maioria dos viajantes brasileiros decide as férias de julho com menos de 30 dias de antecedência, e em 2026 a janela de planejamento ficou ainda mais curta por causa da Copa do Mundo nos EUA, que deslocou demanda e preços em destinos norte-americanos.
+
+A boa notícia: ainda dá tempo. Mas a partir de agora, a cada dia que passa, as opções de voo e hospedagem encolhem e os preços sobem. Montamos uma lista de 10 destinos que fazem sentido para julho, com estimativas reais de investimento e o que você precisa resolver nos próximos dias.
+
+## Brasil: 5 Destinos Para Quem Quer Frio, Natureza ou os Dois
+
+### 1. Gramado e Serra Gaúcha (RS)
+
+Julho é o mês de Gramado. Temperaturas entre 5°C e 15°C, fondue sem culpa, e o Festival de Cinema que transforma a cidade em palco cultural. A Serra Gaúcha funciona particularmente bem para casais e famílias com crianças mais velhas.
+
+**O que resolve rápido:** voos para Porto Alegre ainda têm disponibilidade razoável. Gramado fica a 120 km do aeroporto. Hospedagem é o gargalo: hotéis bons lotam em julho, então priorize isso.
+
+**Investimento estimado (casal, 5 noites):** R$ 4.000 a R$ 7.000 (aéreo + hospedagem + alimentação), dependendo do nível da hospedagem.
+
+**Para quem:** casais, famílias com crianças acima de 8 anos, viajantes que preferem frio e conforto.
+
+### 2. Bonito (MS)
+
+Julho é a melhor época para Bonito. A seca reduz o nível dos rios e a visibilidade na flutuação chega ao máximo. É quando você realmente vê os peixes como nas fotos. As temperaturas ficam amenas (15°C a 25°C) e a chuva é rara.
+
+**O que resolve rápido:** os passeios de flutuação e mergulho em Bonito têm vagas limitadas por dia (controle ambiental). Reserve os passeios antes do hotel. Voos para Campo Grande + transfer ou aluguel de carro até Bonito (270 km).
+
+**Investimento estimado (casal, 5 noites):** R$ 4.500 a R$ 8.000 (aéreo + hospedagem + 4-5 passeios).
+
+**Para quem:** quem gosta de natureza, aventura leve e ecoturismo. Funciona para famílias com crianças a partir de 5 anos (a flutuação tem idade mínima em alguns rios).
+
+### 3. Chapada dos Veadeiros (GO)
+
+A seca de julho deixa as trilhas acessíveis e as cachoeiras com volume de água suficiente para banho sem o risco de tromba d'água da estação chuvosa. O céu limpo de julho no Cerrado é outra vantagem: noites estreladas que você não encontra perto de nenhuma capital.
+
+**O que resolve rápido:** voos para Brasília + carro alugado até Alto Paraíso de Goiás (230 km). A estrada é boa. Hospedagem em Alto Paraíso ou São Jorge tem opções de pousada a lodge, com mais flexibilidade de última hora que Gramado.
+
+**Investimento estimado (casal, 5 noites):** R$ 3.500 a R$ 6.500.
+
+**Para quem:** quem quer desconectar de verdade, trilheiros moderados, casais que preferem natureza a cidade.
+
+### 4. Foz do Iguaçu (PR)
+
+Julho em Foz significa menos chuva e menos volume de água nas Cataratas, o que paradoxalmente é bom: as passarelas ficam mais acessíveis, você se molha menos (ou mais, se quiser no passeio de barco), e as fotos saem mais nítidas. O Parque Nacional atende tanto famílias com crianças quanto viajantes mais velhos.
+
+O lado argentino (Puerto Iguazú) complementa bem o roteiro e dá para cruzar no mesmo dia.
+
+**O que resolve rápido:** voos diretos de São Paulo e Curitiba. Hospedagem tem boa disponibilidade, exceto na semana de recesso escolar propriamente dita (12 a 20 de julho).
+
+**Investimento estimado (casal, 4 noites):** R$ 3.000 a R$ 5.500.
+
+**Para quem:** famílias com crianças de qualquer idade, viajantes de primeira viagem que querem um destino fácil e impactante, casais.
+
+### 5. Monte Verde e Serra da Mantiqueira (MG/SP)
+
+Para quem mora no eixo Rio-SP-Minas e não quer depender de avião, a Serra da Mantiqueira é a escapada de inverno mais acessível do Brasil. Monte Verde, Gonçalves, São Bento do Sapucaí e Visconde de Mauá oferecem frio, gastronomia e silêncio a poucas horas de carro.
+
+**O que resolve rápido:** é drive trip. Sem depender de disponibilidade de voo. Reserve a pousada e vá. Duas a três noites bastam para recarregar.
+
+**Investimento estimado (casal, 3 noites):** R$ 2.000 a R$ 4.000 (hospedagem + alimentação + combustível).
+
+**Para quem:** casais, famílias que querem uma pausa curta, quem não quer aeroporto.
+
+## Internacional: 5 Destinos Com Janela de Reserva em Julho
+
+### 6. Orlando e Parques da Disney (EUA)
+
+Julho é alta temporada nos parques, mas muita gente desiste de ir por causa da Copa (que acontece nos EUA no mesmo período). Isso pode abrir janelas de preço e disponibilidade em hotéis fora do circuito da Copa, já que as cidades-sede dos jogos são outras (Nova York, Miami, Los Angeles, Dallas).
+
+Orlando não é sede de nenhum jogo. Os parques vão funcionar normalmente.
+
+**O que resolver rápido:** passaporte válido, visto americano (se você já tem), passagens aéreas. Hotéis dentro dos complexos da Disney e Universal lotam, mas a região de Kissimmee e International Drive ainda tem opções.
+
+**Investimento estimado (família de 4, 7 noites):** R$ 25.000 a R$ 45.000 (aéreo + hospedagem + ingressos + alimentação). Sim, Disney em julho é investimento alto. Se o orçamento aperta, o [Beto Carrero](/beto-carrero) oferece uma experiência de parque temático no Brasil por uma fração do custo.
+
+**Para quem:** famílias com crianças, fãs dos parques, quem já tem visto americano válido.
+
+[Veja nossos roteiros para Orlando →](/orlando)
+
+### 7. Santiago e Valle Nevado (Chile)
+
+Julho é inverno no Chile, e Valle Nevado, a 46 km de Santiago, oferece a experiência de neve mais acessível para brasileiros. Dá para combinar 2-3 dias de neve com 2-3 dias em Santiago (vinícolas, gastronomia, Valparaíso). Não precisa de visto, o real rende razoavelmente bem contra o peso chileno, e o voo direto de São Paulo leva 4 horas.
+
+**O que resolver rápido:** passaporte ou RG (sim, dá para entrar no Chile com RG). Passagens para Santiago, reserva em Valle Nevado ou Farellones, e aluguel de roupas de neve (não precisa comprar).
+
+**Investimento estimado (casal, 6 noites):** R$ 8.000 a R$ 15.000 (aéreo + hospedagem + day trip neve + vinícola).
+
+**Para quem:** casais, famílias com crianças acima de 6 anos, quem quer experiência de neve sem precisar de visto ou voo de 10 horas.
+
+### 8. Buenos Aires (Argentina)
+
+Buenos Aires em julho é frio (5°C a 15°C), mas é quando a cidade fica mais portenha: cafés lotados, tango ao vivo, livrarias como refúgio, e asado sem culpa porque o frio justifica. O câmbio favorável ao real torna a cidade acessível para um nível de gastronomia e cultura que seria caro na Europa.
+
+**O que resolver rápido:** passaporte ou RG, passagem aérea (voos diretos de 2h30 a partir de SP/RJ/Curitiba). Buenos Aires tem hospedagem abundante, mas reserve em Palermo ou San Telmo para a melhor experiência de bairro.
+
+**Investimento estimado (casal, 5 noites):** R$ 5.000 a R$ 9.000 (aéreo + hotel boutique + alimentação + passeios).
+
+**Para quem:** casais, viajantes culturais, quem gosta de gastronomia e não se importa com frio.
+
+### 9. Cancún e Riviera Maya (México)
+
+Enquanto o Brasil está no inverno, o Caribe mexicano está com 30°C e água cristalina. Cancún funciona para quem quer resort all-inclusive sem pensar, mas a Riviera Maya (Playa del Carmen, Tulum) oferece cenotes, ruínas maias e uma experiência menos genérica.
+
+Brasileiros não precisam de visto para o México, apenas de autorização eletrônica (SAE) gratuita.
+
+**O que resolver rápido:** passaporte válido, SAE do México (online, gratuita), passagens aéreas (voos com escala, 8-12h dependendo da conexão). Resorts all-inclusive simplificam o resto.
+
+**Investimento estimado (casal, 7 noites all-inclusive):** R$ 12.000 a R$ 22.000 (aéreo + resort).
+
+**Para quem:** casais em lua de mel, quem quer calor e praia no inverno brasileiro, viajantes que preferem tudo resolvido.
+
+[Veja mais destinos no Caribe →](/blog/caribe-destinos-para-brasileiros)
+
+### 10. Lisboa e Porto (Portugal)
+
+Julho é verão europeu, e Portugal combina sol, praia, gastronomia e preços mais acessíveis que França ou Itália. Lisboa e Porto são cidades compactas e fáceis de navegar, com voo direto do Brasil (8-9h). A língua comum elimina a barreira que trava muitos viajantes de primeira viagem internacional.
+
+**O que resolver rápido:** passaporte válido (a partir do final de 2026, o ETIAS será necessário, mas para julho ainda não está em vigor). Passagens aéreas diretas lotam em julho. Hotel no centro histórico é mais caro, mas bairros como Alfama e Mouraria em Lisboa, ou Ribeira em Porto, compensam.
+
+**Investimento estimado (casal, 8 noites):** R$ 15.000 a R$ 28.000 (aéreo + hospedagem + alimentação + transporte local).
+
+**Para quem:** casais, famílias, viajantes de primeira viagem internacional, [melhor idade](/melhor-idade).
+
+[Leia nosso guia de roteiro pela Europa →](/blog/roteiro-europa-brasileiros-2026)
+
+## Comparativo Rápido: Os 10 Destinos Lado a Lado
+
+| Destino | Investimento (casal) | Visto/doc | Clima em julho | Melhor para |
+|---|---|---|---|---|
+| Gramado (RS) | R$ 4.000 – 7.000 | — | 5°C – 15°C | Casais, famílias |
+| Bonito (MS) | R$ 4.500 – 8.000 | — | 15°C – 25°C | Ecoturismo, famílias |
+| Chapada dos Veadeiros (GO) | R$ 3.500 – 6.500 | — | 15°C – 28°C | Natureza, desconexão |
+| Foz do Iguaçu (PR) | R$ 3.000 – 5.500 | — | 12°C – 22°C | Famílias, primeira viagem |
+| Monte Verde (MG) | R$ 2.000 – 4.000 | — | 5°C – 18°C | Escapada curta, casais |
+| Orlando (EUA) | R$ 25.000 – 45.000* | Visto | 25°C – 33°C | Famílias com crianças |
+| Santiago + neve (Chile) | R$ 8.000 – 15.000 | RG | 3°C – 15°C | Casais, neve acessível |
+| Buenos Aires (Argentina) | R$ 5.000 – 9.000 | RG | 5°C – 15°C | Cultura, gastronomia |
+| Cancún (México) | R$ 12.000 – 22.000 | SAE online | 28°C – 33°C | Lua de mel, all-inclusive |
+| Lisboa (Portugal) | R$ 15.000 – 28.000 | Passaporte | 20°C – 30°C | Primeira viagem, casais |
+
+*Para família de 4 pessoas.
+
+## O Que Você Precisa Resolver Esta Semana
+
+Se julho é o mês, o relógio está correndo. Aqui vai uma ordem de prioridade para os próximos 7 dias:
+
+1. **Defina o destino.** Use a tabela acima para cruzar orçamento, perfil e documentação que você já tem.
+2. **Verifique documentação.** Passaporte válido? Visto americano em dia? RG para América do Sul?
+3. **Reserve passagens aéreas.** É o item que mais sobe de preço com a proximidade da data.
+4. **Reserve hospedagem.** Para destinos nacionais como Gramado e Bonito, a hospedagem é o gargalo, não o voo.
+5. **Contrate seguro viagem** (para destinos internacionais). [Leia nosso guia completo sobre seguro viagem 2026 →](/blog/seguro-viagem-internacional-2026)
+
+Se a lista de tarefas parece grande demais para resolver sozinho em 15 dias, é exatamente para isso que uma consultora de viagens serve.
+
+## Perguntas Frequentes
+
+### Ainda dá tempo de reservar férias de julho faltando menos de um mês?
+
+Dá, mas a janela está fechando. Destinos nacionais como Foz do Iguaçu e Chapada dos Veadeiros ainda têm boa disponibilidade. Para internacionais como Orlando e Lisboa, os voos ficam mais caros a cada semana, e hotéis bem localizados estão saindo do estoque. A recomendação é fechar passagem e hospedagem esta semana.
+
+### Qual o destino mais barato para férias de julho em 2026?
+
+Entre os nacionais, Monte Verde e a Serra da Mantiqueira são os mais acessíveis (a partir de R$ 2.000 para um casal, 3 noites), principalmente para quem mora perto e pode ir de carro. Para quem precisa voar, Foz do Iguaçu costuma ter boas tarifas e o custo de hospedagem e alimentação é menor que Gramado ou Bonito.
+
+### Preciso de visto para viajar em julho de 2026?
+
+Depende do destino. Para Chile, Argentina e México, brasileiros não precisam de visto (Chile e Argentina aceitam RG; México exige passaporte + autorização eletrônica gratuita). Para os EUA, é necessário visto B1/B2. Para Portugal e Europa, passaporte basta em julho de 2026 (o ETIAS ainda não estará em vigor). [Saiba mais sobre o ETIAS →](/blog/seguro-viagem-internacional-2026)
+
+### A Copa do Mundo 2026 nos EUA afeta quem vai para Orlando em julho?
+
+Orlando não é cidade-sede de nenhum jogo da Copa. Os parques da Disney e Universal funcionam normalmente. O impacto principal é nos preços de passagens aéreas para os EUA em geral, que tendem a subir por causa da demanda extra para cidades-sede como Miami e Nova York. Quem vai direto para Orlando pode encontrar tarifas menos infladas que o esperado.
+
+### Vale a pena contratar uma agência para férias de julho de última hora?
+
+Sim, especialmente quando o prazo é curto. Uma agência boutique como a Anhangá consegue acessar disponibilidade que não aparece nos sites de busca, negociar tarifas de grupo com operadoras, e resolver toda a logística (voo + hotel + passeios + seguro) em uma conversa só. Quando você tem 15 dias, a economia de tempo vale tanto quanto a economia de dinheiro.

--- a/content/blog/seguro-viagem-internacional-2026.mdx
+++ b/content/blog/seguro-viagem-internacional-2026.mdx
@@ -1,0 +1,139 @@
+---
+title: "Seguro Viagem Internacional: Quando É Obrigatório, Quando Vale a Pena e Quanto Custa em 2026"
+excerpt: "Descubra em quais países o seguro viagem é obrigatório, quanto custa por dia, qual cobertura contratar para cada destino e os erros que podem arruinar suas férias."
+date: "2026-06-10"
+author: "queila-oliveira"
+category: "Planejamento"
+image: "images/blog/seguro-viagem-2026.jpg"
+featured: true
+showChatCTA: true
+chatCTADestination: "Viagem Internacional"
+tags: ["seguro-viagem", "planejamento", "europa", "estados-unidos", "viagem-internacional", "etias", "schengen"]
+seoTitle: "Seguro Viagem Internacional 2026: Obrigatório, Preços e Coberturas"
+seoDescription: "Guia completo sobre seguro viagem internacional em 2026: países que exigem, quanto custa por dia, cobertura mínima por destino e como escolher o melhor plano."
+---
+
+Ninguém planeja passar mal durante a viagem. Mas acontece. Uma intoxicação alimentar em Cancún, uma torção no pé em Lisboa, uma crise alérgica em Orlando. O que era para ser a melhor semana do ano vira uma corrida para achar hospital, entender como funciona o sistema de saúde local e, principalmente, descobrir quanto isso vai custar.
+
+A resposta curta: muito. Uma consulta de emergência nos Estados Unidos sai por volta de US$ 300. Uma internação pode passar de US$ 10.000 por dia. Na Europa, dependendo do país, a conta médica não é tão absurda. Mas o repatriamento sanitário (quando você precisa voltar ao Brasil em maca ou com acompanhamento médico) pode ultrapassar US$ 50.000.
+
+O seguro viagem existe para cobrir isso. E em vários destinos, nem é questão de escolha: é obrigatório.
+
+## Em Quais Países o Seguro Viagem É Obrigatório?
+
+A obrigatoriedade varia por destino e pelo tipo de entrada. Estes são os casos mais relevantes para viajantes brasileiros em 2026:
+
+**Espaço Schengen (29 países europeus):** obrigatório para brasileiros em turismo, com cobertura mínima de 30.000 euros para despesas médicas, hospitalização e repatriamento. Isso inclui Alemanha, Áustria, Bélgica, Dinamarca, Espanha, Finlândia, França, Grécia, Holanda, Hungria, Islândia, Itália, Noruega, Polônia, Portugal, República Tcheca, Suécia, Suíça e mais 10 países.
+
+**América Latina:** Cuba, Equador, Uruguai e Venezuela exigem seguro viagem. No Chile, é obrigatório apresentar seguro que cubra despesas médicas por COVID-19.
+
+**Oriente Médio:** Emirados Árabes Unidos, Catar, Israel, Jordânia, Líbano e Omã. Todos exigem.
+
+**Outros:** Austrália (para determinados vistos), Belarus, Romênia, Rússia e Ucrânia.
+
+**E os Estados Unidos?** Não é obrigatório. Mas viajar sem seguro para os EUA é uma aposta que pode sair cara. O sistema de saúde americano é privado, e uma apendicite de urgência pode gerar uma conta de US$ 30.000 a US$ 50.000. Nenhum plano de saúde brasileiro cobre isso no exterior.
+
+## ETIAS e Seguro Viagem: O Que Muda Para Brasileiros na Europa em 2026
+
+O ETIAS (Sistema Europeu de Informação e Autorização de Viagem) entra em vigor no último trimestre de 2026. É uma autorização eletrônica, não um visto, que brasileiros vão precisar solicitar antes de embarcar para qualquer país do Espaço Schengen.
+
+O que você precisa saber:
+
+- **Custo:** 7 euros (isentos para menores de 18 e maiores de 70 anos)
+- **Validade:** 3 anos ou até o vencimento do passaporte
+- **Processamento:** a maioria das aprovações sai em minutos
+- **Exigência de seguro:** o ETIAS não substitui a obrigatoriedade do seguro viagem. Você vai precisar dos dois
+
+Vamos publicar um guia completo sobre o ETIAS em breve. Se quiser ser avisado, [faça o quiz de destinos](/quiz) e entre para nossa newsletter.
+
+## Quanto Custa o Seguro Viagem em 2026?
+
+O preço depende de três coisas: destino, duração da viagem e valor da cobertura médica. Para facilitar, montamos uma tabela com faixas reais de preço em 2026:
+
+| Destino | Viagem de 7 dias | Viagem de 10 dias | Viagem de 15 dias | Cobertura sugerida |
+|---|---|---|---|---|
+| **Europa (Schengen)** | R$ 100 – R$ 280 | R$ 139 – R$ 400 | R$ 200 – R$ 500 | Mínimo € 30.000 (obrigatório) |
+| **Estados Unidos** | R$ 140 – R$ 350 | R$ 200 – R$ 450 | R$ 280 – R$ 600 | Mínimo US$ 100.000 |
+| **América do Sul** | R$ 60 – R$ 130 | R$ 80 – R$ 180 | R$ 110 – R$ 250 | US$ 30.000 – US$ 60.000 |
+| **Caribe** | R$ 90 – R$ 250 | R$ 120 – R$ 350 | R$ 170 – R$ 450 | US$ 60.000 – US$ 100.000 |
+| **Ásia** | R$ 100 – R$ 250 | R$ 140 – R$ 350 | R$ 220 – R$ 500 | US$ 60.000 – US$ 100.000 |
+
+**Traduzindo:** para uma viagem de 10 dias para a Europa, o seguro custa entre R$ 14 e R$ 40 por dia. Para os EUA, entre R$ 20 e R$ 45 por dia. É menos que o preço de um almoço no destino.
+
+## Qual Cobertura Contratar Para Cada Destino?
+
+Não basta comprar o mais barato. A cobertura precisa fazer sentido para onde você vai e para quem vai:
+
+**Europa (Schengen):** o mínimo obrigatório é € 30.000, mas não é suficiente se algo grave acontecer. Recomendamos € 60.000 ou mais se você vai para países com custo médico alto como Suíça, Noruega ou Islândia.
+
+**Estados Unidos e Canadá:** mínimo de US$ 100.000. O custo hospitalar americano justifica essa cobertura com sobra. Se tem mais de 60 anos, considere US$ 150.000.
+
+**América do Sul:** US$ 30.000 a US$ 60.000 é suficiente para a maioria dos destinos. Chile e Argentina têm bom atendimento público, mas esperas longas.
+
+**Caribe:** US$ 60.000 a US$ 100.000. Infraestrutura médica é limitada em ilhas menores, e evacuação aérea para o continente é cara.
+
+**Viajantes 60+:** independente do destino, recomendamos cobertura mínima de US$ 100.000. Muitas seguradoras cobram mais para essa faixa etária, mas a diferença de preço é pequena comparada ao risco.
+
+## O Que o Seguro Viagem Cobre (e o Que Não Cobre)
+
+Todo seguro viagem internacional decente cobre pelo menos:
+
+- Despesas médicas e hospitalares de urgência e emergência
+- Atendimento odontológico de emergência
+- Repatriamento sanitário (volta ao Brasil com acompanhamento médico)
+- Translado de corpo em caso de falecimento
+- Indenização em caso de extravio de bagagem
+
+Coberturas adicionais que valem a pena considerar:
+
+- Cancelamento ou interrupção de viagem (se você tem voo e hotel caros, essa cobertura se paga)
+- Atraso de voo (reembolso de hospedagem e alimentação)
+- Cobertura para prática de esportes (se vai esquiar, mergulhar ou fazer trilha, verifique se está coberto)
+- Assistência jurídica no exterior
+
+**O que geralmente NÃO cobre:** condições pré-existentes não declaradas, prática de esportes radicais sem cobertura específica, e qualquer situação em que o viajante esteja sob efeito de álcool ou drogas.
+
+## 5 Erros Que as Pessoas Cometem ao Contratar Seguro Viagem
+
+1. **Contratar pelo preço mais baixo sem ler a cobertura.** Um plano de R$ 5/dia para os EUA com cobertura de US$ 15.000 não vai cobrir nem a entrada do pronto-socorro.
+
+2. **Achar que o cartão de crédito resolve.** Alguns cartões platinum e black oferecem seguro viagem, mas a cobertura costuma ser limitada (US$ 25.000 a US$ 50.000) e o processo de acionamento é burocrático. Leia as condições do seu cartão antes de contar com isso.
+
+3. **Não declarar condições pré-existentes.** Hipertensão, diabetes, problemas cardíacos. Se não declarar na contratação, a seguradora pode negar a cobertura exatamente quando você mais precisa.
+
+4. **Contratar depois de já ter saído do Brasil.** A maioria dos planos exige contratação antes do embarque. Faça isso junto com a compra das passagens.
+
+5. **Não verificar se o plano cobre o destino inteiro.** Vai fazer Europa + Turquia? Turquia não faz parte do Schengen. Confira se o plano cobre todos os países do roteiro.
+
+## Como Escolher o Melhor Plano
+
+Checklist rápido antes de contratar:
+
+- **Verifique a cobertura médica mínima** para o seu destino (tabela acima)
+- **Confira se cobre seus esportes e atividades:** esqui, mergulho, trilha
+- **Veja o processo de acionamento:** app, telefone 24h, WhatsApp?
+- **Pesquise a reputação da seguradora:** Reclame Aqui e SUSEP
+- **Compare pelo menos 3 cotações:** use comparadores como Seguros Promo, Real Seguro Viagem ou Assistente de Viagem
+- **Contrate com antecedência:** idealmente junto com as passagens, para já ter cobertura de cancelamento
+
+## Perguntas Frequentes
+
+### Seguro viagem é obrigatório para quais países?
+
+É obrigatório em todos os 29 países do Espaço Schengen (Europa), Cuba, Equador, Uruguai, Venezuela, Emirados Árabes, Catar, Israel e outros. Para Estados Unidos, Canadá e Ásia não é obrigatório, mas é altamente recomendado pelo alto custo médico.
+
+### Quanto custa um seguro viagem internacional em 2026?
+
+O preço varia de R$ 8 a R$ 45 por dia dependendo do destino e da cobertura. Para uma viagem de 10 dias à Europa, espere pagar entre R$ 139 e R$ 400. Para os EUA, entre R$ 200 e R$ 450 no mesmo período.
+
+### Seguro do cartão de crédito substitui o seguro viagem?
+
+Na maioria dos casos, não. A cobertura dos cartões costuma ser limitada (US$ 25.000 a US$ 50.000), o acionamento é burocrático, e raramente cobre repatriamento sanitário. Para o Espaço Schengen, o seguro do cartão pode não atender à exigência mínima de € 30.000. Confira as condições do seu cartão antes de depender dele.
+
+### Qual a cobertura mínima recomendada para os Estados Unidos?
+
+US$ 100.000. Uma consulta de emergência nos EUA custa em torno de US$ 300, um atendimento no pronto-socorro pode passar de US$ 2.000, e uma internação pode ultrapassar US$ 10.000 por dia. Para viajantes acima de 60 anos, recomendamos US$ 150.000.
+
+### O ETIAS substitui o seguro viagem na Europa?
+
+Não. O ETIAS é uma autorização eletrônica de viagem que será obrigatória a partir do final de 2026 para entrar no Espaço Schengen. Ele não substitui o seguro viagem. Você vai precisar dos dois documentos para embarcar.

--- a/content/blog/seguro-viagem-internacional-2026.mdx
+++ b/content/blog/seguro-viagem-internacional-2026.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Seguro Viagem Internacional: Quando É Obrigatório, Quando Vale a Pena e Quanto Custa em 2026"
-excerpt: "Descubra em quais países o seguro viagem é obrigatório, quanto custa por dia, qual cobertura contratar para cada destino e os erros que podem arruinar suas férias."
+excerpt: "Saiba em quais países o seguro viagem é obrigatório, quanto custa por dia, qual cobertura contratar e os erros comuns que podem arruinar suas férias."
 date: "2026-06-10"
 author: "queila-oliveira"
 category: "Planejamento"
@@ -8,7 +8,7 @@ image: "images/blog/seguro-viagem-2026.jpg"
 featured: true
 showChatCTA: true
 chatCTADestination: "Viagem Internacional"
-tags: ["seguro-viagem", "planejamento", "europa", "estados-unidos", "viagem-internacional", "etias", "schengen"]
+tags: ["seguro-viagem", "planejamento", "europa", "eua", "viagem-internacional", "etias", "schengen", "america-latina", "america-do-sul", "caribe", "asia"]
 seoTitle: "Seguro Viagem Internacional 2026: Obrigatório, Preços e Coberturas"
 seoDescription: "Guia completo sobre seguro viagem internacional em 2026: países que exigem, quanto custa por dia, cobertura mínima por destino e como escolher o melhor plano."
 ---


### PR DESCRIPTION
## Posts incluídos

**Férias de Julho 2026** (`ferias-julho-2026-destinos`)
- 10 destinos (5 nacionais + 5 internacionais) com disponibilidade para julho
- Tabela comparativa cruzando investimento, clima, documentação e perfil
- FAQ com 5 perguntas, `showChatCTA: true`, `featured: true`
- Publicar: **hoje, 04/06**

**Seguro Viagem Internacional 2026** (`seguro-viagem-internacional-2026`)
- Guia completo: quando é obrigatório, quanto custa, 5 erros comuns
- Lista de países que exigem seguro, comparação de coberturas
- Publicar: **10/06 (terça)**

## Checklist

- [x] Imagens hero no CDN (`images/blog/ferias-julho-2026.jpg`, `images/blog/seguro-viagem-2026.jpg`)
- [x] Newsletter Férias de Julho criada no Mautic (ID 30, rascunho, envio 05/06)
- [x] Links internos verificados (`/orlando`, `/beto-carrero`, `/melhor-idade`, etc.)
- [x] FAQ 5 itens por post
- [x] `showChatCTA: true` nos dois posts