### PR TITLE
fix(generate): mapear erros 4xx do upstream para GEMINI_UPSTREAM_ERROR

### DIFF
--- a/api/generate.ts
+++ b/api/generate.ts
@@ -529,10 +529,19 @@ export async function buildGenerateSuccessBody(
 
 export function buildGeminiErrorResponse(error: unknown, corsHeaders: Record<string, string>): Response {
     const normalized = normalizeError(error);
-    // Include the error constructor name to distinguish network errors (TypeError)
-    // from upstream HTTP errors (ApiError) in log analysis.
-    const errorClass = error instanceof Error ? error.constructor.name : 'UnknownError';
-    logger.error('SERVER: Error proxying to Gemini', { ...normalized, errorClass });
+    // Pass the original Error instance to preserve instanceof checks in Sentry.
+    // Define toJSON so the logger serializes the extra properties we care about.
+    if (error instanceof Error) {
+        const errorClass = error.constructor.name;
+        Object.defineProperty(error, 'toJSON', {
+            value: () => ({ ...normalized, errorClass, stack: error.stack }),
+            configurable: true,
+            writable: true,
+        });
+        logger.error('SERVER: Error proxying to Gemini', error);
+    } else {
+        logger.error('SERVER: Error proxying to Gemini', { ...normalized, errorClass: 'UnknownError' });
+    }
 
     if (normalized.status === 401 || normalized.status === 403) {
         return buildJsonResponse({

--- a/api/generate.ts
+++ b/api/generate.ts
@@ -529,7 +529,10 @@ export async function buildGenerateSuccessBody(
 
 export function buildGeminiErrorResponse(error: unknown, corsHeaders: Record<string, string>): Response {
     const normalized = normalizeError(error);
-    logger.error('SERVER: Error proxying to Gemini', normalized);
+    // Include the error constructor name to distinguish network errors (TypeError)
+    // from upstream HTTP errors (ApiError) in log analysis.
+    const errorClass = error instanceof Error ? error.constructor.name : 'UnknownError';
+    logger.error('SERVER: Error proxying to Gemini', { ...normalized, errorClass });
 
     if (normalized.status === 401 || normalized.status === 403) {
         return buildJsonResponse({
@@ -552,13 +555,17 @@ export function buildGeminiErrorResponse(error: unknown, corsHeaders: Record<str
         }, 500, corsHeaders);
     }
 
-    if (normalized.status && normalized.status >= 500) {
+    // Any remaining HTTP error from the upstream (gateway 404/400/other 4xx, or 5xx)
+    // is treated as a temporary upstream unavailability rather than an internal error.
+    if (normalized.status && normalized.status >= 400) {
         return buildJsonResponse({
             code: 'GEMINI_UPSTREAM_ERROR',
             error: 'Serviço de IA temporariamente indisponível'
         }, 503, corsHeaders);
     }
 
+    // No HTTP status means a network-level failure (TypeError: Failed to fetch,
+    // DNS error, connection refused, etc.) — report as internal error.
     return buildJsonResponse({
         code: 'GEMINI_INTERNAL_ERROR',
         error: 'Error processing request'

--- a/lib/sentry-client.ts
+++ b/lib/sentry-client.ts
@@ -16,8 +16,8 @@ function isBrowserExtensionFrame(frame: { filename?: string }): boolean {
 // filter above cannot catch these, so we also match against known extension
 // error message patterns.
 function isBrowserExtensionMessage(values: Array<{ value?: string }> | undefined): boolean {
-    return (values ?? []).some(({ value = '' }) =>
-        /runtime\.sendMessage|Extension context invalidated/i.test(value)
+    return !!values?.some(({ value }) =>
+        !!value && /runtime\.sendMessage|Extension context invalidated/i.test(value)
     );
 }
 

--- a/lib/sentry-client.ts
+++ b/lib/sentry-client.ts
@@ -11,6 +11,16 @@ function isBrowserExtensionFrame(frame: { filename?: string }): boolean {
         || filename.includes('safari-web-extension://');
 }
 
+// Some browser extension errors arrive as unhandled rejections with no stack
+// frames (e.g. `runtime.sendMessage()` messaging failures). The frame-based
+// filter above cannot catch these, so we also match against known extension
+// error message patterns.
+function isBrowserExtensionMessage(values: Array<{ value?: string }> | undefined): boolean {
+    return (values ?? []).some(({ value = '' }) =>
+        /runtime\.sendMessage|Extension context invalidated/i.test(value)
+    );
+}
+
 export function initClientErrorTracking(): void {
     const dsn = import.meta.env.VITE_SENTRY_DSN;
 
@@ -27,11 +37,13 @@ export function initClientErrorTracking(): void {
         ],
         tracePropagationTargets: ['localhost', /^https:\/\/(?:www\.)?anhanga\.tur\.br\/api/],
         beforeSend(event) {
-            const frames = event.exception?.values?.flatMap(
+            const exceptions = event.exception?.values;
+            const frames = exceptions?.flatMap(
                 (exception) => exception.stacktrace?.frames ?? []
             ) ?? [];
 
             if (frames.some(isBrowserExtensionFrame)) return null;
+            if (isBrowserExtensionMessage(exceptions)) return null;
 
             return event;
         },

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -120,6 +120,16 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://www.anhanga.tur.br/blog/agencia-de-viagens-ou-por-conta-propria/</loc>
+    <lastmod>2026-06-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://media.anhanga.tur.br/images/blog/agencia-de-viagens-ou-conta-propria.jpg</image:loc>
+      <image:caption>Agência de Viagens ou Por Conta Própria? O Que Vale Mais — e Quando</image:caption>
+    </image:image>
+  </url>
+  <url>
     <loc>https://www.anhanga.tur.br/blog/seguro-viagem-internacional-2026/</loc>
     <lastmod>2026-06-10</lastmod>
     <changefreq>monthly</changefreq>
@@ -271,7 +281,7 @@
   </url>
   <url>
     <loc>https://www.anhanga.tur.br/blog/malas-de-mao-o-guia-definitivo/</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>

--- a/tests/api-generate.test.ts
+++ b/tests/api-generate.test.ts
@@ -227,7 +227,33 @@ test('buildGeminiErrorResponse maps 404 with model message to GEMINI_MODEL_ERROR
     assert.equal(body.code, 'GEMINI_MODEL_ERROR');
 });
 
-test('buildGeminiErrorResponse maps unknown errors to GEMINI_INTERNAL_ERROR', async () => {
+test('buildGeminiErrorResponse maps 404 without model message to GEMINI_UPSTREAM_ERROR', async () => {
+    // A 404 from the AI Gateway (gateway not found, no model context) must not
+    // silently collapse to GEMINI_INTERNAL_ERROR — it is an upstream reachability failure.
+    const corsHeaders = buildCorsHeaders();
+    const error = { status: 404, message: 'Not Found' };
+
+    const response = buildGeminiErrorResponse(error, corsHeaders);
+    const body = await response.json() as { code: string; error: string };
+
+    assert.equal(response.status, 503);
+    assert.equal(body.code, 'GEMINI_UPSTREAM_ERROR');
+    assert.ok(!body.error.includes('Not Found'), 'must not leak raw upstream error');
+});
+
+test('buildGeminiErrorResponse maps 400 from upstream to GEMINI_UPSTREAM_ERROR', async () => {
+    const corsHeaders = buildCorsHeaders();
+    const error = { status: 400, message: 'Bad Request from AI Gateway' };
+
+    const response = buildGeminiErrorResponse(error, corsHeaders);
+    const body = await response.json() as { code: string };
+
+    assert.equal(response.status, 503);
+    assert.equal(body.code, 'GEMINI_UPSTREAM_ERROR');
+});
+
+test('buildGeminiErrorResponse maps unknown errors (no status) to GEMINI_INTERNAL_ERROR', async () => {
+    // No status means a network-level failure: TypeError, DNS error, connection refused, etc.
     const corsHeaders = buildCorsHeaders();
     const error = { message: 'something unexpected happened' };
 


### PR DESCRIPTION
## Problema

Com `AI_GATEWAY_ENABLED=true` em produção, o chatbot retorna "⚙️ Tivemos um problema técnico interno" quando o AI Gateway da Cloudflare não está acessível ou não existe. Isso acontecia porque erros 4xx que não são 401/403/429 (ex: 404 de gateway não encontrado, 400 de bad request) caíam no fallback genérico `GEMINI_INTERNAL_ERROR`.

## Causa-raiz

`buildGeminiErrorResponse` só elevava para `GEMINI_UPSTREAM_ERROR` erros com `status >= 500`. Um 404 do gateway Cloudflare (ex: gateway "av-site" inexistente) ou um 400 ficavam sem tratamento e caíam no `GEMINI_INTERNAL_ERROR`.

## Fix

- `>= 500` → `>= 400`: qualquer erro HTTP do upstream com status definido agora mapeia para `GEMINI_UPSTREAM_ERROR` (503 para o cliente → "🕐 serviço temporariamente indisponível"), que é semanticamente mais correto
- Somente erros **sem** status HTTP (TypeError: Failed to fetch, DNS, connection refused) continuam como `GEMINI_INTERNAL_ERROR`
- Adiciona `errorClass` ao log de erro para distinguir `TypeError` (falha de rede) de `ApiError` (resposta HTTP) nos logs do Cloudflare

## Diagnóstico do AI Gateway

Se o chatbot ainda não responder após este fix, verifique no Cloudflare Dashboard:
1. **AI Gateway** → existe um gateway chamado `av-site`?
2. **Pages → Settings → Variables and Secrets** → `CLOUDFLARE_ACCOUNT_ID` está definido como **secret** (não apenas como var pública)?

## Test plan

- [x] 2 novos testes: `404 sem "model"` → `GEMINI_UPSTREAM_ERROR`; `400` → `GEMINI_UPSTREAM_ERROR`
- [x] `pnpm test:regression` — 597 testes passando
- [x] `pnpm typecheck` — sem erros

https://claude.ai/code/session_01MuMEgkmHyc1RaB3U3yxez5

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuMEgkmHyc1RaB3U3yxez5)_