### PR TITLE
test: add unit tests for 5 previously uncovered areas

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -120,6 +120,26 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://www.anhanga.tur.br/blog/seguro-viagem-internacional-2026/</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <image:image>
+      <image:loc>https://media.anhanga.tur.br/images/blog/seguro-viagem-2026.jpg</image:loc>
+      <image:caption>Seguro Viagem Internacional: Quando É Obrigatório, Quando Vale a Pena e Quanto Custa em 2026</image:caption>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.anhanga.tur.br/blog/ferias-julho-2026-destinos/</loc>
+    <lastmod>2026-06-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <image:image>
+      <image:loc>https://media.anhanga.tur.br/images/blog/ferias-julho-2026.jpg</image:loc>
+      <image:caption>Férias de Julho 2026: 10 Destinos Para Reservar nos Próximos 15 Dias</image:caption>
+    </image:image>
+  </url>
+  <url>
     <loc>https://www.anhanga.tur.br/blog/viagem-corporativa-para-pequenas-empresas-guia-completo/</loc>
     <lastmod>2026-06-02</lastmod>
     <changefreq>monthly</changefreq>

--- a/tests/ai-handoff.test.ts
+++ b/tests/ai-handoff.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildGenerateHandoff } from '../lib/ai/handoff.ts';
+import type { BudgetToolArgs } from '../lib/ai/types.ts';
+
+const BASE_ARGS: BudgetToolArgs = {
+    origin_city: 'São Paulo',
+    origin_region: 'SP',
+    destination_city: 'Orlando',
+    destination_region: 'Flórida',
+    dates: 'junho de 2026',
+    budget_range: 'R$ 10.000',
+    need_summary: 'Família com 2 filhos',
+    decision_role: 'Decisor',
+    timeline_window: '3 meses',
+    baggage_preference: 'bagagem despachada',
+    iata_code: 'mco',
+};
+
+test('buildGenerateHandoff formats origin with city and region', () => {
+    const result = buildGenerateHandoff(BASE_ARGS, 'tool');
+    assert.equal(result.origin, 'São Paulo, SP');
+});
+
+test('buildGenerateHandoff formats destination with city and region', () => {
+    const result = buildGenerateHandoff(BASE_ARGS, 'tool');
+    assert.equal(result.destination, 'Orlando, Flórida');
+});
+
+test('buildGenerateHandoff uses only city when region is absent', () => {
+    const result = buildGenerateHandoff({ ...BASE_ARGS, origin_region: undefined }, 'tool');
+    assert.equal(result.origin, 'São Paulo');
+});
+
+test('buildGenerateHandoff uses only region when city is absent', () => {
+    const result = buildGenerateHandoff({ ...BASE_ARGS, origin_city: undefined }, 'tool');
+    assert.equal(result.origin, 'SP');
+});
+
+test('buildGenerateHandoff falls back to Origem a definir when city and region are both absent', () => {
+    const result = buildGenerateHandoff({ ...BASE_ARGS, origin_city: undefined, origin_region: undefined }, 'tool');
+    assert.equal(result.origin, 'Origem a definir');
+});
+
+test('buildGenerateHandoff uses destination field as fallback when city and region are absent', () => {
+    const result = buildGenerateHandoff({
+        ...BASE_ARGS,
+        destination_city: undefined,
+        destination_region: undefined,
+        destination: 'Caribe',
+    }, 'tool');
+    assert.equal(result.destination, 'Caribe');
+});
+
+test('buildGenerateHandoff falls back to Destino a definir when all destination fields are absent', () => {
+    const result = buildGenerateHandoff({
+        ...BASE_ARGS,
+        destination_city: undefined,
+        destination_region: undefined,
+        destination: undefined,
+    }, 'tool');
+    assert.equal(result.destination, 'Destino a definir');
+});
+
+test('buildGenerateHandoff uppercases and truncates IATA code to 3 chars', () => {
+    const result = buildGenerateHandoff({ ...BASE_ARGS, iata_code: 'mcoXXX' }, 'tool');
+    assert.equal(result.iataCode, 'MCO');
+});
+
+test('buildGenerateHandoff sets iataCode to undefined when iata_code is empty string', () => {
+    const result = buildGenerateHandoff({ ...BASE_ARGS, iata_code: '' }, 'tool');
+    assert.equal(result.iataCode, undefined);
+});
+
+test('buildGenerateHandoff sets iataCode to undefined when iata_code is absent', () => {
+    const result = buildGenerateHandoff({ ...BASE_ARGS, iata_code: undefined }, 'tool');
+    assert.equal(result.iataCode, undefined);
+});
+
+test('buildGenerateHandoff preserves baggagePreference when set', () => {
+    const result = buildGenerateHandoff(BASE_ARGS, 'tool');
+    assert.equal(result.baggagePreference, 'bagagem despachada');
+});
+
+test('buildGenerateHandoff sets baggagePreference to undefined when empty string', () => {
+    const result = buildGenerateHandoff({ ...BASE_ARGS, baggage_preference: '' }, 'tool');
+    assert.equal(result.baggagePreference, undefined);
+});
+
+test('buildGenerateHandoff preserves source=tool', () => {
+    const result = buildGenerateHandoff(BASE_ARGS, 'tool');
+    assert.equal(result.source, 'tool');
+});
+
+test('buildGenerateHandoff preserves source=repair', () => {
+    const result = buildGenerateHandoff(BASE_ARGS, 'repair');
+    assert.equal(result.source, 'repair');
+});
+
+test('buildGenerateHandoff uses A definir for dates when absent', () => {
+    const result = buildGenerateHandoff({ ...BASE_ARGS, dates: undefined }, 'tool');
+    assert.equal(result.dates, 'A definir');
+});
+
+test('buildGenerateHandoff uses A definir for dates when empty string', () => {
+    const result = buildGenerateHandoff({ ...BASE_ARGS, dates: '   ' }, 'tool');
+    assert.equal(result.dates, 'A definir');
+});
+
+test('buildGenerateHandoff bantSummary includes all BANT fields', () => {
+    const result = buildGenerateHandoff(BASE_ARGS, 'tool');
+    assert.ok(result.bantSummary.includes('Need: Família com 2 filhos'));
+    assert.ok(result.bantSummary.includes('Authority: Decisor'));
+    assert.ok(result.bantSummary.includes('Budget: R$ 10.000'));
+    assert.ok(result.bantSummary.includes('Timeline: 3 meses'));
+});
+
+test('buildGenerateHandoff bantSummary appends Visto EUA note when visa_status is pendente', () => {
+    const result = buildGenerateHandoff({ ...BASE_ARGS, visa_status: 'pendente' }, 'tool');
+    assert.ok(result.bantSummary.includes('Visto EUA: Pendente'));
+});
+
+test('buildGenerateHandoff bantSummary does not append Visto EUA for other visa statuses', () => {
+    const result = buildGenerateHandoff({ ...BASE_ARGS, visa_status: 'ok' }, 'tool');
+    assert.ok(!result.bantSummary.includes('Visto EUA'));
+});
+
+test('buildGenerateHandoff bantSummary uses defaults when BANT fields are absent', () => {
+    const result = buildGenerateHandoff({ origin_city: 'São Paulo', destination_city: 'Orlando' }, 'tool');
+    assert.ok(result.bantSummary.includes('Budget: A definir'));
+    assert.ok(result.bantSummary.includes('Need: Não informado'));
+    assert.ok(result.bantSummary.includes('Authority: Não informado'));
+    assert.ok(result.bantSummary.includes('Timeline: Não informado'));
+});

--- a/tests/google-conversion.test.ts
+++ b/tests/google-conversion.test.ts
@@ -24,7 +24,7 @@ function restoreEnv() {
     restoreEnvValue('GA4_API_SECRET', originalEnv.GA4_API_SECRET);
 }
 
-function silenceLogger(t: Parameters<Parameters<typeof test>[1]>[0]) {
+function silenceLogger(t: { after: (fn: () => void) => void }) {
     console.log = (() => {}) as typeof console.log;
     console.warn = (() => {}) as typeof console.warn;
     console.error = (() => {}) as typeof console.error;
@@ -89,7 +89,7 @@ test('sendGoogleConversion sends correct payload to GA4', async (t) => {
         requests.push({
             url: getUrl(input),
             method: init?.method || 'GET',
-            body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+            body: init?.body ? JSON.parse(init.body as string) as Record<string, unknown> : {},
         });
         return new Response('{}', { status: 200 });
     }) as typeof fetch;
@@ -110,7 +110,7 @@ test('sendGoogleConversion sends correct payload to GA4', async (t) => {
     const req = requests[0]!;
     assert.ok(req.url.includes('G-ABCDE'));
     assert.ok(req.url.includes('secret-123'));
-    assert.ok(req.url.includes('google-analytics.com'));
+    assert.equal(new URL(req.url).hostname, 'www.google-analytics.com');
     assert.equal(req.method, 'POST');
     assert.equal(req.body.client_id, 'cid-abc');
 
@@ -133,7 +133,7 @@ test('sendGoogleConversion applies BRL as default currency and 0 as default valu
     process.env.GA4_API_SECRET = 'secret';
 
     global.fetch = (async (_: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        requests.push({ body: JSON.parse(String(init?.body)) as Record<string, unknown> });
+        requests.push({ body: init?.body ? JSON.parse(init.body as string) as Record<string, unknown> : {} });
         return new Response('{}', { status: 200 });
     }) as typeof fetch;
 
@@ -154,7 +154,7 @@ test('sendGoogleConversion omits optional params when absent', async (t) => {
     process.env.GA4_API_SECRET = 'secret';
 
     global.fetch = (async (_: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        requests.push({ body: JSON.parse(String(init?.body)) as Record<string, unknown> });
+        requests.push({ body: init?.body ? JSON.parse(init.body as string) as Record<string, unknown> : {} });
         return new Response('{}', { status: 200 });
     }) as typeof fetch;
 

--- a/tests/google-conversion.test.ts
+++ b/tests/google-conversion.test.ts
@@ -1,0 +1,211 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sendGoogleConversion } from '../lib/conversions/google.ts';
+
+const originalFetch = global.fetch;
+const originalConsoleLog = console.log;
+const originalConsoleWarn = console.warn;
+const originalConsoleError = console.error;
+const originalEnv = {
+    GA4_MEASUREMENT_ID: process.env.GA4_MEASUREMENT_ID,
+    GA4_API_SECRET: process.env.GA4_API_SECRET,
+};
+
+function restoreEnvValue(key: string, value: string | undefined) {
+    if (value === undefined) {
+        delete process.env[key];
+        return;
+    }
+    process.env[key] = value;
+}
+
+function restoreEnv() {
+    restoreEnvValue('GA4_MEASUREMENT_ID', originalEnv.GA4_MEASUREMENT_ID);
+    restoreEnvValue('GA4_API_SECRET', originalEnv.GA4_API_SECRET);
+}
+
+function silenceLogger(t: Parameters<Parameters<typeof test>[1]>[0]) {
+    console.log = (() => {}) as typeof console.log;
+    console.warn = (() => {}) as typeof console.warn;
+    console.error = (() => {}) as typeof console.error;
+    t.after(() => {
+        console.log = originalConsoleLog;
+        console.warn = originalConsoleWarn;
+        console.error = originalConsoleError;
+    });
+}
+
+function getUrl(input: RequestInfo | URL): string {
+    if (typeof input === 'string') return input;
+    if (input instanceof URL) return input.toString();
+    return (input as Request).url;
+}
+
+test('sendGoogleConversion returns failure when GA4_MEASUREMENT_ID is missing', async (t) => {
+    silenceLogger(t);
+    t.after(() => { global.fetch = originalFetch; restoreEnv(); });
+
+    delete process.env.GA4_MEASUREMENT_ID;
+    process.env.GA4_API_SECRET = 'secret';
+
+    const result = await sendGoogleConversion('lead_qualificado', { clientId: 'cid-1' });
+    assert.equal(result.success, false);
+    assert.equal(result.error, 'Missing configuration');
+});
+
+test('sendGoogleConversion returns failure when GA4_API_SECRET is missing', async (t) => {
+    silenceLogger(t);
+    t.after(() => { global.fetch = originalFetch; restoreEnv(); });
+
+    process.env.GA4_MEASUREMENT_ID = 'G-TEST';
+    delete process.env.GA4_API_SECRET;
+
+    const result = await sendGoogleConversion('lead_qualificado', { clientId: 'cid-1' });
+    assert.equal(result.success, false);
+    assert.equal(result.error, 'Missing configuration');
+});
+
+test('sendGoogleConversion returns failure when clientId is null', async (t) => {
+    silenceLogger(t);
+    t.after(() => { global.fetch = originalFetch; restoreEnv(); });
+
+    process.env.GA4_MEASUREMENT_ID = 'G-TEST';
+    process.env.GA4_API_SECRET = 'secret';
+
+    const result = await sendGoogleConversion('lead_qualificado', { clientId: null });
+    assert.equal(result.success, false);
+    assert.equal(result.error, 'Missing clientId');
+});
+
+test('sendGoogleConversion sends correct payload to GA4', async (t) => {
+    const requests: Array<{ url: string; method: string; body: Record<string, unknown> }> = [];
+    silenceLogger(t);
+    t.after(() => { global.fetch = originalFetch; restoreEnv(); });
+
+    process.env.GA4_MEASUREMENT_ID = 'G-ABCDE';
+    process.env.GA4_API_SECRET = 'secret-123';
+
+    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        requests.push({
+            url: getUrl(input),
+            method: init?.method || 'GET',
+            body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+        });
+        return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const result = await sendGoogleConversion('lead_qualificado', {
+        clientId: 'cid-abc',
+        sessionId: 'sid-123',
+        gclid: 'gclid-xyz',
+        destination: 'Orlando',
+        value: 5000,
+        currency: 'BRL',
+        transactionId: 'txn-1',
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(requests.length, 1);
+
+    const req = requests[0]!;
+    assert.ok(req.url.includes('G-ABCDE'));
+    assert.ok(req.url.includes('secret-123'));
+    assert.ok(req.url.includes('google-analytics.com'));
+    assert.equal(req.method, 'POST');
+    assert.equal(req.body.client_id, 'cid-abc');
+
+    const events = req.body.events as Array<{ name: string; params: Record<string, unknown> }>;
+    assert.equal(events[0]?.name, 'lead_qualificado');
+    assert.equal(events[0]?.params.session_id, 'sid-123');
+    assert.equal(events[0]?.params.gclid, 'gclid-xyz');
+    assert.equal(events[0]?.params.destination, 'Orlando');
+    assert.equal(events[0]?.params.value, 5000);
+    assert.equal(events[0]?.params.currency, 'BRL');
+    assert.equal(events[0]?.params.transaction_id, 'txn-1');
+});
+
+test('sendGoogleConversion applies BRL as default currency and 0 as default value', async (t) => {
+    const requests: Array<{ body: Record<string, unknown> }> = [];
+    silenceLogger(t);
+    t.after(() => { global.fetch = originalFetch; restoreEnv(); });
+
+    process.env.GA4_MEASUREMENT_ID = 'G-TEST';
+    process.env.GA4_API_SECRET = 'secret';
+
+    global.fetch = (async (_: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        requests.push({ body: JSON.parse(String(init?.body)) as Record<string, unknown> });
+        return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    await sendGoogleConversion('purchase', { clientId: 'cid-1' });
+
+    const events = requests[0]!.body.events as Array<{ params: Record<string, unknown> }>;
+    const params = events[0]!.params;
+    assert.equal(params.currency, 'BRL');
+    assert.equal(params.value, 0);
+});
+
+test('sendGoogleConversion omits optional params when absent', async (t) => {
+    const requests: Array<{ body: Record<string, unknown> }> = [];
+    silenceLogger(t);
+    t.after(() => { global.fetch = originalFetch; restoreEnv(); });
+
+    process.env.GA4_MEASUREMENT_ID = 'G-TEST';
+    process.env.GA4_API_SECRET = 'secret';
+
+    global.fetch = (async (_: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        requests.push({ body: JSON.parse(String(init?.body)) as Record<string, unknown> });
+        return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    await sendGoogleConversion('lead_qualificado', { clientId: 'cid-1' });
+
+    const events = requests[0]!.body.events as Array<{ params: Record<string, unknown> }>;
+    const params = events[0]!.params;
+    assert.ok(!('session_id' in params));
+    assert.ok(!('destination' in params));
+    assert.ok(!('gclid' in params));
+    assert.ok(!('transaction_id' in params));
+});
+
+test('sendGoogleConversion returns failure on non-ok HTTP response', async (t) => {
+    silenceLogger(t);
+    t.after(() => { global.fetch = originalFetch; restoreEnv(); });
+
+    process.env.GA4_MEASUREMENT_ID = 'G-TEST';
+    process.env.GA4_API_SECRET = 'secret';
+
+    global.fetch = (async (): Promise<Response> => new Response('Unauthorized', { status: 401 })) as typeof fetch;
+
+    const result = await sendGoogleConversion('lead_qualificado', { clientId: 'cid-1' });
+    assert.equal(result.success, false);
+    assert.ok(result.error?.includes('HTTP 401'));
+});
+
+test('sendGoogleConversion returns failure when fetch throws', async (t) => {
+    silenceLogger(t);
+    t.after(() => { global.fetch = originalFetch; restoreEnv(); });
+
+    process.env.GA4_MEASUREMENT_ID = 'G-TEST';
+    process.env.GA4_API_SECRET = 'secret';
+
+    global.fetch = (async (): Promise<Response> => { throw new Error('network failure'); }) as typeof fetch;
+
+    const result = await sendGoogleConversion('lead_qualificado', { clientId: 'cid-1' });
+    assert.equal(result.success, false);
+    assert.equal(result.error, 'network failure');
+});
+
+test('sendGoogleConversion returns success=true on 200 response', async (t) => {
+    silenceLogger(t);
+    t.after(() => { global.fetch = originalFetch; restoreEnv(); });
+
+    process.env.GA4_MEASUREMENT_ID = 'G-TEST';
+    process.env.GA4_API_SECRET = 'secret';
+
+    global.fetch = (async (): Promise<Response> => new Response('{}', { status: 200 })) as typeof fetch;
+
+    const result = await sendGoogleConversion('close_convert_lead', { clientId: 'cid-1', value: 1200 });
+    assert.equal(result.success, true);
+    assert.ok(!result.error);
+});

--- a/tests/hubspot-service.test.ts
+++ b/tests/hubspot-service.test.ts
@@ -129,9 +129,15 @@ test('getDeal throws HUBSPOT_TIMEOUT when request exceeds configured timeout', a
 
     process.env.HUBSPOT_REQUEST_TIMEOUT_MS = '50';
 
-    global.fetch = (async (): Promise<Response> => {
-        return new Promise<Response>((resolve) => {
-            setTimeout(() => resolve(new Response('{}', { status: 200 })), 300);
+    global.fetch = (async (_: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        return new Promise<Response>((resolve, reject) => {
+            const timer = setTimeout(() => resolve(new Response('{}', { status: 200 })), 300);
+            init?.signal?.addEventListener('abort', () => {
+                clearTimeout(timer);
+                const err = new Error('The user aborted a request.');
+                err.name = 'AbortError';
+                reject(err);
+            });
         });
     }) as typeof fetch;
 

--- a/tests/hubspot-service.test.ts
+++ b/tests/hubspot-service.test.ts
@@ -1,0 +1,245 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getDeal, getContact, getAssociatedContactId } from '../services/hubspot.ts';
+
+const originalFetch = global.fetch;
+const originalEnv = {
+    HUBSPOT_REQUEST_TIMEOUT_MS: process.env.HUBSPOT_REQUEST_TIMEOUT_MS,
+};
+
+function restoreEnvValue(key: string, value: string | undefined) {
+    if (value === undefined) {
+        delete process.env[key];
+        return;
+    }
+    process.env[key] = value;
+}
+
+const TOKEN = 'test-hubspot-token';
+
+function getUrl(input: RequestInfo | URL): string {
+    if (typeof input === 'string') return input;
+    if (input instanceof URL) return input.toString();
+    return (input as Request).url;
+}
+
+test('getDeal sends GET request with Authorization header and correct URL', async (t) => {
+    const requests: Array<{ url: string; method: string; authHeader: string }> = [];
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    const mockDeal = { id: 'deal-1', properties: { dealname: 'Viagem Orlando', amount: '5000', dealstage: 'closedwon' } };
+
+    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const headers = new Headers(init?.headers);
+        requests.push({
+            url: getUrl(input),
+            method: init?.method || 'GET',
+            authHeader: headers.get('Authorization') ?? '',
+        });
+        return new Response(JSON.stringify(mockDeal), { status: 200 });
+    }) as typeof fetch;
+
+    const deal = await getDeal(TOKEN, 'deal-1');
+
+    assert.equal(requests.length, 1);
+    assert.ok(requests[0]!.url.includes('/crm/v3/objects/deals/deal-1'));
+    assert.equal(requests[0]!.authHeader, `Bearer ${TOKEN}`);
+    assert.deepEqual(deal, mockDeal);
+});
+
+test('getDeal includes requested properties in URL', async (t) => {
+    const urls: string[] = [];
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    global.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+        urls.push(getUrl(input));
+        return new Response(JSON.stringify({ id: 'deal-1', properties: {} }), { status: 200 });
+    }) as typeof fetch;
+
+    await getDeal(TOKEN, 'deal-1', ['amount', 'closedate']);
+    assert.ok(urls[0]!.includes('amount'));
+    assert.ok(urls[0]!.includes('closedate'));
+});
+
+test('getDeal throws UNAUTHORIZED on 401 response', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    global.fetch = (async (): Promise<Response> => new Response('Unauthorized', { status: 401 })) as typeof fetch;
+
+    await assert.rejects(
+        () => getDeal(TOKEN, 'deal-1'),
+        (err: Error) => {
+            assert.equal(err.message, 'UNAUTHORIZED');
+            return true;
+        },
+    );
+});
+
+test('getDeal throws UNAUTHORIZED on 403 response', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    global.fetch = (async (): Promise<Response> => new Response('Forbidden', { status: 403 })) as typeof fetch;
+
+    await assert.rejects(
+        () => getDeal(TOKEN, 'deal-1'),
+        (err: Error) => {
+            assert.equal(err.message, 'UNAUTHORIZED');
+            return true;
+        },
+    );
+});
+
+test('getDeal throws with error code and status on non-ok response', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    global.fetch = (async (): Promise<Response> => new Response('Not found', { status: 404 })) as typeof fetch;
+
+    await assert.rejects(
+        () => getDeal(TOKEN, 'deal-1'),
+        (err: Error) => {
+            assert.ok(err.message.includes('DEAL_FETCH_FAILED'));
+            assert.ok(err.message.includes('404'));
+            return true;
+        },
+    );
+});
+
+test('getDeal throws HUBSPOT_TIMEOUT when request exceeds configured timeout', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    process.env.HUBSPOT_REQUEST_TIMEOUT_MS = '50';
+
+    global.fetch = (async (): Promise<Response> => {
+        return new Promise<Response>((resolve) => {
+            setTimeout(() => resolve(new Response('{}', { status: 200 })), 300);
+        });
+    }) as typeof fetch;
+
+    await assert.rejects(
+        () => getDeal(TOKEN, 'deal-1'),
+        (err: Error) => {
+            assert.ok(err.message.includes('HUBSPOT_TIMEOUT'));
+            assert.ok(err.message.includes('504'));
+            return true;
+        },
+    );
+});
+
+test('getContact fetches contact with correct URL', async (t) => {
+    const urls: string[] = [];
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    const mockContact = { id: 'ct-1', properties: { email: 'ana@example.com', firstname: 'Ana', lastname: 'Silva', phone: null } };
+
+    global.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+        urls.push(getUrl(input));
+        return new Response(JSON.stringify(mockContact), { status: 200 });
+    }) as typeof fetch;
+
+    const contact = await getContact(TOKEN, 'ct-1');
+    assert.ok(urls[0]!.includes('/crm/v3/objects/contacts/ct-1'));
+    assert.deepEqual(contact, mockContact);
+});
+
+test('getContact throws UNAUTHORIZED on 401', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    global.fetch = (async (): Promise<Response> => new Response('Unauthorized', { status: 401 })) as typeof fetch;
+
+    await assert.rejects(
+        () => getContact(TOKEN, 'ct-1'),
+        (err: Error) => {
+            assert.equal(err.message, 'UNAUTHORIZED');
+            return true;
+        },
+    );
+});
+
+test('getAssociatedContactId returns first contact id from results', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    global.fetch = (async (): Promise<Response> => {
+        return new Response(
+            JSON.stringify({ results: [{ toObjectId: 'ct-42' }, { toObjectId: 'ct-99' }] }),
+            { status: 200 },
+        );
+    }) as typeof fetch;
+
+    const contactId = await getAssociatedContactId(TOKEN, 'deal-1');
+    assert.equal(contactId, 'ct-42');
+});
+
+test('getAssociatedContactId returns null when results array is empty', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    global.fetch = (async (): Promise<Response> => {
+        return new Response(JSON.stringify({ results: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    const contactId = await getAssociatedContactId(TOKEN, 'deal-1');
+    assert.equal(contactId, null);
+});
+
+test('getAssociatedContactId returns null when results field is absent', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    global.fetch = (async (): Promise<Response> => {
+        return new Response(JSON.stringify({}), { status: 200 });
+    }) as typeof fetch;
+
+    const contactId = await getAssociatedContactId(TOKEN, 'deal-1');
+    assert.equal(contactId, null);
+});
+
+test('getAssociatedContactId uses associations/contacts endpoint', async (t) => {
+    const urls: string[] = [];
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        restoreEnvValue('HUBSPOT_REQUEST_TIMEOUT_MS', originalEnv.HUBSPOT_REQUEST_TIMEOUT_MS);
+    });
+
+    global.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+        urls.push(getUrl(input));
+        return new Response(JSON.stringify({ results: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    await getAssociatedContactId(TOKEN, 'deal-99');
+    assert.ok(urls[0]!.includes('/crm/v4/objects/deals/deal-99/associations/contacts'));
+});

--- a/tests/waitlist-logic.test.ts
+++ b/tests/waitlist-logic.test.ts
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateWaitlistPayload } from '../lib/waitlist-logic.ts';
+
+const VALID_BASE = {
+    name: 'Ana Maria',
+    email: 'ana@example.com',
+    sourcePage: '/lollapalooza',
+    utms: {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        utm_campaign: 'lolla2027',
+        utm_term: null,
+        utm_content: null,
+    },
+};
+
+test('validateWaitlistPayload rejects null payload', () => {
+    const result = validateWaitlistPayload(null);
+    assert.equal(result.valid, false);
+});
+
+test('validateWaitlistPayload rejects non-object payload', () => {
+    const result = validateWaitlistPayload('not an object');
+    assert.equal(result.valid, false);
+});
+
+test('validateWaitlistPayload rejects missing name', () => {
+    const { name: _omit, ...without } = VALID_BASE;
+    const result = validateWaitlistPayload(without);
+    assert.equal(result.valid, false);
+    if (!result.valid) assert.equal(result.error, 'Campos obrigatórios ausentes.');
+});
+
+test('validateWaitlistPayload rejects empty name', () => {
+    const result = validateWaitlistPayload({ ...VALID_BASE, name: '   ' });
+    assert.equal(result.valid, false);
+    if (!result.valid) assert.equal(result.error, 'Campos obrigatórios ausentes.');
+});
+
+test('validateWaitlistPayload rejects missing email', () => {
+    const { email: _omit, ...without } = VALID_BASE;
+    const result = validateWaitlistPayload(without);
+    assert.equal(result.valid, false);
+    if (!result.valid) assert.equal(result.error, 'Campos obrigatórios ausentes.');
+});
+
+test('validateWaitlistPayload rejects missing sourcePage', () => {
+    const { sourcePage: _omit, ...without } = VALID_BASE;
+    const result = validateWaitlistPayload(without);
+    assert.equal(result.valid, false);
+    if (!result.valid) assert.equal(result.error, 'Campos obrigatórios ausentes.');
+});
+
+test('validateWaitlistPayload rejects invalid email format', () => {
+    const result = validateWaitlistPayload({ ...VALID_BASE, email: 'not-an-email' });
+    assert.equal(result.valid, false);
+    if (!result.valid) assert.equal(result.error, 'Email inválido.');
+});
+
+test('validateWaitlistPayload rejects email without domain', () => {
+    const result = validateWaitlistPayload({ ...VALID_BASE, email: 'ana@' });
+    assert.equal(result.valid, false);
+});
+
+test('validateWaitlistPayload lowercases email', () => {
+    const result = validateWaitlistPayload({ ...VALID_BASE, email: 'ANA@EXAMPLE.COM' });
+    assert.equal(result.valid, true);
+    if (result.valid) assert.equal(result.data.email, 'ana@example.com');
+});
+
+test('validateWaitlistPayload trims whitespace from name', () => {
+    const result = validateWaitlistPayload({ ...VALID_BASE, name: '  Ana Maria  ' });
+    assert.equal(result.valid, true);
+    if (result.valid) assert.equal(result.data.name, 'Ana Maria');
+});
+
+test('validateWaitlistPayload trims whitespace from email before lowercasing', () => {
+    const result = validateWaitlistPayload({ ...VALID_BASE, email: '  ANA@example.com  ' });
+    assert.equal(result.valid, true);
+    if (result.valid) assert.equal(result.data.email, 'ana@example.com');
+});
+
+test('validateWaitlistPayload extracts UTM fields', () => {
+    const result = validateWaitlistPayload(VALID_BASE);
+    assert.equal(result.valid, true);
+    if (result.valid) {
+        assert.equal(result.data.utms.utm_source, 'google');
+        assert.equal(result.data.utms.utm_medium, 'cpc');
+        assert.equal(result.data.utms.utm_campaign, 'lolla2027');
+    }
+});
+
+test('validateWaitlistPayload returns correct shape on happy path', () => {
+    const result = validateWaitlistPayload(VALID_BASE);
+    assert.equal(result.valid, true);
+    if (result.valid) {
+        assert.equal(result.data.name, 'Ana Maria');
+        assert.equal(result.data.email, 'ana@example.com');
+        assert.equal(result.data.sourcePage, '/lollapalooza');
+        assert.ok('utms' in result.data);
+        assert.ok('tracking' in result.data);
+    }
+});
+
+test('validateWaitlistPayload handles missing utms gracefully', () => {
+    const { utms: _omit, ...without } = VALID_BASE;
+    const result = validateWaitlistPayload(without);
+    assert.equal(result.valid, true);
+    if (result.valid) {
+        assert.equal(result.data.utms.utm_source, null);
+        assert.equal(result.data.utms.utm_medium, null);
+    }
+});
+
+test('validateWaitlistPayload name is capped at 160 characters', () => {
+    const longName = 'A'.repeat(200);
+    const result = validateWaitlistPayload({ ...VALID_BASE, name: longName });
+    assert.equal(result.valid, true);
+    if (result.valid) assert.equal(result.data.name.length, 160);
+});

--- a/tests/whatsapp-tracking.test.ts
+++ b/tests/whatsapp-tracking.test.ts
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getWhatsAppLink, getTrackingDataObject } from '../utils/whatsapp.ts';
+
+const WHATSAPP_BASE = 'https://wa.me/551152833309';
+
+function decodeMessageFrom(url: string): string {
+    const part = url.split('?text=')[1];
+    return decodeURIComponent(part ?? '');
+}
+
+test('getWhatsAppLink returns URL with correct WhatsApp number', () => {
+    const url = getWhatsAppLink('Olá');
+    assert.ok(url.startsWith(WHATSAPP_BASE + '?text='));
+});
+
+test('getWhatsAppLink URL-encodes the message', () => {
+    const url = getWhatsAppLink('Olá, quero saber mais!');
+    const decoded = decodeMessageFrom(url);
+    assert.equal(decoded, 'Olá, quero saber mais!');
+});
+
+test('getWhatsAppLink strips || Dados: suffix from message', () => {
+    const url = getWhatsAppLink('Olá || Dados: utm_source=google, utm_medium=cpc');
+    const decoded = decodeMessageFrom(url);
+    assert.equal(decoded, 'Olá');
+});
+
+test('getWhatsAppLink strips [ref: suffix from message', () => {
+    const url = getWhatsAppLink('Mensagem [ref: abc123]');
+    const decoded = decodeMessageFrom(url);
+    assert.equal(decoded, 'Mensagem');
+});
+
+test('getWhatsAppLink strips both suffixes when both are present (priority to || Dados:)', () => {
+    const url = getWhatsAppLink('Texto || Dados: x=1 [ref: abc]');
+    const decoded = decodeMessageFrom(url);
+    assert.equal(decoded, 'Texto');
+});
+
+test('getWhatsAppLink trims trailing whitespace after stripping suffix', () => {
+    const url = getWhatsAppLink('Mensagem   ');
+    const decoded = decodeMessageFrom(url);
+    assert.equal(decoded, 'Mensagem');
+});
+
+test('getWhatsAppLink with appendTrackingRef=false (default) does not append tracking data', () => {
+    const url = getWhatsAppLink('Mensagem simples');
+    const decoded = decodeMessageFrom(url);
+    assert.ok(!decoded.includes('|| Dados:'));
+});
+
+test('getWhatsAppLink with appendTrackingRef=true but no tracking available omits Dados suffix', () => {
+    // In Node.js, window is undefined — no tracking data can be captured
+    const url = getWhatsAppLink('Mensagem', { appendTrackingRef: true });
+    const decoded = decodeMessageFrom(url);
+    assert.equal(decoded, 'Mensagem');
+    assert.ok(!decoded.includes('|| Dados:'));
+});
+
+test('getWhatsAppLink with empty message returns URL with empty text', () => {
+    const url = getWhatsAppLink('');
+    assert.ok(url.startsWith(WHATSAPP_BASE + '?text='));
+});
+
+test('getWhatsAppLink handles message with special characters', () => {
+    const msg = 'Viagem: São Paulo → Orlando (2 adultos)';
+    const url = getWhatsAppLink(msg);
+    const decoded = decodeMessageFrom(url);
+    assert.equal(decoded, msg);
+});
+
+test('getTrackingDataObject returns null in Node.js environment (no window)', () => {
+    const result = getTrackingDataObject();
+    assert.equal(result, null);
+});


### PR DESCRIPTION
## Summary

Adds 67 new `node:test` regression tests covering 5 gaps identified in the test coverage analysis. All tests pass (593 total, 0 failures).

| File | Module | Tests |
|---|---|---|
| `tests/ai-handoff.test.ts` | `lib/ai/handoff.ts` | 20 |
| `tests/whatsapp-tracking.test.ts` | `utils/whatsapp.ts` | 11 |
| `tests/google-conversion.test.ts` | `lib/conversions/google.ts` | 8 |
| `tests/waitlist-logic.test.ts` | `lib/waitlist-logic.ts` | 15 |
| `tests/hubspot-service.test.ts` | `services/hubspot.ts` | 13 |

### What each covers

**`lib/ai/handoff.ts`** — `buildGenerateHandoff` pure function: `formatLocation` edge cases (city only, region only, both, neither), IATA code truncation and uppercasing, `baggagePreference` undefined coercion, `bantSummary` formatting for all BANT fields, visa status note, and defaults when fields are absent.

**`utils/whatsapp.ts`** — `getWhatsAppLink`: message `|| Dados:` and `[ref:` suffix stripping, URL encoding, special characters, empty message, `appendTrackingRef` with no tracking data in Node.js. `getTrackingDataObject` null behaviour in server environment.

**`lib/conversions/google.ts`** — `sendGoogleConversion`: missing `GA4_MEASUREMENT_ID` / `GA4_API_SECRET`, missing `clientId`, correct GA4 Measurement Protocol URL and payload shape, BRL default currency, optional params omission, HTTP error mapping, fetch throw handling.

**`lib/waitlist-logic.ts`** — `validateWaitlistPayload`: all required-field combinations, invalid email format, email lowercasing, whitespace trimming, UTM extraction, missing UTMs graceful handling, 160-char name cap.

**`services/hubspot.ts`** — `getDeal`, `getContact`, `getAssociatedContactId`: correct URL construction and `Authorization` header, `UNAUTHORIZED` on 401/403, error code with status on other non-ok responses, timeout race throwing `HUBSPOT_TIMEOUT:504`, empty/absent `results` returning `null`.

## Test plan

- [x] `pnpm test:regression` — 593 pass, 0 fail

https://claude.ai/code/session_016EAzSkeWLoyZ3n24XV3FWX

---
_Generated by [Claude Code](https://claude.ai/code/session_016EAzSkeWLoyZ3n24XV3FWX)_