### PR TITLE
fix(chatbot): chatbot inresponsivo após handoff + filtro de ruído Sentry

### DIFF
--- a/lib/sentry-client.ts
+++ b/lib/sentry-client.ts
@@ -16,8 +16,8 @@ function isBrowserExtensionFrame(frame: { filename?: string }): boolean {
 // filter above cannot catch these, so we also match against known extension
 // error message patterns.
 function isBrowserExtensionMessage(values: Array<{ value?: string }> | undefined): boolean {
-    return (values ?? []).some(({ value = '' }) =>
-        /runtime\.sendMessage|Extension context invalidated/i.test(value)
+    return !!values?.some(({ value }) =>
+        !!value && /runtime\.sendMessage|Extension context invalidated/i.test(value)
     );
 }
 

--- a/lib/sentry-client.ts
+++ b/lib/sentry-client.ts
@@ -11,6 +11,16 @@ function isBrowserExtensionFrame(frame: { filename?: string }): boolean {
         || filename.includes('safari-web-extension://');
 }
 
+// Some browser extension errors arrive as unhandled rejections with no stack
+// frames (e.g. `runtime.sendMessage()` messaging failures). The frame-based
+// filter above cannot catch these, so we also match against known extension
+// error message patterns.
+function isBrowserExtensionMessage(values: Array<{ value?: string }> | undefined): boolean {
+    return (values ?? []).some(({ value = '' }) =>
+        /runtime\.sendMessage|Extension context invalidated/i.test(value)
+    );
+}
+
 export function initClientErrorTracking(): void {
     const dsn = import.meta.env.VITE_SENTRY_DSN;
 
@@ -27,11 +37,13 @@ export function initClientErrorTracking(): void {
         ],
         tracePropagationTargets: ['localhost', /^https:\/\/(?:www\.)?anhanga\.tur\.br\/api/],
         beforeSend(event) {
-            const frames = event.exception?.values?.flatMap(
+            const exceptions = event.exception?.values;
+            const frames = exceptions?.flatMap(
                 (exception) => exception.stacktrace?.frames ?? []
             ) ?? [];
 
             if (frames.some(isBrowserExtensionFrame)) return null;
+            if (isBrowserExtensionMessage(exceptions)) return null;
 
             return event;
         },

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -120,6 +120,16 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://www.anhanga.tur.br/blog/agencia-de-viagens-ou-por-conta-propria/</loc>
+    <lastmod>2026-06-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://media.anhanga.tur.br/images/blog/agencia-de-viagens-ou-conta-propria.jpg</image:loc>
+      <image:caption>Agência de Viagens ou Por Conta Própria? O Que Vale Mais — e Quando</image:caption>
+    </image:image>
+  </url>
+  <url>
     <loc>https://www.anhanga.tur.br/blog/seguro-viagem-internacional-2026/</loc>
     <lastmod>2026-06-10</lastmod>
     <changefreq>monthly</changefreq>
@@ -271,7 +281,7 @@
   </url>
   <url>
     <loc>https://www.anhanga.tur.br/blog/malas-de-mao-o-guia-definitivo/</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>


### PR DESCRIPTION
## Resumo

- **Bug crítico (chatbot):** Após um handoff bem-sucedido (geração do link de orçamento), o chatbot ficava inresponsivo para qualquer nova mensagem do usuário.
- **Falso positivo (Sentry NODE-4):** O filtro de erros de browser extensions não cobria erros sem stack trace, deixando passar ruído de `runtime.sendMessage()`.

## Causa-raiz do chatbot

Ao concluir um handoff, o `AIChat` adicionava dois `role: 'model'` consecutivos ao estado:
1. O texto do handoff ("Perfeito. Seu pré-atendimento está pronto…")
2. O card de ação (`isAction: true`, "Orçamento Pronto")

Na próxima mensagem do usuário, esses dois turns consecutivos chegavam à API Gemini que exige alternância `user↔model` e rejeitava com `400 INVALID_ARGUMENT` — tornando o chatbot silencioso após qualquer handoff.

**Fix:** Filtrar `msg.isAction === true` do histórico antes de chamar `getTravelAdvice` (`components/AIChat.tsx`). Mensagens de ação são artefatos de UI e não carregam contexto conversacional para o modelo.

## Sentry NODE-4

O erro `Invalid call to runtime.sendMessage(). Tab not found.` capturado como `onunhandledrejection` **não é um bug da aplicação** — é ruído de uma browser extension do usuário. O filtro existente (`isBrowserExtensionFrame`) só atuava em erros com stack frames; rejeições sem trace bypassavam o filtro.

**Fix:** Adicionar `isBrowserExtensionMessage` em `lib/sentry-client.ts` para filtrar também por padrão de mensagem de erro.

## Test plan

- [x] `pnpm test:regression` — 595 testes passando, incluindo 2 novos em `chatbot-regressions.test.ts` que documentam o bug e validam o fix
- [x] `pnpm typecheck` — sem erros de tipo

Closes #825

https://claude.ai/code/session_01MuMEgkmHyc1RaB3U3yxez5

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuMEgkmHyc1RaB3U3yxez5)_