### PR TITLE
fix(test): corrige flaky no Playwright (hero_ux dropdown Crianças)

### DIFF
--- a/tests/e2e/hero_ux.spec.ts
+++ b/tests/e2e/hero_ux.spec.ts
@@ -49,8 +49,9 @@ test.describe('Hero UX and Accessibility', () => {
 
     // Open Guests
     await page.getByTestId('guests-filter-btn').click();
-    // The dropdown contains "Adultos", "Crianças", etc.
-    const guestLabel = page.getByText('Crianças').first();
+    // The dropdown contains exact labels "Adultos", "Crianças", etc.
+    // Use exact match to avoid matching blog card headings that contain "Crianças" as a substring.
+    const guestLabel = page.getByText('Crianças', { exact: true });
     await expect(guestLabel).toBeVisible();
 
     await page.keyboard.press('Escape');


### PR DESCRIPTION
## Problema

O workflow **Playwright Tests** da `main` estava falhando em 1 teste (275 passando):

`tests/e2e/hero_ux.spec.ts:39` → *"should dismiss other dropdowns with Escape key"*

### Causa raiz

O teste usava `page.getByText('Crianças').first()` **sem `exact`**. Como `getByText` casa por substring, o locator casava com o `<h4>` de um card de blog na home — **"Disney vs Beto Carrero: Qual Escolher para Crianças"** — que está sempre visível. O `.first()` agarrava esse heading em vez do `<p>Crianças</p>` do dropdown de hóspedes.

Consequência: a asserção `expect(...).not.toBeVisible()` após `Escape` falhava, porque o card de blog continuava visível independentemente do estado do dropdown. Não havia regressão no app — apenas um teste frágil exposto quando o conteúdo da home mudou.

## Correção

Troca para `page.getByText('Crianças', { exact: true })`, que casa apenas o `<p>Crianças</p>` exato do dropdown (o `<h4>` do card tem texto longo e é descartado).

## Verificação

`pnpm exec playwright test tests/e2e/hero_ux.spec.ts --project=chromium` → **3 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)