### PR TITLE
chore: regenerate sitemap with two new blog entries

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -120,6 +120,26 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://www.anhanga.tur.br/blog/seguro-viagem-internacional-2026/</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <image:image>
+      <image:loc>https://media.anhanga.tur.br/images/blog/seguro-viagem-2026.jpg</image:loc>
+      <image:caption>Seguro Viagem Internacional: Quando É Obrigatório, Quando Vale a Pena e Quanto Custa em 2026</image:caption>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.anhanga.tur.br/blog/ferias-julho-2026-destinos/</loc>
+    <lastmod>2026-06-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <image:image>
+      <image:loc>https://media.anhanga.tur.br/images/blog/ferias-julho-2026.jpg</image:loc>
+      <image:caption>Férias de Julho 2026: 10 Destinos Para Reservar nos Próximos 15 Dias</image:caption>
+    </image:image>
+  </url>
+  <url>
     <loc>https://www.anhanga.tur.br/blog/viagem-corporativa-para-pequenas-empresas-guia-completo/</loc>
     <lastmod>2026-06-02</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## Summary

- Auto-regenerated `public/sitemap.xml` picks up two new blog posts added since the last build: `seguro-viagem-internacional-2026` and `ferias-julho-2026-destinos`
- No logic changes — this is purely a generated file updated by the sitemap script that runs on `pnpm typecheck` / `pnpm dev`

## Test plan

- [ ] Confirm sitemap entries render correctly at `/sitemap.xml` in preview
- [ ] Verify no other files were unintentionally modified

https://claude.ai/code/session_016EAzSkeWLoyZ3n24XV3FWX

---
_Generated by [Claude Code](https://claude.ai/code/session_016EAzSkeWLoyZ3n24XV3FWX)_