### PR TITLE
refactor(api): extrair helper de resposta JSON dos handlers submit-*

### DIFF
--- a/api/submit-contact.ts
+++ b/api/submit-contact.ts
@@ -1,9 +1,8 @@
 import type {
     SubmitContactErrorCode,
     SubmitContactRequest,
-    SubmitContactResponse,
 } from '../types/contactCapture';
-import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
+import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import {
     cleanString,
@@ -35,23 +34,6 @@ function getContactConfig(): ContactConfig | null {
     const webhookSecret = process.env.N8N_WEBHOOK_SECRET?.trim() || '';
     if (!webhookUrl || !webhookSecret) return null;
     return { webhookUrl, webhookSecret };
-}
-
-function buildJsonResponse(
-    body: SubmitContactResponse,
-    status: number,
-    corsHeaders: Record<string, string>,
-): Response {
-    const requestId =
-        'requestId' in body && typeof body.requestId === 'string' ? body.requestId : undefined;
-    return new Response(JSON.stringify(body), {
-        status,
-        headers: {
-            'Content-Type': 'application/json',
-            ...(requestId ? { 'X-Request-Id': requestId } : {}),
-            ...corsHeaders,
-        },
-    });
 }
 
 async function getRateLimitResponse(

--- a/api/submit-lead-sf.ts
+++ b/api/submit-lead-sf.ts
@@ -1,4 +1,4 @@
-import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
+import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import { cleanString, normalizeWhatsappNumber, maskEmail } from '../lib/lead-logic';
 import { logger } from '../lib/logger';
@@ -25,17 +25,6 @@ const VALID_LEAD_SOURCES = new Set([
     'Word of mouth',
     'Other',
 ]);
-
-function buildJsonResponse(
-    body: Record<string, unknown>,
-    status: number,
-    corsHeaders: Record<string, string>,
-): Response {
-    return new Response(JSON.stringify(body), {
-        status,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-}
 
 const UTM_VALUE_MAX_LENGTH = 255;
 
@@ -124,7 +113,7 @@ export default async function handler(request: Request): Promise<Response> {
     }
 
     if (request.method !== 'POST') {
-        return buildJsonResponse({ ok: false, requestId, error: 'Method not allowed' }, 405, corsHeaders);
+        return buildJsonResponse({ ok: false, requestId, error: 'Method not allowed' }, 405, corsHeaders, { requestId: null });
     }
 
     const clientIP = getClientIP(request);
@@ -136,12 +125,13 @@ export default async function handler(request: Request): Promise<Response> {
 
     if (!rateLimit.allowed) {
         if (rateLimit.serviceUnavailable) {
-            return buildJsonResponse({ ok: false, requestId, error: 'Serviço temporariamente indisponível.' }, 503, corsHeaders);
+            return buildJsonResponse({ ok: false, requestId, error: 'Serviço temporariamente indisponível.' }, 503, corsHeaders, { requestId: null });
         }
         return buildJsonResponse(
             { ok: false, requestId, error: 'Muitas tentativas. Tente novamente em breve.' },
             429,
             { ...corsHeaders, 'Retry-After': String(Math.ceil(rateLimit.resetIn / 1000)) },
+            { requestId: null },
         );
     }
 
@@ -149,12 +139,12 @@ export default async function handler(request: Request): Promise<Response> {
     try {
         rawBody = await request.json();
     } catch {
-        return buildJsonResponse({ ok: false, requestId, error: 'JSON inválido.' }, 400, corsHeaders);
+        return buildJsonResponse({ ok: false, requestId, error: 'JSON inválido.' }, 400, corsHeaders, { requestId: null });
     }
 
     const validation = validateSfLeadBody(rawBody);
     if (!validation.valid) {
-        return buildJsonResponse({ ok: false, requestId, error: validation.error }, 400, corsHeaders);
+        return buildJsonResponse({ ok: false, requestId, error: validation.error }, 400, corsHeaders, { requestId: null });
     }
 
     const fields = validation.data;
@@ -171,11 +161,11 @@ export default async function handler(request: Request): Promise<Response> {
 
         if (!result.ok) {
             logger.error('SUBMIT_LEAD_SF', { requestId, stage: 'sf_rejected' });
-            return buildJsonResponse({ ok: false, requestId, error: 'Falha ao enviar para Salesforce.' }, 502, corsHeaders);
+            return buildJsonResponse({ ok: false, requestId, error: 'Falha ao enviar para Salesforce.' }, 502, corsHeaders, { requestId: null });
         }
 
         logger.info('SUBMIT_LEAD_SF', { requestId, stage: 'success' });
-        return buildJsonResponse({ ok: true, requestId }, 201, corsHeaders);
+        return buildJsonResponse({ ok: true, requestId }, 201, corsHeaders, { requestId: null });
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
         const isTimeout = error instanceof Error && error.name === 'AbortError';
@@ -190,6 +180,7 @@ export default async function handler(request: Request): Promise<Response> {
             { ok: false, requestId, error: 'Erro ao processar envio para Salesforce.' },
             isTimeout ? 504 : 500,
             corsHeaders,
+            { requestId: null },
         );
     }
 }

--- a/api/submit-lead.ts
+++ b/api/submit-lead.ts
@@ -1,5 +1,5 @@
-import type { SubmitLeadRequest, SubmitLeadResponse } from '../types/leadCapture';
-import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
+import type { SubmitLeadRequest } from '../types/leadCapture';
+import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import { cleanString, maskEmail, maskName, maskPhone, validatePayload } from '../lib/lead-logic';
 import { logger } from '../lib/logger';
@@ -45,25 +45,6 @@ function emitLeadLog(level: LeadLogLevel, requestId: string, stage: string, deta
     }
 
     logger.info('SUBMIT_LEAD', payload);
-}
-
-function buildJsonResponse(
-    body: SubmitLeadResponse,
-    status: number,
-    corsHeaders: Record<string, string>,
-): Response {
-    const requestId = typeof body === 'object' && body && 'requestId' in body && typeof body.requestId === 'string'
-        ? body.requestId
-        : undefined;
-
-    return new Response(JSON.stringify(body), {
-        status,
-        headers: {
-            'Content-Type': 'application/json',
-            ...(requestId ? { 'X-Request-Id': requestId } : {}),
-            ...corsHeaders,
-        },
-    });
 }
 
 // getClientIP falls back to 'unknown' when no edge header is present. Meta CAPI

--- a/api/submit-nps.ts
+++ b/api/submit-nps.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
+import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import { cleanString, maskEmail } from '../lib/lead-logic';
 import { logger } from '../lib/logger';
@@ -14,22 +14,6 @@ export const config = {
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 3;
 const N8N_WEBHOOK_ERROR_PATTERN = /^N8N_WEBHOOK_ERROR:(\d{3}):/;
-
-function buildJsonResponse(
-  body: unknown,
-  status: number,
-  corsHeaders: Record<string, string>,
-  requestId?: string,
-): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(requestId ? { 'X-Request-Id': requestId } : {}),
-      ...corsHeaders,
-    },
-  });
-}
 
 function mapNpsZodError(error: z.ZodError): string {
   const issue = error.issues[0];
@@ -66,7 +50,6 @@ export default async function handler(request: Request): Promise<Response> {
       { ok: false, requestId, code: 'METHOD_NOT_ALLOWED', error: 'Method not allowed' },
       405,
       corsHeaders,
-      requestId,
     );
   }
 
@@ -78,7 +61,6 @@ export default async function handler(request: Request): Promise<Response> {
       { ok: false, requestId, code: 'SERVER_CONFIG_ERROR', error: 'Serviço de NPS indisponível no momento.' },
       500,
       corsHeaders,
-      requestId,
     );
   }
 
@@ -96,7 +78,6 @@ export default async function handler(request: Request): Promise<Response> {
         { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
         503,
         corsHeaders,
-        requestId,
       );
     }
 
@@ -120,7 +101,6 @@ export default async function handler(request: Request): Promise<Response> {
         'X-RateLimit-Remaining': String(rateLimit.remaining),
         'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimit.resetIn) / 1000)),
       },
-      requestId,
     );
   }
 
@@ -132,7 +112,6 @@ export default async function handler(request: Request): Promise<Response> {
       { ok: false, requestId, code: 'VALIDATION_ERROR', error: 'JSON inválido no corpo da requisição.' },
       400,
       corsHeaders,
-      requestId,
     );
   }
 
@@ -142,7 +121,6 @@ export default async function handler(request: Request): Promise<Response> {
       { ok: false, requestId, code: 'VALIDATION_ERROR', error: mapNpsZodError(parsed.error) },
       400,
       corsHeaders,
-      requestId,
     );
   }
 
@@ -180,7 +158,6 @@ export default async function handler(request: Request): Promise<Response> {
       },
       status,
       corsHeaders,
-      requestId,
     );
   }
 
@@ -189,6 +166,5 @@ export default async function handler(request: Request): Promise<Response> {
     { ok: true, requestId, message: 'Avaliação registrada com sucesso.' },
     201,
     corsHeaders,
-    requestId,
   );
 }

--- a/api/submit-quiz.ts
+++ b/api/submit-quiz.ts
@@ -1,5 +1,5 @@
-import type { SubmitQuizRequest, SubmitQuizResponse } from '../types/quiz';
-import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
+import type { SubmitQuizRequest } from '../types/quiz';
+import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import { logger } from '../lib/logger';
 import { cleanString, maskEmail, maskName, maskPhone } from '../lib/lead-logic';
@@ -44,17 +44,6 @@ function emitQuizLog(level: QuizLogLevel, requestId: string, stage: string, deta
     }
 
     logger.info('SUBMIT_QUIZ', payload);
-}
-
-function buildJsonResponse(body: SubmitQuizResponse, status: number, corsHeaders: Record<string, string>): Response {
-    return new Response(JSON.stringify(body), {
-        status,
-        headers: {
-            'Content-Type': 'application/json',
-            'X-Request-Id': body.requestId,
-            ...corsHeaders,
-        },
-    });
 }
 
 function getSubmitQuizConfig(): SubmitQuizConfig | null {
@@ -151,7 +140,6 @@ export default async function handler(request: Request): Promise<Response> {
                 requestId,
                 error: 'Muitas tentativas. Aguarde um momento.',
                 code: 'RATE_LIMIT_EXCEEDED',
-                // @ts-expect-error - retryAfter is used by discovery schemas but not in strict response type
                 retryAfter: retryAfterSec,
             },
             429,

--- a/api/submit-waitlist.ts
+++ b/api/submit-waitlist.ts
@@ -1,5 +1,5 @@
-import type { SubmitWaitlistRequest, SubmitWaitlistResponse } from '../types/waitlist';
-import { buildCorsHeaders, createRequestId, getClientIP } from '../lib/network';
+import type { SubmitWaitlistRequest } from '../types/waitlist';
+import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import { cleanString } from '../lib/lead-logic';
 import { buildN8nWaitlistPayload } from '../lib/n8n-payloads';
@@ -23,17 +23,6 @@ function truncateDetail(detail: string): string | undefined {
     if (!trimmed) return undefined;
 
     return trimmed.slice(0, 200);
-}
-
-function buildJsonResponse(body: SubmitWaitlistResponse, status: number, corsHeaders: Record<string, string>): Response {
-    return new Response(JSON.stringify(body), {
-        status,
-        headers: {
-            'Content-Type': 'application/json',
-            'X-Request-Id': body.requestId,
-            ...corsHeaders,
-        },
-    });
 }
 
 function getSubmitWaitlistConfig(): SubmitWaitlistConfig | null {

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -59,8 +59,8 @@ export function buildCorsHeaders(allowedOrigin?: string): Record<string, string>
  * - options.requestId é string  → usa esse valor.
  * - options.requestId ausente   → auto-deriva de body.requestId (se string).
  */
-export function buildJsonResponse(
-    body: unknown,
+export function buildJsonResponse<T = unknown>(
+    body: T,
     status: number,
     corsHeaders: Record<string, string>,
     options: { requestId?: string | null } = {},

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -54,6 +54,42 @@ export function buildCorsHeaders(allowedOrigin?: string): Record<string, string>
 }
 
 /**
+ * Resposta JSON padrão dos handlers. O header X-Request-Id é resolvido assim:
+ * - options.requestId === null  → suprime o header (ex.: submit-lead-sf).
+ * - options.requestId é string  → usa esse valor.
+ * - options.requestId ausente   → auto-deriva de body.requestId (se string).
+ */
+export function buildJsonResponse(
+    body: unknown,
+    status: number,
+    corsHeaders: Record<string, string>,
+    options: { requestId?: string | null } = {},
+): Response {
+    let requestId: string | undefined;
+    if (options.requestId === null) {
+        requestId = undefined;
+    } else if (typeof options.requestId === 'string') {
+        requestId = options.requestId;
+    } else if (
+        body !== null &&
+        typeof body === 'object' &&
+        'requestId' in body &&
+        typeof (body as { requestId?: unknown }).requestId === 'string'
+    ) {
+        requestId = (body as { requestId: string }).requestId;
+    }
+
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: {
+            'Content-Type': 'application/json',
+            ...(requestId ? { 'X-Request-Id': requestId } : {}),
+            ...corsHeaders,
+        },
+    });
+}
+
+/**
  * Builds a structured JSON error response.
  */
 export function buildJsonError(status: number, code: string, message: string): Response {

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildCorsHeaders, getClientIP } from '../lib/network.ts';
+import { buildCorsHeaders, buildJsonResponse, getClientIP } from '../lib/network.ts';
 
 test('getClientIP uses Cloudflare connecting IP before spoofable headers', () => {
     const request = new Request('https://example.com/api/generate', {
@@ -81,4 +81,36 @@ test('buildCorsHeaders falls back to the default origin when ALLOWED_ORIGIN is a
 
     const headers = buildCorsHeaders();
     assert.equal(headers['Access-Control-Allow-Origin'], 'https://www.anhanga.tur.br');
+});
+
+test('buildJsonResponse auto-derives X-Request-Id from body.requestId', async () => {
+    const response = buildJsonResponse({ requestId: 'r1', ok: true }, 200, {});
+    assert.equal(response.headers.get('X-Request-Id'), 'r1');
+    assert.equal(response.headers.get('Content-Type'), 'application/json');
+});
+
+test('buildJsonResponse omits X-Request-Id when body has no requestId', async () => {
+    const response = buildJsonResponse({ ok: true }, 200, {});
+    assert.equal(response.headers.get('X-Request-Id'), null);
+});
+
+test('buildJsonResponse uses options.requestId over body.requestId', async () => {
+    const response = buildJsonResponse({ requestId: 'r1', ok: true }, 200, {}, { requestId: 'explicit' });
+    assert.equal(response.headers.get('X-Request-Id'), 'explicit');
+});
+
+test('buildJsonResponse suppresses X-Request-Id when options.requestId is null', async () => {
+    const response = buildJsonResponse({ requestId: 'r1', ok: true }, 200, {}, { requestId: null });
+    assert.equal(response.headers.get('X-Request-Id'), null);
+});
+
+test('buildJsonResponse handles a null body without throwing', async () => {
+    const response = buildJsonResponse(null, 200, {});
+    assert.equal(response.headers.get('X-Request-Id'), null);
+    assert.equal(response.headers.get('Content-Type'), 'application/json');
+});
+
+test('buildJsonResponse merges corsHeaders', async () => {
+    const response = buildJsonResponse({ ok: true }, 200, { 'Access-Control-Allow-Origin': 'https://example.com' });
+    assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://example.com');
 });


### PR DESCRIPTION
## O que

Consolida o `buildJsonResponse` duplicado nos 6 handlers `submit-*` num único helper em `lib/network.ts`. Mudar o shape da resposta, CORS ou propagação de request ID agora vive num lugar só.

## Contexto importante

A premissa inicial ("6 handlers idênticos") estava errada — havia **4 variantes** de tratamento do `X-Request-Id`. O helper foi desenhado flexível para **preservar exatamente** o comportamento de cada handler, sem mudança observável:

| Handler(s) | Comportamento preservado |
|---|---|
| contact, lead | header condicional, derivado de `body.requestId` |
| quiz, waitlist | header sempre presente (requestId sempre existe) |
| nps | derivado do body (equivalente ao 4º-param anterior) |
| **lead-sf** | **sem** `X-Request-Id` — suprimido via `{ requestId: null }` |

## Como

- **`lib/network.ts`** — novo `buildJsonResponse(body, status, corsHeaders, options?)`:
  - `options.requestId === null` → suprime o header (lead-sf)
  - `options.requestId` string → usa esse valor
  - ausente → auto-deriva de `body.requestId` se for string
- 6 handlers migrados removendo a função local; `submit-lead-sf` passa `{ requestId: null }` em todas as call sites (preserva o `Retry-After` no 429)
- **`tests/network.test.ts`** — 6 casos novos cobrindo os 3 modos do helper

## Verificação

- `pnpm typecheck` → exit 0
- `tests/network.test.ts` → 15/15
- `pnpm test:regression` → 647/647, **nenhum teste de handler editado**

## Notas

- Pequenas limpezas forçadas pela tipagem: removido `@ts-expect-error` que virou diretiva não-usada em `submit-quiz` (campo `retryAfter` preservado) e imports de tipo agora não-usados nos 4 handlers.
- **Follow-up**: a omissão do `X-Request-Id` no `submit-lead-sf` foi preservada de propósito; alinhá-la aos demais (consistência de observabilidade) é mudança de comportamento separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)