### PR TITLE
ci: pin react-doctor à release v2.1.0 por SHA em vez de commit do main

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.3
-      # Pinado por SHA: o branch main da action quebrou em 10/06/2026
-      # ("error: too many arguments") — atualizar o pin só após validar upstream.
-      - uses: millionco/react-doctor@a64093c8a14255dc2108d834d56f4d21b9d9ac60
+      # Pinado na release v2.1.0 (esquema --diff, estável). O main migrou para
+      # --scope (PR #769), que ainda não chegou ao react-doctor@latest do npm;
+      # revisitar quando sair a release com --scope + latest correspondente.
+      - uses: millionco/react-doctor@547e1e4ecdb70315d81a91ec3605701d58616ee2 # v2.1.0


### PR DESCRIPTION
## Contexto

O workflow `react-doctor.yml` seguia um **SHA arbitrário do branch `main`** da action (`a64093c8`) — a esteira instável de desenvolvimento, não uma release.

Em 10/06 o `main` da action migrou para a flag `--scope` ([PR #769](https://github.com/millionco/react-doctor)), o que quebrou contra `react-doctor@latest` = `0.5.1` do npm (ainda no esquema `--diff`): `error: too many arguments`.

## Mudança

Troca o pin para a **release oficial `v2.1.0`** (commit `547e1e4`), pinada por SHA com o comentário da versão — best-practice de supply-chain para GitHub Actions.

```diff
- - uses: millionco/react-doctor@a64093c8a14255dc2108d834d56f4d21b9d9ac60
+ - uses: millionco/react-doctor@547e1e4ecdb70315d81a91ec3605701d58616ee2 # v2.1.0
```

## Risco

**Nenhum risco de regressão** — `v2.1.0` e o pin anterior são comportamentalmente idênticos (ambos invocam a CLI com `--diff false`). O ganho é um alvo versionado, imune a pushes futuros no `main`.

### Pendência (follow-up)

A action roda `react-doctor@latest` em runtime. Quando o upstream promover uma versão com `--scope` para `latest` no npm, qualquer wrapper que ainda passe `--diff` quebrará novamente. Revisitar o pin (e considerar fixar `version:`) quando sair a release estável com `--scope` + `latest` correspondente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)