### PR TITLE
fix: block GTM/GA4 in non-prod to stop CI polluting conversions (G0)

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,12 @@
       var loadGtm = function () {
         if (gtmLoaded) return;
         gtmLoaded = true;
+        // Não carregar GTM em ambientes não-produtivos (dev local + Playwright/CI em 127.0.0.1).
+        // Sem este gate, submits de teste disparam generate_lead -> GTM -> GA4 de produção e
+        // poluem o sinal de conversão (treina o Smart Bidding com tráfego de bot). Espelha o
+        // gate de host do loadMautic.
+        var h = location.hostname;
+        if (h === 'localhost' || h === '127.0.0.1' || h.endsWith('.local') || h.endsWith('.test')) return;
         window.dataLayer.push({
           'gtm.start': new Date().getTime(),
           event: 'gtm.js'

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
         // poluem o sinal de conversão (treina o Smart Bidding com tráfego de bot). Espelha o
         // gate de host do loadMautic.
         var h = location.hostname;
-        if (h === 'localhost' || h === '127.0.0.1' || h.endsWith('.local') || h.endsWith('.test')) return;
+        if (h === 'localhost' || h === '127.0.0.1' || h === '[::1]' || h === '::1' || h === '0.0.0.0' || h.endsWith('.local') || h.endsWith('.test')) return;
         window.dataLayer.push({
           'gtm.start': new Date().getTime(),
           event: 'gtm.js'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,11 +29,17 @@ export default defineConfig({
         },
       ],
     },
-    // Block third-party tracking during tests — prevents test data from polluting production CRMs
+    // Block third-party tracking during tests — prevents test data from polluting production
+    // CRMs and the production GA4 property (generate_lead via GTM/sGTM). Belt-and-suspenders
+    // alongside the localhost gate in index.html's loadGtm.
     launchOptions: {
       args: [
         '--host-resolver-rules='
         + 'MAP mkt.anhanga.tur.br ~NOTFOUND, '
+        + 'MAP load.sst.anhanga.tur.br ~NOTFOUND, '
+        + 'MAP *.googletagmanager.com ~NOTFOUND, '
+        + 'MAP *.google-analytics.com ~NOTFOUND, '
+        + 'MAP *.analytics.google.com ~NOTFOUND, '
         + 'MAP *.hubspot.com ~NOTFOUND, '
         + 'MAP *.hsforms.com ~NOTFOUND, '
         + 'MAP *.hsforms.net ~NOTFOUND, '

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -91,6 +91,9 @@ test('loadGtm tem gate de host para não poluir o GA4 de produção em dev/CI', 
   assert.match(body, /location\.hostname/, 'loadGtm deve checar location.hostname');
   assert.match(body, /'localhost'/, 'gate deve cobrir localhost');
   assert.match(body, /'127\.0\.0\.1'/, 'gate deve cobrir 127.0.0.1');
+  assert.match(body, /'\[::1\]'/, 'gate deve cobrir o loopback IPv6 [::1]');
+  assert.match(body, /'::1'/, 'gate deve cobrir o loopback IPv6 ::1');
+  assert.match(body, /'0\.0\.0\.0'/, 'gate deve cobrir 0.0.0.0 (Docker/CI)');
   assert.match(body, /\.endsWith\('\.local'\)/, 'gate deve cobrir hosts .local');
   assert.match(body, /\.endsWith\('\.test'\)/, 'gate deve cobrir hosts .test');
 

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -81,6 +81,26 @@ test('index.html configura gtag consent defaults antes da IIFE de scripts lazy',
   assert.match(indexHtml, /wait_for_update:\s*2000/, 'wait_for_update deve ser 2000ms');
 });
 
+test('loadGtm tem gate de host para não poluir o GA4 de produção em dev/CI', () => {
+  const loadGtmMatch = indexHtml.match(/var loadGtm\s*=\s*function\s*\(\)\s*\{([\s\S]*?)};/);
+  assert.ok(loadGtmMatch, 'loadGtm deve estar definida');
+  const body = loadGtmMatch[1];
+
+  // O gate de host deve bloquear localhost/127.0.0.1/.local/.test, onde o Playwright/CI roda.
+  // Sem isto, generate_lead de testes vaza para o GA4 de produção (gatilho G0 do plano 360).
+  assert.match(body, /location\.hostname/, 'loadGtm deve checar location.hostname');
+  assert.match(body, /'localhost'/, 'gate deve cobrir localhost');
+  assert.match(body, /'127\.0\.0\.1'/, 'gate deve cobrir 127.0.0.1');
+  assert.match(body, /\.endsWith\('\.local'\)/, 'gate deve cobrir hosts .local');
+  assert.match(body, /\.endsWith\('\.test'\)/, 'gate deve cobrir hosts .test');
+
+  // O return do gate precisa vir ANTES da injeção do loader do GTM/sGTM.
+  const gateIndex = body.indexOf('location.hostname');
+  const injectIndex = body.indexOf('load.sst.anhanga.tur.br');
+  assert.ok(gateIndex > -1 && injectIndex > -1, 'gate e injeção devem existir em loadGtm');
+  assert.ok(gateIndex < injectIndex, 'o gate de host deve preceder a injeção do GTM');
+});
+
 test('loadMautic tem gate de consentimento LGPD', () => {
   const loadMauticMatch = indexHtml.match(/var loadMautic\s*=\s*function\s*\(\)\s*\{([\s\S]*?)};/);
   assert.ok(loadMauticMatch, 'loadMautic deve estar definida');


### PR DESCRIPTION
## Por quê

Gatilho **G0** do Plano de Marketing 360 — pré-requisito do G2 (importar `generate_lead` como conversão primária do Google). Sem isto, o Smart Bidding seria treinado com tráfego de bot.

**Causa-raiz:** `loadGtm()` no `index.html` não tinha gate de host (o `loadMautic()` logo abaixo tinha). O container `GTM-T2KGS86G` carregava até em `127.0.0.1`, exatamente onde o Playwright/CI roda (`pnpm dev` em 127.0.0.1:3100). Submits de teste empurravam `generate_lead` → GTM → **GA4 de produção**.

Bate com o diagnóstico GA4 de 13/06: **84%** dos disparos em `/corporativo`, **91%** `(direct)/(none)` (assinatura de bot).

## O que muda

| Arquivo | Mudança |
|---|---|
| `index.html` | Gate de host no `loadGtm()` — não carrega GTM em `localhost`/`127.0.0.1`/`.local`/`.test`. Espelha o gate que o `loadMautic` já tinha. |
| `playwright.config.ts` | Bloqueia `load.sst.anhanga.tur.br` + `*.googletagmanager.com` + `*.google-analytics.com` + `*.analytics.google.com` via `host-resolver-rules` (defense in depth, mesmo padrão do bloqueio de HubSpot existente). |
| `tests/index-third-party-scripts.test.ts` | Teste de regressão travando o gate de host do `loadGtm`. |

`generate_lead` continua sendo empurrado para `window.dataLayer` localmente — só a entrega ao GA4 foi cortada. As asserções do e2e `chatbot-lead-submit` não são afetadas.

## Verificação

- `pnpm exec tsx --test tests/index-third-party-scripts.test.ts` → **11/11** ✅
- `pnpm exec playwright test tests/e2e/chatbot-lead-submit.spec.ts --project=chromium` → **2/2** ✅

## Follow-up (fora deste PR)

- Após deploy, validar no GA4 que `generate_lead` zera em `/corporativo`, `/s/login`, `/auth/login` no recorte pós-fix.
- Opcional: criar Internal Traffic Rule (`traffic_type=internal`) no GA4 para o IP de trabalho (cobre QA/dev manual de IP fixo).
- ⚠️ `/s/login` e `/auth/login` não são páginas de lead — se `generate_lead` persistir nesses paths pós-deploy, o emissor é outro (trigger de GTM mal configurado ou bot em produção), follow-up separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)