### PR TITLE
fix(security): restringir links do markdown da IA a allowlist no chat

### DIFF
--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -16,6 +16,7 @@ import { PassportStamp } from './ui/PassportStamp';
 import { ChatLeadForm, type LeadFinalizePayload, type LeadFinalizeResult } from './ChatLeadForm';
 import type { SubmitLeadRequest } from '../types/leadCapture';
 import { triggerHaptic } from '../utils/haptics';
+import { sanitizeAiLinkUrl } from '../lib/ai/safe-link';
 
 interface Message {
   id: string;
@@ -540,7 +541,19 @@ const AIChat: React.FC = memo(() => {
                       }`}>
                       {msg.role === 'model' ? (
                         <div className="prose prose-sm max-w-none prose-p:text-zinc-700 prose-p:leading-relaxed prose-strong:text-zinc-900 prose-strong:font-bold prose-ul:text-zinc-700">
-                          <ReactMarkdown>{msg.text}</ReactMarkdown>
+                          <ReactMarkdown
+                            urlTransform={sanitizeAiLinkUrl}
+                            components={{
+                              a: ({ href, children, ...props }) =>
+                                href ? (
+                                  <a href={href} rel="noopener noreferrer" {...props}>{children}</a>
+                                ) : (
+                                  <span>{children}</span>
+                                ),
+                            }}
+                          >
+                            {msg.text}
+                          </ReactMarkdown>
                         </div>
                       ) : (
                         <div className="text-white font-medium leading-relaxed max-w-[300px] break-words">

--- a/components/AIChat.tsx
+++ b/components/AIChat.tsx
@@ -544,12 +544,22 @@ const AIChat: React.FC = memo(() => {
                           <ReactMarkdown
                             urlTransform={sanitizeAiLinkUrl}
                             components={{
-                              a: ({ href, children, ...props }) =>
-                                href ? (
-                                  <a href={href} rel="noopener noreferrer" {...props}>{children}</a>
-                                ) : (
-                                  <span>{children}</span>
-                                ),
+                              a: ({ href, children, ...props }) => {
+                                if (!href) return <span>{children}</span>;
+                                // Internal SPA links stay in-tab; external (allowlisted)
+                                // links open in a new tab to preserve chat state.
+                                const isInternal = href.startsWith('/') && !href.startsWith('//');
+                                return (
+                                  <a
+                                    href={href}
+                                    rel="noopener noreferrer"
+                                    target={isInternal ? undefined : '_blank'}
+                                    {...props}
+                                  >
+                                    {children}
+                                  </a>
+                                );
+                              },
                             }}
                           >
                             {msg.text}

--- a/lib/ai/safe-link.ts
+++ b/lib/ai/safe-link.ts
@@ -7,7 +7,9 @@ const ANHANGA_SUBDOMAIN_SUFFIX = `.${ANHANGA_HOSTNAME}`;
  * that tries to render phishing links inside the branded chat UI.
  */
 export function sanitizeAiLinkUrl(url: string): string {
-  if (url.startsWith('/') || url.startsWith('#')) {
+  // Reject protocol-relative URLs (`//evil.com`): they start with `/` but
+  // resolve to an external origin, bypassing the host allowlist below.
+  if ((url.startsWith('/') && !url.startsWith('//')) || url.startsWith('#')) {
     return url;
   }
 

--- a/lib/ai/safe-link.ts
+++ b/lib/ai/safe-link.ts
@@ -1,0 +1,33 @@
+const ANHANGA_HOSTNAME = 'anhanga.tur.br';
+const ANHANGA_SUBDOMAIN_SUFFIX = `.${ANHANGA_HOSTNAME}`;
+
+/**
+ * Restricts links rendered from AI-generated markdown to an allowlist.
+ * Used as react-markdown's `urlTransform` to defend against prompt-injection
+ * that tries to render phishing links inside the branded chat UI.
+ */
+export function sanitizeAiLinkUrl(url: string): string {
+  if (url.startsWith('/') || url.startsWith('#')) {
+    return url;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return '';
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return '';
+  }
+
+  const isAnhangaHost =
+    parsed.hostname === ANHANGA_HOSTNAME || parsed.hostname.endsWith(ANHANGA_SUBDOMAIN_SUFFIX);
+
+  if (!isAnhangaHost) {
+    return '';
+  }
+
+  return url;
+}

--- a/tests/ai-markdown-links.test.ts
+++ b/tests/ai-markdown-links.test.ts
@@ -41,6 +41,10 @@ test('blocks lookalike subdomains that are actually other domains', () => {
   assert.equal(sanitizeAiLinkUrl('https://anhanga.tur.br.evil.com'), '');
 });
 
+test('blocks protocol-relative URLs', () => {
+  assert.equal(sanitizeAiLinkUrl('//evil.com'), '');
+});
+
 test('blocks unparseable strings', () => {
   assert.equal(sanitizeAiLinkUrl('not a url'), '');
 });

--- a/tests/ai-markdown-links.test.ts
+++ b/tests/ai-markdown-links.test.ts
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sanitizeAiLinkUrl } from '../lib/ai/safe-link';
+
+test('allows internal relative links', () => {
+  assert.equal(sanitizeAiLinkUrl('/blog'), '/blog');
+});
+
+test('allows internal anchors', () => {
+  assert.equal(sanitizeAiLinkUrl('#secao'), '#secao');
+});
+
+test('allows https links to www.anhanga.tur.br', () => {
+  assert.equal(
+    sanitizeAiLinkUrl('https://www.anhanga.tur.br/consultoria'),
+    'https://www.anhanga.tur.br/consultoria',
+  );
+});
+
+test('allows https links to anhanga.tur.br', () => {
+  assert.equal(sanitizeAiLinkUrl('https://anhanga.tur.br/x'), 'https://anhanga.tur.br/x');
+});
+
+test('blocks links to other domains', () => {
+  assert.equal(sanitizeAiLinkUrl('https://phishing.example/login'), '');
+});
+
+test('blocks http (non-https) links to anhanga.tur.br', () => {
+  assert.equal(sanitizeAiLinkUrl('http://anhanga.tur.br'), '');
+});
+
+test('blocks javascript: links', () => {
+  assert.equal(sanitizeAiLinkUrl('javascript:alert(1)'), '');
+});
+
+test('blocks data: links', () => {
+  assert.equal(sanitizeAiLinkUrl('data:text/html,...'), '');
+});
+
+test('blocks lookalike subdomains that are actually other domains', () => {
+  assert.equal(sanitizeAiLinkUrl('https://anhanga.tur.br.evil.com'), '');
+});
+
+test('blocks unparseable strings', () => {
+  assert.equal(sanitizeAiLinkUrl('not a url'), '');
+});


### PR DESCRIPTION
## O que

Restringe os links renderizados a partir do markdown do modelo Gemini no chat (`AIChat.tsx`) a uma allowlist, como defesa-em-profundidade contra phishing via prompt injection / jailbreak.

O `react-markdown` v10 bloqueia `javascript:`/`data:` por padrão, mas **permite links http(s) para qualquer domínio**. Um modelo confundido por input adversarial poderia emitir `[clique aqui](https://phishing.example)` renderizado como link clicável dentro da interface de marca da Anhangá. O texto legítimo do bot é conselho de viagem PT-BR + CTAs internos — não precisa de links externos arbitrários.

## Como

- **`lib/ai/safe-link.ts`** (novo) — helper puro `sanitizeAiLinkUrl(url)`:
  - aceita links relativos internos (`/...`, `#...`)
  - aceita URLs absolutas **apenas** se `https:` e hostname `anhanga.tur.br` ou subdomínio
  - qualquer outra coisa → `''` (neutraliza o href)
- **`components/AIChat.tsx`** — `<ReactMarkdown urlTransform={sanitizeAiLinkUrl}>` + override do componente `a` com `rel="noopener noreferrer"`
- **`tests/ai-markdown-links.test.ts`** (novo) — 10 casos, incluindo o lookalike `anhanga.tur.br.evil.com`

## Verificação

- `pnpm typecheck` → exit 0
- `pnpm test:regression` → 651/651 (10 testes novos)

## Notas

- Se a agência passar a usar links de afiliados/parceiros no chat, estender `sanitizeAiLinkUrl` com allowlist explícita — nunca reabrir para `*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)