### PR TITLE
fix(corporativo): fallback visível quando globe.gl falha ao carregar

### DIFF
--- a/components/landings/corporativo/CorpGlobe.tsx
+++ b/components/landings/corporativo/CorpGlobe.tsx
@@ -119,7 +119,7 @@ export function CorpGlobe() {
                 className="w-full h-full flex flex-col items-center justify-center gap-3 text-center px-6"
             >
                 <svg
-                    className="w-16 h-16 text-yellow"
+                    className="w-16 h-16 text-brand-yellow"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"

--- a/components/landings/corporativo/CorpGlobe.tsx
+++ b/components/landings/corporativo/CorpGlobe.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const SP = { lat: -23.5505, lng: -46.6333 };
 
@@ -31,6 +31,7 @@ const POINTS = [
 
 export function CorpGlobe() {
     const containerRef = useRef<HTMLDivElement>(null);
+    const [loadFailed, setLoadFailed] = useState(false);
 
     useEffect(() => {
         let cancelled = false;
@@ -101,6 +102,7 @@ export function CorpGlobe() {
             };
         }).catch((err) => {
             console.error('Failed to load globe.gl:', err);
+            if (!cancelled) setLoadFailed(true);
         });
 
         return () => {
@@ -109,6 +111,31 @@ export function CorpGlobe() {
             cleanup = null;
         };
     }, []);
+
+    if (loadFailed) {
+        return (
+            <div
+                data-testid="corp-globe-fallback"
+                className="w-full h-full flex flex-col items-center justify-center gap-3 text-center px-6"
+            >
+                <svg
+                    className="w-16 h-16 text-yellow"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    aria-hidden="true"
+                >
+                    <circle cx="12" cy="12" r="9" />
+                    <ellipse cx="12" cy="12" rx="4" ry="9" />
+                    <path d="M3 12h18" />
+                </svg>
+                <p className="text-sm font-medium text-white/80 max-w-xs">
+                    Conectamos empresas a destinos no mundo todo
+                </p>
+            </div>
+        );
+    }
 
     return (
         <div

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -180,6 +180,15 @@ test.describe('Corporativo Landing Page', () => {
     expect(hubspotRequests).toEqual([]);
   });
 
+  test('should show fallback when globe.gl fails to load', async ({ page }) => {
+    await page.route(/globe(\.|__)gl|three-globe/, route => route.abort());
+
+    const landing = new CorporativoPage(page);
+    await landing.goto();
+
+    await expect(page.getByTestId('corp-globe-fallback')).toBeVisible();
+  });
+
   test('should handle navigation to #contato anchor', async ({ page, isMobile }) => {
     const landing = new CorporativoPage(page);
     await landing.goto();

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -180,7 +180,12 @@ test.describe('Corporativo Landing Page', () => {
     expect(hubspotRequests).toEqual([]);
   });
 
-  test('should show fallback when globe.gl fails to load', async ({ page }) => {
+  test('should show fallback when globe.gl fails to load', async ({ page, isMobile }) => {
+    // O globo (e seu fallback) só é montado em telas lg+ — o wrapper em
+    // CorpHero usa `hidden lg:block`. Em viewports mobile fica display:none
+    // por design, então a asserção de visibilidade só vale no desktop.
+    test.skip(isMobile, 'Globo é decorativo desktop-only (hidden lg:block)');
+
     await page.route(/globe(\.|__)gl|three-globe/, route => route.abort());
 
     const landing = new CorporativoPage(page);


### PR DESCRIPTION
## O que

`CorpGlobe` (landing `/corporativo`) carrega `globe.gl` via `import('globe.gl')` num `useEffect`. Se o import falhar (rede, chunk não servido, WebGL indisponível), o único tratamento era `console.error` — o usuário ficava com um container vazio onde deveria haver o globo 3D. Numa landing B2B de captação, um buraco visual silencioso prejudica a percepção de qualidade.

## Como

- **`components/landings/corporativo/CorpGlobe.tsx`** — estado `loadFailed`, setado no `.catch` com guard `cancelled` (não atualiza estado após unmount). Quando `true`, renderiza um fallback estático de marca (ícone de globo SVG + "Conectamos empresas a destinos no mundo todo") via early-return, mantendo `w-full h-full` (sem layout shift) e `data-testid="corp-globe-fallback"`.
- **`tests/e2e/corporativo.spec.ts`** — teste que aborta o chunk do globe.gl (`page.route`) e assere o fallback visível.

## Verificação

- `pnpm typecheck` → exit 0
- E2E `corporativo.spec.ts` (chromium) → 7/7 (o novo teste confirma o abort disparando o catch e o fallback renderizando)
- `pnpm test:regression` → 641/641

## Notas

- O matcher de rota foi ajustado para `/globe(\.|__)gl|three-globe/` — o Vite serve o chunk pré-bundlado como `globe__gl.js` em dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)