### PR TITLE
chore: aplicar correções rápidas do react-doctor

### DIFF
--- a/components/ChunkErrorBoundary.tsx
+++ b/components/ChunkErrorBoundary.tsx
@@ -61,6 +61,7 @@ class ChunkErrorBoundary extends React.Component<Props, State> {
             Ocorreu um erro ao carregar esta página.
           </p>
           <button
+            type="button"
             onClick={() => window.location.reload()}
             className="px-6 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors"
           >

--- a/components/Header/index.ts
+++ b/components/Header/index.ts
@@ -1,1 +1,0 @@
-export { default } from './Header';


### PR DESCRIPTION
## Resumo

Triagem completa do `npx react-doctor` (32 warnings, score 81/100). Este PR aplica os 2 únicos achados confirmados como verdadeiros positivos de baixo risco:

- **`components/ChunkErrorBoundary.tsx`** — `type="button"` explícito no botão "Atualizar página" (botão sem `type` é `submit` por padrão).
- **`components/Header/index.ts`** — barrel órfão removido; nenhum módulo importa `components/Header` (o `App.tsx` importa `Header/Header` diretamente).

## Falsos positivos descartados na triagem (sem mudança)

- `unused-export: config` ×8 em `api/*` — contrato `export const config = { runtime: 'edge' }` dos handlers; os wrappers em `functions/` importam só o default.
- `unused-file: public/utm-tracking.js` — injetado via `injectScript` no `index.html:145`.
- `unused-export` em `lib/head.tsx` — usado por `App.tsx` e `ssr.tsx`.
- `SearchForm.tsx:183` (`role="combobox"`) — padrão ARIA APG correto para autocomplete; remover quebraria `aria-expanded`/`aria-activedescendant`.
- `SearchForm.tsx:435` (controle sem label) — input tem `<label htmlFor>` associada; o linter não resolve o id em template literal.
- `js-set-map-lookups` em `api/auth/callback.ts:16` e `utils/whatsapp.ts:92` — são `String.indexOf('=')` para parse de `chave=valor`, não varredura de array.
- `BlogPostContent.tsx:53` (cinza sobre amarelo) — `[&_blockquote_p]:text-brand-dark` já sobrescreve `prose-p:text-zinc-600` dentro dos blockquotes `bg-yellow-50`.

Refactors de médio porte (`no-initialize-state` ×8, `no-event-handler` ×4, `prefer-useReducer` ×2) ficam para um passe futuro, caso a caso.

## Testes

- `pnpm typecheck` ✅
- `npx react-doctor` re-rodado: 32 → 30 issues, sem regressão
- Sem testes novos: mudanças sem alteração de comportamento observável (botão fora de form + remoção de arquivo morto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)