### PR TITLE
fix(leads): normalizar click IDs vazios para null nos payloads do n8n

### DIFF
--- a/lib/n8n-payloads.ts
+++ b/lib/n8n-payloads.ts
@@ -85,7 +85,9 @@ export interface N8nContactPayload {
 }
 
 function toNullableTrackingValue(value: string | null | undefined): string | null {
-    return value ?? null;
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
 }
 
 function buildLeadTrackingUtms(payload: SubmitLeadRequest) {

--- a/lib/n8n-payloads.ts
+++ b/lib/n8n-payloads.ts
@@ -85,9 +85,8 @@ export interface N8nContactPayload {
 }
 
 function toNullableTrackingValue(value: string | null | undefined): string | null {
-    if (typeof value !== 'string') return null;
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : null;
+    // Mesma normalização do contexto: trima e converte vazio/whitespace em null.
+    return normalizeContextValue(value);
 }
 
 function buildLeadTrackingUtms(payload: SubmitLeadRequest) {

--- a/tests/lib-n8n-payloads.test.ts
+++ b/tests/lib-n8n-payloads.test.ts
@@ -84,6 +84,24 @@ test('buildN8nLeadPayload — utms são repassados intactos e extras default é 
     assert.deepEqual(result.tracking.extras, {});
 });
 
+test('buildN8nLeadPayload — click ID vazio/whitespace é normalizado para null', () => {
+    const payload: SubmitLeadRequest = {
+        ...LEAD_PAYLOAD,
+        tracking: {
+            utm_source: null,
+            utm_medium: null,
+            utm_campaign: null,
+            utm_term: null,
+            utm_content: null,
+            gclid: '',
+            fbclid: '   ',
+        },
+    };
+    const result = buildN8nLeadPayload(payload, 'req-lead-9');
+    assert.equal(result.tracking.gclid, null);
+    assert.equal(result.tracking.fbclid, null);
+});
+
 const CONTACT_PAYLOAD: SubmitContactRequest = {
     firstName: 'João',
     lastName: 'Pereira',
@@ -119,7 +137,7 @@ test('buildN8nContactPayload — fallback de UTM usa payload.utms quando trackin
     assert.equal(result.tracking.utm_source, BASE_UTMS.utm_source);
 });
 
-test('buildN8nContactPayload — click ID vazio/whitespace é repassado sem normalização (toNullableTrackingValue só trata undefined/null)', () => {
+test('buildN8nContactPayload — click ID vazio/whitespace é normalizado para null', () => {
     const payload: SubmitContactRequest = {
         ...CONTACT_PAYLOAD,
         tracking: {
@@ -133,11 +151,11 @@ test('buildN8nContactPayload — click ID vazio/whitespace é repassado sem norm
         },
     };
     const result = buildN8nContactPayload(payload, 'req-contact-4');
-    assert.equal(result.tracking.gclid, '');
-    assert.equal(result.tracking.fbclid, '   ');
+    assert.equal(result.tracking.gclid, null);
+    assert.equal(result.tracking.fbclid, null);
 });
 
-test('buildN8nContactPayload — click ID válido ecoa o valor', () => {
+test('buildN8nContactPayload — click ID válido ecoa o valor trimado', () => {
     const payload: SubmitContactRequest = {
         ...CONTACT_PAYLOAD,
         tracking: {
@@ -147,10 +165,12 @@ test('buildN8nContactPayload — click ID válido ecoa o valor', () => {
             utm_term: null,
             utm_content: null,
             gclid: 'abc123',
+            fbclid: ' xyz789 ',
         },
     };
     const result = buildN8nContactPayload(payload, 'req-contact-5');
     assert.equal(result.tracking.gclid, 'abc123');
+    assert.equal(result.tracking.fbclid, 'xyz789');
 });
 
 test('buildN8nContactPayload — tracking.extras é {} quando payload.tracking.extras ausente', () => {


### PR DESCRIPTION
## O que

Os click IDs de atribuição (`gclid`, `fbclid`, `msclkid`, `ttclid`, `wbraid`, `gbraid`, `fbc`, `fbp`, `cid`, `sid`) passam por `toNullableTrackingValue` antes de entrar nos payloads de **lead** e **contato** enviados ao n8n → Salesforce. O helper só convertia `null`/`undefined` → `null`, então um click ID vazio (`?gclid=`) ou whitespace chegava ao CRM como `''` em vez de `null` — poluindo a atribuição com valores que parecem preenchidos mas não são.

Achado documentado durante o PR #874 (testes dos builders), que registrou o comportamento de passthrough. Este PR corrige.

## Como

- **`lib/n8n-payloads.ts`** — `toNullableTrackingValue` agora trima e converte vazio/whitespace → `null`, espelhando o `normalizeContextValue` já existente no mesmo arquivo. Click ID válido retorna a versão trimada (`' abc123 '` → `'abc123'`). Aplica-se aos 10 click IDs nos caminhos de lead e contato.
- **`tests/lib-n8n-payloads.test.ts`** — teste de passthrough invertido (`gclid: '' → null`), novo teste no caminho de lead, assert de trim.

## Escopo

Só o corpo de `toNullableTrackingValue` + testes. **Não** altera UTMs (usam `?? ` direto, contrato de fallback distinto) nem unifica os dois helpers de normalização.

## Verificação

- `pnpm typecheck` → exit 0
- `tests/lib-n8n-payloads.test.ts` → 20/20
- `pnpm test:regression` → 680/680 (nenhum teste de handler quebrou — nada dependia do passthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)