### PR TITLE
docs: atualizar CLAUDE.md, README e deploy para Cloudflare Pages + Salesforce

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,7 +44,7 @@ Copy `.env.example` to `.env`. Required groups:
 GEMINI_API_KEY=           # Google Gemini API key
 GEMINI_MODEL=             # Optional override (default: gemini-3.1-flash-lite)
 
-# CRM ativo: Salesforce via n8n + api/submit-lead-sf.ts (web-to-lead)
+# CRM ativo: Salesforce + api/submit-lead-sf.ts (web-to-lead)
 # Leads novos criados pelo chatbot seguem este caminho; HubSpot abaixo é legado.
 
 # n8n Webhooks (required in prod)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Anhangá Viagens is an institutional website for a Brazilian boutique travel agency. It features an AI-powered chatbot (Google Gemini) for travel consultation, destination showcases, blog, and WhatsApp lead generation.
 
-**Stack:** React 19 + TypeScript + Vite + Tailwind CSS + Vercel Edge Functions
+**Stack:** React 19 + TypeScript + Vite + Tailwind CSS + Cloudflare Pages Functions (handlers edge-style em `api/`, adaptados em `functions/`)
 
 ## Development Commands
 
@@ -44,10 +44,8 @@ Copy `.env.example` to `.env`. Required groups:
 GEMINI_API_KEY=           # Google Gemini API key
 GEMINI_MODEL=             # Optional override (default: gemini-3.1-flash-lite)
 
-# HubSpot CRM (required)
-HUBSPOT_TOKEN=            # Private app token
-HUBSPOT_DEAL_PIPELINE_ID= # Pipeline for new deals
-HUBSPOT_DEAL_STAGE_ID=    # Stage for new deals
+# CRM ativo: Salesforce via n8n + api/submit-lead-sf.ts (web-to-lead)
+# Leads novos criados pelo chatbot seguem este caminho; HubSpot abaixo é legado.
 
 # n8n Webhooks (required in prod)
 N8N_WEBHOOK_SECRET=           # Shared HMAC secret for inbound n8n calls
@@ -71,6 +69,10 @@ AI_GATEWAY_ENABLED=       # Route Gemini through Cloudflare AI Gateway
 AI_GATEWAY_BYOK_ALIAS=    # AI Gateway Provider Key alias (BYOK); makes GEMINI_API_KEY optional
 ALLOWED_ORIGIN=           # CORS allowed origin (default: https://www.anhanga.tur.br)
 DEBUG=                    # Enable verbose server logs
+
+# Legacy (somente webhook de deals Closed-Won — não usar para leads novos)
+HUBSPOT_TOKEN=            # Private app token
+HUBSPOT_WEBHOOK_SECRET=   # HMAC secret para validar payloads do HubSpot webhook
 ```
 
 ## Architecture
@@ -87,7 +89,7 @@ Two layout tiers, resolved at the top-level `Routes`:
 ### Directory Layout (key areas)
 
 ```
-/api          Vercel Edge Functions (15 handlers)
+/api          Handlers edge-style (executados como Cloudflare Pages Functions via `functions/`)
 /lib          Shared server-side helpers (40+ files, organized into subsystems)
   /ai         Gemini config, BANT prompt, tool definitions, handoff logic
   /schemas    Zod validators for each API endpoint
@@ -105,17 +107,17 @@ Two layout tiers, resolved at the top-level `Routes`:
 
 ### API Handlers (`/api`)
 
-All handlers export `export const config = { runtime: 'edge' }`. Standard response shape: `{ ok: boolean, code?: string, error?: string, data?: T }`.
+Handlers rodam como Cloudflare Pages Functions (via `functions/`). O campo `export const config = { runtime: 'edge' }` é um legado do Vercel e não tem efeito no Cloudflare — ignorar. Standard response shape: `{ ok: boolean, code?: string, error?: string, data?: T }`.
 
 | Handler | Purpose |
 |---|---|
 | `generate.ts` | Gemini chatbot proxy; runs BANT qualification state machine |
-| `submit-lead.ts` | Lead capture → HubSpot via n8n webhook |
+| `submit-lead.ts` | Lead capture → n8n webhook |
 | `submit-contact.ts` | Quick contact form → n8n |
 | `submit-waitlist.ts` | Event waitlist → n8n |
 | `submit-nps.ts` | Post-trip NPS form → n8n |
 | `submit-quiz.ts` | Travel quiz results → n8n |
-| `submit-lead-sf.ts` | Alternative Salesforce lead path |
+| `submit-lead-sf.ts` | Lead capture via Salesforce web-to-lead (CRM ativo) |
 | `hubspot-webhook.ts` | Inbound HubSpot "Closed-Won" deal events |
 | `purchase-dispatch.ts` | Receives n8n purchase events; validates `N8N_WEBHOOK_SECRET` |
 | `auth.ts` / `auth/callback.ts` | GitHub OAuth for Decap CMS `/admin` |
@@ -141,12 +143,12 @@ The AI subsystem is fully isolated in `lib/ai/`: `constants.ts` (models, budget 
 
 ### Lead Capture Flow
 
-Lead data flows through n8n (not directly to HubSpot):
+Lead data flows through n8n e Salesforce (CRM ativo desde mai/2026):
 1. `useLeadCapture.ts` collects BANT summary + UTM attribution from `geminiService.ts`
 2. Submits to `/api/submit-lead.ts`
 3. Handler validates + normalizes via `lib/lead-logic.ts` and Zod schema in `lib/schemas/submit-lead.ts`
 4. Calls n8n webhook (`N8N_SUBMIT_CONTACT_WEBHOOK_URL`) via `services/n8n.ts` with payload shaped by `lib/n8n-payloads.ts`
-5. n8n creates/updates the HubSpot contact and deal via `HUBSPOT_TOKEN`
+5. n8n cria/atualiza o lead no **Salesforce** via `api/submit-lead-sf.ts` + `services/salesforce.ts` (web-to-lead). O caminho HubSpot é legado — não usar para leads novos.
 6. Error codes: 400 (validation), 401 (bad token), 429 (rate limit), 500 (server/n8n)
 
 ### UTM Tracking (`utils/whatsapp.ts`)
@@ -177,9 +179,10 @@ Tailwind CSS (`tailwind.config.mjs`). Brand palette: `action` (#0056D2), `action
 
 ### Deployment
 
-- **Vercel** (primary) — `vercel.json`: security headers, SPA rewrite, domain redirects (`anhanga.tur.br` → `www`, `beto.anhanga.tur.br` → `/beto-carrero`)
-- **Netlify** — `netlify.toml`
-- **GitHub Pages** — `pnpm deploy` with `VITE_BASE_PATH`
+- **Cloudflare Pages** (primário) — `wrangler.toml` (`pages_build_output_dir = "dist"`), functions em `functions/` (incl. `_middleware.ts`), Node 24 via `.node-version`. Secrets configurados no dashboard do Pages.
+- **Vercel** (legado/secundário) — `vercel.json` mantido no repo para compatibilidade; não é a plataforma ativa.
+- **Netlify** (legado/secundário) — `netlify.toml` mantido no repo.
+- **GitHub Pages** — `pnpm deploy` with `VITE_BASE_PATH` (estático, sem API)
 
 Build chunks: `react-vendor`, `ai-vendor`, `leaflet-vendor` (manual split in `vite.config.ts`).
 

--- a/.env.example
+++ b/.env.example
@@ -32,11 +32,11 @@ SENTRY_DSN=
 VITE_SENTRY_DSN=
 
 # =============================================================================
-# REQUIRED - HubSpot CRM (para captura de leads via chatbot)
+# --- Legado (webhook de deals HubSpot — somente Closed-Won, não usar para leads novos) ---
+# CRM ativo é Salesforce via n8n + api/submit-lead-sf.ts (web-to-lead).
 # =============================================================================
-HUBSPOT_TOKEN=seu_token_do_app_privado
-HUBSPOT_DEAL_PIPELINE_ID=id_do_pipeline_deals
-HUBSPOT_DEAL_STAGE_ID=id_do_stage_deals
+# HUBSPOT_TOKEN=seu_token_do_app_privado
+# HUBSPOT_WEBHOOK_SECRET=seu_hubspot_webhook_secret  # HMAC para validar payloads do webhook
 
 # OPTIONAL - Property name for BANT summary on Deal (default: bant_summary)
 # HUBSPOT_DEAL_BANT_PROPERTY=bant_summary
@@ -125,7 +125,7 @@ N8N_SUBMIT_CONTACT_WEBHOOK_URL=https://seu-n8n.com/webhook/contact-form
 #    - Application name: Anhangá Viagens CMS
 #    - Homepage URL: https://www.anhanga.tur.br
 #    - Authorization callback URL: https://www.anhanga.tur.br/api/auth/callback
-# 2. Adicione as 2 variáveis abaixo no Vercel Dashboard (Production + Preview + Development)
+# 2. Adicione as 2 variáveis abaixo no dashboard do Cloudflare Pages (Settings → Environment Variables)
 GITHUB_CLIENT_ID=seu_github_oauth_client_id
 GITHUB_CLIENT_SECRET=seu_github_oauth_client_secret
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ O deploy primário é **Cloudflare Pages**. Vercel e Netlify são plataformas le
 
 1. Conecte o repositório ao Cloudflare Pages via dashboard.
 2. Build command: `pnpm build` | Output directory: `dist` | Node version: 24.
-3. Configure os secrets no dashboard do Pages (Settings → Environment Variables): `GEMINI_API_KEY`, variáveis n8n/Salesforce, Upstash Redis, GitHub OAuth. Consulte `.env.example` para a lista completa.
+3. Configure os secrets no dashboard do Pages (Settings → Environment Variables): `GEMINI_API_KEY`, variáveis do n8n, Upstash Redis, GitHub OAuth. Consulte `.env.example` para a lista completa.
 4. O deploy é feito automaticamente a cada push para `main`.
 
 ### Vercel / Netlify (legado/secundário)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ O site institucional da **Anhangá Viagens** é uma plataforma moderna e interat
 ## ✨ Features
 
 - **🤖 Chat com IA Gemini:** Assistente de viagens integrado que responde dúvidas, sugere roteiros e oferece informações personalizadas em tempo real.
-- **🎯 Captura de Leads Inteligente:** Integração automatizada com HubSpot via chatbot para qualificação e criação de deals.
+- **🎯 Captura de Leads Inteligente:** Integração automatizada com Salesforce via chatbot e n8n para qualificação e criação de leads.
 - **🏝️ Landing Pages Especializadas:** Experiências otimizadas para destinos de alta conversão (Orlando, Beto Carrero, Lollapalooza).
-- **📊 Rastreamento e Performance:** Monitoramento via Vercel Analytics/Speed Insights e persistência de UTMs/GCLID para atribuição.
+- **📊 Rastreamento e Performance:** Monitoramento via GTM/sGTM (Stape) e persistência de UTMs/GCLID para atribuição.
 - **✈️ Vitrine de Destinos:** Seção visualmente atraente para apresentar os principais pacotes da agência.
 - **⭐ Depoimentos de Clientes:** Prova social integrada para aumentar a confiança na conversão.
 - **❓ FAQ Interativo:** Respostas rápidas para as dúvidas mais frequentes.
@@ -30,8 +30,8 @@ O site institucional da **Anhangá Viagens** é uma plataforma moderna e interat
 - **Tailwind CSS:** Design system utility-first para estilização de alta performance.
 - **React Router 7:** Gerenciamento de rotas e navegação SPA.
 - **Google Gemini AI + Cloudflare AI Gateway:** Motor de inteligência artificial generativa com proxy opcional para observabilidade de uso.
-- **HubSpot CRM:** API para gestão de leads e automação de vendas.
-- **Vercel Analytics & Speed Insights:** Monitoramento de experiência do usuário em tempo real.
+- **Salesforce CRM:** Web-to-lead via n8n para gestão de leads (CRM ativo desde mai/2026).
+- **Cloudflare Pages:** Deploy primário com Pages Functions para API edge-style.
 - **Lucide React:** Biblioteca de ícones moderna e leve.
 - **Leaflet:** Biblioteca para mapas interativos e geolocalização.
 
@@ -41,8 +41,7 @@ O site institucional da **Anhangá Viagens** é uma plataforma moderna e interat
 - pnpm (Gerenciador de pacotes)
 - Chave da API do Google Gemini no ambiente server-side
 - Opcional: Cloudflare AI Gateway autenticado para monitoramento de uso da IA
-- Token de app privado do HubSpot (para captura de leads do chatbot)
-- IDs de Pipeline e Stage de Deals no HubSpot
+- Secrets configurados no dashboard do **Cloudflare Pages** (ver `.env.example`)
 
 ## 📦 Instalação
 
@@ -64,7 +63,7 @@ O site institucional da **Anhangá Viagens** é uma plataforma moderna e interat
    cp .env.example .env
    ```
    
-   Em seguida, adicione sua chave da API do Gemini e o token do HubSpot ao arquivo `.env`.
+   Em seguida, adicione as variáveis necessárias ao arquivo `.env` (consulte `.env.example` para a lista completa).
    O frontend chama `/api/generate`; a chave do Gemini fica apenas no runtime da API.
    ```env
    GEMINI_API_KEY=sua_chave_api_aqui
@@ -73,19 +72,8 @@ O site institucional da **Anhangá Viagens** é uma plataforma moderna e interat
    CLOUDFLARE_ACCOUNT_ID=seu_account_id_cloudflare
    CLOUDFLARE_AI_GATEWAY_ID=default
    CLOUDFLARE_AI_GATEWAY_TOKEN=seu_token_com_permissao_run
-   HUBSPOT_TOKEN=seu_token_do_app_privado
-   HUBSPOT_DEAL_PIPELINE_ID=id_do_pipeline_deals
-   HUBSPOT_DEAL_STAGE_ID=id_do_stage_deals
-   # Opcional (default: bant_summary)
-   HUBSPOT_DEAL_BANT_PROPERTY=bant_summary
-   # Opcional (fallback para tracking não mapeado)
-   HUBSPOT_CONTACT_TRACKING_FALLBACK_PROPERTY=tracking_payload_json
-   # Opcional (lista estática para contatos da waitlist do Lollapalooza)
-   HUBSPOT_LOLLAPALOOZA_LIST_ID=123
    # Opcional (o projeto já usa este domínio por padrão; defina só se quiser explicitar)
    VITE_MEDIA_BASE_URL=https://media.anhanga.tur.br
-   # Opcional (para assets do R2, prefira o host de mídia como zona de resize)
-   VITE_MEDIA_TRANSFORM_ZONE_URL=https://media.anhanga.tur.br
    # Opcional (ative depois de validar o /cdn-cgi/image no host de mídia)
    VITE_MEDIA_ENABLE_TRANSFORMS=true
    ```
@@ -116,19 +104,18 @@ O site institucional da **Anhangá Viagens** é uma plataforma moderna e interat
 
 ## 🚢 Deploy
 
-O projeto está pré-configurado para deploy simplificado em plataformas como Vercel e Netlify.
+O deploy primário é **Cloudflare Pages**. Vercel e Netlify são plataformas legadas com configs mantidas no repo.
 
-### Vercel
+### Cloudflare Pages (primário)
 
-1. Faça o fork do repositório.
-2. Conecte sua conta do GitHub ao Vercel.
-3. Importe o repositório e configure as variáveis de ambiente `GEMINI_API_KEY`, `HUBSPOT_TOKEN`, `HUBSPOT_DEAL_PIPELINE_ID`, `HUBSPOT_DEAL_STAGE_ID` e, se quiser classificar a waitlist do festival em uma lista estática, `HUBSPOT_LOLLAPALOOZA_LIST_ID` no painel do projeto. Para rotear o chat pelo Cloudflare AI Gateway, adicione também `AI_GATEWAY_ENABLED=true`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_AI_GATEWAY_ID` e `CLOUDFLARE_AI_GATEWAY_TOKEN`.
-4. O deploy será feito automaticamente a cada push para a branch principal.
+1. Conecte o repositório ao Cloudflare Pages via dashboard.
+2. Build command: `pnpm build` | Output directory: `dist` | Node version: 24.
+3. Configure os secrets no dashboard do Pages (Settings → Environment Variables): `GEMINI_API_KEY`, variáveis n8n/Salesforce, Upstash Redis, GitHub OAuth. Consulte `.env.example` para a lista completa.
+4. O deploy é feito automaticamente a cada push para `main`.
 
-### Netlify
+### Vercel / Netlify (legado/secundário)
 
-1. Siga os mesmos passos da Vercel.
-2. O arquivo `netlify.toml` já contém as configurações de build (`pnpm build`) e o diretório de publicação (`dist`).
+Os arquivos `vercel.json` e `netlify.toml` estão mantidos no repo para compatibilidade. Não são a plataforma ativa.
 
 ## 📁 Estrutura do Código
 

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -75,7 +75,7 @@ Consulte `.env.example` para a lista completa com descrições. Grupos principai
 
 ### Rotas não funcionam
 
-- Pages Functions em `functions/` tratam as rotas de API. Verifique se o build inclui a pasta `functions/`.
+- Pages Functions em `functions/` tratam as rotas de API. Verifique se a pasta `functions/` está presente na raiz do repositório.
 - Para rotas do SPA, o `_redirects` ou a config de Pages deve reescrever `/*` para `/index.html`.
 
 ## Plataformas Legadas / Secundárias

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -1,40 +1,44 @@
-# 🚀 Guia de Deploy - Anhangá Viagens
+# Guia de Deploy - Anhangá Viagens
 
-## Segurança da API Key
+## Plataforma Primária: Cloudflare Pages
 
-O chat usa `/api/generate` como proxy server-side. A chave `GEMINI_API_KEY` deve ficar somente nas variáveis de ambiente da plataforma de deploy e não deve ser exposta com prefixo `VITE_`.
+O deploy ativo é **Cloudflare Pages** (migrado de Vercel em mai/2026). Handlers de API rodam como Pages Functions em `functions/`, que envolvem os handlers em `api/`.
 
-### Cloudflare AI Gateway
+### Segurança da API Key
 
-O Cloudflare AI Gateway é opcional e controlado por feature flag. Use esta rota para monitorar requests, tokens, erros e custo antes de qualquer migração futura para outro provedor/modelo.
+O chat usa `/api/generate` como proxy server-side. A chave `GEMINI_API_KEY` deve ficar somente nas variáveis de ambiente da plataforma e não deve ser exposta com prefixo `VITE_`.
+
+### Cloudflare AI Gateway (opcional)
+
+O Cloudflare AI Gateway é opcional e controlado por feature flag. Use para monitorar requests, tokens, erros e custo.
 
 1. Crie ou selecione um AI Gateway no painel da Cloudflare.
 2. Habilite Authenticated Gateway.
 3. Gere um token com permissão `Run` e salve-o com segurança.
-4. Configure as variáveis server-side:
+4. Configure as variáveis server-side no dashboard do Pages:
    - `AI_GATEWAY_ENABLED=true`
    - `CLOUDFLARE_ACCOUNT_ID`
    - `CLOUDFLARE_AI_GATEWAY_ID` (opcional; default: `default`)
    - `CLOUDFLARE_AI_GATEWAY_TOKEN`
 5. Mantenha `GEMINI_API_KEY` configurada; nesta fase ela ainda é enviada pelo servidor ao endpoint nativo Google AI Studio via Gateway.
 
-## 📋 Checklist de Deploy
+## Checklist de Deploy
 
 ### Antes do Deploy:
 
-- [ ] Configure a variável `GEMINI_API_KEY` na plataforma de deploy
+- [ ] Configure todas as variáveis de ambiente no dashboard do Cloudflare Pages (Settings → Environment Variables). Consulte `.env.example` para a lista completa.
 - [ ] Se usar AI Gateway, configure `AI_GATEWAY_ENABLED=true`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_AI_GATEWAY_ID` e `CLOUDFLARE_AI_GATEWAY_TOKEN`
 - [ ] Teste o build localmente: `pnpm build && pnpm preview`
 - [ ] Verifique se todas as rotas funcionam corretamente
 - [ ] Teste o chat AI com a chave de produção
 - [ ] Configure restrições de domínio na API Key (se aplicável)
 
-### Durante o Deploy:
+### Configuração do Build no Cloudflare Pages:
 
-- [ ] Build command: `pnpm build`
-- [ ] Output directory: `dist`
-- [ ] Node version: 24.x
-- [ ] Environment variables: `GEMINI_API_KEY` e, se habilitado, variáveis `CLOUDFLARE_*`
+- Build command: `pnpm build`
+- Output directory: `dist`
+- Node version: 24 (fixado via `.node-version`)
+- Functions directory: `functions/` (auto-detectado pelo Pages)
 
 ### Após o Deploy:
 
@@ -43,76 +47,18 @@ O Cloudflare AI Gateway é opcional e controlado por feature flag. Use esta rota
 - [ ] Teste em diferentes navegadores
 - [ ] Verifique performance e carregamento
 
-## 🔧 Configurações por Plataforma
+## Variáveis de Ambiente Necessárias
 
-### Vercel
+Consulte `.env.example` para a lista completa com descrições. Grupos principais:
 
-```bash
-# Instalar CLI
-pnpm add -g vercel
+- **Gemini AI** (required): `GEMINI_API_KEY`
+- **n8n Webhooks** (required in prod): `N8N_WEBHOOK_SECRET`, `N8N_SUBMIT_CONTACT_WEBHOOK_URL`, `NPS_WEBHOOK_URL`
+- **Rate Limiting** (required in prod): `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`
+- **Decap CMS OAuth** (required in prod): `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`
+- **Meta CAPI** (optional): `META_PIXEL_ID`, `META_ACCESS_TOKEN`
+- **Legado HubSpot** (somente webhook Closed-Won): `HUBSPOT_TOKEN`, `HUBSPOT_WEBHOOK_SECRET`
 
-# Deploy
-vercel --prod
-```
-
-**Variáveis de Ambiente:**
-- Adicione `GEMINI_API_KEY` em: Project Settings → Environment Variables
-- Para observabilidade via Cloudflare, adicione `AI_GATEWAY_ENABLED=true`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_AI_GATEWAY_ID` e `CLOUDFLARE_AI_GATEWAY_TOKEN`
-
-### Netlify
-
-```bash
-# Instalar CLI
-pnpm add -g netlify-cli
-
-# Deploy
-netlify deploy --prod
-```
-
-**Configurações no netlify.toml (opcional):**
-```toml
-[build]
-  command = "pnpm build"
-  publish = "dist"
-
-[build.environment]
-  NODE_VERSION = "24"
-```
-
-### GitHub Pages
-
-1. Instale `gh-pages`:
-```bash
-pnpm install --save-dev gh-pages
-```
-
-2. Adicione ao `package.json`:
-```json
-"scripts": {
-  "deploy": "pnpm build && gh-pages -d dist"
-}
-```
-
-3. **IMPORTANTE**: Configure o base path antes do build:
-   - Se o repositório for `username.github.io/repo-name`, crie um arquivo `.env.production`:
-   ```env
-   VITE_BASE_PATH=/repo-name/
-   # Configure GEMINI_API_KEY na plataforma server-side; nao exponha no build estatico.
-   ```
-   - Se for `username.github.io` (sem subdiretório), use:
-   ```env
-   VITE_BASE_PATH=/
-   # Configure GEMINI_API_KEY na plataforma server-side; nao exponha no build estatico.
-   ```
-
-4. Deploy:
-```bash
-pnpm deploy
-```
-
-**Nota**: O `vite.config.ts` já está configurado para usar `VITE_BASE_PATH` automaticamente.
-
-## 🐛 Troubleshooting
+## Troubleshooting
 
 ### Build falha
 
@@ -123,17 +69,57 @@ pnpm deploy
 
 ### Chat AI não funciona em produção
 
-- Verifique se `GEMINI_API_KEY` está configurada corretamente
+- Verifique se `GEMINI_API_KEY` está configurada corretamente no dashboard do Pages
 - Se usar AI Gateway, confirme que o Gateway autenticado está ativo e que o token tem permissão `Run`
 - Verifique o console do navegador para erros
 
 ### Rotas não funcionam
 
-- Este projeto usa `HashRouter`, então todas as rotas devem funcionar
-- Se usar `BrowserRouter`, configure redirects no servidor para `/index.html`
+- Pages Functions em `functions/` tratam as rotas de API. Verifique se o build inclui a pasta `functions/`.
+- Para rotas do SPA, o `_redirects` ou a config de Pages deve reescrever `/*` para `/index.html`.
 
-## 📞 Suporte
+## Plataformas Legadas / Secundárias
+
+Os arquivos `vercel.json` e `netlify.toml` estão mantidos no repo para compatibilidade, mas não são a plataforma ativa.
+
+### Vercel (legado)
+
+```bash
+# Instalar CLI
+pnpm add -g vercel
+
+# Deploy
+vercel --prod
+```
+
+### Netlify (legado)
+
+```bash
+# Instalar CLI
+pnpm add -g netlify-cli
+
+# Deploy
+netlify deploy --prod
+```
+
+O arquivo `netlify.toml` já contém as configurações de build (`pnpm build`) e o diretório de publicação (`dist`).
+
+### GitHub Pages (estático)
+
+GitHub Pages não suporta API serverless — use apenas para deploy estático sem chatbot.
+
+1. **IMPORTANTE**: Configure o base path antes do build:
+   ```env
+   VITE_BASE_PATH=/repo-name/
+   ```
+
+2. Deploy:
+```bash
+pnpm deploy
+```
+
+## Suporte
 
 Para problemas relacionados ao deploy, consulte:
+- Documentação do Cloudflare Pages: https://developers.cloudflare.com/pages/
 - Documentação do Vite: https://vitejs.dev/guide/static-deploy.html
-- Documentação da sua plataforma de deploy


### PR DESCRIPTION
## O que mudou

Atualiza a documentação para refletir as duas migrações de infraestrutura já em produção, mas ainda não documentadas:

- **Deploy primário: Vercel → Cloudflare Pages** (migrado em mai/2026). Handlers em `api/` rodam como Pages Functions via `functions/`.
- **CRM ativo: HubSpot → Salesforce** (via n8n + `api/submit-lead-sf.ts` web-to-lead). HubSpot rebaixado a legado (somente webhook de deals Closed-Won).

Arquivos:
- `.claude/CLAUDE.md` — stack, env vars, tabela de handlers, Lead Capture Flow e seção Deployment.
- `README.md` — features, tecnologias, pré-requisitos e seção de Deploy.
- `.env.example` — bloco HubSpot comentado como legado; adicionado `HUBSPOT_WEBHOOK_SECRET` (usado por `api/hubspot-webhook.ts`, faltava no exemplo); comentário OAuth → dashboard do Cloudflare Pages.
- `docs/ops/deploy.md` — reescrito liderando com Cloudflare Pages; Vercel/Netlify movidos para "Plataformas Legadas".

## Por que importa

`.claude/CLAUDE.md` é carregado em toda sessão de agente de IA. Enquanto descreve Vercel/HubSpot como stack primária, cada sessão parte de premissas erradas sobre a arquitetura. Este é um dos planos gerados pela skill `/improve` (plano 001).

## Notas para o revisor

- **Docs-only** — nenhum código em `api/`, `functions/`, `lib/`, `services/` foi tocado. `vercel.json` e `netlify.toml` permanecem (deploys secundários); só a documentação mudou.
- `HUBSPOT_DEAL_PIPELINE_ID`/`HUBSPOT_DEAL_STAGE_ID` removidos do `.env.example` — confirmado por grep que não são lidos por nenhum caminho de código atual.
- Ponto menor: `VITE_MEDIA_TRANSFORM_ZONE_URL` saiu do exemplo inline do README (ainda ativo em `data/mediaConfig.ts`), mas permanece no `.env.example` canônico, que o README agora referencia.
- Verificação: `pnpm test:regression` → 626 pass / 0 fail. Os 12 testes que leem `.env.example`/README revalidados isoladamente.
- A limpeza do código HubSpot legado é uma decisão futura separada (deals Closed-Won ainda passam por lá) — fora do escopo deste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)