### PR TITLE
chore: remove dependência sirv não utilizada

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "react-doctor": "^0.2.3",
     "rollup-plugin-visualizer": "^7.0.1",
     "sharp": "^0.34.5",
-    "sirv": "^3.0.2",
     "tailwindcss": "^4.3.0",
     "tsx": "^4.22.4",
     "turndown": "^7.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,9 +129,6 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
-      sirv:
-        specifier: ^3.0.2
-        version: 3.0.2
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1266,9 +1263,6 @@ packages:
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
-
-  '@polka/url@1.0.0-next.29':
-    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -3072,10 +3066,6 @@ packages:
   motion-utils@12.39.0:
     resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
-  mrmime@2.0.1:
-    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
-    engines: {node: '>=10'}
-
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -3488,10 +3478,6 @@ packages:
   simplesignal@2.1.7:
     resolution: {integrity: sha512-PEo2qWpUke7IMhlqiBxrulIFvhJRLkl1ih52Rwa+bPjzhJepcd4GIjn2RiQmFSx3dQvsEAgF0/lXMwMN7vODaA==}
 
-  sirv@3.0.2:
-    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
-    engines: {node: '>=18'}
-
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -3616,10 +3602,6 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-
-  totalist@3.0.1:
-    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
-    engines: {node: '>=6'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -4760,8 +4742,6 @@ snapshots:
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
-
-  '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
     dependencies:
@@ -6781,8 +6761,6 @@ snapshots:
 
   motion-utils@12.39.0: {}
 
-  mrmime@2.0.1: {}
-
   ms@2.0.0: {}
 
   ms@2.1.3: {}
@@ -7382,12 +7360,6 @@ snapshots:
 
   simplesignal@2.1.7: {}
 
-  sirv@3.0.2:
-    dependencies:
-      '@polka/url': 1.0.0-next.29
-      mrmime: 2.0.1
-      totalist: 3.0.1
-
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
@@ -7520,8 +7492,6 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
-
-  totalist@3.0.1: {}
 
   tr46@0.0.3: {}
 


### PR DESCRIPTION
## O que muda

Remove a devDependency `sirv`, que estava órfã no projeto.

## Por quê

- Zero referências em código, scripts ou configs — só aparecia em `package.json` e no lockfile.
- Foi adicionada em mar/2026 (commit `a892f5c`, refactor do prerender que na época usava Puppeteer + servidor HTTP). O prerender atual (`scripts/prerender.mjs`) usa `MemoryRouter`/SSR estático, **sem servidor HTTP**, então o `sirv` ficou para trás.

## Verificação

Varredura de todas as 46 dependências (prod + dev). `sirv` foi a única genuinamente órfã. As demais "sem referência via grep" são justificadas:
- `@types/*` — consumidos implicitamente pelo TypeScript
- `bundlesize2` (fornece o bin `bundlesize` do `test:size`) e `decap-server` (bin do `cms:proxy`) — binários de script
- `@aws-sdk/client-s3` + `sharp` — usados em `scripts/optimize-r2-images.ts`

Sem impacto em runtime: `sirv` era devDependency e não entrava no bundle das Functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)