### PR TITLE
docs: reescreve README para refletir o porte real do projeto

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,139 +2,132 @@
 ![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/felipewilliam2/AV-SITE)
 
 
-## Anhangá Viagens - Site Institucional
+## Anhangá Viagens — Site Institucional
 
-O site institucional da **Anhangá Viagens** é uma plataforma moderna e interativa desenvolvida para oferecer aos clientes uma experiência completa, desde a exploração de destinos até o planejamento de viagens com o auxílio de inteligência artificial.
+Site institucional da **Anhangá Viagens**, uma agência de viagens boutique brasileira. A plataforma combina vitrine de destinos, blog de turismo e um chatbot com IA (Google Gemini) que qualifica leads em tempo real e os encaminha para o CRM. Roda em React 19 sobre Cloudflare Pages, com handlers de API edge-style e prerender estático das rotas no build.
 
 
 ## ✨ Features
 
-- **🤖 Chat com IA Gemini:** Assistente de viagens integrado que responde dúvidas, sugere roteiros e oferece informações personalizadas em tempo real.
-- **🎯 Captura de Leads Inteligente:** Integração automatizada com Salesforce via chatbot e n8n para qualificação e criação de leads.
-- **🏝️ Landing Pages Especializadas:** Experiências otimizadas para destinos de alta conversão (Orlando, Beto Carrero, Lollapalooza).
-- **📊 Rastreamento e Performance:** Monitoramento via GTM/sGTM (Stape) e persistência de UTMs/GCLID para atribuição.
-- **✈️ Vitrine de Destinos:** Seção visualmente atraente para apresentar os principais pacotes da agência.
-- **⭐ Depoimentos de Clientes:** Prova social integrada para aumentar a confiança na conversão.
-- **❓ FAQ Interativo:** Respostas rápidas para as dúvidas mais frequentes.
-- **📝 Blog de Viagens:** CMS headless integrado para publicação de roteiros e dicas de turismo.
-- **📱 Design Responsivo:** Interface Mobile-First otimizada para todos os dispositivos.
-- **📈 SEO de Alta Performance:** Estrutura otimizada com metadados dinâmicos e componentes de Schema.org.
-- **🗺️ Mapas Interativos:** Visualização geográfica de destinos e hotéis utilizando Leaflet.
+- **🤖 Chat com IA Gemini:** Assistente de viagens que responde dúvidas, sugere roteiros e conduz uma qualificação BANT (Need, Authority, Budget, Timeline) com handoff para atendimento humano em reservas de curto prazo.
+- **🎯 Captura de Leads Inteligente:** Leads do chatbot e dos formulários fluem para o **Salesforce** via n8n (web-to-lead), com atribuição de UTMs/click IDs preservada.
+- **🏝️ Landing Pages Especializadas:** Páginas de alta conversão sem o shell do site (Orlando, Beto Carrero, Lollapalooza, Melhor Idade, Corporativo, Cruzeiros, NPS, Quiz).
+- **📊 Rastreamento e Performance:** GTM/sGTM (Stape) com persistência de UTMs/GCLID e conversões server-side (Meta CAPI) com deduplicação por `event_id`.
+- **📝 Blog de Viagens:** Posts em MDX, manifest gerado no build e CMS headless (Decap) em `/admin` via OAuth do GitHub.
+- **📈 SEO de Alta Performance:** Prerender estático por rota, metadados dinâmicos SSR-safe e componentes Schema.org (LocalBusiness, FAQ, Breadcrumb).
+- **🗺️ Mapas Interativos:** Visualização geográfica de destinos e hotéis com Leaflet.
+- **📱 Design Responsivo:** Interface Mobile-First com design tokens compartilhados entre CSS e TS.
 
 
-## 🛠️ Tecnologias Utilizadas
+## 🛠️ Stack
 
-- **React 19:** O estado da arte em bibliotecas de UI.
-- **Vite:** Build tool ultrarrápida para desenvolvimento moderno.
-- **TypeScript:** Segurança e escalabilidade com tipagem estática.
-- **Tailwind CSS:** Design system utility-first para estilização de alta performance.
-- **React Router 7:** Gerenciamento de rotas e navegação SPA.
-- **Google Gemini AI + Cloudflare AI Gateway:** Motor de inteligência artificial generativa com proxy opcional para observabilidade de uso.
-- **Salesforce CRM:** Web-to-lead via n8n para gestão de leads (CRM ativo desde mai/2026).
-- **Cloudflare Pages:** Deploy primário com Pages Functions para API edge-style.
-- **Lucide React:** Biblioteca de ícones moderna e leve.
-- **Leaflet:** Biblioteca para mapas interativos e geolocalização.
+| Camada | Tecnologia |
+|---|---|
+| UI | React 19, React Router 7, Tailwind CSS, Lucide React, Leaflet |
+| Build | Vite, TypeScript, prerender via `MemoryRouter` |
+| IA | Google Gemini + Cloudflare AI Gateway (proxy opcional para observabilidade) |
+| API | Cloudflare Pages Functions (handlers edge-style em `api/`, adaptados em `functions/`) |
+| CRM / Automação | Salesforce (web-to-lead) + n8n webhooks |
+| Infra | Cloudflare Pages (deploy), Upstash Redis (rate limiting), R2 (mídia) |
+| Conteúdo | MDX, Decap CMS |
+| Testes | `node:test` (regressão) + Playwright (e2e) |
+
+
+## 🏗️ Arquitetura
+
+**Dois tiers de layout** resolvidos no `App.tsx`:
+- **Landing pages** — sem Header/Footer/AIChat, para campanhas de conversão.
+- **Shell principal** (`MainSiteShell`) — Header + AIChat + Footer, para o restante do site (home, blog, páginas legais, etc.).
+
+**Fluxo do chatbot:** `AIChat.tsx` → `services/geminiService.ts` → `api/generate.ts`, que valida a entrada, aplica rate limit, chama o Gemini com o prompt de `lib/ai/`, extrai a tool call de orçamento quando a qualificação BANT está completa e roda o handoff em `lib/ai/handoff.ts`.
+
+**Fluxo de leads:** `hooks/useLeadCapture.ts` → `api/submit-lead.ts` (valida + normaliza via `lib/lead-logic.ts` e schemas Zod) → webhook n8n → Salesforce.
+
+**Build:** os scripts de `scripts/` geram o manifest do blog, sitemap e feeds; o Vite empacota; e `scripts/prerender.mjs` renderiza cada rota em HTML estático.
+
+> A fonte de verdade de engenharia é **`docs/standards/`** — leia antes de alterar código (code style, testes, convenções de API, segurança).
+
 
 ## 🚀 Pré-requisitos
 
 - Node.js 24.x
-- pnpm (Gerenciador de pacotes)
+- pnpm (o repo usa `node-linker=hoisted`, configurado em `pnpm-workspace.yaml`)
 - Chave da API do Google Gemini no ambiente server-side
-- Opcional: Cloudflare AI Gateway autenticado para monitoramento de uso da IA
-- Secrets configurados no dashboard do **Cloudflare Pages** (ver `.env.example`)
+- Para produção: secrets configurados no dashboard do **Cloudflare Pages** (ver `.env.example`)
+
 
 ## 📦 Instalação
 
-1. **Clone o repositório:**
-   ```bash
-   git clone https://github.com/seu-usuario/anhanga-viagens.git
-   cd anhanga-viagens
-   ```
+```bash
+git clone https://github.com/felipewilliam2/AV-SITE.git
+cd AV-SITE
+pnpm install
+cp .env.example .env   # preencha GEMINI_API_KEY (mínimo para o chatbot rodar localmente)
+pnpm dev
+```
 
-2. **Instale as dependências:**
-   ```bash
-   pnpm install
-   ```
+O site sobe em `http://localhost:3000`. Consulte `.env.example` para a lista completa de variáveis (IA, n8n, Upstash, OAuth do Decap, mídia R2 etc.).
 
-3. **Configure as variáveis de ambiente:**
-   
-   Copie o arquivo de exemplo `.env.example` para um novo arquivo `.env`:
-   ```bash
-   cp .env.example .env
-   ```
-   
-   Em seguida, adicione as variáveis necessárias ao arquivo `.env` (consulte `.env.example` para a lista completa).
-   O frontend chama `/api/generate`; a chave do Gemini fica apenas no runtime da API.
-   ```env
-   GEMINI_API_KEY=sua_chave_api_aqui
-   # Opcional: habilite depois de criar o gateway autenticado no Cloudflare
-   AI_GATEWAY_ENABLED=false
-   CLOUDFLARE_ACCOUNT_ID=seu_account_id_cloudflare
-   CLOUDFLARE_AI_GATEWAY_ID=default
-   CLOUDFLARE_AI_GATEWAY_TOKEN=seu_token_com_permissao_run
-   # Opcional (o projeto já usa este domínio por padrão; defina só se quiser explicitar)
-   VITE_MEDIA_BASE_URL=https://media.anhanga.tur.br
-   # Opcional (ative depois de validar o /cdn-cgi/image no host de mídia)
-   VITE_MEDIA_ENABLE_TRANSFORMS=true
-   ```
-
-   O projeto já aponta por padrão para `https://media.anhanga.tur.br`. Use
-   `VITE_MEDIA_BASE_URL` apenas se precisar sobrescrever a origem em outro ambiente.
-   `VITE_MEDIA_TRANSFORM_ZONE_URL` só entra em uso quando
-   `VITE_MEDIA_ENABLE_TRANSFORMS=true`. O padrão atual mantém as imagens servidas
-   diretamente do bucket do R2, o que evita quebra quando `/cdn-cgi/image/...`
-   ainda não está ativo. Quando ativado, o helper só transforma imagens do
-   próprio host de mídia; URLs externas seguem diretas.
+> **Nota:** `pnpm preview` serve apenas estáticos — não há servidor de API. Para testar o chatbot localmente use `pnpm dev` com `GEMINI_API_KEY` no `.env`.
 
 
-4. **Execute o projeto:**
-   ```bash
-   pnpm dev
-   ```
-   O site estará disponível em `http://localhost:3000` (ou outra porta indicada no terminal).
+## 📝 Scripts
 
+| Script | Descrição |
+|---|---|
+| `pnpm dev` | Gera manifest/sitemap/feeds e sobe o Vite em `:3000` |
+| `pnpm build` | Gera artefatos, builda e prerendeza as rotas estáticas |
+| `pnpm preview` | Serve o build de produção em `:4173` (sem API) |
+| `pnpm typecheck` | Type-check sem emitir |
+| `pnpm test:regression` | Testes unitários/regressão (`node:test` via tsx) |
+| `pnpm test:e2e` | Testes e2e Playwright (`:ui` para modo interativo) |
+| `pnpm test:size` | Verifica limites de bundle (bundlesize) |
+| `pnpm doctor` | Diagnósticos react-doctor |
+| `pnpm cms:proxy` | Proxy local do Decap CMS para `/admin` |
 
-## 📝 Scripts Disponíveis
+Rodar um teste isolado: `tsx --test tests/submit-lead.test.ts`
 
-- `pnpm dev`: Inicia o servidor de desenvolvimento.
-- `pnpm build`: Gera a versão de produção do site na pasta `dist/`.
-- `pnpm preview`: Inicia um servidor local para visualizar o build.
-- `pnpm deploy`: Executa o build e faz o deploy para o GitHub Pages.
-- `pnpm test:regression`: Executa testes de regressão do chatbot.
 
 ## 🚢 Deploy
 
-O deploy primário é **Cloudflare Pages**. Vercel e Netlify são plataformas legadas com configs mantidas no repo.
+Deploy primário em **Cloudflare Pages**. Vercel e Netlify são legados (configs mantidas no repo para compatibilidade, mas não são a plataforma ativa).
 
-### Cloudflare Pages (primário)
+**Cloudflare Pages:**
+1. Conecte o repositório no dashboard do Cloudflare Pages.
+2. Build command `pnpm build` · Output `dist` · Node 24 (pinado via `.node-version` e `wrangler.toml`).
+3. Configure os secrets em Settings → Environment Variables (`GEMINI_API_KEY`, n8n, Upstash Redis, GitHub OAuth — ver `.env.example`).
+4. Deploy automático a cada push em `main`.
 
-1. Conecte o repositório ao Cloudflare Pages via dashboard.
-2. Build command: `pnpm build` | Output directory: `dist` | Node version: 24.
-3. Configure os secrets no dashboard do Pages (Settings → Environment Variables): `GEMINI_API_KEY`, variáveis do n8n, Upstash Redis, GitHub OAuth. Consulte `.env.example` para a lista completa.
-4. O deploy é feito automaticamente a cada push para `main`.
+`pnpm deploy` publica uma versão **estática (sem API)** no GitHub Pages, usado apenas para previews/mirror.
 
-### Vercel / Netlify (legado/secundário)
 
-Os arquivos `vercel.json` e `netlify.toml` estão mantidos no repo para compatibilidade. Não são a plataforma ativa.
+## 📁 Estrutura
 
-## 📁 Estrutura do Código
+Código organizado de forma flat no top-level (não há `/src` de aplicação — `src/` contém apenas `index.css`):
 
-A estrutura do projeto foi organizada para facilitar a manutenção e escalabilidade:
+```
+api/          15 handlers edge-style (chatbot, leads, webhooks, OAuth, health)
+functions/    Adaptadores das Pages Functions + _middleware.ts
+lib/          Helpers server-side (44 arquivos)
+  ai/         Config do Gemini, prompt BANT, tools, handoff
+  schemas/    Validadores Zod por endpoint
+  conversions/  Helpers de pixels Google + Meta
+services/     Integrações de provider (gemini, n8n, salesforce)
+hooks/        Hooks de formulário (useLeadCapture, useContactForm, ...)
+components/   UI React (118) — /ui, /schemas, /landings, /blog
+pages/        Componentes de rota (19) — /landings para eventos
+utils/        Utilitários de browser (UTM, share, blog)
+data/         Dados estáticos e manifests gerados
+scripts/      Geradores de build (manifest, sitemap, feeds, prerender)
+tests/        Testes node:test + Playwright (/tests/e2e) — 84 arquivos
+docs/         Documentação por domínio (standards, ops, seo, ...)
+content/      Posts MDX do blog
+```
 
-- **`/src`**: Contém todo o código-fonte da aplicação.
-  - **`/components`**: Componentes React reutilizáveis (Header, Footer, etc.).
-    - **`/ui`**: Componentes de UI genéricos (botões, inputs).
-    - **`/schemas`**: Componentes para dados estruturados (SEO).
-  - **`/pages`**: Componentes que representam as páginas da aplicação (Home, Blog, etc.).
-  - **`/services`**: Módulos para comunicação com APIs externas (ex: Gemini).
-  - **`/data`**: Mock de dados e informações estáticas.
-  - **`/utils`**: Funções utilitárias.
-- **`/public`**: Arquivos estáticos que não passam pelo processo de build (imagens, favicon).
-- **`/api`**: Funções serverless (neste caso, para a comunicação segura com a API do Gemini).
 
 ## 📄 Licença
 
-Este projeto é de propriedade privada da Anhangá Viagens.
+Projeto de propriedade privada da Anhangá Viagens.
 
 ---
 


### PR DESCRIPTION
## O que mudou

Reescrita do `README.md` para refletir a arquitetura e o porte reais do projeto, que estavam subdimensionados na versão anterior.

### Correções factuais
- **Estrutura do código:** a versão antiga descrevia tudo sob `/src/components`, `/src/pages` etc. — mas `src/` contém apenas `index.css`. O código real é flat no top-level (`api/`, `lib/`, `components/`, `pages/`…). A seção agora reflete isso, com os subsistemas de `lib/` (`ai`, `schemas`, `conversions`).
- **Deploy:** `pnpm deploy` (GitHub Pages) não aparece mais como deploy principal — fica claro que é mirror estático sem API e que o primário é **Cloudflare Pages**.
- **URL do `git clone`** apontando para o repo correto (`felipewilliam2/AV-SITE`).

### Adições
- Seção **Arquitetura**: dois tiers de layout, fluxo do chatbot (qualificação BANT → handoff), fluxo de leads (chatbot → n8n → Salesforce) e prerender.
- **Stack** e **Scripts** convertidos em tabelas, incluindo scripts ausentes (`typecheck`, `test:e2e`, `test:size`, `doctor`, `cms:proxy`).
- Números concretos (15 handlers, 44 libs, 118 componentes, 84 testes) e ponteiro para `docs/standards/` como fonte de verdade de engenharia.
- Nota sobre a limitação do `pnpm preview` (serve estáticos, sem API).

## Por quê
O README lia como projeto starter e não dava noção do escopo real, além de ter informação incorreta sobre a estrutura de pastas — o que confunde quem chega ao repo.

## Notas para o revisor
- Mudança **docs-only**. `pnpm typecheck` roda limpo (sem erros de tipo).
- O badge do React Doctor mantém o score fixo `s=92` na URL — vale avaliar regenerar/remover se estiver desatualizado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)