### PR TITLE
chore(ci): guard de reviews ignora mudança só de lastFetched

### DIFF
--- a/.github/workflows/refresh-reviews.yml
+++ b/.github/workflows/refresh-reviews.yml
@@ -47,11 +47,16 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/googleReviews.json
-          if git diff --cached --quiet; then
-            echo "No changes to googleReviews.json — skipping."
+          # Compara conteúdo ignorando o carimbo `lastFetched`, que muda a cada
+          # run. Sem isso, todo run semanal abriria um PR só de timestamp.
+          NEW_CONTENT="$(jq -S 'del(.lastFetched)' data/googleReviews.json)"
+          OLD_CONTENT="$(git show HEAD:data/googleReviews.json | jq -S 'del(.lastFetched)')"
+          if [ "$NEW_CONTENT" = "$OLD_CONTENT" ]; then
+            echo "Apenas lastFetched mudou — nenhum review novo. Pulando PR."
+            git checkout -- data/googleReviews.json
             exit 0
           fi
+          git add data/googleReviews.json
           BRANCH="chore/update-google-reviews-${{ github.run_id }}"
           git checkout -b "$BRANCH"
           git commit -m "chore: atualiza data/googleReviews.json"


### PR DESCRIPTION
## Resumo
Faz o guard de no-op do workflow `refresh-reviews.yml` comparar o conteúdo dos reviews **ignorando o campo `lastFetched`** (via `jq 'del(.lastFetched)'`). Assim, só abre PR quando há review novo de fato — acaba o ruído de PRs semanais cujo único diff é o timestamp.

## Por quê
`scripts/fetch-google-reviews.ts` reescreve `lastFetched` a cada run, então o guard antigo (`git diff --cached --quiet`) sempre detectava mudança. O #922 (validação do workflow) foi exatamente isso: um PR só de timestamp.

## Mudança
- Só o passo `Open PR with updated reviews` em `.github/workflows/refresh-reviews.yml`
- No caminho de skip, restaura o arquivo (`git checkout --`) para o working tree do runner não ficar sujo
- O script **não muda** — segue gravando `lastFetched` a cada run; a deduplicação é decisão do workflow

## Efeito colateral aceito
Em semanas sem review novo, o `lastFetched` no repo não avança (passa a significar "última vez que o conteúdo mudou"). O histórico de execuções fica no Actions.

## Verificação
- Lint YAML `ok`
- Simulação shell das duas direções: só-timestamp → SKIP; conteúdo real → abre PR
- `pnpm test:regression` → 720/720

Plano: `plans/018-reviews-guard-ignore-lastfetched.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
