### PR TITLE
fix(nav): usar Link/href relativo para navegação interna nas landings

### DIFF
--- a/components/ChatLeadForm.tsx
+++ b/components/ChatLeadForm.tsx
@@ -316,7 +316,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
                 <CheckCircle2 className="absolute size-3 text-white opacity-0 peer-checked:opacity-100 left-0.5 pointer-events-none transition-opacity" />
               </div>
               <span className="text-xs text-zinc-500 leading-tight">
-                Aceito receber comunicações e autorizo o tratamento dos meus dados conforme a <a href="https://www.anhanga.tur.br/politica-privacidade/" target="_blank" rel="noopener noreferrer" className="underline hover:text-brand-vibrant">Política de Privacidade</a>.
+                Aceito receber comunicações e autorizo o tratamento dos meus dados conforme a <a href="/politica-privacidade/" target="_blank" rel="noopener noreferrer" className="underline hover:text-brand-vibrant">Política de Privacidade</a>.
               </span>
             </label>
             {fieldErrors.lgpd && <span className="text-[10px] text-red-500 font-bold ml-7 uppercase">{fieldErrors.lgpd}</span>}

--- a/components/blog/BlogPostHero.tsx
+++ b/components/blog/BlogPostHero.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { ArrowLeft, Tag, User, Calendar, Clock } from 'lucide-react';
 import { PostMeta } from '../../lib/mdx';
 import { optimizeRemoteImageUrl } from '../../data/mediaConfig';
@@ -28,9 +29,9 @@ export const BlogPostHero: React.FC<BlogPostHeroProps> = ({ post, authorName }) 
 
             <div className="absolute inset-0 flex items-end pb-14 pt-36 md:pb-16 md:pt-40 lg:pb-20 lg:pt-44">
                 <div className="container mx-auto px-6">
-                    <a href="https://www.anhanga.tur.br/" className="inline-flex items-center gap-2 text-white/80 hover:text-white mb-8 font-bold uppercase tracking-wider text-xs transition-colors backdrop-blur-sm bg-white/10 px-4 py-2 rounded-full w-fit hover:bg-white/20 border border-white/20">
+                    <Link to="/" className="inline-flex items-center gap-2 text-white/80 hover:text-white mb-8 font-bold uppercase tracking-wider text-xs transition-colors backdrop-blur-sm bg-white/10 px-4 py-2 rounded-full w-fit hover:bg-white/20 border border-white/20">
                         <ArrowLeft className="size-4" /> Voltar para o Blog
-                    </a>
+                    </Link>
                     <div className="max-w-3xl">
                         <div className="flex items-center gap-3 mb-6">
                             <span className={`inline-flex items-center gap-2 px-4 py-2 rounded-xl border-2 ${getCategoryColor(post.category)} shadow-[4px_4px_0px_rgba(0,0,0,0.3)] font-black text-xs uppercase tracking-widest transform -rotate-1`}>

--- a/components/landings/corporativo/CorpLgpdConsent.tsx
+++ b/components/landings/corporativo/CorpLgpdConsent.tsx
@@ -23,7 +23,7 @@ export function CorpLgpdConsent({ checked, onChange, error }: CorpLgpdConsentPro
                 <span className="text-xs text-zinc-500 leading-tight">
                     Aceito receber comunicações e autorizo o tratamento dos meus dados conforme a{' '}
                     <a
-                        href="https://www.anhanga.tur.br/politica-privacidade/"
+                        href="/politica-privacidade/"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="underline hover:text-brand-cyan"

--- a/components/landings/lollapalooza/WaitlistSection.tsx
+++ b/components/landings/lollapalooza/WaitlistSection.tsx
@@ -228,7 +228,7 @@ const WaitlistSection: React.FC = () => {
                   <span className="text-xs text-zinc-400 leading-snug group-hover:text-zinc-300 transition-colors">
                     Autorizo a Anhangá a me enviar novidades exclusivas conforme a{' '}
                     <a
-                      href="https://www.anhanga.tur.br/politica-privacidade/"
+                      href="/politica-privacidade/"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-white hover:text-anhanga-yellow underline underline-offset-4"

--- a/components/landings/shared/LandingFooter.tsx
+++ b/components/landings/shared/LandingFooter.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { BRAND_LOGO_BLUE_URL } from '@/lib/media-assets';
 import { triggerResetBanner } from '@/lib/consent';
 
@@ -15,12 +16,12 @@ export function LandingFooter() {
                 <p className="text-xs text-white/50 font-medium text-center">
                     ANHANGA TURISMO LTDA • CNPJ 37.036.732/0001-41
                 </p>
-                <a
-                    href="https://www.anhanga.tur.br/"
+                <Link
+                    to="/"
                     className="text-xs text-white/50 hover:text-white transition-colors duration-150 font-medium underline underline-offset-2"
                 >
                     Ir para o site principal →
-                </a>
+                </Link>
                 <button
                     type="button"
                     onClick={triggerResetBanner}

--- a/components/landings/shared/LandingNav.tsx
+++ b/components/landings/shared/LandingNav.tsx
@@ -1,4 +1,5 @@
 import { WhatsappLogo } from '@phosphor-icons/react';
+import { Link } from 'react-router-dom';
 import { BRAND_LOGO_BLUE_URL } from '@/lib/media-assets';
 import { openContactModal } from '@/utils/contactForm';
 
@@ -10,7 +11,7 @@ export function LandingNav({ source }: LandingNavProps) {
     return (
         <nav className="bg-white/90 backdrop-blur-md border-b border-zinc-100 sticky top-0 z-50 px-6 py-2">
             <div className="container mx-auto flex items-center justify-between">
-                <a href="https://www.anhanga.tur.br/" aria-label="Voltar para o site principal">
+                <Link to="/" aria-label="Voltar para o site principal">
                     <img
                         src={BRAND_LOGO_BLUE_URL}
                         alt="Anhangá Viagens"
@@ -18,7 +19,7 @@ export function LandingNav({ source }: LandingNavProps) {
                         height="83"
                         className="h-12 w-auto object-contain"
                     />
-                </a>
+                </Link>
                 <button
                     type="button"
                     onClick={() => openContactModal({ source })}

--- a/components/privacy/PrivacySection14Canais.tsx
+++ b/components/privacy/PrivacySection14Canais.tsx
@@ -9,7 +9,7 @@ export function PrivacySection14Canais() {
                     <strong>WhatsApp:</strong> <a href="https://wa.me/551152833309" className="text-primary underline" target="_blank" rel="noopener noreferrer">+55 (11) 5283-3309</a><br />
                     <strong>Instagram:</strong> <a href="https://instagram.com/anhangaviagens" className="text-primary underline" target="_blank" rel="noopener noreferrer">@anhangaviagens</a><br />
                     <strong>Facebook Messenger:</strong> Anhangá Viagens<br />
-                    <strong>Website:</strong> <a href="https://www.anhanga.tur.br/" target="_blank" rel="noopener noreferrer" className="text-primary underline">https://www.anhanga.tur.br/</a>
+                    <strong>Website:</strong> <a href="/" target="_blank" rel="noopener noreferrer" className="text-primary underline">https://www.anhanga.tur.br/</a>
                 </p>
             </div>
         </section>

--- a/pages/Terms.tsx
+++ b/pages/Terms.tsx
@@ -36,7 +36,7 @@ const Terms = () => {
                                 Os presentes Termos e Condições de Uso ("Termos") são estabelecidos pela <strong>Anhangá Turismo Ltda.</strong>,
                                 pessoa jurídica de direito privado, inscrita no CNPJ sob o nº <strong>37.036.732/0001-41</strong>, com sede em
                                 <em> Avenida Dom Pedro I, 773, Vila Monumento, São Paulo-SP</em> ("Anhangá Turismo", "Controladora" ou "nós"), que opera o website
-                                <a href="https://www.anhanga.tur.br/" target="_blank" rel="noopener noreferrer" className="text-primary underline"> https://www.anhanga.tur.br/</a>
+                                <a href="/" target="_blank" rel="noopener noreferrer" className="text-primary underline"> https://www.anhanga.tur.br/</a>
                                 e demais plataformas digitais correlatas.
                             </p>
                             <h3 className="font-merriweather font-semibold">1.2 Aceitação e Concordância</h3>
@@ -132,7 +132,7 @@ const Terms = () => {
                             <h3 className="font-merriweather font-semibold">6.1 Remissão à Política Específica</h3>
                             <p>
                                 O tratamento de dados pessoais é regulamentado por nossa <strong>Política de Privacidade e Proteção de Dados Pessoais</strong>,
-                                disponível em: <a href="https://www.anhanga.tur.br/politica-privacidade/" target="_blank" rel="noopener noreferrer" className="text-primary underline">https://www.anhanga.tur.br/politica-privacidade/</a>.
+                                disponível em: <a href="/politica-privacidade/" target="_blank" rel="noopener noreferrer" className="text-primary underline">https://www.anhanga.tur.br/politica-privacidade/</a>.
                             </p>
                             <h3 className="font-merriweather font-semibold">6.2 Bases Legais do Tratamento</h3>
                             <ul className="list-disc pl-6 space-y-1">
@@ -255,7 +255,7 @@ const Terms = () => {
                             <p><strong>E-mail Geral:</strong> privacidade@anhanga.tur.br<br />
                                 <strong>WhatsApp Business:</strong> +55 (11) 5283-3309<br />
                                 <strong>Instagram:</strong> <a href="https://instagram.com/anhangaviagens" target="_blank" rel="noopener noreferrer" className="text-primary underline">@anhangaviagens</a><br />
-                                <strong>Website:</strong> <a href="https://www.anhanga.tur.br/" target="_blank" rel="noopener noreferrer" className="text-primary underline">https://www.anhanga.tur.br/</a></p>
+                                <strong>Website:</strong> <a href="/" target="_blank" rel="noopener noreferrer" className="text-primary underline">https://www.anhanga.tur.br/</a></p>
                             <h3 className="font-merriweather font-semibold">14.3 Atendimento</h3>
                             <p>Nossos canais funcionam em horário comercial, com compromisso de resposta em até 5 dias úteis para questões relacionadas a estes Termos.</p>
                         </div>

--- a/pages/landings/BetoCarreroLanding.tsx
+++ b/pages/landings/BetoCarreroLanding.tsx
@@ -52,9 +52,9 @@ const BetoCarreroLanding: React.FC = () => {
       <FAQPageSchema items={BETO_FAQ_ITEMS} />
       <div className="bg-brand-surface py-2 border-b border-zinc-100">
         <div className="container mx-auto px-6">
-          <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1">
+          <Link to="/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1">
             ← Voltar para o site principal
-          </a>
+          </Link>
         </div>
       </div>
 
@@ -97,9 +97,9 @@ const BetoCarreroLanding: React.FC = () => {
             >
               Falar com especialista
             </button>
-            <a href="https://www.anhanga.tur.br/orlando/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <Link to="/orlando/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ver pacotes para Orlando
-            </a>
+            </Link>
             <a href="/blog/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ver dicas de planejamento
             </a>

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -322,8 +322,8 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                 Escolha o navio e a cabine certos para você
               </div>
             </Link>
-            <a
-              href="https://www.anhanga.tur.br/"
+            <Link
+              to="/"
               className="block p-5 rounded-xl bg-brand-surface hover:bg-anhanga-blue/5 transition-colors group"
             >
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
@@ -332,7 +332,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               <div className="text-sm text-zinc-600 mt-1">
                 Conheça todos os serviços da Anhangá
               </div>
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/pages/landings/CorporativoLanding.tsx
+++ b/pages/landings/CorporativoLanding.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { Seo } from '@/components/Seo';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { CorpNav } from '@/components/landings/corporativo/CorpNav';
@@ -44,15 +45,15 @@ const CorporativoLanding: React.FC = () => {
                     <div className="container mx-auto px-6 text-center">
                         <p className="text-sm text-zinc-500 font-medium mb-4">Conheça também</p>
                         <div className="flex flex-wrap justify-center gap-3">
-                            <a href="https://www.anhanga.tur.br/consultoria-de-viagem/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+                            <Link to="/consultoria-de-viagem/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
                                 Consultoria de Viagem
-                            </a>
-                            <a href="https://www.anhanga.tur.br/melhor-idade/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+                            </Link>
+                            <Link to="/melhor-idade/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
                                 Viagens Melhor Idade
-                            </a>
-                            <a href="https://www.anhanga.tur.br/curadoria-cruzeiros-brasil/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+                            </Link>
+                            <Link to="/curadoria-cruzeiros-brasil/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
                                 Cruzeiros pelo Brasil
-                            </a>
+                            </Link>
                         </div>
                     </div>
                 </nav>

--- a/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
+++ b/pages/landings/CuradoriaCruzeirosBrasilLanding.tsx
@@ -338,8 +338,8 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
                 Planejamento com precisão para profissionais
               </div>
             </Link>
-            <a
-              href="https://www.anhanga.tur.br/"
+            <Link
+              to="/"
               className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
             >
               <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
@@ -348,7 +348,7 @@ const CuradoriaCruzeirosBrasilLanding: React.FC = () => {
               <div className="text-sm text-zinc-600 mt-1">
                 Conheça todos os serviços da Anhangá
               </div>
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/pages/landings/LollapaloozaLanding.tsx
+++ b/pages/landings/LollapaloozaLanding.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Seo } from '../../components/Seo';
 import { LandingFAQ } from '../../components/LandingFAQ';
 import LollapaloozaApp from '../../components/landings/lollapalooza/LollapaloozaApp';
@@ -54,9 +55,9 @@ const LollapaloozaLanding: React.FC = () => {
       <FAQPageSchema items={LOLLAPALOOZA_FAQ_ITEMS} />
       <div className="bg-brand-surface py-2 border-b border-zinc-100 relative z-[60]">
         <div className="container mx-auto px-6">
-          <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1 font-sans">
+          <Link to="/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1 font-sans">
             ← Voltar para o site principal
-          </a>
+          </Link>
         </div>
       </div>
 
@@ -78,9 +79,9 @@ const LollapaloozaLanding: React.FC = () => {
           </p>
           <p className="text-zinc-700 text-lg leading-relaxed mb-5">
             Se você quer chegar antes da próxima abertura, entre na <strong>Lista de Espera Lolla 2027</strong>. A <strong>Anhangá Viagens</strong> é uma{' '}
-            <a href="https://www.anhanga.tur.br/" className="text-brand-cyan font-semibold hover:underline">
+            <Link to="/" className="text-brand-cyan font-semibold hover:underline">
               agência de viagens em São Paulo
-            </a>{' '}
+            </Link>{' '}
             com foco em atendimento consultivo e <strong>viagens personalizadas</strong>, do planejamento inicial ao suporte no destino.
           </p>
           <h3 className="text-xl md:text-2xl font-extrabold text-brand-dark mb-3">O que segue valendo para quem quer ir ao festival</h3>
@@ -113,12 +114,12 @@ const LollapaloozaLanding: React.FC = () => {
             >
               Falar com especialista
             </button>
-            <a href="https://www.anhanga.tur.br/orlando/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <Link to="/orlando/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ver pacotes para Orlando
-            </a>
-            <a href="https://www.anhanga.tur.br/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            </Link>
+            <Link to="/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Conhecer a Anhangá Viagens
-            </a>
+            </Link>
             <a href="/blog/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ler guia de festivais
             </a>

--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -212,15 +212,15 @@ const MelhorIdadeLanding: React.FC = () => {
             Falar com um Consultor
           </button>
           <div className="flex flex-wrap justify-center gap-3 mt-8 relative z-10">
-            <a href="https://www.anhanga.tur.br/curadoria-cruzeiros-brasil/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
+            <Link to="/curadoria-cruzeiros-brasil/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
               Cruzeiros pelo Brasil
-            </a>
-            <a href="https://www.anhanga.tur.br/consultoria-de-viagem/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
+            </Link>
+            <Link to="/consultoria-de-viagem/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
               Consultoria de Viagem
-            </a>
-            <a href="https://www.anhanga.tur.br/blog/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
+            </Link>
+            <Link to="/blog/" className="px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white font-semibold hover:bg-white/20 transition-colors">
               Dicas de Viagem
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/pages/landings/OrlandoLanding.tsx
+++ b/pages/landings/OrlandoLanding.tsx
@@ -57,9 +57,9 @@ const OrlandoLanding: React.FC = () => {
       <FAQPageSchema items={ORLANDO_FAQ_ITEMS} />
       <div className="bg-brand-surface py-2 border-b border-zinc-100 relative z-[60]">
         <div className="container mx-auto px-6">
-          <a href="https://www.anhanga.tur.br/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1 font-sans">
+          <Link to="/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1 font-sans">
             ← Voltar para o site principal
-          </a>
+          </Link>
         </div>
       </div>
 
@@ -102,9 +102,9 @@ const OrlandoLanding: React.FC = () => {
             >
               Falar com especialista
             </button>
-            <a href="https://www.anhanga.tur.br/beto-carrero/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <Link to="/beto-carrero/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ver pacote Beto Carrero
-            </a>
+            </Link>
             <a href="/blog/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
               Ler dicas no blog
             </a>

--- a/tests/e2e/landing-spa-navigation.spec.ts
+++ b/tests/e2e/landing-spa-navigation.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Landing SPA navigation', () => {
+  test('LandingNav "Voltar para o site principal" navigates client-side to home', async ({ page }) => {
+    await page.goto('/beto-carrero/');
+
+    // Sanity: still on the landing page before clicking.
+    await expect(page).toHaveURL(/\/beto-carrero\/?$/);
+
+    const homeLink = page.getByRole('link', { name: 'Voltar para o site principal' });
+    await expect(homeLink).toHaveAttribute('href', '/');
+
+    // The landing's own sticky nav visually overlaps this top bar; the link
+    // remains a real, interactive element, so a forced click is appropriate here.
+    await homeLink.click({ force: true });
+
+    // SPA navigation should land on the same host's root without a full reload
+    // to an absolute production URL (react-router <Link> keeps the test's own host).
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator('body')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Resumo

Item do backlog (`TODO.MD`, "Técnico & Performance") — plano `plans/004`:

Converte `<a href="https://www.anhanga.tur.br/...">` usados para navegação **interna** em:
- `<Link>` do react-router (navegação interna normal: `LandingNav`, `LandingFooter` e links das landings) → navegação SPA, sem full reload
- href **relativo** mantendo `<a>` para links `target="_blank"` (política de privacidade) e para o texto exibido em `Terms.tsx`/`PrivacySection14Canais.tsx` (a URL visível é copy intencional — só o `href` muda)

Fora de escopo (intocado): URLs canônicas/JSON-LD/SEO, WhatsApp/CTAs externas. Trailing slashes preservados.

## Testes

- `pnpm typecheck` → exit 0
- `pnpm build` (+ prerender de 38 rotas) → exit 0
- `grep` de URLs absolutas internas em `components`/`pages` → vazio
- Novo spec `tests/e2e/landing-spa-navigation.spec.ts` (passou em chromium + Mobile Chrome)

⚠️ **Antes de mergear**: rodar `pnpm test:e2e` completo localmente (firefox/webkit/Mobile Safari + suítes corporativo/lollapalooza) — o ambiente de execução não tinha todos os binários do Playwright nem `.env`. A falha de visual regression na home é **pré-existente na main** (não relacionada a esta mudança).

🤖 Generated with [Claude Code](https://claude.com/claude-code)