### PR TITLE
fix(security): adicionar CSP à página de callback OAuth do Decap

### DIFF
--- a/api/auth/callback.ts
+++ b/api/auth/callback.ts
@@ -10,8 +10,14 @@ const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 const GITHUB_TOKEN_TIMEOUT_MS = 8000;
 const PROVIDER = 'github';
 
-/** CSP for the OAuth callback HTML page: only the inline handshake script is allowed; no other resources, framing, or forms. */
-const CALLBACK_CSP = "default-src 'none'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'";
+/**
+ * CSP for the OAuth callback HTML page: only the nonce-tagged handshake script
+ * runs; no other resources, framing, or forms. A fresh nonce per request avoids
+ * 'unsafe-inline', so an injected inline script without the nonce won't execute.
+ */
+function buildCallbackCsp(nonce: string): string {
+    return `default-src 'none'; script-src 'nonce-${nonce}'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'`;
+}
 
 function parseCookies(header: string): Record<string, string> {
     const cookies: Record<string, string> = {};
@@ -48,6 +54,7 @@ export function buildPostMessageHtml(status: 'success' | 'error', content: strin
     const safeStatus = safeJsonString(status);
     const safeContent = safeJsonString(content);
     const allowedOrigin = process.env.ALLOWED_ORIGIN || 'https://www.anhanga.tur.br';
+    const nonce = crypto.randomUUID();
 
     const html = `<!doctype html>
 <html lang="pt-BR">
@@ -57,7 +64,7 @@ export function buildPostMessageHtml(status: 'success' | 'error', content: strin
   <title>Autenticação</title>
 </head>
 <body>
-<script>
+<script nonce="${nonce}">
 (function () {
   var provider = ${safeProvider};
   var status = ${safeStatus};
@@ -112,7 +119,7 @@ export function buildPostMessageHtml(status: 'success' | 'error', content: strin
         status: httpStatus,
         headers: {
             'Content-Type': 'text/html; charset=utf-8',
-            'Content-Security-Policy': CALLBACK_CSP,
+            'Content-Security-Policy': buildCallbackCsp(nonce),
             'Set-Cookie': 'oauth_state=; Path=/api/auth; Max-Age=0; HttpOnly; SameSite=Lax; Secure',
         },
     });

--- a/api/auth/callback.ts
+++ b/api/auth/callback.ts
@@ -10,6 +10,9 @@ const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 const GITHUB_TOKEN_TIMEOUT_MS = 8000;
 const PROVIDER = 'github';
 
+/** CSP for the OAuth callback HTML page: only the inline handshake script is allowed; no other resources, framing, or forms. */
+const CALLBACK_CSP = "default-src 'none'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'";
+
 function parseCookies(header: string): Record<string, string> {
     const cookies: Record<string, string> = {};
     for (const part of header.split(';')) {
@@ -109,6 +112,7 @@ export function buildPostMessageHtml(status: 'success' | 'error', content: strin
         status: httpStatus,
         headers: {
             'Content-Type': 'text/html; charset=utf-8',
+            'Content-Security-Policy': CALLBACK_CSP,
             'Set-Cookie': 'oauth_state=; Path=/api/auth; Max-Age=0; HttpOnly; SameSite=Lax; Secure',
         },
     });

--- a/tests/auth-callback-security.test.ts
+++ b/tests/auth-callback-security.test.ts
@@ -23,11 +23,24 @@ test('buildPostMessageHtml includes origin validation logic', async () => {
     assert.match(html, /if \(!isTrusted\) \{/);
 });
 
-test('buildPostMessageHtml sets a restrictive Content-Security-Policy header', async () => {
+test('buildPostMessageHtml sets a nonce-based Content-Security-Policy without unsafe-inline', async () => {
     const response = await buildPostMessageHtml('success', '{"token":"test"}', 200);
     const csp = response.headers.get('Content-Security-Policy');
+    const html = await response.text();
 
     assert.ok(csp, 'Content-Security-Policy header must be present');
     assert.match(csp, /default-src 'none'/);
-    assert.match(csp, /script-src 'unsafe-inline'/);
+    assert.doesNotMatch(csp, /unsafe-inline/, 'CSP must not fall back to unsafe-inline');
+
+    // The script-src nonce must match the nonce on the <script> tag.
+    const cspNonce = csp.match(/script-src 'nonce-([^']+)'/);
+    assert.ok(cspNonce, "CSP script-src must use a nonce");
+    assert.match(html, new RegExp(`<script nonce="${cspNonce[1]}">`));
+});
+
+test('buildPostMessageHtml uses a fresh nonce per request', async () => {
+    const csp1 = (await buildPostMessageHtml('success', '{}', 200)).headers.get('Content-Security-Policy');
+    const csp2 = (await buildPostMessageHtml('success', '{}', 200)).headers.get('Content-Security-Policy');
+
+    assert.notEqual(csp1, csp2, 'each response must carry a distinct nonce');
 });

--- a/tests/auth-callback-security.test.ts
+++ b/tests/auth-callback-security.test.ts
@@ -22,3 +22,12 @@ test('buildPostMessageHtml includes origin validation logic', async () => {
     // Ensure it doesn't just blindly trust e.origin anymore
     assert.match(html, /if \(!isTrusted\) \{/);
 });
+
+test('buildPostMessageHtml sets a restrictive Content-Security-Policy header', async () => {
+    const response = await buildPostMessageHtml('success', '{"token":"test"}', 200);
+    const csp = response.headers.get('Content-Security-Policy');
+
+    assert.ok(csp, 'Content-Security-Policy header must be present');
+    assert.match(csp, /default-src 'none'/);
+    assert.match(csp, /script-src 'unsafe-inline'/);
+});


### PR DESCRIPTION
## O que

`api/auth/callback.ts` retorna uma página HTML com JavaScript inline que faz o handshake `postMessage` com a janela do Decap CMS (`/admin`). A resposta não enviava `Content-Security-Policy`. Adiciona uma CSP restritiva como hardening de camada-2: limita o dano caso surja qualquer injeção, impede recursos externos não previstos e framing.

## Como

- **`api/auth/callback.ts`** — constante `CALLBACK_CSP` aplicada ao header da resposta HTML (há uma única função builder `buildPostMessageHtml`, usada para sucesso e erro):
  ```
  default-src 'none'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
  ```
  - `default-src 'none'` bloqueia tudo por padrão
  - `script-src 'unsafe-inline'` permite o script de handshake (gerado em runtime, sem nonce/build); **sem** `unsafe-eval`
  - sem `style-src` — o HTML não tem estilo inline
  - `frame-ancestors 'none'` previne clickjacking
- **`tests/auth-callback-security.test.ts`** — assert do header CSP (`default-src 'none'` + `script-src 'unsafe-inline'`)

## Verificação

- `pnpm typecheck` → exit 0
- `tests/auth-callback-security.test.ts` → 2/2
- `pnpm test:regression` → 642/642
- E2E `decap-admin.spec.ts` (chromium) → passa

## ⚠️ Validação manual obrigatória antes do merge

O login real do `/admin` não roda em CI (sem OAuth real / `cms:proxy`). Antes de mergear, validar manualmente: `pnpm dev` + `pnpm cms:proxy`, logar via GitHub OAuth em `/admin`, confirmar que o token chega ao CMS e que **não há violação de CSP** no DevTools → Console.

Análise no lugar do login: a página só executa script inline + `postMessage` (não controlado por CSP), sem fetch/style/img externos — a CSP não deve quebrar o handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)