### PR TITLE
fix(ci): don't persist GITHUB_TOKEN across pnpm install in workflows

### DIFF
--- a/.github/workflows/generate-blog-manifest.yml
+++ b/.github/workflows/generate-blog-manifest.yml
@@ -18,7 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Não persistir o GITHUB_TOKEN como credencial git no runner: assim um
+          # script de lifecycle de dependência (pnpm install abaixo) não consegue
+          # lê-lo. O push reautentica explicitamente via token no passo final.
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.9
@@ -49,7 +52,7 @@ jobs:
           BRANCH="chore/update-blog-manifest-${{ github.run_id }}"
           git checkout -b "$BRANCH"
           git commit -m "chore: regenerate blogManifest.ts"
-          git push origin "$BRANCH"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}" "HEAD:refs/heads/$BRANCH"
           gh pr create \
             --title "chore: regenerate blogManifest.ts" \
             --body "Regeneração automática do blog manifest disparada por mudança em \`content/blog/\`." \

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,7 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v6.0.3
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        # Não persistir o GITHUB_TOKEN como credencial git: evita que scripts de
+        # lifecycle de dependências (pnpm install) leiam o token. O push de
+        # snapshots reautentica explicitamente via token URL no passo final.
+        persist-credentials: false
         fetch-depth: 0
     - uses: pnpm/action-setup@v6.0.9
     - uses: actions/setup-node@v6
@@ -33,6 +36,7 @@ jobs:
     - name: Commit updated snapshots
       env:
         HEAD_REF: ${{ github.head_ref }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -41,11 +45,12 @@ jobs:
           echo "No snapshot changes to commit."
         else
           git commit -m "test: update visual regression baselines [skip ci]"
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}"
           # Push to the PR head branch (HEAD_REF is set only on pull_request events)
           if [ -n "$HEAD_REF" ]; then
-            git push origin "HEAD:$HEAD_REF"
+            git push "$REMOTE" "HEAD:refs/heads/$HEAD_REF"
           else
-            git push
+            git push "$REMOTE" "HEAD:refs/heads/${{ github.ref_name }}"
           fi
         fi
     - name: Run Playwright tests

--- a/.github/workflows/refresh-reviews.yml
+++ b/.github/workflows/refresh-reviews.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Não persistir o GITHUB_TOKEN como credencial git no runner: assim os
+          # scripts de lifecycle do pnpm install não conseguem lê-lo. O push
+          # reautentica explicitamente via token no passo de abertura do PR.
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.9
@@ -60,7 +63,7 @@ jobs:
           BRANCH="chore/update-google-reviews-${{ github.run_id }}"
           git checkout -b "$BRANCH"
           git commit -m "chore: atualiza data/googleReviews.json"
-          git push origin "$BRANCH"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}" "HEAD:refs/heads/$BRANCH"
           gh pr create \
             --title "chore: atualiza data/googleReviews.json" \
             --body "Atualização automática semanal dos reviews do Google, disparada pelo workflow agendado \`refresh-reviews.yml\`." \

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -16,7 +16,9 @@ jobs:
     - uses: actions/checkout@v6.0.3
       with:
         ref: ${{ github.event.inputs.branch }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+        # Não persistir o GITHUB_TOKEN como credencial git: evita que scripts de
+        # lifecycle do pnpm install leiam o token. O push reautentica via token URL.
+        persist-credentials: false
     - uses: pnpm/action-setup@v6.0.9
     - uses: actions/setup-node@v6
       with:
@@ -29,6 +31,8 @@ jobs:
     - name: Update visual snapshots
       run: pnpm exec playwright test tests/e2e/visual.spec.ts --update-snapshots
     - name: Commit updated snapshots
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -37,5 +41,5 @@ jobs:
           echo "No snapshot changes to commit."
         else
           git commit -m "test: update visual regression baselines [skip ci]"
-          git push
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}" "HEAD:refs/heads/${{ github.event.inputs.branch }}"
         fi


### PR DESCRIPTION
## Contexto

react-doctor (`build-pipeline-secret-boundary`) apontou que o `pnpm install` roda perto de secrets nos workflows. Dos 5 arquivos reais flagrados, 4 tinham risco genuíno e 1 (`release.yml`) é falso positivo.

## Problema

`actions/checkout` persistia o `GITHUB_TOKEN` como credencial git no runner; o `pnpm install` rodava em seguida. Um script de lifecycle de uma dependência comprometida poderia ler essa credencial e dar push no repo (fronteira de supply-chain). Risco baixo (exige dependência já comprometida), mas é higiene de CI legítima.

## Mudança

Nos 4 workflows afetados:
- `persist-credentials: false` no checkout → o install não consegue mais ler o token.
- Push reautenticado explicitamente via `git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}" "HEAD:refs/heads/<branch>"` no passo final.

Arquivos: `generate-blog-manifest.yml`, `playwright.yml`, `refresh-reviews.yml`, `update-snapshots.yml`.

## Decisões

- **Não** usei `--ignore-scripts`: quebraria os builds allowlisted (`esbuild/sharp/workerd/protobufjs/@google/genai`) no `pnpm-workspace.yaml`.
- `release.yml` deixado intacto — falso positivo (checkout sem token; secrets escopados ao passo do `semantic-release`, sem compartilhar ambiente com o install).
- **Nota:** o react-doctor pode continuar acusando esses workflows por proximidade de texto (o `GH_TOKEN` do passo de push fica perto do install no arquivo), mas agora é falso positivo: o secret está escopado a um passo separado e a credencial não é mais persistida. Zerar o contador exigiria split install/push em jobs separados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)