### PR TITLE
fix(chatbot): filtrar isAction do histórico para evitar 400 na API Gemini

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -266,7 +266,7 @@ const AIChat: React.FC = memo(() => {
     // carries the handoff context for the model.
     const apiHistory = newHistory.filter(msg => !msg.isAction);
 
-    let response;
+    let response: Awaited<ReturnType<typeof getTravelAdvice>>;
     try {
       response = await getTravelAdvice(apiHistory);
     } catch {

--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -257,7 +257,30 @@ const AIChat: React.FC = memo(() => {
 
     setIsLoading(true);
 
-    const response = await getTravelAdvice(newHistory);
+    // Filter out UI-only action messages before sending to the API.
+    // Action messages (isAction: true) represent budget-link handoff cards in
+    // the chat UI, but they are not part of the conversation from the model's
+    // perspective. Including them creates consecutive model-role turns in the
+    // history, which the Gemini API rejects with a 400 INVALID_ARGUMENT error
+    // ("role alternation" requirement). The preceding text message already
+    // carries the handoff context for the model.
+    const apiHistory = newHistory.filter(msg => !msg.isAction);
+
+    let response;
+    try {
+      response = await getTravelAdvice(apiHistory);
+    } catch {
+      setIsLoading(false);
+      setMessages(prev => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          role: 'model' as const,
+          text: '⚙️ Tivemos um problema técnico. Por favor, tente novamente em alguns instantes.',
+        },
+      ]);
+      return;
+    }
     setIsLoading(false);
 
     const nextMessages: Message[] = [];

--- a/tests/chatbot-regressions.test.ts
+++ b/tests/chatbot-regressions.test.ts
@@ -3,6 +3,62 @@ import assert from 'node:assert/strict';
 import { detectBlockedDestination } from '../lib/ai/validation.ts';
 import { SYSTEM_INSTRUCTION } from '../lib/ai/prompt.ts';
 
+// ─── Role alternation invariant ───────────────────────────────────────────────
+// The Gemini API requires strict user↔model alternation in the contents array.
+// After a budget-link handoff, AIChat adds two consecutive model messages:
+//   1. the handoff text ("Perfeito. Seu pré-atendimento está pronto…")
+//   2. the action card ("Orçamento Pronto", isAction: true)
+// Without filtering, the next user message produces consecutive model turns
+// that the API rejects with 400 INVALID_ARGUMENT — making the chatbot appear
+// unresponsive after every successful handoff.
+
+test('post-handoff history without filter has consecutive model turns (Gemini 400 scenario)', () => {
+    const history = [
+        { role: 'model' as const, text: 'Olá! Sou seu guia Anhangá.', isAction: false },
+        { role: 'user' as const, text: 'Quero ir para Paris.' },
+        { role: 'model' as const, text: 'Perfeito. Seu pré-atendimento está pronto.' },
+        { role: 'model' as const, text: 'Orçamento Pronto', isAction: true },
+        { role: 'user' as const, text: 'Posso adicionar mais uma pessoa?' },
+    ];
+
+    const hasConsecutiveModelTurns = history.some(
+        (msg, i) => i > 0 && msg.role === 'model' && history[i - 1].role === 'model',
+    );
+    assert.ok(
+        hasConsecutiveModelTurns,
+        'unfiltered post-handoff history must expose the consecutive-model-turn bug',
+    );
+});
+
+test('filtering isAction messages from post-handoff history eliminates consecutive model turns', () => {
+    const history = [
+        { role: 'model' as const, text: 'Olá! Sou seu guia Anhangá.', isAction: false },
+        { role: 'user' as const, text: 'Quero ir para Paris.' },
+        { role: 'model' as const, text: 'Perfeito. Seu pré-atendimento está pronto.' },
+        { role: 'model' as const, text: 'Orçamento Pronto', isAction: true },
+        { role: 'user' as const, text: 'Posso adicionar mais uma pessoa?' },
+    ];
+
+    // This replicates the filter applied in AIChat.tsx before calling getTravelAdvice.
+    const apiHistory = history.filter(msg => !msg.isAction);
+
+    assert.equal(apiHistory.length, 4, 'one action message should be removed');
+
+    const hasConsecutiveAfterFilter = apiHistory.some(
+        (msg, i) => i > 0 && msg.role === 'model' && apiHistory[i - 1].role === 'model',
+    );
+    assert.ok(
+        !hasConsecutiveAfterFilter,
+        'filtered history must have no consecutive model turns',
+    );
+
+    // Verify turn order is correct: model→user→model→user
+    assert.deepEqual(
+        apiHistory.map(m => m.role),
+        ['model', 'user', 'model', 'user'],
+    );
+});
+
 test('safety check should block "Emirados" (Policy #186)', () => {
     const result = detectBlockedDestination('Dubai, Emirados Árabes Unidos');
     assert.ok(result, 'UAE must be blocked');


### PR DESCRIPTION
## Resumo do problema

Após um handoff bem-sucedido de orçamento, o chatbot ficava inresponsivo para qualquer mensagem subsequente do usuário.

**Root cause:** A API Gemini exige alternância estrita `user → model → user → model` no array `contents`. Após um handoff, o `AIChat` adiciona dois `role: 'model'` consecutivos ao estado:

1. O texto do handoff: `"Perfeito. Seu pré-atendimento está pronto…"` (role: model)  
2. O card de ação: `"Orçamento Pronto"` com `isAction: true` (role: model)

Na próxima mensagem do usuário, esses dois turns consecutivos chegavam à API e ela retornava **400 INVALID_ARGUMENT** — que o `geminiService` tratava como erro genérico, exibindo `"⚙️ Tivemos um problema técnico"` ou ficando sem resposta aparente.

## Mudanças

### `components/AIChat.tsx`
- Filtra `msg.isAction === true` do histórico antes de chamar `getTravelAdvice`
- Mensagens de ação são artefatos da UI (card do formulário de orçamento) sem conteúdo conversacional — o texto que as precede já representa o handoff para o modelo
- Adiciona `try-catch` defensivo em `submitMessage` para garantir que `setIsLoading(false)` seja sempre chamado mesmo em erros inesperados, evitando que o spinner fique preso

### `tests/chatbot-regressions.test.ts`
- 2 novos testes documentando o cenário de bug (turno consecutivo de model) e validando o invariante de alternância após o filtro

## Plano de testes

- [x] `pnpm test:regression` — 595 testes, 0 falhas
- [x] `pnpm typecheck` — sem erros
- [ ] Testar manualmente fluxo completo: conversa → handoff → nova pergunta após o handoff

## Referências

- [Gemini API: role alternation requirement](https://github.com/google-gemini/gemini-cli/issues/8204)
- [Gemini API 400 INVALID_ARGUMENT due to role alternation](https://github.com/badlogic/pi-mono/issues/471)

https://claude.ai/code/session_01Aa5Lh6VEkU7u3o7nrQnTZo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aa5Lh6VEkU7u3o7nrQnTZo)_