### PR TITLE
feat(leads): espelhar chatbot e modal de contato no Salesforce web-to-lead com UTMs

### DIFF
--- a/api/submit-lead-sf.ts
+++ b/api/submit-lead-sf.ts
@@ -53,6 +53,21 @@ function parseUtms(raw: unknown): Partial<Record<SfUtmKey, string>> | undefined 
     return Object.keys(utms).length > 0 ? utms : undefined;
 }
 
+function parseOptionalEmail(raw: unknown): { valid: boolean; email?: string } {
+    const email = cleanString(raw).toLowerCase();
+    if (!email) return { valid: true };
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email) ? { valid: true, email } : { valid: false };
+}
+
+function parseOptionalPhone(raw: unknown): { valid: boolean; phone?: string } {
+    if (typeof raw !== 'string' || raw.trim().length === 0) return { valid: true };
+
+    const phone = normalizeWhatsappNumber(raw) ?? undefined;
+    return phone ? { valid: true, phone } : { valid: false };
+}
+
 function validateSfLeadBody(raw: unknown): { valid: true; data: SalesforceLeadFields } | { valid: false; error: string } {
     if (!raw || typeof raw !== 'object') {
         return { valid: false, error: 'Corpo da requisição inválido.' };
@@ -62,20 +77,18 @@ function validateSfLeadBody(raw: unknown): { valid: true; data: SalesforceLeadFi
 
     const firstName = cleanString(body.firstName);
     const lastName = cleanString(body.lastName);
-    const email = cleanString(body.email).toLowerCase() || undefined;
 
     if (!firstName || !lastName) {
         return { valid: false, error: 'Campos obrigatórios ausentes.' };
     }
 
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (email && !emailRegex.test(email)) {
+    const emailResult = parseOptionalEmail(body.email);
+    if (!emailResult.valid) {
         return { valid: false, error: 'Email inválido.' };
     }
 
-    const hasWhatsapp = typeof body.whatsapp === 'string' && body.whatsapp.trim().length > 0;
-    const phone = hasWhatsapp ? (normalizeWhatsappNumber(body.whatsapp) ?? undefined) : undefined;
-    if (hasWhatsapp && !phone) {
+    const phoneResult = parseOptionalPhone(body.whatsapp);
+    if (!phoneResult.valid) {
         return { valid: false, error: 'Número de telefone inválido.' };
     }
 
@@ -91,8 +104,8 @@ function validateSfLeadBody(raw: unknown): { valid: true; data: SalesforceLeadFi
         data: {
             firstName,
             lastName,
-            email,
-            phone,
+            email: emailResult.email,
+            phone: phoneResult.phone,
             company,
             title,
             leadSource,

--- a/api/submit-lead-sf.ts
+++ b/api/submit-lead-sf.ts
@@ -2,8 +2,8 @@ import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import { cleanString, normalizeWhatsappNumber, maskEmail } from '../lib/lead-logic';
 import { logger } from '../lib/logger';
-import { postWebToLead } from '../services/salesforce';
-import type { SalesforceLeadFields } from '../services/salesforce';
+import { postWebToLead, SF_UTM_KEYS } from '../services/salesforce';
+import type { SalesforceLeadFields, SfUtmKey } from '../services/salesforce';
 
 export const config = {
     runtime: 'edge',
@@ -37,6 +37,22 @@ function buildJsonResponse(
     });
 }
 
+const UTM_VALUE_MAX_LENGTH = 255;
+
+function parseUtms(raw: unknown): Partial<Record<SfUtmKey, string>> | undefined {
+    if (!raw || typeof raw !== 'object') return undefined;
+
+    const source = raw as Record<string, unknown>;
+    const utms: Partial<Record<SfUtmKey, string>> = {};
+
+    for (const key of SF_UTM_KEYS) {
+        const value = cleanString(source[key]).slice(0, UTM_VALUE_MAX_LENGTH);
+        if (value) utms[key] = value;
+    }
+
+    return Object.keys(utms).length > 0 ? utms : undefined;
+}
+
 function validateSfLeadBody(raw: unknown): { valid: true; data: SalesforceLeadFields } | { valid: false; error: string } {
     if (!raw || typeof raw !== 'object') {
         return { valid: false, error: 'Corpo da requisição inválido.' };
@@ -46,14 +62,14 @@ function validateSfLeadBody(raw: unknown): { valid: true; data: SalesforceLeadFi
 
     const firstName = cleanString(body.firstName);
     const lastName = cleanString(body.lastName);
-    const email = cleanString(body.email).toLowerCase();
+    const email = cleanString(body.email).toLowerCase() || undefined;
 
-    if (!firstName || !lastName || !email) {
+    if (!firstName || !lastName) {
         return { valid: false, error: 'Campos obrigatórios ausentes.' };
     }
 
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
+    if (email && !emailRegex.test(email)) {
         return { valid: false, error: 'Email inválido.' };
     }
 
@@ -81,6 +97,7 @@ function validateSfLeadBody(raw: unknown): { valid: true; data: SalesforceLeadFi
             title,
             leadSource,
             description,
+            utms: parseUtms(body.utms),
         },
     };
 }
@@ -132,7 +149,7 @@ export default async function handler(request: Request): Promise<Response> {
     logger.info('SUBMIT_LEAD_SF', {
         requestId,
         stage: 'sending',
-        email: maskEmail(fields.email),
+        email: fields.email ? maskEmail(fields.email) : undefined,
         leadSource: fields.leadSource,
     });
 

--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -213,7 +213,10 @@ const AIChat: React.FC = memo(() => {
       bantSummary: payload.bantSummary,
       destination: payload.destination,
     });
-    const result = await submitLead(payload, { pushDataLayerEvent: false });
+    const result = await submitLead(payload, {
+      pushDataLayerEvent: false,
+      salesforce: { leadSource: 'Web' },
+    });
 
     if (!result.ok) {
       const errorResult = result as Extract<SubmitLeadHookResult, { ok: false }>;

--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -34,21 +34,7 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
             const empresa = state.form.empresa.trim() || 'Não informado';
             const cargo = state.form.cargo.trim() || 'Não informado';
 
-            const sfPromise = fetch('/api/submit-lead-sf', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    firstName: state.form.firstName,
-                    lastName: state.form.lastName,
-                    email: state.form.email,
-                    whatsapp: state.form.whatsapp,
-                    empresa: state.form.empresa,
-                    cargo: state.form.cargo,
-                    leadSource: 'Corporativo',
-                }),
-            }).catch(() => {});
-
-            const n8nPromise = submitLead(
+            const n8nResult = await submitLead(
                 {
                     firstName: state.form.firstName,
                     lastName: state.form.lastName,
@@ -57,10 +43,17 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                     destination: 'Corporativo',
                     bantSummary: `Lead corporativo captado via landing /corporativo. Empresa: ${empresa}. Cargo: ${cargo}.`,
                 },
-                { eventId, pushDataLayerEvent: true, formType: 'corporate_lead' },
+                {
+                    eventId,
+                    pushDataLayerEvent: true,
+                    formType: 'corporate_lead',
+                    salesforce: {
+                        leadSource: 'Corporativo',
+                        empresa: state.form.empresa,
+                        cargo: state.form.cargo,
+                    },
+                },
             );
-
-            const [, n8nResult] = await Promise.all([sfPromise, n8nPromise]);
 
             if (n8nResult.ok) {
                 dispatch({ type: 'submit-success' });

--- a/hooks/useContactForm.ts
+++ b/hooks/useContactForm.ts
@@ -71,6 +71,26 @@ function collectTracking(): { tracking: LeadTracking; utms: SubmitContactRequest
     return { tracking, utms: extractUtms(tracking) };
 }
 
+function mirrorContactToSalesforce(
+    requestBody: SubmitContactRequest,
+    action: 'whatsapp' | 'callback',
+    options: ContactModalOptions,
+): void {
+    sendLeadToSalesforce({
+        firstName: requestBody.firstName,
+        lastName: requestBody.lastName || '-',
+        email: requestBody.email,
+        whatsapp: requestBody.whatsapp,
+        leadSource: 'Web',
+        description: [
+            `Contato rápido via site (${options.source ?? 'modal'}). Ação: ${action}.`,
+            options.destination ? `Destino de interesse: ${options.destination}.` : '',
+            `Newsletter: ${requestBody.emailOptIn ? 'Sim' : 'Não'}.`,
+        ].filter(Boolean).join(' '),
+        utms: requestBody.utms,
+    });
+}
+
 function pushContactDataLayerEvent(
     eventId: string,
     action: 'whatsapp' | 'callback',
@@ -153,19 +173,7 @@ export function useContactForm(options: ContactModalOptions = {}) {
                 tracking,
             };
 
-            sendLeadToSalesforce({
-                firstName: requestBody.firstName,
-                lastName: requestBody.lastName || '-',
-                email: requestBody.email,
-                whatsapp: requestBody.whatsapp,
-                leadSource: 'Web',
-                description: [
-                    `Contato rápido via site (${options.source ?? 'modal'}). Ação: ${action}.`,
-                    options.destination ? `Destino de interesse: ${options.destination}.` : '',
-                    `Newsletter: ${fields.emailOptIn ? 'Sim' : 'Não'}.`,
-                ].filter(Boolean).join(' '),
-                utms,
-            });
+            mirrorContactToSalesforce(requestBody, action, options);
 
             try {
                 const response = await fetch('/api/submit-contact', {

--- a/hooks/useContactForm.ts
+++ b/hooks/useContactForm.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState, useRef } from 'react';
 import { cleanString } from '../lib/lead-logic';
 import { getTrackingDataObject, getWhatsAppLink } from '../utils/whatsapp';
+import { sendLeadToSalesforce } from '../utils/salesforce-lead';
 import { createLeadEventId, extractUtms } from './useLeadCapture';
 import type { ContactFormFields, SubmitContactRequest, SubmitContactResponse } from '../types/contactCapture';
 import type { LeadTracking } from '../types/leadCapture';
@@ -151,6 +152,20 @@ export function useContactForm(options: ContactModalOptions = {}) {
                 utms,
                 tracking,
             };
+
+            sendLeadToSalesforce({
+                firstName: requestBody.firstName,
+                lastName: requestBody.lastName || '-',
+                email: requestBody.email,
+                whatsapp: requestBody.whatsapp,
+                leadSource: 'Web',
+                description: [
+                    `Contato rápido via site (${options.source ?? 'modal'}). Ação: ${action}.`,
+                    options.destination ? `Destino de interesse: ${options.destination}.` : '',
+                    `Newsletter: ${fields.emailOptIn ? 'Sim' : 'Não'}.`,
+                ].filter(Boolean).join(' '),
+                utms,
+            });
 
             try {
                 const response = await fetch('/api/submit-contact', {

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { getTrackingDataObject, getWhatsAppLink } from '../utils/whatsapp';
+import { sendLeadToSalesforce } from '../utils/salesforce-lead';
 import type { LeadTracking, LeadUtms, SubmitLeadRequest } from '../types/leadCapture';
 import { cleanString, normalizeWhatsappNumber } from '../lib/lead-logic';
 
@@ -246,6 +247,29 @@ export function isPreparedSubmitLeadRequest(value: LeadDraftPartial | SubmitLead
 
 export type LeadFormType = 'ai_chatbot_lead' | 'event_lead' | 'corporate_lead';
 
+export interface SalesforceSubmitOptions {
+    leadSource: string;
+    empresa?: string;
+    cargo?: string;
+}
+
+function mirrorLeadToSalesforce(payload: SubmitLeadRequest, options: SalesforceSubmitOptions): void {
+    sendLeadToSalesforce({
+        firstName: payload.firstName,
+        lastName: payload.lastName || '-',
+        email: payload.email || undefined,
+        whatsapp: payload.whatsapp || undefined,
+        empresa: options.empresa,
+        cargo: options.cargo,
+        leadSource: options.leadSource,
+        description: [
+            payload.bantSummary,
+            payload.destination ? `Destino: ${payload.destination}` : '',
+        ].filter(Boolean).join(' | '),
+        utms: payload.utms,
+    });
+}
+
 export function pushGenerateLeadDataLayerEvent(
     payload: SubmitLeadRequest,
     formType: LeadFormType = 'ai_chatbot_lead',
@@ -394,6 +418,7 @@ export function useLeadCapture() {
             eventId?: string;
             pushDataLayerEvent?: boolean;
             formType?: LeadFormType;
+            salesforce?: SalesforceSubmitOptions;
         } = {},
     ): Promise<SubmitLeadHookResult> => {
         setError(null);
@@ -413,6 +438,10 @@ export function useLeadCapture() {
                 error: validationError,
                 code: 'VALIDATION_ERROR',
             };
+        }
+
+        if (options.salesforce) {
+            mirrorLeadToSalesforce(payload, options.salesforce);
         }
 
         try {

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -256,9 +256,9 @@ export interface SalesforceSubmitOptions {
 function mirrorLeadToSalesforce(payload: SubmitLeadRequest, options: SalesforceSubmitOptions): void {
     sendLeadToSalesforce({
         firstName: payload.firstName,
-        lastName: payload.lastName || '-',
-        email: payload.email || undefined,
-        whatsapp: payload.whatsapp || undefined,
+        lastName: payload.lastName,
+        email: payload.email,
+        whatsapp: payload.whatsapp,
         empresa: options.empresa,
         cargo: options.cargo,
         leadSource: options.leadSource,

--- a/hooks/useQuizCapture.ts
+++ b/hooks/useQuizCapture.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { getTrackingDataObject } from '../utils/whatsapp';
+import { sendLeadToSalesforce } from '../utils/salesforce-lead';
 import type { LeadTracking, LeadUtms } from '../types/leadCapture';
 import type { SubmitQuizRequest, SubmitQuizResponse } from '../types/quiz';
 
@@ -104,18 +105,15 @@ export function useQuizCapture() {
         };
 
         // Fire-and-forget — SF failure never blocks the quiz result
-        void fetch('/api/submit-lead-sf', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                firstName: payload.firstName,
-                lastName: payload.lastName || '-',
-                email: payload.email,
-                whatsapp: payload.whatsapp,
-                leadSource: 'Web',
-                description: `${payload.bantSummary} | Newsletter: ${payload.newsletterOptIn ? 'Sim' : 'Não'}`,
-            }),
-        }).catch(() => undefined);
+        sendLeadToSalesforce({
+            firstName: payload.firstName,
+            lastName: payload.lastName || '-',
+            email: payload.email,
+            whatsapp: payload.whatsapp,
+            leadSource: 'Web',
+            description: `${payload.bantSummary} | Newsletter: ${payload.newsletterOptIn ? 'Sim' : 'Não'}`,
+            utms: latest.utms,
+        });
 
         try {
             const response = await fetch('/api/submit-quiz', {

--- a/services/salesforce.ts
+++ b/services/salesforce.ts
@@ -3,30 +3,68 @@ const SF_ORG_ID = '00Das00000EnTnB';
 const SF_RET_URL = 'https://www.anhanga.tur.br';
 const SF_REQUEST_TIMEOUT_MS = 5000;
 
+export const SF_UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'] as const;
+export type SfUtmKey = (typeof SF_UTM_KEYS)[number];
+
+// IDs dos campos personalizados de Lead no Salesforce (formato 00N...).
+// Criar em Setup → Object Manager → Lead → Fields & Relationships (Text 255) e
+// preencher aqui com o ID que aparece no gerador de Web-to-Lead ou na URL do campo.
+// Enquanto um ID estiver vazio, o UTM correspondente é anexado à description
+// para que a atribuição não se perca.
+export const SF_UTM_FIELD_IDS: Record<SfUtmKey, string> = {
+    utm_source: '',
+    utm_medium: '',
+    utm_campaign: '',
+    utm_term: '',
+    utm_content: '',
+};
+
 export interface SalesforceLeadFields {
     firstName: string;
     lastName: string;
-    email: string;
+    email?: string;
     phone?: string;
     company?: string;
     title?: string;
     leadSource: string;
     description?: string;
+    utms?: Partial<Record<SfUtmKey, string>>;
 }
 
-export async function postWebToLead(fields: SalesforceLeadFields): Promise<{ ok: boolean }> {
+export async function postWebToLead(
+    fields: SalesforceLeadFields,
+    utmFieldIds: Record<SfUtmKey, string> = SF_UTM_FIELD_IDS,
+): Promise<{ ok: boolean }> {
     const params = new URLSearchParams();
     params.set('oid', SF_ORG_ID);
     params.set('retURL', SF_RET_URL);
     params.set('first_name', fields.firstName);
     params.set('last_name', fields.lastName);
-    params.set('email', fields.email);
     params.set('lead_source', fields.leadSource);
 
+    if (fields.email) params.set('email', fields.email);
     if (fields.phone) params.set('phone', fields.phone);
     if (fields.company) params.set('company', fields.company);
     if (fields.title) params.set('title', fields.title);
-    if (fields.description) params.set('description', fields.description);
+
+    const unmappedUtms: string[] = [];
+    for (const key of SF_UTM_KEYS) {
+        const value = fields.utms?.[key];
+        if (!value) continue;
+
+        const fieldId = utmFieldIds[key];
+        if (fieldId) {
+            params.set(fieldId, value);
+        } else {
+            unmappedUtms.push(`${key}=${value}`);
+        }
+    }
+
+    const description = unmappedUtms.length > 0
+        ? [fields.description, `UTMs: ${unmappedUtms.join(' | ')}`].filter(Boolean).join('\n')
+        : fields.description;
+
+    if (description) params.set('description', description);
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), SF_REQUEST_TIMEOUT_MS);

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -118,11 +118,13 @@ test.describe('Corporativo Landing Page', () => {
       firstName: 'Maria',
       lastName: 'Santos',
       email: 'maria@empresa.com.br',
-      whatsapp: '(11) 98831-4487',
+      whatsapp: '+5511988314487',
       empresa: 'Empresa Teste LTDA',
       cargo: 'Sócia',
       leadSource: 'Corporativo',
     });
+    expect(String((sfPayload as unknown as Record<string, unknown>).description)).toContain('Lead corporativo');
+    expect(sfPayload as unknown as Record<string, unknown>).toHaveProperty('utms');
 
     const formSubmissionEvent = await page.evaluate(() =>
       (window.dataLayer || []).find(e => e.event === 'form_submission')

--- a/tests/submit-lead-sf.test.ts
+++ b/tests/submit-lead-sf.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import handler from '../api/submit-lead-sf.ts';
+import { postWebToLead } from '../services/salesforce.ts';
 
 const originalFetch = global.fetch;
 
@@ -171,6 +172,118 @@ test('submit-lead-sf: invalid leadSource defaults to Web', async () => {
         const res = await handler(buildRequest(payload));
         assert.equal(res.status, 201);
         assert.ok(capturedBody.includes('lead_source=Web'), 'invalid source should fallback to Web');
+    } finally {
+        global.fetch = originalFetch;
+    }
+});
+
+test('submit-lead-sf: missing email is accepted (lead without email)', async () => {
+    let capturedBody = '';
+
+    global.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = typeof init?.body === 'string' ? init.body : '';
+        return new Response('', { status: 200 });
+    };
+
+    try {
+        const res = await handler(buildRequest({ firstName: 'Ana', lastName: 'Costa', whatsapp: '11988887777' }));
+        assert.equal(res.status, 201);
+        assert.ok(!capturedBody.includes('email='), 'no email param when absent');
+        assert.ok(capturedBody.includes('last_name=Costa'), 'last_name');
+        assert.ok(capturedBody.includes('phone='), 'phone forwarded');
+    } finally {
+        global.fetch = originalFetch;
+    }
+});
+
+test('submit-lead-sf: utms are appended to description while custom field IDs are not configured', async () => {
+    let capturedBody = '';
+
+    global.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = typeof init?.body === 'string' ? init.body : '';
+        return new Response('', { status: 200 });
+    };
+
+    try {
+        const payload = {
+            ...minimalPayload(),
+            description: 'Lead via chatbot.',
+            utms: {
+                utm_source: 'google',
+                utm_medium: 'cpc',
+                utm_campaign: 'verao-2026',
+                utm_term: null,
+                utm_content: '',
+            },
+        };
+        const res = await handler(buildRequest(payload));
+        assert.equal(res.status, 201);
+
+        const decoded = decodeURIComponent(capturedBody.replace(/\+/g, ' '));
+        assert.ok(decoded.includes('Lead via chatbot.'), 'original description preserved');
+        assert.ok(decoded.includes('utm_source=google'), 'utm_source in description');
+        assert.ok(decoded.includes('utm_medium=cpc'), 'utm_medium in description');
+        assert.ok(decoded.includes('utm_campaign=verao-2026'), 'utm_campaign in description');
+        assert.ok(!decoded.includes('utm_term'), 'null utm ignored');
+    } finally {
+        global.fetch = originalFetch;
+    }
+});
+
+test('submit-lead-sf: malformed utms object is ignored', async () => {
+    let capturedBody = '';
+
+    global.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = typeof init?.body === 'string' ? init.body : '';
+        return new Response('', { status: 200 });
+    };
+
+    try {
+        const payload = { ...minimalPayload(), utms: { utm_source: { nested: true }, bogus: 'x' } };
+        const res = await handler(buildRequest(payload));
+        assert.equal(res.status, 201);
+        assert.ok(!capturedBody.includes('utm_source'), 'non-string utm dropped');
+        assert.ok(!capturedBody.includes('bogus'), 'unknown keys dropped');
+    } finally {
+        global.fetch = originalFetch;
+    }
+});
+
+test('salesforce service: utms map to custom field IDs when configured', async () => {
+    let capturedBody = '';
+
+    global.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = typeof init?.body === 'string' ? init.body : '';
+        return new Response('', { status: 200 });
+    };
+
+    try {
+        const result = await postWebToLead(
+            {
+                firstName: 'Maria',
+                lastName: 'Santos',
+                email: 'maria@teste.com.br',
+                leadSource: 'Web',
+                description: 'Lead via chatbot.',
+                utms: { utm_source: 'google', utm_medium: 'cpc' },
+            },
+            {
+                utm_source: '00N000000000001',
+                utm_medium: '00N000000000002',
+                utm_campaign: '00N000000000003',
+                utm_term: '00N000000000004',
+                utm_content: '00N000000000005',
+            },
+        );
+
+        assert.equal(result.ok, true);
+        assert.ok(capturedBody.includes('00N000000000001=google'), 'utm_source mapped to field ID');
+        assert.ok(capturedBody.includes('00N000000000002=cpc'), 'utm_medium mapped to field ID');
+        assert.ok(!capturedBody.includes('00N000000000003'), 'unset utm field omitted');
+
+        const decoded = decodeURIComponent(capturedBody.replace(/\+/g, ' '));
+        assert.ok(!decoded.includes('UTMs:'), 'no description fallback when fields are mapped');
+        assert.ok(decoded.includes('Lead via chatbot.'), 'description untouched');
     } finally {
         global.fetch = originalFetch;
     }

--- a/utils/salesforce-lead.ts
+++ b/utils/salesforce-lead.ts
@@ -1,0 +1,30 @@
+import type { LeadUtms } from '../types/leadCapture';
+
+export interface SalesforceLeadClientPayload {
+    firstName: string;
+    lastName: string;
+    email?: string;
+    whatsapp?: string;
+    empresa?: string;
+    cargo?: string;
+    leadSource: string;
+    description?: string;
+    utms?: LeadUtms;
+}
+
+/**
+ * Fire-and-forget para o web-to-lead do Salesforce via /api/submit-lead-sf.
+ * Nunca bloqueia nem quebra o fluxo principal do formulário — o lead primário
+ * segue pelo n8n/HubSpot; o Salesforce é um espelho best-effort.
+ * `keepalive` garante que o envio sobreviva à navegação para o WhatsApp.
+ */
+export function sendLeadToSalesforce(payload: SalesforceLeadClientPayload): void {
+    if (typeof fetch === 'undefined') return;
+
+    void fetch('/api/submit-lead-sf', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        keepalive: true,
+    }).catch(() => undefined);
+}


### PR DESCRIPTION
## O que muda

Antes, apenas o **quiz** e o formulário **corporativo** enviavam leads ao Salesforce via web-to-lead. Agora os 4 formulários de captura de lead espelham os dados no SF, todos carregando UTMs de atribuição:

| Formulário | Antes | Depois |
|---|---|---|
| Chatbot AI (`ChatLeadForm`) | só n8n/HubSpot | + SF (lead source "Web", description com BANT + destino) |
| Modal de contato (`ContactModal`/`CtaBody`) | só n8n | + SF (lead source "Web", description com origem do CTA, ação e opt-in) |
| Corporativo (`/corporativo`) | SF sem UTMs (fetch duplicado) | SF com UTMs via opção do hook |
| Quiz (`/quiz`) | SF sem UTMs (fetch inline) | SF com UTMs via helper compartilhado |

## Como os UTMs chegam ao Salesforce

- `services/salesforce.ts` ganhou o mapa `SF_UTM_FIELD_IDS` para os 5 campos personalizados de Lead (`00N...`).
- **Enquanto os IDs não forem configurados**, os UTMs são anexados à `description` do lead (`UTMs: utm_source=google | utm_medium=cpc | ...`) — nenhuma atribuição se perde e o deploy não depende da criação dos campos no SF.
- Após criar os campos (Setup → Object Manager → Lead → Text 255) e colar os IDs no mapa, os UTMs passam a ir nos campos estruturados e saem da description. Os dois comportamentos têm teste.

## Outras mudanças

- `email` virou opcional no `/api/submit-lead-sf` (validação de formato só quando presente) — o modal de contato exige apenas nome + WhatsApp, e web-to-lead aceita lead sem email.
- Novo helper client `utils/salesforce-lead.ts`: fire-and-forget com `keepalive: true` (sobrevive à navegação para o WhatsApp). Falha no SF nunca bloqueia o fluxo principal (n8n/HubSpot continua sendo o caminho primário).
- `useLeadCapture.submitLead` ganhou a opção `salesforce` — o corporativo migrou para ela, eliminando o fetch duplicado.
- Handler valida/sanitiza UTMs: trunca em 255 chars, descarta valores não-string e chaves desconhecidas.

## Para o reviewer

- O envio SF é espelhamento best-effort: a única fonte de verdade de erro para o usuário continua sendo o fluxo n8n.
- Limite padrão do web-to-lead é 500 leads/dia por org — com 4 formulários espelhando, vale monitorar se o volume crescer.
- Follow-up pós-merge: criar os 5 campos UTM no SF e preencher `SF_UTM_FIELD_IDS`.

## Testes

- `pnpm test:regression` — 621 testes passando (16 no `submit-lead-sf`, incluindo 4 novos: email opcional, UTMs na description, UTMs malformados, UTMs mapeados para `00N`).
- `pnpm typecheck` — limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)