### PR TITLE
chore(ci): workflow agendado para atualizar reviews do Google

### DIFF
--- a/.github/workflows/refresh-reviews.yml
+++ b/.github/workflows/refresh-reviews.yml
@@ -1,0 +1,63 @@
+name: Refresh Google Reviews
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # toda segunda 06:00 UTC (~03:00 BRT)
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh-reviews:
+    name: Atualizar data/googleReviews.json
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6.0.8
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Fetch Google reviews
+        env:
+          OUTSCRAPER_API_KEY: ${{ secrets.OUTSCRAPER_API_KEY }}
+          GOOGLE_PLACE_ID: ${{ secrets.GOOGLE_PLACE_ID }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_CDN_BASE_URL: ${{ secrets.R2_CDN_BASE_URL }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: pnpm run reviews:fetch
+
+      - name: Open PR with updated reviews
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/googleReviews.json
+          if git diff --cached --quiet; then
+            echo "No changes to googleReviews.json — skipping."
+            exit 0
+          fi
+          BRANCH="chore/update-google-reviews-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          git commit -m "chore: atualiza data/googleReviews.json"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: atualiza data/googleReviews.json" \
+            --body "Atualização automática semanal dos reviews do Google, disparada pelo workflow agendado \`refresh-reviews.yml\`." \
+            --base main \
+            --head "$BRANCH"


### PR DESCRIPTION
## Resumo
Adiciona um workflow agendado (`.github/workflows/refresh-reviews.yml`) que atualiza `data/googleReviews.json` semanalmente (segundas 06:00 UTC / ~03:00 BRT) e sob `workflow_dispatch`, abrindo um PR apenas quando os dados mudam. Modelado no `generate-blog-manifest.yml`, fixado em Node 24.

## Por quê
Os reviews do Google só eram atualizados quando alguém rodava `pnpm reviews:fetch` manualmente. Sem automação agendada, a prova social envelhecia em silêncio.

## ⚠️ Pré-requisito (manutenção)
Antes do primeiro run, adicionar os secrets em Settings → Secrets → Actions:
- `OUTSCRAPER_API_KEY` (obrigatório)
- `GOOGLE_PLACE_ID` (obrigatório)
- `R2_BUCKET_NAME`, `R2_CDN_BASE_URL`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` (opcionais — re-upload de fotos para R2)

Também habilitar "Allow GitHub Actions to create and approve pull requests". Sem os secrets obrigatórios, o job falha em `loadConfig()`. Validar com um `workflow_dispatch` manual após configurar.

## Verificação
- YAML válido (lint `ok`)
- `pnpm test:regression` → 719/719

Plano: `plans/014-automated-google-reviews-refresh.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
