### PR TITLE
fix(ai): rejeitar markdown e URLs em campos de destino do handoff

### DIFF
--- a/lib/ai/validation.ts
+++ b/lib/ai/validation.ts
@@ -25,6 +25,12 @@ export function normalizeChildAges(value: unknown): number[] {
     });
 }
 
+const LINKY_PATTERN = /\[[^\]]*\]\([^)]*\)|https?:\/\/|wa\.me|\bwww\./i;
+
+function isPlainTextLocation(value: string): boolean {
+    return value.length > 0 && !LINKY_PATTERN.test(value);
+}
+
 export function isCityValueAcceptable(value?: string): boolean {
     if (!value) return false;
 
@@ -149,12 +155,17 @@ function buildInvalidBudgetResult(missing: string[], safetyBlock?: SafetyBlock):
     };
 }
 
+function rejectLinkyLocation(value: string): string {
+    return isPlainTextLocation(value) ? value : '';
+}
+
 function sanitizeBudgetFields(raw: BudgetToolArgs) {
-    const destinationCity = cleanString(raw.destination_city);
-    const destinationRegion = cleanString(raw.destination_region);
-    const originCity = cleanString(raw.origin_city);
+    const destinationCity = rejectLinkyLocation(cleanString(raw.destination_city));
+    const destinationRegion = rejectLinkyLocation(cleanString(raw.destination_region));
+    const originCity = rejectLinkyLocation(cleanString(raw.origin_city));
     const providedOriginRegion = cleanString(raw.origin_region);
-    const destination = cleanString(raw.destination) || [destinationCity, destinationRegion].filter(Boolean).join(', ');
+    const rawDestination = rejectLinkyLocation(cleanString(raw.destination));
+    const destination = rawDestination || [destinationCity, destinationRegion].filter(Boolean).join(', ');
 
     return {
         destination,

--- a/lib/ai/validation.ts
+++ b/lib/ai/validation.ts
@@ -163,7 +163,7 @@ function sanitizeBudgetFields(raw: BudgetToolArgs) {
     const destinationCity = rejectLinkyLocation(cleanString(raw.destination_city));
     const destinationRegion = rejectLinkyLocation(cleanString(raw.destination_region));
     const originCity = rejectLinkyLocation(cleanString(raw.origin_city));
-    const providedOriginRegion = cleanString(raw.origin_region);
+    const providedOriginRegion = rejectLinkyLocation(cleanString(raw.origin_region));
     const rawDestination = rejectLinkyLocation(cleanString(raw.destination));
     const destination = rawDestination || [destinationCity, destinationRegion].filter(Boolean).join(', ');
 

--- a/tests/ai-validation-plain-text.test.ts
+++ b/tests/ai-validation-plain-text.test.ts
@@ -94,3 +94,15 @@ test('validateBudgetToolArgs rejects markdown in origin_city', () => {
     assert.equal(result.valid, false);
     assert.ok(result.missing.includes('origin_city'));
 });
+
+test('validateBudgetToolArgs sanitizes markdown links in origin_region to default Brasil', () => {
+    const result = validateBudgetToolArgs(
+        buildValidArgs({
+            origin_region: '[clique aqui](https://attacker.example)',
+        }),
+    );
+
+    assert.equal(result.valid, true);
+    assert.equal(result.normalizedArgs?.origin_region, 'Brasil');
+    assert.equal(result.normalizedArgs?.assumed_origin_br, true);
+});

--- a/tests/ai-validation-plain-text.test.ts
+++ b/tests/ai-validation-plain-text.test.ts
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateBudgetToolArgs } from '../lib/ai/validation.ts';
+import type { BudgetToolArgs } from '../lib/ai/types.ts';
+
+function buildValidArgs(overrides: Partial<BudgetToolArgs>): BudgetToolArgs {
+    return {
+        destination: 'Orlando',
+        destination_city: 'Orlando',
+        destination_region: 'Flórida',
+        origin_city: 'São Paulo',
+        origin_region: 'SP',
+        dates: 'junho de 2026',
+        adults: 2,
+        need_summary: 'Viagem em família',
+        decision_role: 'casal',
+        budget_range: 'R$ 20 mil+',
+        timeline_window: 'junho de 2026',
+        baggage_preference: 'bagagem despachada',
+        trip_scope: 'international',
+        ...overrides,
+    };
+}
+
+test('validateBudgetToolArgs rejects markdown links in destination', () => {
+    const result = validateBudgetToolArgs(
+        buildValidArgs({
+            destination: 'Paris [clique aqui](https://attacker.example)',
+            destination_city: 'Paris [clique aqui](https://attacker.example)',
+            destination_region: '',
+        }),
+    );
+
+    assert.equal(result.valid, false);
+    assert.ok(result.missing.includes('destination_city'));
+});
+
+test('validateBudgetToolArgs rejects raw URLs in destination', () => {
+    const result = validateBudgetToolArgs(
+        buildValidArgs({
+            destination: 'Paris http://attacker.example',
+            destination_city: 'Paris http://attacker.example',
+            destination_region: '',
+        }),
+    );
+
+    assert.equal(result.valid, false);
+    assert.ok(result.missing.includes('destination_city'));
+});
+
+test('validateBudgetToolArgs rejects wa.me links in destination', () => {
+    const result = validateBudgetToolArgs(
+        buildValidArgs({
+            destination: 'Confira wa.me/5511999999999',
+            destination_city: 'Confira wa.me/5511999999999',
+            destination_region: '',
+        }),
+    );
+
+    assert.equal(result.valid, false);
+    assert.ok(result.missing.includes('destination_city'));
+});
+
+test('validateBudgetToolArgs accepts a legitimate destination', () => {
+    const result = validateBudgetToolArgs(buildValidArgs({}));
+
+    assert.equal(result.valid, true);
+    assert.ok(!result.missing.includes('destination_city'));
+});
+
+test('validateBudgetToolArgs accepts accented and hyphenated city names', () => {
+    const result = validateBudgetToolArgs(
+        buildValidArgs({
+            destination: 'São João del-Rei',
+            destination_city: 'São João del-Rei',
+            destination_region: '',
+            trip_scope: 'national',
+            origin_region: 'Brasil',
+            baggage_preference: '',
+        }),
+    );
+
+    assert.equal(result.valid, true);
+    assert.ok(!result.missing.includes('destination_city'));
+});
+
+test('validateBudgetToolArgs rejects markdown in origin_city', () => {
+    const result = validateBudgetToolArgs(
+        buildValidArgs({
+            origin_city: '[São Paulo](https://attacker.example)',
+        }),
+    );
+
+    assert.equal(result.valid, false);
+    assert.ok(result.missing.includes('origin_city'));
+});


### PR DESCRIPTION
## Resumo

Hardening da borda de validação do chatbot (plano `plans/005`):

O tool call `generate_budget_link` do Gemini deriva campos (destino, cidade, origem) de texto do usuário. `cleanString()` escapa HTML mas **não** rejeita markdown (`[texto](url)`), URLs ou `wa.me` embutidos. Esses valores poderiam fluir para a mensagem de handoff e o payload de lead.

Esta mudança adiciona `LINKY_PATTERN`/`isPlainTextLocation` em `lib/ai/validation.ts`: campos de cidade/região/destino com sintaxe "linky" viram string vazia, reaproveitando o fluxo de refinamento existente (`collectMissingBudgetFields` os trata como ausentes e pede o dado de novo). **Sem mudança no shape de retorno**; o strip de links WhatsApp em `api/generate.ts` permanece como defesa em profundidade.

## Testes

- `pnpm typecheck` → exit 0
- `pnpm test:regression` → 632 testes, 0 falhas (6 novos em `tests/ai-validation-plain-text.test.ts`, incluindo regressão de falso-positivo "São João del-Rei")

🤖 Generated with [Claude Code](https://claude.com/claude-code)