### PR TITLE
docs(plans): planos da rodada 3 do /improve (012-017)

### DIFF
--- a/plans/012-root-housekeeping-stale-artifacts.md
+++ b/plans/012-root-housekeeping-stale-artifacts.md
@@ -1,0 +1,222 @@
+# Plan 012: Tirar artefatos/dumps obsoletos da raiz e respeitar a regra "root mínima"
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat ec3029a..HEAD -- .gitignore "SEO/" "ferramentas/" "Anhangá Viagens Design System/" comparacao-ides.html docs/`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" facts against the live tree before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: dx / docs
+- **Planned at**: commit `ec3029a`, 2026-06-21
+- **Revised**: 2026-06-21 — Step 5 (mover o folder do design system) **removido**
+  após execução: `tests/index-third-party-scripts.test.ts` lê o folder da raiz em
+  runtime (`.endsWith('Design System')`) e quebraria. Esse move foi para o
+  plano [017](017-move-design-system-folder.md), que inclui o ajuste do teste no
+  escopo. Este plano agora cobre só os três ganhos independentes (dead file, dump
+  SEO, assinatura de e-mail).
+
+## Why this matters
+
+`CLAUDE.md` documents a hard rule: "Keep the project root minimal — only
+`README.md`, `CLAUDE.md`, and code/tooling configs belong there. All other
+documentation lives under `/docs/`." It also says reports with sensitive
+business data "stay **local only** — add the filename pattern to `.gitignore`
+instead of committing." Today the repo root violates both rules: stale SEO
+crawl dumps, a dead stray HTML file, an email-signature asset, and a parallel
+design-system folder are all tracked at the root. None is referenced by code or
+build config. Cleaning this up reduces noise for contributors and agents, and
+stops 18 point-in-time crawl exports (business data) from living in git history
+going forward. There is precedent: commits `04fa143` and `39d0f62` already
+untracked sensitive marketing docs the same way.
+
+## Current state
+
+Verified at commit `ec3029a`. All paths below are **tracked** in git and have
+**no references** from any `*.ts/*.tsx/*.mjs/*.json/*.toml/*.html` file outside
+the agent-config dirs (`grep` for `Anhangá Viagens Design System`, `/SEO/`,
+`comparacao-ides`, `ferramentas/assinatura` returned nothing in code/config).
+
+- `comparacao-ides.html` (root, ~19 KB) — a stray "IDE comparison" HTML page.
+  Not part of the site, not imported, not referenced anywhere. **Dead artifact.**
+- `SEO/` — 18 files: crawl exports (`*.csv`) plus `All issues - Anhanga1.pdf`,
+  all dated `2026-05-28` (a one-off Ahrefs/crawler dump). These are exactly the
+  "reports containing sensitive business data" the docs say to keep local-only.
+- `ferramentas/assinatura-email.html` — a single email-signature HTML asset
+  (one file in the dir). Misplaced; belongs under `docs/`.
+- `Anhangá Viagens Design System/` — a design-system reference folder
+  (`README.md`, `SKILL.md`, `assets/*.svg`, `colors_and_type.css`, `preview/*.html`).
+  This is **not** the same as `docs/design/` (which holds the machine-readable
+  `design-system.json` + `design-context.md`). It is a parallel human-facing
+  design reference that belongs under `docs/design/`.
+
+Repo conventions to follow:
+- `docs/` is organized by domain (`docs/design/`, `docs/seo/`, `docs/marketing/`,
+  `docs/ops/`, …). See the table in `CLAUDE.md` ("Documentation Organization").
+- `.gitignore` already has a "Marketing reports, audits & campaigns" section
+  (lines 46–57) listing patterns for local-only business docs. Add the SEO dump
+  pattern in the same spirit.
+- Prefer kebab-case, ASCII-only directory names (avoid spaces/accents) for new
+  doc folders — the rest of `docs/` follows this.
+
+## Commands you will need
+
+| Purpose            | Command                                              | Expected on success            |
+|--------------------|------------------------------------------------------|--------------------------------|
+| Regression tests   | `pnpm test:regression`                               | all pass (same as baseline)    |
+| Ref check (code)   | `grep -rln "comparacao-ides\|/SEO/\|ferramentas/assinatura\|Anhangá Viagens Design System" --include="*.ts" --include="*.tsx" --include="*.mjs" --include="*.json" --include="*.toml" --include="*.html" . \| grep -v node_modules` | (empty)  |
+| Tracked-at-root    | `git ls-files \| grep -E '^[^/]+$'`                   | no `comparacao-ides.html`      |
+| Working tree state | `git status --porcelain`                             | only the intended moves/deletes|
+
+> Note: `pnpm install --frozen-lockfile` first if `node_modules` is absent.
+> This plan changes **no** TypeScript, so `pnpm typecheck` and `pnpm build`
+> behavior is unchanged from baseline; running the regression suite is enough.
+
+## Scope
+
+**In scope** (the only paths you should modify/move/delete):
+- `comparacao-ides.html` (delete)
+- `SEO/` (untrack from git + add to `.gitignore`; leave the files on disk)
+- `ferramentas/assinatura-email.html` (move → `docs/marketing/email-signature.html`)
+- `.gitignore` (add the `SEO/` ignore pattern)
+
+**Out of scope** (do NOT touch, even though they look related):
+- `Anhangá Viagens Design System/` (root folder) — do NOT move or delete it here.
+  `tests/index-third-party-scripts.test.ts` reads it from the repo root at runtime
+  (`fs.readdirSync(process.cwd()).find(e => e.endsWith('Design System'))` + reads
+  its `colors_and_type.css`). Moving it breaks that test. Its relocation is
+  plan 017, which updates the test in the same change.
+- `docs/design/design-system.json`, `docs/design/design-context.md` — the
+  canonical token docs; do not merge or overwrite these.
+- Any `*.ts/*.tsx` source file — this plan is file-system housekeeping only.
+- The agent-config dirs (`.agent/`, `.agents/`, `.Jules/`, `.jules/`, `.qwen/`,
+  `.codex/`) — already handled / intentionally local; leave them alone.
+- `content/`, `src/`, `public/`, `data/` — legitimate code/content dirs.
+
+## Git workflow
+
+- Branch: `chore/root-housekeeping` (repo uses `feature/`, `fix/`, `chore/`,
+  `docs/` prefixes — `chore/` fits file housekeeping).
+- Use `git mv` for moves so history is preserved.
+- Conventional commit, e.g. `chore: tira artefatos obsoletos da raiz para docs/`.
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: Confirm nothing references the in-scope paths
+
+Run the "Ref check (code)" command from the table above.
+
+**Verify**: command prints nothing (empty output). If it prints any file path
+outside the agent-config dirs, **STOP** — something depends on a path you were
+about to move/delete.
+
+### Step 2: Delete the dead stray file
+
+```
+git rm comparacao-ides.html
+```
+
+**Verify**: `git ls-files | grep -E '^[^/]+$' | grep comparacao-ides` → no output.
+
+### Step 3: Untrack the SEO crawl dump and ignore it going forward
+
+Keep the files on disk (operator may still want them locally) but stop tracking:
+
+```
+git rm -r --cached SEO/
+```
+
+Then append to `.gitignore`, in the "Marketing reports, audits & campaigns"
+section (after line 57), a new block:
+
+```
+# SEO crawl exports / audit dumps (business data — local only)
+SEO/
+```
+
+**Verify**:
+- `git ls-files SEO/` → no output (untracked).
+- `git check-ignore SEO/` → prints `SEO/` (now ignored).
+- `ls SEO/ | head -1` → still lists files (kept on disk).
+
+### Step 4: Move the email-signature asset into docs/marketing/
+
+```
+mkdir -p docs/marketing
+git mv "ferramentas/assinatura-email.html" "docs/marketing/email-signature.html"
+```
+
+If `ferramentas/` is now empty, remove the empty dir:
+`rmdir ferramentas 2>/dev/null || true`
+
+**Verify**: `git ls-files docs/marketing/email-signature.html` → prints the path;
+`git ls-files ferramentas/` → no output.
+
+### Step 5: Confirm the suite is unaffected
+
+```
+pnpm test:regression
+```
+
+**Verify**: all tests pass (this plan changed no code or test inputs, so the
+result must match the pre-change baseline). In particular
+`tests/package-scripts.test.ts` and any docs/structure tests still pass.
+
+## Test plan
+
+No new automated tests — this is file-system housekeeping with no behavior
+change, which `docs/standards/testing.md` exempts ("Documentation-only changes
+do not require runtime tests"). The safety net is:
+- the ref-check grep (Step 1) proving nothing imports the moved/deleted paths,
+- the full regression suite (Step 6) proving the build/test inputs are intact.
+
+If `pnpm test:regression` references any of these paths (it should not), STOP.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `git ls-files | grep -E '^[^/]+$' | grep -q comparacao-ides` → no match (exit 1)
+- [ ] `git ls-files SEO/` → empty; `git check-ignore SEO/` → `SEO/`
+- [ ] `git ls-files docs/marketing/email-signature.html` → present
+- [ ] `Anhangá Viagens Design System/` still tracked at root (NOT moved — that is plan 017): `git ls-files | grep -c "Anhangá Viagens Design System"` → non-zero
+- [ ] `pnpm test:regression` exits 0
+- [ ] No `*.ts/*.tsx/*.mjs` file modified (`git status --porcelain | grep -E '\.(ts|tsx|mjs)$'` → empty)
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The Step 1 ref check finds any code/config reference to an in-scope path.
+- `git mv` fails because a target already exists under `docs/` (means the move
+  was partially done before, or there's a name collision — report it).
+- `pnpm test:regression` fails, or its failure mentions any in-scope path.
+- The `SEO/` or design-system folder turns out to be referenced by a GitHub
+  Actions workflow under `.github/workflows/` (re-check with
+  `grep -rln "SEO/\|Design System\|ferramentas" .github/`).
+
+## Maintenance notes
+
+- For the reviewer: confirm the moved docs render/open from their new `docs/`
+  homes and that the `SEO/` ignore did not accidentally also ignore a wanted
+  path. The diff should contain only deletes, renames, and one `.gitignore` add.
+- Follow-up deliberately deferred: this does NOT consolidate the agent-config
+  dirs (`.agent/`, `.qwen/`, …) or the legacy `vercel.json`/`netlify.toml` —
+  those were considered and rejected in earlier rounds as low-leverage DX, to be
+  done opportunistically.
+- If someone later wants the `SEO/` exports versioned for audit history, the
+  right home is a dedicated `docs/seo/crawls/` with a `.gitignore` exception —
+  but only if there's a concrete need; default is local-only.

--- a/plans/013-freeze-legacy-brand-tailwind-namespace.md
+++ b/plans/013-freeze-legacy-brand-tailwind-namespace.md
@@ -1,0 +1,297 @@
+# Plan 013: Congelar o namespace Tailwind legado `brand-*` com guard ratchet + documentar `anhanga-*` como canônico
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat ec3029a..HEAD -- tailwind.config.mjs lib/design-tokens.ts tests/tailwind-bare-yellow-guard.test.ts .claude/CLAUDE.md`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: tech-debt
+- **Planned at**: commit `ec3029a`, 2026-06-21
+
+## Why this matters
+
+The Tailwind config defines **two overlapping color namespaces**: `brand.*`
+(legacy) and `anhanga.*` (canonical). `lib/design-tokens.ts` is the declared
+source of truth and maps every semantic token to `anhanga-*` classes, and the
+config itself comments the `anhanga` entries as "(antigo brand-cyan / brand-vibrant)".
+Yet `brand-*` is still used ~629 times across `components/` and `pages/`, and
+**nothing stops new code from adding more** — so the two systems keep growing in
+parallel, which confuses contributors about which token to reach for.
+
+A full migration of all ~629 usages is high-risk (visual regressions, gated only
+by snapshot tests) and low-value, so it is explicitly **not** in scope here.
+Instead this plan stops the bleeding cheaply: a "ratchet" guard test that fails
+CI when the count of legacy `brand-*` utilities **increases** past today's
+baseline, plus a one-line deprecation note pointing future work at `anhanga-*`.
+New code is nudged to the canonical namespace; the legacy usages migrate
+opportunistically as files are touched, lowering the baseline over time. This
+mirrors the existing `tests/tailwind-bare-yellow-guard.test.ts` pattern.
+
+## Current state
+
+Verified at commit `ec3029a`.
+
+- `tailwind.config.mjs:18-45` — `theme.extend.colors` defines both namespaces:
+  ```js
+  colors: {
+      brand: {
+          cyan: '#0ea5e9', cyanDark: '#0284c7', blue: '#1e40af',
+          vibrant: '#0ea5e9', yellow: '#FFD600', dark: '#0f172a',
+          light: '#f0f9ff', surface: '#fffdf5',
+      },
+      // ...
+      anhanga: {
+          action:     '#0ea5e9',   // cor de ação (antigo brand-cyan / brand-vibrant)
+          actionDark: '#0284c7',   // hover de ação (antigo brand-cyanDark)
+          dark:       '#0f172a',
+          blue: '#0056D2', darkBlue: '#003B8E',
+          yellow: '#FFD600', yellowHover: '#E5C000',
+          light: '#F4F8FF', whatsapp: '#25D366',
+      },
+  },
+  ```
+- `lib/design-tokens.ts` — canonical semantic tokens, **all** resolving to
+  `anhanga-*` (e.g. `action: 'anhanga-action'`, `accent: 'anhanga-yellow'`,
+  `dark: 'anhanga-dark'`). This is the authority that makes `anhanga-*` canonical
+  and `brand-*` legacy.
+- `tests/tailwind-bare-yellow-guard.test.ts` — **the exemplar to copy.** A
+  `node:test` that walks `SCAN_DIRS = ['components','pages','services','utils','data']`
+  with extensions `.tsx/.ts/.jsx/.js`, matches a regex per line via `matchAll`,
+  and asserts an offender list. Match your new guard's structure to this file
+  exactly (imports, `collectTailwindFiles`, `ROOT`, scan dirs/exts).
+- Baseline count (measured with the regex this plan specifies, same scan scope):
+  **≈ 629** occurrences (`components` 419, `pages` 204, `utils` 6, `services`/`data` 0).
+  You will re-measure and pin the exact number in Step 2 — do not hardcode 629
+  blindly; use what the guard actually counts in the current tree.
+
+Conventions to follow:
+- `node:test` + `assert/strict`, run via `tsx --test` (see `docs/standards/testing.md`).
+- Portuguese comments matching the surrounding test files; explain the *why*
+  (the ratchet intent), like the bare-yellow guard's header comment does.
+
+## Commands you will need
+
+| Purpose             | Command                                                    | Expected on success        |
+|---------------------|------------------------------------------------------------|----------------------------|
+| Run only this test  | `tsx --test tests/tailwind-brand-namespace-guard.test.ts`  | 1 test, pass               |
+| Full regression     | `pnpm test:regression`                                     | all pass                   |
+| Measure baseline    | (see Step 2 — a `grep -rohE … \| wc -l` over the scan dirs) | a single integer (~629)    |
+
+> Run `pnpm install --frozen-lockfile` first if `node_modules` is absent. This
+> plan adds a test + doc/comment only; no runtime code changes.
+
+## Scope
+
+**In scope** (the only files you should modify/create):
+- `tests/tailwind-brand-namespace-guard.test.ts` (create)
+- `tailwind.config.mjs` (add a deprecation comment above the `brand` block — no
+  value/key changes)
+- `.claude/CLAUDE.md` (one line in the "Styling" section noting `anhanga-*` is
+  canonical and `brand-*` is frozen/legacy)
+
+**Out of scope** (do NOT touch):
+- Any `components/**` or `pages/**` file — do **not** migrate existing `brand-*`
+  usages in this plan. That is deliberate; mass migration is a separate, risky
+  effort to be done opportunistically.
+- `lib/design-tokens.ts` — already canonical; leave it.
+- The `brand` keys/values in `tailwind.config.mjs` — keep them working (629 live
+  usages depend on them). You are only adding a comment.
+- `tests/tailwind-bare-yellow-guard.test.ts` — copy its shape into the new file;
+  do not edit the original.
+
+## Git workflow
+
+- Branch: `test/freeze-brand-namespace` (or `chore/`; repo uses
+  `feature/`/`fix/`/`chore/`/`docs/` and `test:` conventional commits).
+- Commit message style (conventional, matches `git log`):
+  `test(guard): congela namespace legado brand-* com ratchet`.
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: Create the guard test (without the baseline number yet)
+
+Create `tests/tailwind-brand-namespace-guard.test.ts`, structured like
+`tests/tailwind-bare-yellow-guard.test.ts`. Use this regex (mirrors the
+bare-yellow prefix list; matches legacy `-brand-<subtoken>` color utilities and
+not the `anhanga-*` canonical ones):
+
+```ts
+const LEGACY_BRAND =
+  /(?<![\w-])(text|bg|border|fill|stroke|ring|from|to|via|divide|decoration|outline|accent|caret|shadow)-brand-[a-z][a-zA-Z]*(?![\w-])/g;
+```
+
+Reuse the exemplar's `SCAN_DIRS`, `TARGET_EXTENSIONS`, `ROOT`, and
+`collectTailwindFiles` verbatim. Count every match across all scanned files into
+a single integer `total`. Add a header comment explaining the ratchet intent:
+this namespace is legacy (canonical is `anhanga-*`, see `lib/design-tokens.ts`);
+the count must never grow; lower the baseline when you migrate usages away.
+
+For now write the assertion as a temporary print so you can read the count:
+
+```ts
+test('legacy brand-* namespace does not grow (ratchet)', () => {
+  const files = SCAN_DIRS.flatMap(collectTailwindFiles);
+  assert.ok(files.length > 0, 'Expected to scan at least one Tailwind file');
+  let total = 0;
+  for (const file of files) {
+    const text = fs.readFileSync(file, 'utf8');
+    total += [...text.matchAll(LEGACY_BRAND)].length;
+  }
+  console.log('CURRENT_BRAND_COUNT=', total); // TEMP — removed in Step 2
+  assert.ok(true);
+});
+```
+
+**Verify**: `tsx --test tests/tailwind-brand-namespace-guard.test.ts` → passes
+and prints `CURRENT_BRAND_COUNT= <N>`. Confirm `<N>` is in the **620–640** range.
+If it is wildly different (e.g. < 400 or > 800), the tree drifted from this
+plan's baseline — **STOP** and report `<N>`.
+
+### Step 2: Pin the baseline and make the assertion a real ratchet
+
+Replace the temporary body: introduce a constant set to the `<N>` you just
+observed, remove the `console.log`, and assert no growth. Example shape:
+
+```ts
+// Baseline medido em <YYYY-MM-DD> (commit ec3029a-descendant). Ao migrar
+// usos de brand-* para anhanga-*, ABAIXE este número para travar o ganho.
+const BRAND_NAMESPACE_BASELINE = <N>;
+
+test('legacy brand-* namespace does not grow (ratchet)', () => {
+  const files = SCAN_DIRS.flatMap(collectTailwindFiles);
+  assert.ok(files.length > 0, 'Expected to scan at least one Tailwind file');
+  const offenders: string[] = [];
+  let total = 0;
+  for (const file of files) {
+    const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+    lines.forEach((line, i) => {
+      for (const m of line.matchAll(LEGACY_BRAND)) {
+        total += 1;
+        offenders.push(`${path.relative(ROOT, file)}:${i + 1} → ${m[0]}`);
+      }
+    });
+  }
+  assert.ok(
+    total <= BRAND_NAMESPACE_BASELINE,
+    `Uso de brand-* (legado) cresceu para ${total} (baseline ${BRAND_NAMESPACE_BASELINE}).\n` +
+    `Use o namespace canônico anhanga-* (ver lib/design-tokens.ts). Novos usos:\n${offenders.join('\n')}`,
+  );
+});
+```
+
+**Verify**: `tsx --test tests/tailwind-brand-namespace-guard.test.ts` → 1 test,
+pass. There must be **no** remaining `console.log` in the file
+(`grep -n "console.log" tests/tailwind-brand-namespace-guard.test.ts` → empty).
+
+### Step 3: Self-check that the ratchet actually catches growth
+
+Temporarily append a single fake legacy class to any scanned file (e.g. add the
+string `text-brand-cyan` inside a comment in `components/Footer.tsx`), re-run the
+test, and confirm it now **fails** with the offender listed. Then revert the edit.
+
+**Verify**: with the temporary class present →
+`tsx --test tests/tailwind-brand-namespace-guard.test.ts` exits non-zero and the
+message lists the offender. After `git checkout -- components/Footer.tsx`
+(or whichever file you touched) → test passes again. `git status --porcelain`
+shows only the new test file (+ Steps 4–5 docs) as changes.
+
+### Step 4: Add the deprecation comment in the config
+
+In `tailwind.config.mjs`, immediately above the `brand:` object (line ~19), add:
+
+```js
+// LEGADO — não usar em código novo. Namespace canônico: `anhanga-*`
+// (ver lib/design-tokens.ts). Congelado por tests/tailwind-brand-namespace-guard.test.ts;
+// migre usos de brand-* → anhanga-* oportunisticamente e abaixe o baseline do guard.
+```
+
+Do not change any color key or value.
+
+**Verify**: `pnpm test:regression` still passes (config still parses; no token
+removed). `git diff tailwind.config.mjs` shows only added comment lines.
+
+### Step 5: Note the canonical namespace in CLAUDE.md
+
+In `.claude/CLAUDE.md`, in the "### Styling" section (the paragraph that lists
+the brand palette), add one sentence: the canonical Tailwind color namespace is
+`anhanga-*` (semantic tokens in `lib/design-tokens.ts`); `brand-*` is legacy and
+frozen by `tests/tailwind-brand-namespace-guard.test.ts` — new code must use
+`anhanga-*`.
+
+**Verify**: `git diff --stat .claude/CLAUDE.md` shows a small additive change.
+
+### Step 6: Full suite
+
+```
+pnpm test:regression
+```
+
+**Verify**: all tests pass, including the new guard and the existing
+`tailwind-bare-yellow-guard`.
+
+## Test plan
+
+- **New test**: `tests/tailwind-brand-namespace-guard.test.ts` — one ratchet test
+  asserting `total <= BRAND_NAMESPACE_BASELINE`. Cases proven: (1) passes at
+  baseline (Step 2), (2) fails on a synthetic new `brand-*` usage (Step 3).
+- **Pattern to follow**: `tests/tailwind-bare-yellow-guard.test.ts` (structure,
+  scan dirs, regex style, offender-list assertion).
+- **Verification**: `pnpm test:regression` → all pass, including the 1 new test.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `tests/tailwind-brand-namespace-guard.test.ts` exists and
+      `tsx --test tests/tailwind-brand-namespace-guard.test.ts` exits 0
+- [ ] `grep -n "console.log" tests/tailwind-brand-namespace-guard.test.ts` → empty
+- [ ] `grep -n "BRAND_NAMESPACE_BASELINE" tests/tailwind-brand-namespace-guard.test.ts` → shows a numeric constant in 620–640
+- [ ] `pnpm test:regression` exits 0
+- [ ] No file under `components/` or `pages/` modified
+      (`git status --porcelain | grep -E '^.{1,2} (components|pages)/'` → empty)
+- [ ] `tailwind.config.mjs` diff is comment-only (no key/value changed)
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The Step 1 count is outside 620–640 (tree drifted; the baseline number and the
+  excerpts in "Current state" no longer match reality).
+- The new guard fails at baseline (means the regex over-matches `anhanga-*` or
+  numeric scales — report the offender list; do NOT migrate components to make it
+  pass).
+- Step 3 shows the ratchet does **not** fail on a synthetic new `brand-*` usage
+  (the regex is wrong).
+- You find yourself needing to edit a `components/`/`pages/` file to pass — that
+  means scope crept into migration; stop.
+
+## Maintenance notes
+
+- For the reviewer: the diff must be additive — one new test + comments only,
+  zero component changes and zero token removals. Confirm the baseline constant
+  equals the measured count, not a guess.
+- The ratchet permits net-zero churn (adding one `brand-*` while removing another
+  keeps the count flat). That is acceptable: the goal is "no growth + nudge to
+  `anhanga-*`," not perfect prevention. Tightening to per-file/changed-lines
+  enforcement is a possible future upgrade, not needed now.
+- When anyone migrates `brand-*` → `anhanga-*` usages, they should **lower**
+  `BRAND_NAMESPACE_BASELINE` to the new count in the same PR, so the ratchet only
+  ever tightens.
+- Explicitly deferred (and why): the full `brand-*` → `anhanga-*` migration of
+  ~629 usages — L effort, MED–HIGH visual-regression risk, gated only by
+  snapshots; not worth a big-bang. Do it opportunistically as files are touched.

--- a/plans/013-freeze-legacy-brand-tailwind-namespace.md
+++ b/plans/013-freeze-legacy-brand-tailwind-namespace.md
@@ -125,14 +125,18 @@ Conventions to follow:
 ### Step 1: Create the guard test (without the baseline number yet)
 
 Create `tests/tailwind-brand-namespace-guard.test.ts`, structured like
-`tests/tailwind-bare-yellow-guard.test.ts`. Use this regex (mirrors the
-bare-yellow prefix list; matches legacy `-brand-<subtoken>` color utilities and
-not the `anhanga-*` canonical ones):
+`tests/tailwind-bare-yellow-guard.test.ts`. Use this regex (based on the
+bare-yellow prefix list, **extended** with `placeholder` and `ring-offset` so
+those legacy utilities can't slip past the guard; matches legacy
+`-brand-<subtoken>` color utilities and not the `anhanga-*` canonical ones):
 
 ```ts
 const LEGACY_BRAND =
-  /(?<![\w-])(text|bg|border|fill|stroke|ring|from|to|via|divide|decoration|outline|accent|caret|shadow)-brand-[a-z][a-zA-Z]*(?![\w-])/g;
+  /(?<![\w-])(text|bg|border|fill|stroke|ring(?:-offset)?|placeholder|from|to|via|divide|decoration|outline|accent|caret|shadow)-brand-[a-z][a-zA-Z]*(?![\w-])/g;
 ```
+
+(The ~629 baseline was measured with these same prefixes, so the count stays
+aligned. Re-measure in Step 1 regardless and pin what the guard actually counts.)
 
 Reuse the exemplar's `SCAN_DIRS`, `TARGET_EXTENSIONS`, `ROOT`, and
 `collectTailwindFiles` verbatim. Count every match across all scanned files into

--- a/plans/014-automated-google-reviews-refresh.md
+++ b/plans/014-automated-google-reviews-refresh.md
@@ -1,0 +1,213 @@
+# Plan 014: Atualização automática de reviews do Google via GitHub Actions agendado
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat ec3029a..HEAD -- scripts/fetch-google-reviews.ts package.json .github/workflows/generate-blog-manifest.yml data/googleReviews.json`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: direction (ops/DX)
+- **Planned at**: commit `ec3029a`, 2026-06-21
+
+## Why this matters
+
+The site shows Google reviews (average rating, testimonials) sourced from
+`data/googleReviews.json`. That file is regenerated only when a human manually
+runs `pnpm reviews:fetch` and commits the result — there is **no scheduled
+automation** (`grep -rn "schedule:" .github/workflows/` returns nothing). So the
+social proof on the homepage silently goes stale until someone remembers to
+refresh it. The repo already has the exact pattern for fixing this:
+`generate-blog-manifest.yml` runs a generator script and opens a PR with the
+changed data file. This plan adds an analogous **scheduled** workflow for
+reviews, so the testimonials stay current with zero manual effort, and changes
+still land via reviewable PR (not a silent commit to `main`).
+
+## Current state
+
+Verified at commit `ec3029a`.
+
+- `scripts/fetch-google-reviews.ts` — the generator. Run via the npm script
+  `reviews:fetch` (`package.json:22` → `tsx scripts/fetch-google-reviews.ts`).
+  - **Required** env: `OUTSCRAPER_API_KEY`, `GOOGLE_PLACE_ID` (throws "Missing …"
+    if absent — see `loadConfig()` at lines 118–131).
+  - **Optional** env (photo upload to R2): `R2_BUCKET_NAME`, `R2_CDN_BASE_URL`,
+    `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`. If the R2 vars are unset the
+    script still runs and just emits empty `photoUrl`s (see `canUpload` guard,
+    lines 260–272).
+  - Writes `data/googleReviews.json` (line 292–293) and prints a JSON summary.
+  - Reads `data/reviewsBlocklist.json` and `data/reviewAnnotations.json` (kept in
+    git) to filter/annotate — these stay as-is.
+- `.github/workflows/generate-blog-manifest.yml` — **the exemplar to copy.** It:
+  checks out with `secrets.GITHUB_TOKEN`, installs pnpm + Node + deps, runs the
+  generator, then `git add <data file>`, skips if no diff, else creates a branch
+  `chore/…-${{ github.run_id }}`, commits, pushes, and `gh pr create`s. Match
+  this structure. (Note: that file pins Node `22.13.1`; the repo's canonical
+  version is Node 24 — use **24** in the new workflow to match `.node-version`
+  and `ci.yml`. Do not "fix" the old workflow here — out of scope.)
+
+Conventions:
+- Workflows live in `.github/workflows/`, kebab-case `.yml`.
+- `permissions: { contents: write, pull-requests: write }` for PR-opening jobs.
+- Conventional-commit PR titles in Portuguese (see existing workflow body).
+
+## Commands you will need
+
+| Purpose                | Command                                                | Expected on success            |
+|------------------------|--------------------------------------------------------|--------------------------------|
+| YAML lint (local)      | `node -e "import('js-yaml').then(y=>y.load(require('fs').readFileSync('.github/workflows/refresh-reviews.yml','utf8'))).then(()=>console.log('ok'))"` if `js-yaml` is available; otherwise `python3 -c "import yaml,sys;yaml.safe_load(open('.github/workflows/refresh-reviews.yml'));print('ok')"` | prints `ok` |
+| Regression suite       | `pnpm test:regression`                                 | all pass (unchanged baseline)  |
+| Confirm npm script     | `node -e "console.log(require('./package.json').scripts['reviews:fetch'])"` | prints the tsx command |
+
+> This plan adds **only** a workflow YAML file — no TypeScript, so typecheck/test
+> behavior is unchanged. The workflow itself can only be truly exercised on
+> GitHub with secrets present (see Preconditions).
+
+## Preconditions (human, outside the executor's control)
+
+These repo secrets must exist in GitHub → Settings → Secrets → Actions for the
+workflow to succeed at runtime. The executor cannot set these; list them in the
+PR description so the maintainer adds them before enabling the schedule:
+- `OUTSCRAPER_API_KEY` (required), `GOOGLE_PLACE_ID` (required).
+- `R2_BUCKET_NAME`, `R2_CDN_BASE_URL`, `CLOUDFLARE_ACCOUNT_ID`,
+  `CLOUDFLARE_API_TOKEN` (optional — only if review author photos should be
+  re-uploaded to R2; omit to skip photos).
+
+Do **not** put any secret value in the workflow file or anywhere in the repo —
+reference them only via `${{ secrets.NAME }}`.
+
+## Scope
+
+**In scope** (the only files you should create/modify):
+- `.github/workflows/refresh-reviews.yml` (create)
+
+**Out of scope** (do NOT touch):
+- `scripts/fetch-google-reviews.ts` — the generator works; do not modify it.
+- `.github/workflows/generate-blog-manifest.yml` — copy its shape, don't edit it
+  (including its stale Node version).
+- `data/googleReviews.json`, `data/reviewsBlocklist.json`,
+  `data/reviewAnnotations.json` — the workflow regenerates the first at runtime;
+  do not hand-edit any of them in this plan.
+
+## Git workflow
+
+- Branch: `chore/automate-reviews-refresh`.
+- Conventional commit: `chore(ci): workflow agendado para atualizar reviews do Google`.
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: Create the scheduled workflow
+
+Create `.github/workflows/refresh-reviews.yml` modeled on
+`generate-blog-manifest.yml`, with these differences:
+
+- `name: Refresh Google Reviews`
+- Triggers:
+  ```yaml
+  on:
+    schedule:
+      - cron: "0 6 * * 1"   # toda segunda 06:00 UTC (~03:00 BRT)
+    workflow_dispatch: {}     # permite execução manual para teste
+  ```
+- `permissions: { contents: write, pull-requests: write }`
+- Job steps (mirror the exemplar): checkout (`token: ${{ secrets.GITHUB_TOKEN }}`),
+  `pnpm/action-setup@v6.0.8`, `actions/setup-node@v6` with `node-version: 24` and
+  `cache: "pnpm"`, `pnpm install --frozen-lockfile`.
+- Run the generator with the env wired from secrets:
+  ```yaml
+  - name: Fetch Google reviews
+    env:
+      OUTSCRAPER_API_KEY: ${{ secrets.OUTSCRAPER_API_KEY }}
+      GOOGLE_PLACE_ID: ${{ secrets.GOOGLE_PLACE_ID }}
+      R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+      R2_CDN_BASE_URL: ${{ secrets.R2_CDN_BASE_URL }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    run: pnpm run reviews:fetch
+  ```
+- Open-PR step: identical pattern to the exemplar, but `git add data/googleReviews.json`,
+  branch `chore/update-google-reviews-${{ github.run_id }}`, commit message
+  `chore: atualiza data/googleReviews.json`, PR title the same, PR body in
+  Portuguese explaining it's an automated weekly refresh. Keep the
+  `if git diff --cached --quiet; then … exit 0` no-op guard so empty refreshes
+  don't open PRs.
+
+**Verify**: the YAML lint command (table) prints `ok`.
+
+### Step 2: Confirm the suite is unaffected
+
+```
+pnpm test:regression
+```
+
+**Verify**: all tests pass (no code/test inputs changed).
+
+### Step 3: Sanity-check the workflow references
+
+- `grep -n "reviews:fetch" .github/workflows/refresh-reviews.yml` → matches.
+- `grep -n "node-version: 24" .github/workflows/refresh-reviews.yml` → matches.
+- `grep -rn "secrets\." .github/workflows/refresh-reviews.yml` → only `${{ secrets.* }}` refs, **no literal values**.
+
+**Verify**: all three greps behave as described.
+
+## Test plan
+
+No runtime unit test — this is a CI workflow (infra), which the testing standard
+does not require unit coverage for, and the generator's pure helpers are already
+covered by `tests/fetch-google-reviews.test.ts` (`filterReviews`, `applyBlocklist`,
+`mergeAnnotations`, `sanitizeReviewText`). The safety net here is:
+- YAML validity (Step 1),
+- the existing regression suite still green (Step 2),
+- a manual `workflow_dispatch` run by the maintainer after secrets are set
+  (documented in the PR), which is the real end-to-end check.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `.github/workflows/refresh-reviews.yml` exists and is valid YAML (lint prints `ok`)
+- [ ] It triggers on both `schedule` and `workflow_dispatch`
+      (`grep -E "schedule:|workflow_dispatch" .github/workflows/refresh-reviews.yml` → both)
+- [ ] It runs `pnpm run reviews:fetch` and uses `node-version: 24`
+- [ ] No secret literal appears in the file (only `${{ secrets.* }}`)
+- [ ] `pnpm test:regression` exits 0
+- [ ] No file other than the new workflow is modified (`git status --porcelain`)
+- [ ] `plans/README.md` status row updated
+- [ ] PR description lists the required GitHub secrets (Preconditions section)
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- `package.json` no longer has a `reviews:fetch` script, or it points elsewhere.
+- `scripts/fetch-google-reviews.ts` no longer writes `data/googleReviews.json`
+  (the open-PR `git add` path would be wrong).
+- The exemplar `generate-blog-manifest.yml` is gone or radically restructured
+  (you have no pattern to copy — report and ask).
+
+## Maintenance notes
+
+- For the reviewer: this only adds the automation; the **maintainer must add the
+  GitHub secrets** before the first scheduled run, or the job will fail at
+  `loadConfig()` with "Missing OUTSCRAPER_API_KEY". Confirm secrets exist, then
+  trigger one manual `workflow_dispatch` run to validate end-to-end.
+- The cron is weekly (Mondays 06:00 UTC). Adjust frequency to match Outscraper
+  cost tolerance — each run is a paid API call.
+- Pre-existing drift noted but intentionally NOT fixed here: `generate-blog-manifest.yml`
+  pins Node 22.13.1 while the repo standard is Node 24. If someone normalizes CI
+  Node versions later, include that file.
+- If photo re-upload to R2 is wanted, the four optional Cloudflare/R2 secrets
+  must also be set; otherwise reviews refresh with empty `photoUrl` (the UI
+  already tolerates this).

--- a/plans/015-spike-chatbot-tool-surface.md
+++ b/plans/015-spike-chatbot-tool-surface.md
@@ -1,0 +1,174 @@
+# Plan 015 (SPIKE): Definir como expandir a superfície de tools do chatbot além de `generate_budget_link`
+
+> **Executor instructions**: This is a SPIKE — its deliverable is a written
+> design document plus a non-wired prototype, **not** shipped behavior. Do NOT
+> change the live chatbot. Investigate, write the doc, answer the open questions
+> honestly (including "don't build this"), and stop. If a STOP condition occurs,
+> report instead of improvising. When done, update the status row in
+> `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat ec3029a..HEAD -- lib/ai/ api/generate.ts`
+> If these changed since this plan was written, re-read them before writing the
+> doc — your architecture map must reflect the live code.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: M (investigation + writing)
+- **Risk**: LOW (doc + unwired prototype only)
+- **Depends on**: none
+- **Category**: direction (spike)
+- **Planned at**: commit `ec3029a`, 2026-06-21
+
+## Why this matters
+
+The AI chatbot is the core product surface, and its tool layer is cleanly
+isolated — but it currently exposes exactly **one** tool, `generate_budget_link`
+(`lib/ai/tools.ts`). The architecture makes adding structured tools
+*disproportionately cheap in theory*, yet the request handler's routing is
+hardwired to that single tool, so the real cost of a second tool is hidden until
+someone tries. This spike makes the cost explicit and decides **whether** a
+second tool is worth building (product value is currently unproven — treat "not
+yet" as a valid outcome). The output is a decision aid, not a feature.
+
+## Current state (facts to anchor the doc — verify, don't trust blindly)
+
+Verified at commit `ec3029a`:
+
+- `lib/ai/tools.ts` — defines the single `budgetTool: FunctionDeclaration`
+  (name `generate_budget_link`).
+- `api/generate.ts` wires tools at one point:
+  `requestModelResponse()` → `config.tools = [{ functionDeclarations: [budgetTool] }]`
+  (around line 280).
+- The tool-call → handoff pipeline is **hardcoded to `generate_budget_link`** in
+  three spots that any second tool must generalize:
+  - `extractModelOutput()` (~line 337) and `extractBudgetToolCallFromText` —
+    text-fallback extraction assumes the budget tool shape.
+  - `normalizeBudgetToolResponse()` (~line 400) — early-returns unless
+    `responseFunctionCall?.name === 'generate_budget_link'`, then runs
+    `validateBudgetToolArgs`.
+  - `buildStructuredHandoff()` (~line 429) — returns `undefined` unless the name
+    is `generate_budget_link`, then calls `buildGenerateHandoff`.
+- `lib/ai/handoff.ts` — `buildGenerateHandoff(args: BudgetToolArgs, …)` is
+  budget-specific (BANT summary, IATA, etc.). `GenerateHandoff` is a
+  budget-shaped interface.
+- `lib/ai/validation.ts` — `validateBudgetToolArgs`, `buildSafetyMessage`,
+  `buildRefinementMessage`: all budget-specific.
+- Safety/discipline constraints the prompt enforces (`lib/ai/prompt.ts`):
+  single-question-per-response, no manual CTAs/links, handoff only via the tool.
+  A second tool must not erode these (the `repairTextualHandoff` machinery exists
+  precisely to defend the budget handoff).
+- Tests that encode the current contract (read them before proposing changes):
+  `tests/ai-handoff.test.ts`, `tests/api-generate-normalization.test.ts`,
+  `tests/tool-call-fallback.test.ts`, `tests/chatbot-regressions.test.ts`.
+
+## Commands you will need
+
+| Purpose          | Command                          | Expected            |
+|------------------|----------------------------------|---------------------|
+| Read AI tests    | `pnpm test:regression`           | all pass (baseline) |
+| Find tool wiring | `grep -rn "generate_budget_link\|functionDeclarations\|buildStructuredHandoff\|normalizeBudgetToolResponse" api/ lib/ai/` | the sites listed above |
+
+## Scope
+
+**In scope** (create only):
+- `docs/product/chatbot-tool-expansion-spike.md` (the design doc — the deliverable)
+
+**Out of scope** (do NOT modify):
+- Any file under `lib/ai/`, `api/generate.ts`, the prompt, or any test. This spike
+  ships **no** behavior change. A prototype `FunctionDeclaration` goes **inside
+  the doc as a fenced code block**, not as a wired source file.
+
+## Steps
+
+### Step 1: Map the current tool architecture
+
+Trace and record (with `file:line`) how a tool call flows today: prompt → Gemini
+`functionDeclarations` → `extractModelOutput` → `normalizeBudgetToolResponse` →
+`buildStructuredHandoff`/`buildGenerateHandoff` → client `handoff`. Note every
+place that hardcodes `generate_budget_link`.
+
+**Verify**: the doc's "Current architecture" section names each hardcoded site
+from "Current state" with a line reference, confirmed by the `grep` command.
+
+### Step 2: Propose ONE concrete candidate tool
+
+Pick a single, grounded candidate and specify it — do not enumerate ten ideas.
+Grounded options (pick one, justify):
+- `check_destination_status` — surface the existing blocked-destination logic
+  (`detectBlockedDestination` in `lib/ai/validation.ts`) as a user-facing answer
+  ("is X bookable?") instead of only a safety gate.
+- `lookup_faq` — structured answers to common questions, reducing free-text
+  hallucination risk.
+
+For the chosen tool, write a draft `FunctionDeclaration` (parameters, required
+fields, description) as a code block, mirroring `budgetTool`'s style.
+
+**Verify**: the doc has exactly one proposed tool with a complete draft
+declaration and a one-paragraph product justification.
+
+### Step 3: Specify the integration cost (the generalization)
+
+Describe precisely what must change to route N tools instead of one:
+- Generalize the three hardcoded sites (Step 1) into a per-tool dispatch (e.g. a
+  registry keyed by tool name → its validator + result builder).
+- Whether `GenerateHandoff` must become a union, or the new tool returns a
+  different response shape (e.g. an inline answer, not a handoff).
+- Prompt changes needed so the model knows when to use which tool without
+  breaking single-question discipline.
+- Which existing tests would need to change and what **new** tests are required.
+
+**Verify**: the doc's "Integration cost" section references the exact functions
+to refactor and lists the test impact.
+
+### Step 4: Open questions + recommendation
+
+List the unknowns that block a build decision (product value/measurement, prompt
+regression risk, added latency, maintenance). End with an explicit
+recommendation: **build now / build behind a flag / defer** — and why. "Defer"
+is an acceptable, even likely, conclusion.
+
+**Verify**: the doc ends with a dated recommendation and a numbered open-questions
+list.
+
+### Step 5: Confirm nothing shipped
+
+```
+git status --porcelain
+pnpm test:regression
+```
+
+**Verify**: the only changed/added file is `docs/product/chatbot-tool-expansion-spike.md`
+(plus the `plans/README.md` status row). All tests pass (you changed no code).
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `docs/product/chatbot-tool-expansion-spike.md` exists with sections:
+      Current architecture, Proposed tool (+ draft declaration), Integration cost,
+      Open questions, Recommendation.
+- [ ] No file under `lib/ai/`, `api/`, or `tests/` modified
+      (`git status --porcelain | grep -E '^.{1,2} (lib/ai/|api/|tests/)'` → empty)
+- [ ] `pnpm test:regression` exits 0
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back if:
+
+- The tool-routing code has already been generalized (no longer hardcodes
+  `generate_budget_link`) — then this spike's premise is stale; report what you
+  found.
+- You conclude you cannot pick a grounded candidate tool without product input —
+  document the blockers and stop rather than inventing a use case.
+
+## Maintenance notes
+
+- For the maintainer: this is a decision document. If the recommendation is
+  "build", it becomes the input to a separate implementation plan; this spike
+  deliberately ships nothing.
+- Keep the doc honest about the speculative product value flagged when this was
+  raised (`/improve next`, rodada 3): the architecture makes it cheap, but cheap
+  ≠ worth it without demand signal.

--- a/plans/016-spike-quiz-to-chatbot-funnel.md
+++ b/plans/016-spike-quiz-to-chatbot-funnel.md
@@ -1,0 +1,166 @@
+# Plan 016 (SPIKE): Decidir se o resultado do quiz deve semear o chatbot em vez de ir direto ao WhatsApp
+
+> **Executor instructions**: This is a SPIKE — deliverable is a written design
+> document with a recommendation, **not** a behavior change. Do NOT modify the
+> quiz or the chatbot. Investigate the two existing funnels, write the doc,
+> answer the open questions honestly (including "leave it as-is"), and stop. If a
+> STOP condition occurs, report. When done, update the status row in
+> `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat ec3029a..HEAD -- pages/landings/QuizAnhangaLanding.tsx hooks/useQuizCapture.ts utils/aiChat.ts components/AIChat.tsx lib/quiz-scoring.ts`
+> If these changed since this plan was written, re-read them before writing the
+> doc.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: M (investigation + writing)
+- **Risk**: LOW (doc only)
+- **Depends on**: none
+- **Category**: direction (spike)
+- **Planned at**: commit `ec3029a`, 2026-06-21
+
+## Why this matters
+
+The site runs **two independent lead funnels that don't connect**:
+
+1. **Chatbot** — a cold visitor chats; the AI runs BANT qualification and hands
+   off to a human (`api/generate.ts`, `lib/ai/handoff.ts`).
+2. **Quiz** — `/quiz` computes a travel *profile* and a `bantSummary`, captures
+   the lead, then sends the user straight to **WhatsApp**
+   (`pages/landings/QuizAnhangaLanding.tsx`, result CTA `getWhatsAppLink`,
+   `data-tracking="result-quiz-whatsapp"`).
+
+The quiz already produces the *same kind of structured signal* (profile + BANT
+summary) that the chatbot spends a whole conversation building — yet it bypasses
+the chatbot entirely. Meanwhile a seam to seed the chatbot already exists:
+`openAiChat({ message })` (`utils/aiChat.ts`) dispatches a `toggle-ai-chat`
+CustomEvent carrying a seed message, consumed by `components/AIChat.tsx`. So
+routing a warm quiz-taker into the chatbot (pre-seeded with their profile) is an
+*adjacent-possible* — but it might also **hurt** conversion (quiz-takers already
+gave contact info and may convert better via direct WhatsApp). This spike decides
+which, instead of guessing. Likely outcome: "measure before changing."
+
+## Current state (anchor the doc — verify)
+
+Verified at commit `ec3029a`:
+
+- `lib/quiz-scoring.ts` — `matchProfile()` → `ProfileKey`/profile name.
+- `hooks/useQuizCapture.ts` — `submitQuiz()` posts `{ profileKey, profileName,
+  bantSummary, destinos, … }` to `/api/submit-quiz` and fires a Salesforce lead;
+  it has **no** reference to the chatbot.
+- `pages/landings/QuizAnhangaLanding.tsx` — the result step (`WhatsAppUpgrade`,
+  ~lines 695–860) builds a WhatsApp link via `getWhatsAppLink` and renders it as
+  the primary CTA (`data-tracking="result-quiz-whatsapp"`). No `openAiChat` call.
+- `utils/aiChat.ts` — `openAiChat({ message })` dispatches
+  `new CustomEvent('toggle-ai-chat', { detail: { message } })`. **This is the
+  seam** a quiz→chat route would use.
+- `components/AIChat.tsx` — listens for `toggle-ai-chat` and (per `openAiChat`'s
+  contract) can receive a seed `message`. Trace exactly how it consumes
+  `detail.message` (does it inject as a user turn? open the panel? support more
+  than a plain string?).
+
+## Commands you will need
+
+| Purpose            | Command                                                        | Expected |
+|--------------------|----------------------------------------------------------------|----------|
+| Trace the seam     | `grep -rn "toggle-ai-chat\|openAiChat\|detail" components/AIChat.tsx utils/aiChat.ts` | the listener + dispatcher |
+| Quiz result CTA    | `grep -n "getWhatsAppLink\|openAiChat\|result-quiz" pages/landings/QuizAnhangaLanding.tsx` | the WhatsApp CTA, no chat |
+| Baseline tests     | `pnpm test:regression`                                         | all pass |
+
+## Scope
+
+**In scope** (create only):
+- `docs/product/quiz-to-chatbot-funnel-spike.md` (the deliverable)
+
+**Out of scope** (do NOT modify):
+- `pages/landings/QuizAnhangaLanding.tsx`, `hooks/useQuizCapture.ts`,
+  `utils/aiChat.ts`, `components/AIChat.tsx`, `lib/quiz-*` — no behavior change.
+
+## Steps
+
+### Step 1: Document both funnels and the seed seam
+
+In the doc, describe funnel 1 (chatbot/BANT) and funnel 2 (quiz→WhatsApp) with
+`file:line` anchors, and precisely how `openAiChat({ message })` →
+`toggle-ai-chat` → `AIChat.tsx` works today, including what `AIChat` does with
+`detail.message` (the contract a quiz seed would rely on).
+
+**Verify**: the doc's "Current funnels" section cites the quiz result CTA, the
+`openAiChat` seam, and AIChat's handling of the seed, each with a line reference.
+
+### Step 2: Define the proposed seed contract
+
+Specify what a quiz→chat route would pass: a seed message built from
+`profileName` + `bantSummary` + chosen `destinos`, and whether AIChat would need
+to accept a richer payload than a plain string (e.g. pre-seed BANT state so the
+AI doesn't re-ask what the quiz already learned). Note any change AIChat/`openAiChat`
+would require to honor that.
+
+**Verify**: the doc has a "Proposed seed contract" section with the exact shape
+to pass and the AIChat change (if any) it implies.
+
+### Step 3: Weigh it against the current WhatsApp handoff
+
+Honest trade-off analysis:
+- Why the current WhatsApp CTA may already be optimal (warm lead, human touch,
+  contact already captured).
+- What seeding the chatbot could add (continue qualification, richer handoff) and
+  for which audience.
+- The risk of replacing a working conversion path without data.
+- How to **measure** (A/B the result CTA; the quiz already pushes `dataLayer`
+  events in `useQuizCapture.ts` — note `quiz_lead`/`form_submission` as the
+  measurement hook).
+
+**Verify**: the doc has a "Trade-offs & measurement" section naming the existing
+`dataLayer` events as the A/B instrumentation point.
+
+### Step 4: Recommendation
+
+End with an explicit, dated recommendation: **A/B test / build behind a flag /
+leave as-is** — and the reasoning. Do not recommend a full build without a
+measurement plan.
+
+**Verify**: the doc ends with a dated recommendation + numbered open questions.
+
+### Step 5: Confirm nothing shipped
+
+```
+git status --porcelain
+pnpm test:regression
+```
+
+**Verify**: only `docs/product/quiz-to-chatbot-funnel-spike.md` (and the
+`plans/README.md` row) changed; all tests pass.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `docs/product/quiz-to-chatbot-funnel-spike.md` exists with sections:
+      Current funnels, Proposed seed contract, Trade-offs & measurement,
+      Recommendation.
+- [ ] No `*.ts/*.tsx` source modified
+      (`git status --porcelain | grep -E '\.(ts|tsx)$' | grep -v '^.. docs/'` → empty)
+- [ ] `pnpm test:regression` exits 0
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back if:
+
+- The quiz result already routes into the chatbot (the asymmetry is gone) — then
+  this spike's premise is stale; report what you found.
+- `openAiChat`/`toggle-ai-chat` no longer exists or AIChat ignores `detail.message`
+  — the seed seam you'd build on is gone; report it.
+
+## Maintenance notes
+
+- For the maintainer: decision document only. If the recommendation is to test,
+  it feeds a separate implementation plan (add a secondary "Continuar com nossa
+  IA" CTA on the quiz result that calls `openAiChat` with the seed, A/B against
+  the WhatsApp CTA).
+- Keep honest about the framing from `/improve next` (rodada 3): the asymmetry is
+  real, the value is **unproven** — the current quiz→WhatsApp path converts a
+  warm lead and should not be replaced on intuition.

--- a/plans/017-move-design-system-folder.md
+++ b/plans/017-move-design-system-folder.md
@@ -1,0 +1,178 @@
+# Plan 017: Mover o folder do design system da raiz para `docs/design/brand-system/` e atualizar o teste que o referencia
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. Touch
+> only the files listed as in scope. If a STOP condition occurs, stop and report.
+> Commit your work in the worktree following the git workflow section. SKIP
+> updating `plans/README.md` if a reviewer dispatched you and said they maintain
+> the index; otherwise update it.
+>
+> **Drift check (run first)**:
+> `git diff --stat ec3029a..HEAD -- "Anhangá Viagens Design System/" tests/index-third-party-scripts.test.ts docs/design/`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3 (optional aesthetics — see "Why")
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none (independent of plan 012)
+- **Category**: dx / docs
+- **Planned at**: commit `ec3029a`, 2026-06-21
+
+## Why this matters
+
+`CLAUDE.md` says non-code documentation belongs under `/docs/`, yet the
+human-facing design-system reference (`Anhangá Viagens Design System/`, with
+`README.md`, `SKILL.md`, brand SVGs, `colors_and_type.css`, preview HTML) sits at
+the repo root. Plan 012 deliberately left this folder alone because it is **not
+inert clutter**: `tests/index-third-party-scripts.test.ts` reads it from the root
+at runtime and asserts its `colors_and_type.css` documents the production Poppins
+weights. So relocating it is only safe if the test is updated in the same change.
+This plan does exactly that. It is genuinely optional — the folder is "load-bearing
+via a test," so the only gain is honoring the root-minimal convention; skip it if
+not worth the churn.
+
+## Current state
+
+Verified at commit `ec3029a`.
+
+- `Anhangá Viagens Design System/` (repo root) — tracked folder. Files include
+  `README.md`, `SKILL.md`, `assets/*.svg`, `colors_and_type.css`, `preview/*.html`.
+  No code references it except the test below; the literal string
+  `Anhangá Viagens Design System` does not appear in any `.ts/.tsx/.mjs/.json`.
+- `tests/index-third-party-scripts.test.ts` — at **module load** (top level, not
+  inside a `test()`), lines 6–13:
+  ```ts
+  const designSystemDir = fs.readdirSync(process.cwd()).find((entry) => entry.endsWith('Design System'));
+  assert.ok(designSystemDir, 'design system directory should exist');
+  const designSystemCssPath = path.resolve(process.cwd(), designSystemDir, 'colors_and_type.css');
+  const designSystemCss = fs.readFileSync(designSystemCssPath, 'utf8');
+  ```
+  and the test `design system documents the production Poppins font weights`
+  (lines 62–69) asserts `designSystemCss` contains the `@import` Google Fonts URL
+  with `Poppins:wght@400;600;700;900`, no `800`, and the string
+  `Poppins is loaded with 400/600/700/900 only`.
+  The `.endsWith('Design System')` discovery is why a literal grep misses it.
+- `docs/design/` already exists (holds `design-system.json`, `design-context.md`).
+  The moved folder goes to `docs/design/brand-system/` (kebab-case, ASCII, no spaces).
+
+Convention: ASCII kebab-case dir names under `docs/`; `node:test` + `assert/strict`.
+
+## Commands you will need
+
+| Purpose           | Command                                                    | Expected                       |
+|-------------------|------------------------------------------------------------|--------------------------------|
+| Install (once)    | `pnpm install --frozen-lockfile`                           | exit 0 (fresh worktree)        |
+| This test only    | `tsx --test tests/index-third-party-scripts.test.ts`       | all pass                       |
+| Full regression   | `pnpm test:regression`                                     | all pass                       |
+| Old-ref check     | `git ls-files \| grep -c "Anhangá Viagens Design System"`   | `0` after the move             |
+
+## Scope
+
+**In scope** (the only files you should modify/move):
+- `Anhangá Viagens Design System/` → `docs/design/brand-system/` (move)
+- `tests/index-third-party-scripts.test.ts` (update the path resolution only)
+
+**Out of scope** (do NOT touch):
+- The *contents* of any moved file (move only; do not edit `colors_and_type.css`,
+  the SVGs, etc.).
+- `docs/design/design-system.json`, `docs/design/design-context.md`.
+- The other 11 tests in `index-third-party-scripts.test.ts` — change only the
+  top-level folder-resolution lines; leave every `test()` body intact.
+- Anything plan 012 touches (dead file, `SEO/`, email signature) — independent.
+
+## Git workflow
+
+- Branch: `chore/move-design-system-docs`.
+- Use `git mv` for the move (preserve history).
+- Conventional commit: `chore: move design system para docs/design/brand-system`.
+- Do NOT push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Move the folder
+
+```
+git mv "Anhangá Viagens Design System" "docs/design/brand-system"
+```
+
+**Verify**: `git ls-files "docs/design/brand-system/" | head` lists the files;
+`git ls-files | grep -c "Anhangá Viagens Design System"` → `0`.
+
+### Step 2: Point the test at the new location
+
+In `tests/index-third-party-scripts.test.ts`, replace the runtime discovery
+(lines ~8 and ~12) with a direct path to the new home. Change:
+
+```ts
+const designSystemDir = fs.readdirSync(process.cwd()).find((entry) => entry.endsWith('Design System'));
+assert.ok(designSystemDir, 'design system directory should exist');
+const designSystemCssPath = path.resolve(process.cwd(), designSystemDir, 'colors_and_type.css');
+```
+
+to:
+
+```ts
+const designSystemCssPath = path.resolve(process.cwd(), 'docs/design/brand-system', 'colors_and_type.css');
+assert.ok(fs.existsSync(designSystemCssPath), 'design system colors_and_type.css should exist at docs/design/brand-system');
+```
+
+Leave the `designSystemCss = fs.readFileSync(designSystemCssPath, 'utf8')` line
+and all `test()` blocks unchanged. Do not touch the unrelated `fs`/`path` imports.
+
+**Verify**: `tsx --test tests/index-third-party-scripts.test.ts` → all pass,
+including `design system documents the production Poppins font weights`.
+
+### Step 3: Full suite
+
+```
+pnpm test:regression
+```
+
+**Verify**: all tests pass.
+
+## Test plan
+
+No new test file. The behavior being preserved is exactly what
+`tests/index-third-party-scripts.test.ts` already guards (the design-system CSS
+documents the production font weights); this plan keeps that test green against
+the new path. The regression suite (Step 3) is the safety net.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `git ls-files | grep -c "Anhangá Viagens Design System"` → `0`
+- [ ] `git ls-files docs/design/brand-system/colors_and_type.css` → present
+- [ ] `tsx --test tests/index-third-party-scripts.test.ts` exits 0
+- [ ] `pnpm test:regression` exits 0
+- [ ] Only the move + that one test file changed
+      (`git status --porcelain` shows renames under `docs/design/brand-system/`
+      and a modified `tests/index-third-party-scripts.test.ts`, nothing else)
+- [ ] `docs/design/design-system.json` / `design-context.md` unchanged
+- [ ] `plans/README.md` status row updated (unless reviewer maintains it)
+
+## STOP conditions
+
+Stop and report back if:
+
+- The folder `Anhangá Viagens Design System/` no longer exists at the root (maybe
+  plan 012 was run with the old scope, or it was already moved) — report what you
+  find; do not guess.
+- After Step 2, the Poppins-weights test fails — it means `colors_and_type.css`
+  did not move intact or the new path is wrong; do not edit the CSS to force a
+  pass.
+- Any OTHER test in `index-third-party-scripts.test.ts` starts failing — you
+  changed more than the folder-resolution lines; revert and report.
+
+## Maintenance notes
+
+- For the reviewer: the diff should be a folder rename plus a 2-line change in one
+  test. Confirm no `test()` body was altered and the CSS content is byte-identical
+  to before the move.
+- This makes the design-system reference's location no longer "magic" (a literal
+  path instead of a `.endsWith` scan), which is also why a future grep will find
+  it. Worth noting in the PR.

--- a/plans/README.md
+++ b/plans/README.md
@@ -19,12 +19,26 @@ começar, honre as STOP conditions e atualize sua linha ao terminar.
 | 009 | Fallback visível quando globe.gl falha (CorpGlobe) | P3 | S | — | MERGED (#876) |
 | 010 | Header CSP na página de callback OAuth do Decap | P3 | S | — | MERGED (#878) |
 | 011 | Normalizar click IDs vazios/whitespace → null nos payloads n8n | P3 | S | 007 | MERGED (#879) |
+| 012 | Tirar artefatos/dumps obsoletos da raiz para `docs/` (root mínima) | P3 | S | — | PR ABERTO (#914) |
+| 013 | Congelar namespace Tailwind legado `brand-*` com guard ratchet | P3 | S | — | TODO |
+| 014 | Atualização automática de reviews do Google (GH Actions agendado) | P3 | S | — | TODO |
+| 015 | SPIKE: expandir superfície de tools do chatbot (design doc) | P3 | M | — | TODO |
+| 016 | SPIKE: rotear resultado do quiz para o chatbot (design doc) | P3 | M | — | TODO |
+| 017 | Mover folder do design system → `docs/design/brand-system/` + ajustar teste | P3 | S | — | TODO |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (com motivo) | REJECTED (com justificativa)
 
 > **Rodada 2** (commit `68eecf6`, 2026-06-12): planos 001–005 já executados
 > (DONE, PRs #868–#872). Planos 006–010 são desta rodada — foco em performance
 > (gap da rodada 1), segurança de defesa-em-profundidade e cobertura de testes.
+
+> **Rodada 3** (commit `ec3029a`, 2026-06-21): audit focado no delta de 44
+> commits desde a rodada 2. Núcleos críticos (generate, OAuth callback, leads),
+> cobertura de testes (83 arquivos) e o código novo (otimizador R2, hardening
+> OAuth, UX mobile) estão sólidos e foram mudanças intencionais/testadas. Sobram
+> só achados de baixa alavancagem: 012 (higiene de raiz, ganho claro) e 013
+> (freeze do namespace de cor — versão segura S/LOW, não o big-bang). Direção
+> auditada via `/improve next` — sugestões grounded apresentadas ao mantenedor.
 
 ## Dependency notes
 
@@ -81,6 +95,41 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (com motivo) | REJECTED (com 
 - **Config sprawl (.agent/.agents/.qwen/.codex/.Jules), Vercel/Netlify configs,
   script `verify` unificado** — DX menor; fazer oportunisticamente (já anotado
   na rodada 1).
+
+### Considered and rejected — rodada 3 (commit `ec3029a`)
+
+- **Advisories do `pnpm audit` (ws/undici em wrangler→miniflare)** — dev-only.
+  Atingem só o emulador local; não estão no runtime de produção (Cloudflare
+  edge) nem no output de build. Ruído de baixo sinal, sem plano.
+- **Big-bang `brand-*` → `anhanga-*` (~629 usos)** — débito real, mas L de
+  esforço e risco MED–HIGH com só snapshots visuais de rede; péssimo encaixe
+  para executor barato. Reformulado como plano 013 (freeze ratchet, S/LOW);
+  migração fica oportunística.
+- **Tokens de cor pouco usados (`brand.blue`, `brand.cyanDark` — 3 usos cada)**
+  — removê-los exige migrar os call sites; coberto pela política do 013, sem
+  plano isolado.
+- **`feat(ai)` #908 (liberação de destinos Oriente Médio + visa_status)** —
+  mudança de produto intencional (estabilização do conflito), testada. By-design.
+- **`functions/api/*` fazem `Object.assign(process.env, env)` por request** —
+  padrão canônico de bridge das Pages Functions; coberto por
+  `cloudflare-config.test.ts`. By-design.
+- **Decomposição de `SearchForm.tsx` (1005) / `QuizAnhangaLanding.tsx` (1110)**
+  — segue sendo débito real (L), reafirmado das rodadas 1–2; sem bug ativo, não
+  priorizado.
+
+### Direção (`/improve next`) — rodada 3
+
+- **D1: loop NPS → review no Google** — **já implementado**. `pages/NpsPage.tsx`
+  ramifica por nota (`score >= 9 → thank-promoter`) e `components/nps/NpsThankPromoter.tsx`
+  já mostra o CTA "Deixar minha review no Google". O que falta é automação no
+  lado n8n (fora do repo). Sem plano.
+- **D2 → plano 014**: refresh automático de reviews (gap real — nenhum workflow
+  `schedule:` hoje).
+- **D3 → plano 015 (spike)**: expandir tools do chatbot. Arquitetura permite, mas
+  roteamento é hardcoded p/ `generate_budget_link`; valor de produto especulativo.
+- **D4 → plano 016 (spike)**: rotear resultado do quiz p/ o chatbot. Assimetria
+  real (quiz → WhatsApp, ignora o chatbot apesar de já ter perfil + bantSummary),
+  mas o caminho atual converte lead morno — medir antes de mudar.
 
 ## Audit gaps
 


### PR DESCRIPTION
## Contexto

Registro dos planos de implementação gerados pela 3ª rodada da skill `/improve` (audit focado no delta desde a rodada 2). São documentos de handoff — não alteram código de aplicação.

## Planos

- **012** — higiene da raiz (artefatos/dumps obsoletos → `docs/`). Já executado e em revisão no **#914**.
- **013** — congelar namespace Tailwind legado `brand-*` com guard ratchet (canônico é `anhanga-*`).
- **014** — refresh automático de reviews do Google via GitHub Actions agendado.
- **015** *(spike)* — design doc: expandir a superfície de tools do chatbot.
- **016** *(spike)* — design doc: rotear resultado do quiz para o chatbot (vs. WhatsApp atual).
- **017** — mover o folder do design system → `docs/design/brand-system/` + ajustar `tests/index-third-party-scripts.test.ts` (separado do 012 porque o teste lê a pasta da raiz em runtime).
- **README** — índice reconciliado: rodadas 1–3, ordem de execução, e seção de "considered & rejected".

## Escopo

Apenas `plans/**` (1299 linhas, 7 arquivos). Zero código de aplicação tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)