### PR TITLE
chore: migrar config do campo "pnpm" do package.json (pnpm 11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ jobs:
   build-and-test:
     name: Build / Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [24]
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3
@@ -21,10 +18,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.8
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 24
           cache: "pnpm"
 
       - name: Node version check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.13.1]
+        node-version: [24]
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3

--- a/package.json
+++ b/package.json
@@ -71,28 +71,7 @@
     "vite": "^8.0.16",
     "wrangler": "^4.97.0"
   },
-  "overrides": {
-    "rimraf": "^6.1.3",
-    "glob": "^13.0.6",
-    "minimatch": "^10.2.2",
-    "qs": "^6.15.2"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@google/genai",
-      "esbuild",
-      "protobufjs",
-      "sharp",
-      "workerd"
-    ],
-    "overrides": {
-      "rimraf": "^6.1.3",
-      "glob": "^13.0.6",
-      "minimatch": "^10.2.2",
-      "qs": "^6.15.2"
-    }
-  },
   "engines": {
-    "node": "24.x"
+    "node": ">=24"
   }
 }

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -29,8 +29,8 @@ test('pnpm settings live in pnpm-workspace.yaml, not in the package.json "pnpm" 
   assert.equal(packageJson.pnpm, undefined, 'the "pnpm" field is ignored by pnpm >= 11 and must not exist');
   assert.equal(packageJson.overrides, undefined, 'npm-style "overrides" is not read by pnpm; use pnpm-workspace.yaml');
 
-  assert.match(workspaceConfig, /^overrides:$/m);
-  assert.match(workspaceConfig, /^onlyBuiltDependencies:$/m);
+  assert.match(workspaceConfig, /^overrides:\s*$/m);
+  assert.match(workspaceConfig, /^onlyBuiltDependencies:\s*$/m);
   for (const pinned of ['rimraf', 'glob', 'minimatch', 'qs']) {
     assert.match(workspaceConfig, new RegExp(`^  ${pinned}: `, 'm'), `security override for ${pinned} must stay pinned`);
   }

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -11,10 +11,27 @@ test('validation scripts regenerate the blog manifest before running checks', as
   assert.match(packageJson.scripts?.['test:regression'] ?? '', /generate:blog-manifest/);
 });
 
-test('package engines should target the active Node.js LTS line used by deploys', async () => {
+test('package engines should accept the deploy Node.js line (24) and newer local runtimes', async () => {
   const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8')) as {
     engines?: Record<string, string>;
   };
 
-  assert.equal(packageJson.engines?.node, '24.x');
+  assert.equal(packageJson.engines?.node, '>=24');
+});
+
+test('pnpm settings live in pnpm-workspace.yaml, not in the package.json "pnpm" field ignored by pnpm 11', async () => {
+  const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8')) as Record<
+    string,
+    unknown
+  >;
+  const workspaceConfig = await readFile(new URL('../pnpm-workspace.yaml', import.meta.url), 'utf8');
+
+  assert.equal(packageJson.pnpm, undefined, 'the "pnpm" field is ignored by pnpm >= 11 and must not exist');
+  assert.equal(packageJson.overrides, undefined, 'npm-style "overrides" is not read by pnpm; use pnpm-workspace.yaml');
+
+  assert.match(workspaceConfig, /^overrides:$/m);
+  assert.match(workspaceConfig, /^onlyBuiltDependencies:$/m);
+  for (const pinned of ['rimraf', 'glob', 'minimatch', 'qs']) {
+    assert.match(workspaceConfig, new RegExp(`^  ${pinned}: `, 'm'), `security override for ${pinned} must stay pinned`);
+  }
 });


### PR DESCRIPTION
Closes #851

## O que mudou

- **`package.json`**: removido o campo `pnpm` (`onlyBuiltDependencies` + `overrides`), que o pnpm 11 ignora com warning. As mesmas configs já existiam no `pnpm-workspace.yaml`, que é o novo local oficial (https://pnpm.io/settings) — não foi preciso mover nada, só remover a duplicata morta.
- **`package.json`**: removido também o `overrides` top-level (formato npm), que o pnpm tampouco lê — era uma terceira cópia dos mesmos pins, com risco de drift silencioso.
- **`engines.node`**: `"24.x"` → `">=24"`. O deploy continua pinado em Node 24 (`.node-version` e `NODE_VERSION=24` no `wrangler.toml`); o range aberto apenas elimina o `Unsupported engine` em runtimes locais mais novos (ex.: Node 25.9.0).
- **`ci.yml`**: Node `22.13.1` → `24`, alinhando o CI com o ambiente de build do Cloudflare Pages (antes o CI violava o próprio `engines`).
- **`tests/package-scripts.test.ts`**: asserção do `engines` atualizada e novo teste de regressão garantindo que (a) o campo `pnpm` e o `overrides` npm-style não voltem ao `package.json` e (b) os pins de segurança (`rimraf`, `glob`, `minimatch`, `qs`) e o `onlyBuiltDependencies` permaneçam no `pnpm-workspace.yaml`.

## Checklist da issue

- [x] ~Mover~ Confirmar `onlyBuiltDependencies` e `overrides` no `pnpm-workspace.yaml` (já estavam lá) e remover o campo `pnpm`
- [x] `pnpm install` sem warning e `pnpm-lock.yaml` inalterado — seção `overrides:` do lockfile segue com os 4 pins
- [x] `pnpm build` ok — scripts de build das deps nativas (`sharp`, `protobufjs`, `@google/genai`) executaram no install
- [x] Interação com `node-linker=hoisted`: o `.npmrc` não existe mais; `nodeLinker: hoisted` já vive no `pnpm-workspace.yaml` e segue ativo — sem regressão
- [x] Pendência do `engines` resolvida no mesmo PR (range `>=24` + CI em Node 24)

## Validação

- `pnpm install` — zero warnings, lockfile sem diff
- `pnpm test:regression` — 613 testes passando
- `pnpm typecheck` — limpo
- `pnpm build` — prerender completo

🤖 Generated with [Claude Code](https://claude.com/claude-code)