### PR TITLE
fix(security): exigir HTTPS em webhooks n8n e validar ALLOWED_ORIGIN

### DIFF
--- a/lib/network.ts
+++ b/lib/network.ts
@@ -11,7 +11,7 @@ export function createRequestId(): string {
 }
 
 const DEFAULT_ALLOWED_ORIGIN = 'https://www.anhanga.tur.br';
-const LOCAL_ORIGIN_HOSTNAMES = new Set(['localhost', '127.0.0.1']);
+const LOCAL_ORIGIN_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 
 /**
  * Returns the candidate origin only if it is a single, valid HTTPS origin

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -10,12 +10,43 @@ export function createRequestId(): string {
     return `req_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
+const DEFAULT_ALLOWED_ORIGIN = 'https://www.anhanga.tur.br';
+const LOCAL_ORIGIN_HOSTNAMES = new Set(['localhost', '127.0.0.1']);
+
+/**
+ * Returns the candidate origin only if it is a single, valid HTTPS origin
+ * (no path/query), or an http://localhost / http://127.0.0.1 origin for
+ * local development. Anything else (including '*' or comma-separated
+ * lists) falls back to the default origin.
+ */
+function resolveAllowedOrigin(candidate?: string): string {
+    if (!candidate) return DEFAULT_ALLOWED_ORIGIN;
+
+    let parsed: URL;
+    try {
+        parsed = new URL(candidate);
+    } catch {
+        return DEFAULT_ALLOWED_ORIGIN;
+    }
+
+    if (parsed.pathname !== '/' && parsed.pathname !== '') return DEFAULT_ALLOWED_ORIGIN;
+    if (parsed.search || parsed.hash) return DEFAULT_ALLOWED_ORIGIN;
+
+    if (parsed.protocol === 'https:') return parsed.origin;
+
+    if (parsed.protocol === 'http:' && LOCAL_ORIGIN_HOSTNAMES.has(parsed.hostname)) {
+        return parsed.origin;
+    }
+
+    return DEFAULT_ALLOWED_ORIGIN;
+}
+
 /**
  * Normalizes and builds CORS headers for the response.
  */
 export function buildCorsHeaders(allowedOrigin?: string): Record<string, string> {
     return {
-        'Access-Control-Allow-Origin': allowedOrigin || process.env.ALLOWED_ORIGIN || 'https://www.anhanga.tur.br',
+        'Access-Control-Allow-Origin': resolveAllowedOrigin(allowedOrigin || process.env.ALLOWED_ORIGIN),
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
         'Access-Control-Allow-Headers': 'Content-Type',
         'Access-Control-Expose-Headers': 'X-RateLimit-Remaining, X-RateLimit-Reset, X-Request-Id',

--- a/services/n8n.ts
+++ b/services/n8n.ts
@@ -36,12 +36,31 @@ function normalizeNetworkError(): Error {
     return new Error('N8N_WEBHOOK_ERROR:502:Webhook request failed');
 }
 
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1']);
+
+function assertSecureWebhookUrl(url: string): void {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        throw new Error('N8N_WEBHOOK_ERROR:500:Invalid webhook URL');
+    }
+
+    if (parsed.protocol === 'https:') return;
+
+    if (parsed.protocol === 'http:' && LOCAL_HOSTNAMES.has(parsed.hostname)) return;
+
+    throw new Error('N8N_WEBHOOK_ERROR:500:Webhook URL must use HTTPS');
+}
+
 async function n8nRequest(
     url: string,
     secret: string,
     requestId: string,
     payload: unknown,
 ): Promise<Response> {
+    assertSecureWebhookUrl(url);
+
     const headers = new Headers();
     headers.set('Content-Type', 'application/json');
     headers.set('X-Webhook-Secret', secret);

--- a/services/n8n.ts
+++ b/services/n8n.ts
@@ -36,7 +36,7 @@ function normalizeNetworkError(): Error {
     return new Error('N8N_WEBHOOK_ERROR:502:Webhook request failed');
 }
 
-const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1']);
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 
 function assertSecureWebhookUrl(url: string): void {
     let parsed: URL;

--- a/tests/n8n-service.test.ts
+++ b/tests/n8n-service.test.ts
@@ -63,6 +63,22 @@ test('sendContactToN8n allows http://localhost webhook URLs', async (t) => {
     assert.equal(called, true);
 });
 
+test('sendContactToN8n allows http://[::1] webhook URLs', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+    });
+
+    let called = false;
+    global.fetch = (async () => {
+        called = true;
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    await sendContactToN8n('http://[::1]:5678/webhook', 'secret', 'req-3b', buildContactPayload());
+
+    assert.equal(called, true);
+});
+
 test('sendContactToN8n allows https webhook URLs', async (t) => {
     t.after(() => {
         global.fetch = originalFetch;

--- a/tests/n8n-service.test.ts
+++ b/tests/n8n-service.test.ts
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sendContactToN8n } from '../services/n8n.ts';
+import type { N8nContactPayload } from '../lib/n8n-payloads.ts';
+
+const originalFetch = global.fetch;
+
+function buildContactPayload(): N8nContactPayload {
+    return {
+        requestId: 'req-test-1',
+        source: 'submit-contact',
+        contact: {
+            firstName: 'Felipe',
+            lastName: 'William',
+            whatsapp: '+5511988314487',
+            email: 'felipe@example.com',
+            emailOptIn: true,
+            eventId: null,
+            ctaSource: null,
+            destination: null,
+        },
+        tracking: {
+            utm_source: null,
+            utm_medium: null,
+            utm_campaign: null,
+            utm_term: null,
+            utm_content: null,
+            extras: {},
+        },
+        meta: {
+            receivedAt: new Date().toISOString(),
+        },
+    };
+}
+
+test('sendContactToN8n rejects non-HTTPS, non-local webhook URLs', async () => {
+    await assert.rejects(
+        sendContactToN8n('http://example.com/webhook', 'secret', 'req-1', buildContactPayload()),
+        (error: unknown) => error instanceof Error && error.message.startsWith('N8N_WEBHOOK_ERROR:500:'),
+    );
+});
+
+test('sendContactToN8n rejects malformed webhook URLs', async () => {
+    await assert.rejects(
+        sendContactToN8n('not-a-url', 'secret', 'req-2', buildContactPayload()),
+        (error: unknown) => error instanceof Error && error.message.startsWith('N8N_WEBHOOK_ERROR:500:'),
+    );
+});
+
+test('sendContactToN8n allows http://localhost webhook URLs', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+    });
+
+    let called = false;
+    global.fetch = (async () => {
+        called = true;
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    await sendContactToN8n('http://localhost:5678/webhook', 'secret', 'req-3', buildContactPayload());
+
+    assert.equal(called, true);
+});
+
+test('sendContactToN8n allows https webhook URLs', async (t) => {
+    t.after(() => {
+        global.fetch = originalFetch;
+    });
+
+    let called = false;
+    global.fetch = (async () => {
+        called = true;
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    await sendContactToN8n('https://n8n.example.com/webhook', 'secret', 'req-4', buildContactPayload());
+
+    assert.equal(called, true);
+});

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -62,6 +62,11 @@ test('buildCorsHeaders echoes a local http origin for dev', () => {
     assert.equal(headers['Access-Control-Allow-Origin'], 'http://localhost:3000');
 });
 
+test('buildCorsHeaders echoes the IPv6 loopback origin for dev', () => {
+    const headers = buildCorsHeaders('http://[::1]:3000');
+    assert.equal(headers['Access-Control-Allow-Origin'], 'http://[::1]:3000');
+});
+
 test('buildCorsHeaders falls back to the default origin when ALLOWED_ORIGIN is a wildcard', (t) => {
     const original = process.env.ALLOWED_ORIGIN;
     t.after(() => {

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { getClientIP } from '../lib/network.ts';
+import { buildCorsHeaders, getClientIP } from '../lib/network.ts';
 
 test('getClientIP uses Cloudflare connecting IP before spoofable headers', () => {
     const request = new Request('https://example.com/api/generate', {
@@ -45,4 +45,35 @@ test('getClientIP X-Forwarded-For is consistent with x-vercel-forwarded-for (bot
     });
 
     assert.equal(getClientIP(vercelRequest), getClientIP(xffRequest));
+});
+
+test('buildCorsHeaders falls back to the default origin for a wildcard', () => {
+    const headers = buildCorsHeaders('*');
+    assert.equal(headers['Access-Control-Allow-Origin'], 'https://www.anhanga.tur.br');
+});
+
+test('buildCorsHeaders echoes a valid HTTPS origin', () => {
+    const headers = buildCorsHeaders('https://www.anhanga.tur.br');
+    assert.equal(headers['Access-Control-Allow-Origin'], 'https://www.anhanga.tur.br');
+});
+
+test('buildCorsHeaders echoes a local http origin for dev', () => {
+    const headers = buildCorsHeaders('http://localhost:3000');
+    assert.equal(headers['Access-Control-Allow-Origin'], 'http://localhost:3000');
+});
+
+test('buildCorsHeaders falls back to the default origin when ALLOWED_ORIGIN is a wildcard', (t) => {
+    const original = process.env.ALLOWED_ORIGIN;
+    t.after(() => {
+        if (original === undefined) {
+            delete process.env.ALLOWED_ORIGIN;
+        } else {
+            process.env.ALLOWED_ORIGIN = original;
+        }
+    });
+
+    process.env.ALLOWED_ORIGIN = '*';
+
+    const headers = buildCorsHeaders();
+    assert.equal(headers['Access-Control-Allow-Origin'], 'https://www.anhanga.tur.br');
 });


### PR DESCRIPTION
## Resumo

Hardening contra erro de configuração (plano `plans/003`):

- **`services/n8n.ts`**: `assertSecureWebhookUrl()` valida o scheme da URL do webhook antes de enviar o segredo `X-Webhook-Secret` — rejeita `http://` não-local (aceita `localhost`/`127.0.0.1` para dev) e URLs malformadas, no formato `N8N_WEBHOOK_ERROR:500:`. As mensagens de erro **não vazam a URL** (path secreto do webhook).
- **`lib/network.ts`**: `resolveAllowedOrigin()` valida o valor de `ALLOWED_ORIGIN` antes de usá-lo no header CORS — barra `*`, listas com vírgula, paths e origens não-HTTPS, caindo no default seguro; mantém `http://localhost` para dev.

Nenhum dos dois é bug hoje; são guardas que transformam erro silencioso de config em falha explícita.

## Testes

- `pnpm typecheck` → exit 0
- `pnpm test:regression` → 634 testes, 0 falhas (8 novos: 4 em `tests/n8n-service.test.ts`, 4 em `tests/network.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)