### PR TITLE
🛡️ Sentinel: [MEDIUM] Move Meta CAPI access_token out of request URL

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -97,3 +97,8 @@ Standardized the "Zero-Trust CORS" pattern for internal APIs. Public-facing endp
 **Vulnerability:** Insecure (timing-sensitive) token comparison and lack of rate limiting on sensitive OAuth endpoints.
 **Learning:** Authentication flows, even if for administrative use, require multi-layered protection including rate limiting and timing-safe comparisons to prevent brute-force and side-channel attacks. Centralizing these utilities ensures consistency across the codebase.
 **Prevention:** Centralize security-critical utilities like `timingSafeEqual` in `lib/security.ts`. Enforce rate limits on all public-facing authentication or data ingestion endpoints to provide defense-in-depth against automated abuse.
+
+## 2026-06-22 - [Secrets in Outbound Request URLs (CWE-598)]
+**Vulnerability:** `lib/conversions/meta.ts` passed the Meta CAPI `access_token` as a query-string parameter (`?access_token=...`). On Cloudflare Pages Functions, outbound request URLs are exposed to edge/CDN observability, proxies, and APM tooling, while request bodies are not — so a long-lived provider secret rode along in a loggable surface.
+**Learning:** The Graph API accepts `access_token` in the POST body; moving it there removes the URL exposure with zero behavior change. NOT all providers can do this — GA4 Measurement Protocol (`lib/conversions/google.ts`) *requires* `api_secret` in the query string, so that one is an unavoidable exception, not a bug to "fix".
+**Prevention:** When integrating a provider, prefer sending credentials in headers or the request body. Only place a secret in a URL when the provider's API offers no alternative, and document why. Add a test asserting the secret never appears in the request URL.

--- a/lib/conversions/meta.ts
+++ b/lib/conversions/meta.ts
@@ -113,11 +113,17 @@ function buildMetaCustomData(payload: MetaConversionPayload): Record<string, unk
 
 async function buildMetaRequestBody(
   payload: MetaConversionPayload,
+  accessToken: string,
   testEventCode: string | undefined,
   nowMs: number
 ): Promise<Record<string, unknown>> {
   const eventId = normalizeString(payload.eventId);
   const body: Record<string, unknown> = {
+    // access_token is sent in the POST body rather than the query string so the
+    // secret never appears in a URL (CWE-598). Outbound request URLs can be
+    // captured by edge/CDN observability, proxies, and APM tooling; request
+    // bodies are not. Meta's Graph API accepts access_token as a body param.
+    access_token: accessToken,
     data: [
       {
         event_name: payload.eventName,
@@ -137,8 +143,8 @@ async function buildMetaRequestBody(
   return body;
 }
 
-function buildMetaUrl(pixelId: string, accessToken: string): string {
-  return `https://graph.facebook.com/${META_GRAPH_VERSION}/${pixelId}/events?access_token=${accessToken}`;
+function buildMetaUrl(pixelId: string): string {
+  return `https://graph.facebook.com/${META_GRAPH_VERSION}/${pixelId}/events`;
 }
 
 async function postMetaConversion(url: string, body: Record<string, unknown>): Promise<Response> {
@@ -182,8 +188,8 @@ export async function sendMetaConversion(
   try {
     const nowMs = Date.now();
     const testEventCode = normalizeString(process.env.META_TEST_EVENT_CODE);
-    const body = await buildMetaRequestBody(payload, testEventCode, nowMs);
-    const url = buildMetaUrl(pixelId, accessToken);
+    const body = await buildMetaRequestBody(payload, accessToken, testEventCode, nowMs);
+    const url = buildMetaUrl(pixelId);
     const response = await postMetaConversion(url, body);
     return await handleMetaResponse(payload, response);
   } catch (error) {

--- a/tests/meta-conversion.test.ts
+++ b/tests/meta-conversion.test.ts
@@ -81,10 +81,11 @@ test('sendMetaConversion should build the expected Meta CAPI payload', async (t)
 
   assert.deepEqual(result, { success: true });
   assert.equal(requests.length, 1);
-  assert.equal(
-    requests[0]?.url,
-    'https://graph.facebook.com/v19.0/pixel-1/events?access_token=token-1',
-  );
+  // Security (CWE-598): the access token must never appear in the URL/query
+  // string — it is sent in the POST body instead.
+  assert.equal(requests[0]?.url, 'https://graph.facebook.com/v19.0/pixel-1/events');
+  assert.ok(!requests[0]?.url.includes('token-1'), 'access token must not leak into the URL');
+  assert.equal(requests[0]?.body?.access_token, 'token-1');
   assert.equal(requests[0]?.method, 'POST');
 
   const event = (requests[0]?.body?.data as Array<Record<string, unknown>> | undefined)?.[0];


### PR DESCRIPTION
## 🛡️ Sentinel Security Review

🚨 **Severity:** MEDIUM (defense-in-depth / secret-handling)

💡 **Vulnerability:** `lib/conversions/meta.ts` sent the Meta Conversions API `access_token` as a URL query-string parameter (`?access_token=...`) — CWE-598 (Information Exposure Through Query String).

🎯 **Impact:** This site runs on Cloudflare Pages Functions. Outbound request **URLs** can be captured by edge/CDN observability, proxies, and APM tooling, whereas request **bodies** are not. A long-lived provider secret riding in the URL therefore sits on a loggable surface where it doesn't need to be. Leakage of the Meta access token would let an attacker forge conversion events against the pixel.

🔧 **Fix:** Send `access_token` in the POST body instead of the URL. Meta's Graph API fully supports `access_token` as a body parameter, so the conversion event itself is unchanged.
- `buildMetaUrl()` no longer embeds the token.
- `buildMetaRequestBody()` now includes `access_token` in the body, with an explanatory security comment.
- GA4 (`lib/conversions/google.ts`) is intentionally **left as-is** — the Measurement Protocol *requires* `api_secret` in the query string, so it's an unavoidable exception, not a comparable bug.

✅ **Verification:**
- Updated `tests/meta-conversion.test.ts` to assert the token never appears in the request URL and is present in the body.
- `pnpm exec tsx --test tests/meta-conversion.test.ts` → 3/3 pass
- Conversion regression suite (`purchase-dispatch` + `meta-conversion`) → 18/18 pass
- `tsc --noEmit` → clean (exit 0)

Scope: 3 files, ~20 lines. No behavior change to emitted conversion events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1iY2cuWTw5fFt9p8knT2H

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1iY2cuWTw5fFt9p8knT2H)_