### PR TITLE
fix(deps): pin protobufjs >=7.6.3 (Dependabot #35)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   glob: ^13.0.6
   minimatch: ^10.2.2
   qs: ^6.15.2
+  protobufjs: '>=7.6.3 <8'
 
 importers:
 
@@ -3273,8 +3274,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.6.2:
-    resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
+  protobufjs@7.6.3:
+    resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -4332,7 +4333,7 @@ snapshots:
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
-      protobufjs: 7.6.2
+      protobufjs: 7.6.3
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -7014,7 +7015,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.6.2:
+  protobufjs@7.6.3:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,10 @@ overrides:
   glob: "^13.0.6"
   minimatch: "^10.2.2"
   qs: "^6.15.2"
+  # Dependabot #35 (medium): protobufjs <= 7.6.2 schema-property shadowing.
+  # Transitivo via @google/genai (SDK do Gemini, produção). 7.6.3 corrige.
+  # Pinado na linha 7.6.x: a 8.x não tem trusted publisher e viola no-downgrade.
+  protobufjs: ">=7.6.3 <8"
 
 legacyPeerDeps: true
 nodeLinker: hoisted


### PR DESCRIPTION
## Contexto

Resolve o alerta [Dependabot #35](https://github.com/felipewilliam2/AV-SITE/security/dependabot/35) (severidade **média**): `protobufjs <= 7.6.2` permite que nomes derivados de schema sobrescrevam propriedades runtime-significativas.

A dependência chega **transitivamente** via `@google/genai@2.8.0` (SDK do Gemini) — é a única das 3 vulnerabilidades abertas que está em **dependência de produção**.

## Mudança

Adiciona override `protobufjs: ">=7.6.3 <8"` no `pnpm-workspace.yaml`, resolvendo para `7.6.3`.

- Pinado na linha **7.6.x** de propósito: a linha 8.x não tem trusted publisher e violaria a política `no-downgrade` do pnpm (`ERR_PNPM_TRUST_DOWNGRADE`).
- A `7.6.4` (12/jun) ainda está dentro da janela do `minimumReleaseAge` (7 dias), então o resolver cai em `7.6.3` automaticamente.

## Verificação

- `pnpm install` — resolve `protobufjs@7.6.3` ✓
- `pnpm typecheck` — `tsc --noEmit` exit 0 ✓
- `pnpm test:regression` — 719/719 passando ✓

## Pendências relacionadas (fora deste PR)

- **#31 esbuild** (baixa, devDep, dev server só Windows): patch `0.28.1` ainda bloqueado pelo `minimumReleaseAge` até ~18/jun. PR separado a partir de amanhã.
- **#34 js-yaml** (média, devDep build-time): será dispensado — superfície inexistente (só processa frontmatter do próprio repo) e o patch `4.2.0` quebraria `gray-matter` (depende de `js-yaml ^3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)