### PR TITLE
test(guard): congela namespace legado brand-* com ratchet

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -171,7 +171,7 @@ Decap CMS at `/admin`. Authenticates via GitHub OAuth through `api/auth.ts` + `a
 
 ### Styling
 
-Tailwind CSS (`tailwind.config.mjs`). Brand palette: `action` (#0056D2), `actionDark` (#003B8E), `yellow` (#FFD600). Custom animations: `fade-in-up`, `fade-in-down`, `pop-in`, `draw`, `float`, `blob`. Custom shadows: `glow`, `float`, `hard`, `hard-yellow`. Fonts: Poppins (sans + display headings), Merriweather (serif for blog prose). Design tokens shared between CSS and TS via `lib/design-tokens.ts`.
+Tailwind CSS (`tailwind.config.mjs`). Brand palette: `action` (#0056D2), `actionDark` (#003B8E), `yellow` (#FFD600). Custom animations: `fade-in-up`, `fade-in-down`, `pop-in`, `draw`, `float`, `blob`. Custom shadows: `glow`, `float`, `hard`, `hard-yellow`. Fonts: Poppins (sans + display headings), Merriweather (serif for blog prose). Design tokens shared between CSS and TS via `lib/design-tokens.ts`. The canonical Tailwind color namespace is `anhanga-*` (semantic tokens in `lib/design-tokens.ts`); `brand-*` is legacy and frozen by `tests/tailwind-brand-namespace-guard.test.ts` — new code must use `anhanga-*`.
 
 ### SEO + Prerender
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -16,6 +16,9 @@ export default {
     theme: {
         extend: {
             colors: {
+                // LEGADO — não usar em código novo. Namespace canônico: `anhanga-*`
+                // (ver lib/design-tokens.ts). Congelado por tests/tailwind-brand-namespace-guard.test.ts;
+                // migre usos de brand-* → anhanga-* oportunisticamente e abaixe o baseline do guard.
                 brand: {
                     cyan: '#0ea5e9', // Sky 500
                     cyanDark: '#0284c7', // Sky 600

--- a/tests/tailwind-brand-namespace-guard.test.ts
+++ b/tests/tailwind-brand-namespace-guard.test.ts
@@ -35,12 +35,22 @@ function collectTailwindFiles(dir: string): string[] {
   return out;
 }
 
+// O content do tailwind.config.mjs também inclui `./*.{js,ts,jsx,tsx}` —
+// arquivos na raiz (ex: App.tsx, index.tsx, ssr.tsx). Varremos a raiz (não
+// recursivo) para o guard cobrir todo o escopo que o Tailwind compila.
+function collectRootFiles(): string[] {
+  return fs
+    .readdirSync(ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && TARGET_EXTENSIONS.some((ext) => entry.name.endsWith(ext)))
+    .map((entry) => path.join(ROOT, entry.name));
+}
+
 // Baseline medido em 2026-06-21 (commit e14a6cd-descendant). Ao migrar
 // usos de brand-* para anhanga-*, ABAIXE este número para travar o ganho.
 const BRAND_NAMESPACE_BASELINE = 629;
 
 test('legacy brand-* namespace does not grow (ratchet)', () => {
-  const files = SCAN_DIRS.flatMap(collectTailwindFiles);
+  const files = [...SCAN_DIRS.flatMap(collectTailwindFiles), ...collectRootFiles()];
   assert.ok(files.length > 0, 'Expected to scan at least one Tailwind file');
   const offenders: string[] = [];
   let total = 0;

--- a/tests/tailwind-brand-namespace-guard.test.ts
+++ b/tests/tailwind-brand-namespace-guard.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Guard ratchet: o namespace Tailwind legado `brand-*` (definido em
+// tailwind.config.mjs) coexiste com o namespace canônico `anhanga-*`, cuja
+// fonte de verdade são os tokens semânticos em lib/design-tokens.ts. Migração
+// completa de `brand-*` → `anhanga-*` está fora de escopo deste guard — o
+// objetivo aqui é apenas impedir que o uso do namespace legado CRESÇA.
+// Ao migrar usos de brand-* para anhanga-*, ABAIXE o baseline abaixo para
+// travar o ganho (nunca aumente sem justificativa documentada).
+const LEGACY_BRAND =
+  /(?<![\w-])(text|bg|border|fill|stroke|ring(?:-offset)?|placeholder|from|to|via|divide|decoration|outline|accent|caret|shadow)-brand-[a-z][a-zA-Z]*(?![\w-])/g;
+
+// Espelha o `content` do tailwind.config.mjs — qualquer arquivo que o Tailwind
+// processa pode introduzir uma utility brand-*, então o guard precisa varrer o
+// mesmo escopo (dirs + extensões).
+const SCAN_DIRS = ['components', 'pages', 'services', 'utils', 'data'];
+const TARGET_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js'];
+const ROOT = process.cwd();
+
+function collectTailwindFiles(dir: string): string[] {
+  const abs = path.resolve(ROOT, dir);
+  if (!fs.existsSync(abs)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(abs, { withFileTypes: true })) {
+    const full = path.join(abs, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectTailwindFiles(path.relative(ROOT, full)));
+    } else if (entry.isFile() && TARGET_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Baseline medido em 2026-06-21 (commit e14a6cd-descendant). Ao migrar
+// usos de brand-* para anhanga-*, ABAIXE este número para travar o ganho.
+const BRAND_NAMESPACE_BASELINE = 629;
+
+test('legacy brand-* namespace does not grow (ratchet)', () => {
+  const files = SCAN_DIRS.flatMap(collectTailwindFiles);
+  assert.ok(files.length > 0, 'Expected to scan at least one Tailwind file');
+  const offenders: string[] = [];
+  let total = 0;
+  for (const file of files) {
+    const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+    lines.forEach((line, i) => {
+      for (const m of line.matchAll(LEGACY_BRAND)) {
+        total += 1;
+        offenders.push(`${path.relative(ROOT, file)}:${i + 1} → ${m[0]}`);
+      }
+    });
+  }
+  assert.ok(
+    total <= BRAND_NAMESPACE_BASELINE,
+    `Uso de brand-* (legado) cresceu para ${total} (baseline ${BRAND_NAMESPACE_BASELINE}).\n` +
+    `Use o namespace canônico anhanga-* (ver lib/design-tokens.ts). Novos usos:\n${offenders.join('\n')}`,
+  );
+});


### PR DESCRIPTION
## Resumo
Congela o namespace Tailwind legado `brand-*` com um teste *ratchet* (`tests/tailwind-brand-namespace-guard.test.ts`) que falha o CI se o número de usos de `brand-*` crescer além do baseline atual (629). Documenta `anhanga-*` como o namespace canônico.

## Por quê
`brand.*` e `anhanga.*` coexistem em `tailwind.config.mjs`; `lib/design-tokens.ts` já trata `anhanga-*` como fonte de verdade, mas nada impedia novo código de aumentar o uso legado. Este guard estanca o crescimento; a migração dos ~629 usos fica oportunística (abaixe o baseline ao migrar).

## Mudanças
- Novo teste ratchet (espelha `tailwind-bare-yellow-guard.test.ts`)
- Comentário de deprecação acima do bloco `brand` no config (sem mudar chaves/valores)
- 1 frase na seção Styling do `.claude/CLAUDE.md`

## Verificação
- `tsx --test tests/tailwind-brand-namespace-guard.test.ts` → pass
- `pnpm test:regression` → 720/720

Plano: `plans/013-freeze-legacy-brand-tailwind-namespace.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
