### PR TITLE
chore(media): otimizador em lote de imagens do R2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,3 +145,9 @@ NPS_WEBHOOK_URL=https://seu-n8n.com/webhook/nps-pos-viagem
 # R2_CDN_BASE_URL=https://media.anhanga.tur.br
 # CLOUDFLARE_API_TOKEN=your_r2_edit_token  # Token with R2 Storage: Edit permission
 # CLOUDFLARE_ACCOUNT_ID=your_cloudflare_account_id  # Also used by AI Gateway above
+
+# OPTIONAL - R2 batch image optimizer (scripts/optimize-r2-images.ts)
+# S3-compatible credentials. Create an R2 API token with "Object Read & Write".
+# R2_ACCOUNT_ID=your_cloudflare_account_id            # the <id>.r2.cloudflarestorage.com host
+# R2_ACCESS_KEY_ID=your_r2_access_key_id
+# R2_SECRET_ACCESS_KEY=your_r2_secret_access_key

--- a/lib/image-optimization.ts
+++ b/lib/image-optimization.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure decision helpers for the R2 batch image optimizer (`scripts/optimize-r2-images.ts`).
+ *
+ * Kept free of I/O so the policy — which objects to touch, how to resize, where to
+ * back up — can be unit tested without hitting the network or the filesystem.
+ */
+
+/** Objects below this size are already light enough to leave untouched. */
+export const DEFAULT_MIN_BYTES = 300 * 1024;
+
+/** Retina 2x of the 1200px hero — never downscale below the largest real usage. */
+export const DEFAULT_MAX_WIDTH = 2400;
+
+/** mozjpeg quality for JPEG recompression. */
+export const DEFAULT_QUALITY = 80;
+
+/** Prefix where untouched originals are copied before any overwrite. */
+export const DEFAULT_BACKUP_PREFIX = 'originals/';
+
+export type ImageFormat = 'jpeg' | 'png' | 'webp' | 'avif' | 'gif' | 'svg' | 'unknown';
+
+const EXTENSION_TO_FORMAT: Record<string, ImageFormat> = {
+  '.jpg': 'jpeg',
+  '.jpeg': 'jpeg',
+  '.png': 'png',
+  '.webp': 'webp',
+  '.avif': 'avif',
+  '.gif': 'gif',
+  '.svg': 'svg',
+};
+
+/**
+ * Formats we recompress in place. WebP/AVIF originals are already efficient,
+ * GIF risks dropping animation, and SVG is vector — all left alone so we never
+ * change a URL's effective format or break OG/social embeds.
+ */
+const RECOMPRESSIBLE: ReadonlySet<ImageFormat> = new Set<ImageFormat>(['jpeg', 'png']);
+
+export function detectFormatFromKey(key: string): ImageFormat {
+  const lower = key.toLowerCase();
+  const dot = lower.lastIndexOf('.');
+  if (dot === -1) return 'unknown';
+  return EXTENSION_TO_FORMAT[lower.slice(dot)] ?? 'unknown';
+}
+
+export function isRecompressibleFormat(format: ImageFormat): boolean {
+  return RECOMPRESSIBLE.has(format);
+}
+
+export function isBackupKey(key: string, backupPrefix: string = DEFAULT_BACKUP_PREFIX): boolean {
+  return key.startsWith(backupPrefix);
+}
+
+export function buildBackupKey(key: string, backupPrefix: string = DEFAULT_BACKUP_PREFIX): string {
+  return `${backupPrefix}${key}`;
+}
+
+export interface OptimizeDecision {
+  process: boolean;
+  /** Machine-readable reason for skipping/processing, used in the report. */
+  reason: 'ok' | 'backup-object' | 'unsupported-format' | 'already-light';
+}
+
+/**
+ * Decide whether an object is a candidate for recompression based only on its
+ * key and size. Pixel-level decisions (resize) happen later once dimensions are
+ * known via {@link planResize}.
+ */
+export function shouldOptimize(params: {
+  key: string;
+  sizeBytes: number;
+  minBytes?: number;
+  backupPrefix?: string;
+}): OptimizeDecision {
+  const { key, sizeBytes, minBytes = DEFAULT_MIN_BYTES, backupPrefix = DEFAULT_BACKUP_PREFIX } = params;
+
+  if (isBackupKey(key, backupPrefix)) {
+    return { process: false, reason: 'backup-object' };
+  }
+  if (!isRecompressibleFormat(detectFormatFromKey(key))) {
+    return { process: false, reason: 'unsupported-format' };
+  }
+  if (sizeBytes < minBytes) {
+    return { process: false, reason: 'already-light' };
+  }
+  return { process: true, reason: 'ok' };
+}
+
+export interface ResizePlan {
+  /** Target width to pass to sharp, or null to keep original dimensions. */
+  targetWidth: number | null;
+  willResize: boolean;
+}
+
+/**
+ * Only ever downscale: resize to `maxWidth` when the original is wider, never
+ * enlarge. Originals narrower than `maxWidth` keep their dimensions and are only
+ * recompressed.
+ */
+export function planResize(originalWidth: number, maxWidth: number = DEFAULT_MAX_WIDTH): ResizePlan {
+  if (Number.isFinite(originalWidth) && originalWidth > maxWidth) {
+    return { targetWidth: maxWidth, willResize: true };
+  }
+  return { targetWidth: null, willResize: false };
+}
+
+/**
+ * Keep an overwrite only when it actually saves bytes. Recompression can grow a
+ * file (e.g. already-optimized JPEGs); in that case the original is preserved.
+ */
+export function isWorthOverwriting(originalBytes: number, optimizedBytes: number): boolean {
+  return optimizedBytes > 0 && optimizedBytes < originalBytes;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  return `${(kb / 1024).toFixed(2)} MB`;
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "reviews:fetch": "tsx scripts/fetch-google-reviews.ts",
     "update:dates": "node scripts/update-post-dates.mjs --all",
     "doctor": "react-doctor",
-    "generate:feeds": "tsx scripts/generate-feeds.ts"
+    "generate:feeds": "tsx scripts/generate-feeds.ts",
+    "images:optimize": "tsx scripts/optimize-r2-images.ts"
   },
   "dependencies": {
     "@google/genai": "^2.8.0",
@@ -51,6 +52,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.700.0",
     "@playwright/test": "^1.60.0",
     "@types/leaflet": "^1.9.21",
     "@types/mdx": "^2.0.14",
@@ -63,6 +65,7 @@
     "gray-matter": "^4.0.3",
     "react-doctor": "^0.2.3",
     "rollup-plugin-visualizer": "^7.0.1",
+    "sharp": "^0.34.5",
     "sirv": "^3.0.2",
     "tailwindcss": "^4.3.0",
     "tsx": "^4.22.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.700.0
+        version: 3.1064.0
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -123,6 +126,9 @@ importers:
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.0.3)(rollup@4.60.1)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       sirv:
         specifier: ^3.0.2
         version: 3.0.2
@@ -150,6 +156,109 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/checksums@3.1000.3':
+    resolution: {integrity: sha512-vkPd3NMJf6Gw4QjBBdiUdu2uo4P0HfHrx5+1hqjDYZhZAF4HWkMHXoQtxHQmDi/LyysUgTU5uNhcZLCkpF9LKg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1064.0':
+    resolution: {integrity: sha512-6OQhE4Qpt94oTw7ruBHE2E6/PS57alsCSdemMf4c3gBSUM0emoXRRykYffFSL56oluL49AZh/DLWRnQafynbLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.19':
+    resolution: {integrity: sha512-SMNfLCU/41xxfFaC5Slwy8V/f1FRhakvyeeMeDeIxqNF0DzhDlXsXnJDELJYke1EtnJbfzfilW7tvulGfxMY6A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.45':
+    resolution: {integrity: sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.47':
+    resolution: {integrity: sha512-1XdgHDIPbARHuzZXM7ouzIbSUZFU9dTi9k+ryMhiZU4QCam4dvwOyUEFjEHNxAZehCYUIOmsSUZ2un6BIgUkWg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.51':
+    resolution: {integrity: sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.50':
+    resolution: {integrity: sha512-NHHsKoMhw6UylSU0XDnDc87+IQW8tRBTIe6vnOX12GSIlBDtoce6bSzONleIglCyu8d3H9bmTSfk+sIN5yh3WA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.53':
+    resolution: {integrity: sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.45':
+    resolution: {integrity: sha512-QMJXjTGLmHE4Ie03T5H4hHOLfcvMc9DaODO6b5dgte3S8ECf5bBuHUJW4cQREcYZyRkOU8iymqtiBxqF4icxZg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.50':
+    resolution: {integrity: sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.50':
+    resolution: {integrity: sha512-9DbaPaT2aMbz18wtSpq9HVBErjBQwxykqTFgG6n8Bn05GN68mITz+G1869ekYx0mVT/BDjETj5czz/3cPgLwxA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.28':
+    resolution: {integrity: sha512-XkHArJreL8hnpKrBTlnwrIcynZT4kDiAF6BF/z7AVxV7VUvojrjL2RzeK8QLVNyfzkEJGIYBKoufOIOSSpd6nQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.49':
+    resolution: {integrity: sha512-9CQoJfMZMqGJVBqFO/C8Gwke6WM7CLskQBiAjGU5LyXsVtqhymAATfqFnIa87Dw23ssfgGzqBHpSSwSchldFXw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.18':
+    resolution: {integrity: sha512-xBWrodBvW5SHCZV11UZUJG0pSHkLCEREIBoNbff1C1sacOUCmxJnTCPE80sCGLCtqgXg98I2MQJe2z28tcZSsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.33':
+    resolution: {integrity: sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1064.0':
+    resolution: {integrity: sha512-sjI+iA4JtgeckBgKwPQF7KzWillRoNDmtpiM0TRa0syiAKFHKUSf84kPXSO3+gA7aMMSxrcxzOM2oPSecaJvEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.12':
+    resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.7':
+    resolution: {integrity: sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.29':
+    resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -763,6 +872,9 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1491,6 +1603,42 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
+  '@smithy/core@3.24.6':
+    resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.8':
+    resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.6':
+    resolution: {integrity: sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.7':
+    resolution: {integrity: sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.6':
+    resolution: {integrity: sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.3':
+    resolution: {integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
@@ -1796,6 +1944,9 @@ packages:
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -2237,6 +2388,13 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3029,6 +3187,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -3380,6 +3542,9 @@ packages:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
     engines: {node: '>=0.10.0'}
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -3687,6 +3852,10 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3719,6 +3888,236 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.12
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.12
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/util-locate-window': 3.965.7
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/util-locate-window': 3.965.7
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.12
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/checksums@3.1000.3':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1064.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/credential-provider-node': 3.972.53
+      '@aws-sdk/middleware-flexible-checksums': 3.974.28
+      '@aws-sdk/middleware-sdk-s3': 3.972.49
+      '@aws-sdk/signature-v4-multi-region': 3.996.33
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.19':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/xml-builder': 3.972.29
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.6
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/credential-provider-env': 3.972.45
+      '@aws-sdk/credential-provider-http': 3.972.47
+      '@aws-sdk/credential-provider-login': 3.972.50
+      '@aws-sdk/credential-provider-process': 3.972.45
+      '@aws-sdk/credential-provider-sso': 3.972.50
+      '@aws-sdk/credential-provider-web-identity': 3.972.50
+      '@aws-sdk/nested-clients': 3.997.18
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/nested-clients': 3.997.18
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.53':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.45
+      '@aws-sdk/credential-provider-http': 3.972.47
+      '@aws-sdk/credential-provider-ini': 3.972.51
+      '@aws-sdk/credential-provider-process': 3.972.45
+      '@aws-sdk/credential-provider-sso': 3.972.50
+      '@aws-sdk/credential-provider-web-identity': 3.972.50
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/nested-clients': 3.997.18
+      '@aws-sdk/token-providers': 3.1064.0
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/nested-clients': 3.997.18
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.28':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.3
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/signature-v4-multi-region': 3.996.33
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.18':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/signature-v4-multi-region': 3.996.33
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.33':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1064.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/nested-clients': 3.997.18
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.12':
+    dependencies:
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.29':
+    dependencies:
+      '@smithy/types': 4.14.3
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/runtime@7.29.2': {}
 
@@ -4146,6 +4545,8 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@nodable/entities@2.1.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4577,6 +4978,54 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
+  '@smithy/core@3.24.6':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.8':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.6':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.7':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.6':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@so-ric/colorspace@1.1.6':
     dependencies:
       color: 5.0.3
@@ -4851,6 +5300,8 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   brace-expansion@5.0.6:
     dependencies:
@@ -5361,6 +5812,18 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.1
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
 
   fastq@1.20.1:
     dependencies:
@@ -6480,6 +6943,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.5.0
@@ -6964,6 +7429,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
+  strnum@2.3.0: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -7249,6 +7716,8 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xml-naming@0.1.0: {}
 
   y18n@5.0.8: {}
 

--- a/scripts/optimize-r2-images.ts
+++ b/scripts/optimize-r2-images.ts
@@ -208,6 +208,66 @@ interface RowResult {
   reason: string;
 }
 
+/** Copy the original to the backup prefix once, before it is overwritten. */
+async function backupOriginal(client: S3Client, bucket: string, key: string, backupPrefix: string): Promise<void> {
+  const backupKey = buildBackupKey(key, backupPrefix);
+  if (await backupExists(client, bucket, backupKey)) return;
+  await client.send(
+    new CopyObjectCommand({ Bucket: bucket, Key: backupKey, CopySource: encodeCopySource(bucket, key) }),
+  );
+}
+
+function formatSaving(before: number, after: number, width: number, resized: boolean): string {
+  const pct = (((before - after) / before) * 100).toFixed(0);
+  return `${formatBytes(before)} → ${formatBytes(after)}  (-${pct}%)${resized ? `  ↧${width}px` : ''}`;
+}
+
+/** Fetch, re-encode and (when --apply) back up + overwrite a single object. */
+async function processObject(client: S3Client, bucket: string, obj: _Object, opts: Options): Promise<RowResult> {
+  const key = obj.Key!;
+  const before = obj.Size ?? 0;
+  const format = detectFormatFromKey(key);
+
+  try {
+    const getRes = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+    if (!getRes.Body) {
+      throw new Error('R2 object has no body');
+    }
+    const input = Buffer.from(await getRes.Body.transformToByteArray());
+    const { output, width, resized } = await reencode(input, format, opts);
+    const after = output.length;
+
+    if (!isWorthOverwriting(before, after)) {
+      console.log(`  ↷ ${key}  ${formatBytes(before)} → ${formatBytes(after)}  (sem ganho, mantido)`);
+      return { key, before, after, status: 'skipped-no-gain', reason: 'recompressão não reduziu' };
+    }
+
+    const detail = formatSaving(before, after, width, resized);
+
+    if (!opts.apply) {
+      console.log(`  • ${key}  ${detail}`);
+      return { key, before, after, status: 'would-optimize', reason: 'dry-run' };
+    }
+
+    await backupOriginal(client, bucket, key, opts.backupPrefix);
+    await client.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: output,
+        ContentType: contentTypeFor(format, getRes.ContentType),
+        CacheControl: getRes.CacheControl,
+      }),
+    );
+
+    console.log(`  ✓ ${key}  ${detail}`);
+    return { key, before, after, status: 'optimized', reason: 'ok' };
+  } catch (err) {
+    console.error(`  ✗ ${key}  erro: ${err instanceof Error ? err.message : err}`);
+    return { key, before, after: before, status: 'skipped', reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 async function main(): Promise<void> {
   const opts = parseArgs(process.argv.slice(2));
   const bucket = process.env.R2_BUCKET_NAME || 'av-site-media';
@@ -235,60 +295,7 @@ async function main(): Promise<void> {
 
   const rows: RowResult[] = [];
   for (const obj of selected) {
-    const key = obj.Key!;
-    const before = obj.Size ?? 0;
-    const format = detectFormatFromKey(key);
-
-    try {
-      const getRes = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
-      if (!getRes.Body) {
-        throw new Error('R2 object has no body');
-      }
-      const input = Buffer.from(await getRes.Body.transformToByteArray());
-      const { output, width, resized } = await reencode(input, format, opts);
-      const after = output.length;
-
-      if (!isWorthOverwriting(before, after)) {
-        rows.push({ key, before, after, status: 'skipped-no-gain', reason: 'recompressão não reduziu' });
-        console.log(`  ↷ ${key}  ${formatBytes(before)} → ${formatBytes(after)}  (sem ganho, mantido)`);
-        continue;
-      }
-
-      const detail = `${formatBytes(before)} → ${formatBytes(after)}  (-${(((before - after) / before) * 100).toFixed(0)}%)${resized ? `  ↧${width}px` : ''}`;
-
-      if (!opts.apply) {
-        rows.push({ key, before, after, status: 'would-optimize', reason: 'dry-run' });
-        console.log(`  • ${key}  ${detail}`);
-        continue;
-      }
-
-      const backupKey = buildBackupKey(key, opts.backupPrefix);
-      if (!(await backupExists(client, bucket, backupKey))) {
-        await client.send(
-          new CopyObjectCommand({
-            Bucket: bucket,
-            Key: backupKey,
-            CopySource: encodeCopySource(bucket, key),
-          }),
-        );
-      }
-
-      await client.send(
-        new PutObjectCommand({
-          Bucket: bucket,
-          Key: key,
-          Body: output,
-          ContentType: contentTypeFor(format, getRes.ContentType),
-          CacheControl: getRes.CacheControl,
-        }),
-      );
-
-      rows.push({ key, before, after, status: 'optimized', reason: 'ok' });
-      console.log(`  ✓ ${key}  ${detail}`);
-    } catch (err) {
-      rows.push({ key, before, after: before, status: 'skipped', reason: err instanceof Error ? err.message : String(err) });
-      console.error(`  ✗ ${key}  erro: ${err instanceof Error ? err.message : err}`);
-    }
+    rows.push(await processObject(client, bucket, obj, opts));
   }
 
   const touched = rows.filter((r) => r.status === 'optimized' || r.status === 'would-optimize');

--- a/scripts/optimize-r2-images.ts
+++ b/scripts/optimize-r2-images.ts
@@ -74,7 +74,7 @@ interface Options {
   backupPrefix: string;
 }
 
-function parseArgs(argv: string[]): Options {
+export function parseArgs(argv: string[]): Options {
   const opts: Options = {
     apply: false,
     prefix: 'images/',
@@ -84,17 +84,31 @@ function parseArgs(argv: string[]): Options {
     quality: DEFAULT_QUALITY,
     backupPrefix: DEFAULT_BACKUP_PREFIX,
   };
-  for (let i = 0; i < argv.length; i++) {
+  let i = 0;
+  const next = (arg: string): string => {
+    const value = argv[++i];
+    if (value === undefined) {
+      throw new Error(`Missing value for argument: ${arg}`);
+    }
+    return value;
+  };
+  const nextNum = (arg: string): number => {
+    const value = Number(next(arg));
+    if (Number.isNaN(value)) {
+      throw new Error(`Invalid numeric value for argument: ${arg}`);
+    }
+    return value;
+  };
+  for (; i < argv.length; i++) {
     const arg = argv[i];
-    const next = () => argv[++i];
     switch (arg) {
       case '--apply': opts.apply = true; break;
-      case '--prefix': opts.prefix = next(); break;
-      case '--limit': opts.limit = Number(next()); break;
-      case '--max-width': opts.maxWidth = Number(next()); break;
-      case '--min-kb': opts.minBytes = Number(next()) * 1024; break;
-      case '--quality': opts.quality = Number(next()); break;
-      case '--backup-prefix': opts.backupPrefix = next(); break;
+      case '--prefix': opts.prefix = next(arg); break;
+      case '--limit': opts.limit = nextNum(arg); break;
+      case '--max-width': opts.maxWidth = nextNum(arg); break;
+      case '--min-kb': opts.minBytes = nextNum(arg) * 1024; break;
+      case '--quality': opts.quality = nextNum(arg); break;
+      case '--backup-prefix': opts.backupPrefix = next(arg); break;
       default:
         throw new Error(`Unknown argument: ${arg}`);
     }
@@ -138,8 +152,21 @@ async function listAllObjects(client: S3Client, bucket: string, prefix: string):
   return objects;
 }
 
-function contentTypeFor(format: ImageFormat, existing?: string): string {
-  if (existing) return existing;
+/**
+ * Build an S3 `CopySource` for `bucket/key`. Each path segment is URL-encoded
+ * (so spaces/specials in keys are safe) while the `/` separators stay literal —
+ * the form R2 accepts unambiguously, avoiding reliance on the store decoding
+ * `%2F` back into a separator.
+ */
+export function encodeCopySource(bucket: string, key: string): string {
+  const encodedKey = key.split('/').map(encodeURIComponent).join('/');
+  return `${bucket}/${encodedKey}`;
+}
+
+export function contentTypeFor(format: ImageFormat, existing?: string): string {
+  // Trust the stored type only when it is already an image/* type; correct
+  // generic uploads (e.g. application/octet-stream) to the real mime-type.
+  if (existing && existing.startsWith('image/')) return existing;
   return format === 'png' ? 'image/png' : 'image/jpeg';
 }
 
@@ -214,7 +241,10 @@ async function main(): Promise<void> {
 
     try {
       const getRes = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
-      const input = Buffer.from(await getRes.Body!.transformToByteArray());
+      if (!getRes.Body) {
+        throw new Error('R2 object has no body');
+      }
+      const input = Buffer.from(await getRes.Body.transformToByteArray());
       const { output, width, resized } = await reencode(input, format, opts);
       const after = output.length;
 
@@ -238,7 +268,7 @@ async function main(): Promise<void> {
           new CopyObjectCommand({
             Bucket: bucket,
             Key: backupKey,
-            CopySource: `${bucket}/${encodeURIComponent(key).replace(/%2F/g, '/')}`,
+            CopySource: encodeCopySource(bucket, key),
           }),
         );
       }

--- a/scripts/optimize-r2-images.ts
+++ b/scripts/optimize-r2-images.ts
@@ -1,0 +1,286 @@
+/**
+ * Batch-optimize the heavy original images stored in the Cloudflare R2 bucket
+ * (`av-site-media`, served at https://media.anhanga.tur.br).
+ *
+ * This is SEO/technical hygiene and origin robustness — the live site already
+ * serves ~200 KB AVIF/WebP via Cloudflare Image Transformations, so this does
+ * not change runtime LCP. It re-encodes the *originals* so the raw URLs indexed
+ * by crawlers stop being multi-MB, and so the transform layer reads from leaner
+ * sources.
+ *
+ * Guarantees:
+ *   - Same key, same extension, same Content-Type — URLs / OG tags never change.
+ *   - Originals are copied to `originals/<key>` (server-side) before any write.
+ *   - Never upscales; only downscales when wider than --max-width.
+ *   - Only overwrites when the re-encode is actually smaller.
+ *   - Dry-run by default. Nothing is written without --apply.
+ *
+ * Auth (S3-compatible API). Set via env or .env / .env.local:
+ *   R2_ACCOUNT_ID         Cloudflare account id (the r2.cloudflarestorage.com host)
+ *   R2_ACCESS_KEY_ID      R2 API token Access Key ID (Object Read & Write)
+ *   R2_SECRET_ACCESS_KEY  R2 API token Secret Access Key
+ *   R2_BUCKET_NAME        defaults to "av-site-media"
+ *
+ * Usage:
+ *   tsx scripts/optimize-r2-images.ts                       # dry-run, whole bucket under images/
+ *   tsx scripts/optimize-r2-images.ts --prefix images/blog/ # scope a folder
+ *   tsx scripts/optimize-r2-images.ts --limit 3             # first 3 candidates (validation pass)
+ *   tsx scripts/optimize-r2-images.ts --apply               # actually back up + overwrite
+ *   tsx scripts/optimize-r2-images.ts --apply --limit 3 --prefix images/blog/
+ *
+ * Flags: --max-width (2400), --min-kb (300), --quality (80), --backup-prefix (originals/)
+ */
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import sharp from 'sharp';
+import {
+  S3Client,
+  ListObjectsV2Command,
+  GetObjectCommand,
+  PutObjectCommand,
+  CopyObjectCommand,
+  HeadObjectCommand,
+  type _Object,
+} from '@aws-sdk/client-s3';
+import {
+  DEFAULT_BACKUP_PREFIX,
+  DEFAULT_MAX_WIDTH,
+  DEFAULT_MIN_BYTES,
+  DEFAULT_QUALITY,
+  buildBackupKey,
+  detectFormatFromKey,
+  formatBytes,
+  isWorthOverwriting,
+  planResize,
+  shouldOptimize,
+  type ImageFormat,
+} from '../lib/image-optimization';
+
+for (const file of ['.env.local', '.env']) {
+  const path = resolve(process.cwd(), file);
+  if (existsSync(path) && typeof process.loadEnvFile === 'function') {
+    process.loadEnvFile(path);
+  }
+}
+
+interface Options {
+  apply: boolean;
+  prefix: string;
+  limit: number | null;
+  maxWidth: number;
+  minBytes: number;
+  quality: number;
+  backupPrefix: string;
+}
+
+function parseArgs(argv: string[]): Options {
+  const opts: Options = {
+    apply: false,
+    prefix: 'images/',
+    limit: null,
+    maxWidth: DEFAULT_MAX_WIDTH,
+    minBytes: DEFAULT_MIN_BYTES,
+    quality: DEFAULT_QUALITY,
+    backupPrefix: DEFAULT_BACKUP_PREFIX,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => argv[++i];
+    switch (arg) {
+      case '--apply': opts.apply = true; break;
+      case '--prefix': opts.prefix = next(); break;
+      case '--limit': opts.limit = Number(next()); break;
+      case '--max-width': opts.maxWidth = Number(next()); break;
+      case '--min-kb': opts.minBytes = Number(next()) * 1024; break;
+      case '--quality': opts.quality = Number(next()); break;
+      case '--backup-prefix': opts.backupPrefix = next(); break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Missing ${name}. Set R2_ACCOUNT_ID, R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY ` +
+        `(R2 API token with Object Read & Write) in your environment or .env.`,
+    );
+  }
+  return value;
+}
+
+function createClient(): S3Client {
+  const accountId = requireEnv('R2_ACCOUNT_ID');
+  return new S3Client({
+    region: 'auto',
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: requireEnv('R2_ACCESS_KEY_ID'),
+      secretAccessKey: requireEnv('R2_SECRET_ACCESS_KEY'),
+    },
+  });
+}
+
+async function listAllObjects(client: S3Client, bucket: string, prefix: string): Promise<_Object[]> {
+  const objects: _Object[] = [];
+  let continuationToken: string | undefined;
+  do {
+    const res = await client.send(
+      new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix, ContinuationToken: continuationToken }),
+    );
+    objects.push(...(res.Contents ?? []));
+    continuationToken = res.IsTruncated ? res.NextContinuationToken : undefined;
+  } while (continuationToken);
+  return objects;
+}
+
+function contentTypeFor(format: ImageFormat, existing?: string): string {
+  if (existing) return existing;
+  return format === 'png' ? 'image/png' : 'image/jpeg';
+}
+
+/** Re-encode a buffer preserving its format. Returns the smaller-or-equal bytes. */
+async function reencode(input: Buffer, format: ImageFormat, opts: Options): Promise<{ output: Buffer; width: number; resized: boolean }> {
+  const image = sharp(input, { failOn: 'none' }).rotate(); // bake EXIF orientation, then strip metadata
+  const meta = await image.metadata();
+  const originalWidth = meta.width ?? 0;
+  const { targetWidth, willResize } = planResize(originalWidth, opts.maxWidth);
+
+  let pipeline = image;
+  if (targetWidth) {
+    pipeline = pipeline.resize({ width: targetWidth, withoutEnlargement: true });
+  }
+
+  pipeline =
+    format === 'png'
+      ? pipeline.png({ compressionLevel: 9, adaptiveFiltering: true, effort: 8 })
+      : pipeline.jpeg({ quality: opts.quality, mozjpeg: true });
+
+  const output = await pipeline.toBuffer();
+  return { output, width: targetWidth ?? originalWidth, resized: willResize };
+}
+
+async function backupExists(client: S3Client, bucket: string, key: string): Promise<boolean> {
+  try {
+    await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface RowResult {
+  key: string;
+  before: number;
+  after: number;
+  status: 'optimized' | 'would-optimize' | 'skipped-no-gain' | 'skipped';
+  reason: string;
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  const bucket = process.env.R2_BUCKET_NAME || 'av-site-media';
+  const client = createClient();
+
+  console.log(
+    `\nR2 image optimizer — bucket="${bucket}" prefix="${opts.prefix}" ` +
+      `mode=${opts.apply ? 'APPLY (writes enabled)' : 'DRY-RUN'} ` +
+      `maxWidth=${opts.maxWidth} minKB=${Math.round(opts.minBytes / 1024)} quality=${opts.quality}\n`,
+  );
+
+  const all = await listAllObjects(client, bucket, opts.prefix);
+  const candidates = all.filter((o) => {
+    const decision = shouldOptimize({
+      key: o.Key ?? '',
+      sizeBytes: o.Size ?? 0,
+      minBytes: opts.minBytes,
+      backupPrefix: opts.backupPrefix,
+    });
+    return decision.process;
+  });
+
+  const selected = opts.limit ? candidates.slice(0, opts.limit) : candidates;
+  console.log(`Found ${all.length} objects, ${candidates.length} candidates, processing ${selected.length}.\n`);
+
+  const rows: RowResult[] = [];
+  for (const obj of selected) {
+    const key = obj.Key!;
+    const before = obj.Size ?? 0;
+    const format = detectFormatFromKey(key);
+
+    try {
+      const getRes = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+      const input = Buffer.from(await getRes.Body!.transformToByteArray());
+      const { output, width, resized } = await reencode(input, format, opts);
+      const after = output.length;
+
+      if (!isWorthOverwriting(before, after)) {
+        rows.push({ key, before, after, status: 'skipped-no-gain', reason: 'recompressão não reduziu' });
+        console.log(`  ↷ ${key}  ${formatBytes(before)} → ${formatBytes(after)}  (sem ganho, mantido)`);
+        continue;
+      }
+
+      const detail = `${formatBytes(before)} → ${formatBytes(after)}  (-${(((before - after) / before) * 100).toFixed(0)}%)${resized ? `  ↧${width}px` : ''}`;
+
+      if (!opts.apply) {
+        rows.push({ key, before, after, status: 'would-optimize', reason: 'dry-run' });
+        console.log(`  • ${key}  ${detail}`);
+        continue;
+      }
+
+      const backupKey = buildBackupKey(key, opts.backupPrefix);
+      if (!(await backupExists(client, bucket, backupKey))) {
+        await client.send(
+          new CopyObjectCommand({
+            Bucket: bucket,
+            Key: backupKey,
+            CopySource: `${bucket}/${encodeURIComponent(key).replace(/%2F/g, '/')}`,
+          }),
+        );
+      }
+
+      await client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: output,
+          ContentType: contentTypeFor(format, getRes.ContentType),
+          CacheControl: getRes.CacheControl,
+        }),
+      );
+
+      rows.push({ key, before, after, status: 'optimized', reason: 'ok' });
+      console.log(`  ✓ ${key}  ${detail}`);
+    } catch (err) {
+      rows.push({ key, before, after: before, status: 'skipped', reason: err instanceof Error ? err.message : String(err) });
+      console.error(`  ✗ ${key}  erro: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  const touched = rows.filter((r) => r.status === 'optimized' || r.status === 'would-optimize');
+  const savedBytes = touched.reduce((sum, r) => sum + (r.before - r.after), 0);
+  const beforeTotal = touched.reduce((sum, r) => sum + r.before, 0);
+
+  console.log('\n— Resumo —');
+  console.log(`  ${opts.apply ? 'Otimizadas' : 'Seriam otimizadas'}: ${touched.length}`);
+  console.log(`  Sem ganho: ${rows.filter((r) => r.status === 'skipped-no-gain').length}`);
+  console.log(`  Erros: ${rows.filter((r) => r.status === 'skipped').length}`);
+  console.log(`  Total antes: ${formatBytes(beforeTotal)}  →  depois: ${formatBytes(beforeTotal - savedBytes)}`);
+  console.log(`  Economia: ${formatBytes(savedBytes)}${beforeTotal ? `  (-${((savedBytes / beforeTotal) * 100).toFixed(0)}%)` : ''}`);
+  if (!opts.apply) {
+    console.log('\n  Dry-run. Reexecute com --apply para gravar (backup automático em originals/).');
+  }
+}
+
+const isDirectRun = !!process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error('Fatal:', err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/tests/image-optimization.test.ts
+++ b/tests/image-optimization.test.ts
@@ -1,0 +1,103 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_MAX_WIDTH,
+  DEFAULT_MIN_BYTES,
+  buildBackupKey,
+  detectFormatFromKey,
+  formatBytes,
+  isBackupKey,
+  isRecompressibleFormat,
+  isWorthOverwriting,
+  planResize,
+  shouldOptimize,
+} from '../lib/image-optimization';
+
+test('detectFormatFromKey maps extensions case-insensitively', () => {
+  assert.equal(detectFormatFromKey('images/blog/foo.jpg'), 'jpeg');
+  assert.equal(detectFormatFromKey('images/blog/FOO.JPEG'), 'jpeg');
+  assert.equal(detectFormatFromKey('images/blog/bar.PNG'), 'png');
+  assert.equal(detectFormatFromKey('images/blog/baz.webp'), 'webp');
+  assert.equal(detectFormatFromKey('images/blog/anim.gif'), 'gif');
+  assert.equal(detectFormatFromKey('images/icon.svg'), 'svg');
+  assert.equal(detectFormatFromKey('images/no-extension'), 'unknown');
+});
+
+test('isRecompressibleFormat only accepts jpeg and png', () => {
+  assert.equal(isRecompressibleFormat('jpeg'), true);
+  assert.equal(isRecompressibleFormat('png'), true);
+  assert.equal(isRecompressibleFormat('webp'), false);
+  assert.equal(isRecompressibleFormat('avif'), false);
+  assert.equal(isRecompressibleFormat('gif'), false);
+  assert.equal(isRecompressibleFormat('svg'), false);
+  assert.equal(isRecompressibleFormat('unknown'), false);
+});
+
+test('shouldOptimize processes a heavy jpeg', () => {
+  const decision = shouldOptimize({ key: 'images/blog/documentos.jpg', sizeBytes: 3_938 * 1024 });
+  assert.deepEqual(decision, { process: true, reason: 'ok' });
+});
+
+test('shouldOptimize skips objects under the size threshold', () => {
+  const decision = shouldOptimize({ key: 'images/blog/5-segredos-disney.jpg', sizeBytes: 284 * 1024 });
+  assert.deepEqual(decision, { process: false, reason: 'already-light' });
+});
+
+test('shouldOptimize skips already-efficient and vector formats', () => {
+  assert.equal(shouldOptimize({ key: 'images/x.webp', sizeBytes: 2_000_000 }).reason, 'unsupported-format');
+  assert.equal(shouldOptimize({ key: 'images/x.avif', sizeBytes: 2_000_000 }).reason, 'unsupported-format');
+  assert.equal(shouldOptimize({ key: 'images/x.svg', sizeBytes: 2_000_000 }).reason, 'unsupported-format');
+  assert.equal(shouldOptimize({ key: 'images/x.gif', sizeBytes: 2_000_000 }).reason, 'unsupported-format');
+});
+
+test('shouldOptimize never re-processes objects already under the backup prefix', () => {
+  const decision = shouldOptimize({ key: 'originals/images/blog/documentos.jpg', sizeBytes: 3_938 * 1024 });
+  assert.deepEqual(decision, { process: false, reason: 'backup-object' });
+});
+
+test('shouldOptimize honours a custom min size', () => {
+  assert.equal(shouldOptimize({ key: 'a.jpg', sizeBytes: 150 * 1024, minBytes: 100 * 1024 }).process, true);
+  assert.equal(shouldOptimize({ key: 'a.jpg', sizeBytes: 90 * 1024, minBytes: 100 * 1024 }).process, false);
+});
+
+test('planResize only downscales wider-than-max originals', () => {
+  assert.deepEqual(planResize(4000), { targetWidth: DEFAULT_MAX_WIDTH, willResize: true });
+  assert.deepEqual(planResize(2400), { targetWidth: null, willResize: false });
+  assert.deepEqual(planResize(1600), { targetWidth: null, willResize: false });
+});
+
+test('planResize never upscales a small original to the max width', () => {
+  const plan = planResize(800);
+  assert.equal(plan.willResize, false);
+  assert.equal(plan.targetWidth, null);
+});
+
+test('planResize respects a custom max width', () => {
+  assert.deepEqual(planResize(3000, 1800), { targetWidth: 1800, willResize: true });
+});
+
+test('isWorthOverwriting requires a strict size reduction', () => {
+  assert.equal(isWorthOverwriting(1000, 800), true);
+  assert.equal(isWorthOverwriting(1000, 1000), false);
+  assert.equal(isWorthOverwriting(1000, 1200), false);
+  assert.equal(isWorthOverwriting(1000, 0), false);
+});
+
+test('backup key helpers round-trip', () => {
+  const key = 'images/blog/documentos.jpg';
+  const backup = buildBackupKey(key);
+  assert.equal(backup, 'originals/images/blog/documentos.jpg');
+  assert.equal(isBackupKey(backup), true);
+  assert.equal(isBackupKey(key), false);
+});
+
+test('formatBytes renders human units', () => {
+  assert.equal(formatBytes(512), '512 B');
+  assert.equal(formatBytes(300 * 1024), '300.0 KB');
+  assert.equal(formatBytes(3_938 * 1024), '3.85 MB');
+});
+
+test('default thresholds match the documented policy', () => {
+  assert.equal(DEFAULT_MIN_BYTES, 300 * 1024);
+  assert.equal(DEFAULT_MAX_WIDTH, 2400);
+});

--- a/tests/optimize-r2-images.test.ts
+++ b/tests/optimize-r2-images.test.ts
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseArgs, contentTypeFor, encodeCopySource } from '../scripts/optimize-r2-images';
+
+test('parseArgs defaults to a safe dry-run', () => {
+  const opts = parseArgs([]);
+  assert.equal(opts.apply, false);
+  assert.equal(opts.prefix, 'images/');
+  assert.equal(opts.limit, null);
+});
+
+test('parseArgs reads all flags', () => {
+  const opts = parseArgs(['--apply', '--prefix', 'images/blog/', '--limit', '3', '--max-width', '1800', '--min-kb', '500', '--quality', '70', '--backup-prefix', 'bak/']);
+  assert.equal(opts.apply, true);
+  assert.equal(opts.prefix, 'images/blog/');
+  assert.equal(opts.limit, 3);
+  assert.equal(opts.maxWidth, 1800);
+  assert.equal(opts.minBytes, 500 * 1024);
+  assert.equal(opts.quality, 70);
+  assert.equal(opts.backupPrefix, 'bak/');
+});
+
+test('parseArgs rejects a flag missing its value', () => {
+  assert.throws(() => parseArgs(['--prefix']), /Missing value for argument: --prefix/);
+  assert.throws(() => parseArgs(['--limit']), /Missing value for argument: --limit/);
+});
+
+test('parseArgs rejects non-numeric values', () => {
+  assert.throws(() => parseArgs(['--limit', 'abc']), /Invalid numeric value for argument: --limit/);
+  assert.throws(() => parseArgs(['--quality', 'x']), /Invalid numeric value for argument: --quality/);
+});
+
+test('parseArgs rejects unknown arguments', () => {
+  assert.throws(() => parseArgs(['--nope']), /Unknown argument: --nope/);
+});
+
+test('contentTypeFor keeps a valid image/* type and corrects generic ones', () => {
+  assert.equal(contentTypeFor('jpeg', 'image/jpeg'), 'image/jpeg');
+  assert.equal(contentTypeFor('png', 'image/png'), 'image/png');
+  assert.equal(contentTypeFor('jpeg', 'application/octet-stream'), 'image/jpeg');
+  assert.equal(contentTypeFor('png', 'binary/octet-stream'), 'image/png');
+  assert.equal(contentTypeFor('jpeg', undefined), 'image/jpeg');
+  assert.equal(contentTypeFor('png'), 'image/png');
+});
+
+test('encodeCopySource encodes specials per segment but keeps slashes literal', () => {
+  assert.equal(
+    encodeCopySource('av-site-media', 'images/blog/foo.jpg'),
+    'av-site-media/images/blog/foo.jpg',
+  );
+  assert.equal(
+    encodeCopySource('av-site-media', 'images/authors/perfil felipe.png'),
+    'av-site-media/images/authors/perfil%20felipe.png',
+  );
+});


### PR DESCRIPTION
## Resumo

Adiciona `scripts/optimize-r2-images.ts` (`pnpm images:optimize`) para reotimizar os **originais pesados** no bucket R2 `av-site-media` (`media.anhanga.tur.br`).

É **higiene de SEO técnico / robustez de origem**, não otimização de LCP: o site já serve ~200 KB AVIF/WebP via Cloudflare Image Transformations (`/cdn-cgi/image`). O objetivo é tirar as URLs cruas multi-MB indexadas por crawlers (Ahrefs acusava "imagens pesadas"), aliviar a origem e proteger a cota Free de transforms.

## O que o script garante
- Mesma chave/extensão/Content-Type → URLs e tags OG/social intactas
- Backup de cada original em `originals/<key>` (server-side copy) antes de qualquer overwrite
- Só **downscale** (nunca upscale; máx. 2400px = retina 2x do hero 1200px)
- JPG → mozjpeg q80; PNG continua PNG (não converte original p/ WebP/AVIF — isso é função do transform em runtime)
- Só sobrescreve se o resultado ficar menor
- **Dry-run por padrão**; grava apenas com `--apply`. Flags: `--prefix` `--limit` `--max-width` `--min-kb` `--quality` `--backup-prefix`

## Execução já realizada neste bucket
| | Antes | Depois | Economia |
|---|---|---|---|
| Total | 175,28 MB | 36,40 MB | **−138,88 MB (−79%)** |

73 imagens otimizadas · 6 mantidas (recompressão cresceria) · 0 erros. Backups íntegros em `originals/`; transforms `/cdn-cgi/image` seguem 200; sem degradação visual a q80/2400px.

## Arquivos
- `scripts/optimize-r2-images.ts` — orquestração (API S3 do R2 via `@aws-sdk/client-s3` + `sharp`)
- `lib/image-optimization.ts` — lógica pura de decisão
- `tests/image-optimization.test.ts` — 14 testes (regressão)
- `package.json` — devDeps `@aws-sdk/client-s3` + `sharp`, script `images:optimize`
- `.env.example` — documenta `R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY`

## Testes
- `pnpm test:regression` → **706/706 ✓**
- `pnpm typecheck` → limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)