### PR TITLE
chore(tracking): remover evento meta_lead órfão do dataLayer

### DIFF
--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -270,13 +270,6 @@ function mirrorLeadToSalesforce(payload: SubmitLeadRequest, options: SalesforceS
     });
 }
 
-// Meta standard "Lead" carries no monetary value at capture time, but we send a
-// zero/BRL pair so the browser Pixel event matches the server-side CAPI Lead
-// (purchase-dispatch sends value 0 / BRL for lead_qualificado), keeping the two
-// events aligned for deduplication.
-const LEAD_EVENT_CURRENCY = 'BRL';
-const LEAD_EVENT_VALUE = 0;
-
 export function pushGenerateLeadDataLayerEvent(
     payload: SubmitLeadRequest,
     formType: LeadFormType = 'ai_chatbot_lead',
@@ -305,24 +298,6 @@ export function pushGenerateLeadDataLayerEvent(
         destination: 'whatsapp',
         page_location: window.location.href,
     });
-
-    // 3. Meta standard "Lead" event. Gated on event_id because it is the dedup key
-    //    shared with the server-side CAPI Lead (api/purchase-dispatch) — firing it
-    //    without one would risk double-counting. Kept separate from the custom
-    //    generate_lead/form_submission events (which still fire for GA4/Ads even
-    //    without an event_id) so a GTM Meta Pixel tag can map 1:1 to the standard
-    //    Lead. Meta's Pixel reads `eventID`; we expose both spellings so a GTM Data
-    //    Layer Variable can bind to either.
-    if (payload.event_id) {
-        window.dataLayer.push({
-            event: 'meta_lead',
-            event_id: payload.event_id,
-            eventID: payload.event_id,
-            currency: LEAD_EVENT_CURRENCY,
-            value: LEAD_EVENT_VALUE,
-            destination: payload.destination,
-        });
-    }
 }
 
 function getSubmitLeadValidationError(payload: SubmitLeadRequest): string | null {

--- a/tests/hooks-useLeadCapture.test.ts
+++ b/tests/hooks-useLeadCapture.test.ts
@@ -223,35 +223,20 @@ function withMockedWindow(run: (dataLayer: DataLayerEvent[]) => void): void {
     }
 }
 
-test('pushGenerateLeadDataLayerEvent emits a standard Meta Lead event sharing the event_id', () => {
-    withMockedWindow((dataLayer) => {
-        pushGenerateLeadDataLayerEvent(validPayload({ event_id: 'lead_abc123', destination: 'Maldivas' }));
-
-        const metaLead = dataLayer.find((entry) => entry.event === 'meta_lead');
-        assert.ok(metaLead, 'a meta_lead event should be pushed');
-        assert.equal(metaLead?.event_id, 'lead_abc123');
-        assert.equal(metaLead?.eventID, 'lead_abc123', 'Meta Pixel reads eventID for dedup');
-        assert.equal(metaLead?.currency, 'BRL');
-        assert.equal(metaLead?.value, 0);
-        assert.equal(metaLead?.destination, 'Maldivas');
-    });
-});
-
-test('pushGenerateLeadDataLayerEvent keeps the custom generate_lead/form_submission events', () => {
+test('pushGenerateLeadDataLayerEvent emits the custom generate_lead/form_submission events', () => {
     withMockedWindow((dataLayer) => {
         pushGenerateLeadDataLayerEvent(validPayload({ event_id: 'lead_abc123' }));
 
         const eventNames = dataLayer.map((entry) => entry.event);
-        assert.deepEqual(eventNames, ['generate_lead', 'form_submission', 'meta_lead']);
+        assert.deepEqual(eventNames, ['generate_lead', 'form_submission']);
     });
 });
 
-test('pushGenerateLeadDataLayerEvent omits meta_lead but keeps custom events without an event_id', () => {
+test('pushGenerateLeadDataLayerEvent keeps custom events even without an event_id', () => {
     withMockedWindow((dataLayer) => {
         pushGenerateLeadDataLayerEvent(validPayload({ event_id: undefined }));
 
         const eventNames = dataLayer.map((entry) => entry.event);
         assert.deepEqual(eventNames, ['generate_lead', 'form_submission']);
-        assert.ok(!eventNames.includes('meta_lead'), 'meta_lead should be omitted without event_id (CAPI dedup fail-safe)');
     });
 });


### PR DESCRIPTION
## Contexto

Parte da issue #863. Durante a auditoria do pipeline Meta→sGTM (via GTM API) descobrimos que o evento `meta_lead`, introduzido no #862 para uma tag Meta Pixel standard `Lead`, **está órfão**: nenhum trigger do GTM o escuta.

O evento canônico do pipeline — Pixel browser + CAPI server, com **dedup por `event_id` já funcional** — é **`generate_lead`**:
- Web (`GTM-T2KGS86G`): tag `50` (template Meta Pixel) dispara `Lead` no `generate_lead`, com `event_id` que casa com o servidor.
- Server (`GTM-5VVM8M4R`): tag `14` (Conversions API) deduplica pelo mesmo `event_id`.

O `meta_lead` era, na prática, **código morto** no browser — só adicionava ruído ao dataLayer e risco de confusão futura.

## Mudança

- Remove o push de `meta_lead` em `pushGenerateLeadDataLayerEvent` e as constantes `LEAD_EVENT_CURRENCY`/`LEAD_EVENT_VALUE`.
- **Mantém** o relaxamento do guard do #862: `generate_lead` e `form_submission` seguem disparando mesmo sem `event_id` (essenciais para GA4/Ads).
- Atualiza os testes do hook (remove asserções de `meta_lead`, mantém a cobertura dos eventos custom com e sem `event_id`).

> Escopo intencionalmente restrito ao browser. A propagação de IP/UA server-side do #862 (n8n/`purchase-dispatch`) **não** é tocada aqui — faz parte da limpeza do caminho CAPI legado, tratada à parte na #863.

## Verificação

- `pnpm test:regression` → 626 passam (exit 0)
- `pnpm typecheck` → exit 0
- `git grep meta_lead` → nenhuma referência remanescente

## Fora deste PR (follow-up #863)

- Desativar o workflow n8n fantasma "🔵 Meta CAPI - Lead Events"
- Confirmar `META_PIXEL_ID`/`META_ACCESS_TOKEN` ausentes no Cloudflare Pages (deixa o `purchase-dispatch` no-op)
- Campos de atribuição no web-to-lead Salesforce (event_id/fbp/fbc/gclid)

Refs #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)