### PR TITLE
⚡ Bolt: build LazyImage srcsets in a single pass

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,7 @@
 ## 2026-06-16 - ⚡ Bolt: Media Configuration Memoization
 **Learning:** Utilities like `getMediaRuntimeConfig` that access environment variables (`import.meta.env`) and global browser state (`window.location`) can become significant overhead when called within high-frequency paths, such as `LazyImage` rendering or `srcset` generation in large lists. Since these values are effectively static during a session, redundant lookups and object allocations can be avoided entirely.
 **Action:** Always memoize session-static configuration lookups that are used within the rendering loop of repeatable UI components.
+
+## 2026-06-23 - ⚡ Bolt: LazyImage srcset fan-out
+**Learning:** `LazyImage` is the single render hot path for nearly every image (lists, galleries, blog). It called `generateSrcSet` + `generateAvifSrcSet` + `generateWebpSrcSet` independently, and the AVIF/WebP generators each recomputed the *same* unformatted base URL per size to detect whether transforms applied — so the base URL was computed 3× per size (16 `optimizeImageUrl` calls/image). Production runs with `VITE_MEDIA_ENABLE_TRANSFORMS=true` (wrangler.toml), so this redundancy hit real users.
+**Action:** When several derived outputs share a comparison baseline, compute the baseline once in a single-pass helper (`generateResponsiveSrcSets`) and keep the old functions as thin wrappers for API/test stability. Cut per-image work 16→10 calls (~37%).

--- a/components/ui/LazyImage.tsx
+++ b/components/ui/LazyImage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { Image as ImageIcon } from 'lucide-react';
-import { optimizeRemoteImageUrl, generateAvifSrcSet, generateWebpSrcSet, generateSrcSet } from '../../data/mediaConfig';
+import { optimizeRemoteImageUrl, generateResponsiveSrcSets } from '../../data/mediaConfig';
 
 interface LazyImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
     src: string;
@@ -38,11 +38,14 @@ export const LazyImage = React.memo<LazyImageProps>(({
         if (!src) return { optimizedSrc: '', avifSrcSet: '', webpSrcSet: '', srcSet: '' };
         const numericWidth = typeof width === 'number' ? width : 1200;
         const numericHeight = typeof height === 'number' ? height : undefined;
+        // Single pass builds all three srcsets while computing each size's base
+        // URL only once, instead of three generators recomputing it separately.
+        const { srcSet, avifSrcSet, webpSrcSet } = generateResponsiveSrcSets(src);
         return {
             optimizedSrc: optimizeRemoteImageUrl(src, numericWidth, numericHeight),
-            avifSrcSet: generateAvifSrcSet(src),
-            webpSrcSet: generateWebpSrcSet(src),
-            srcSet: generateSrcSet(src),
+            avifSrcSet,
+            webpSrcSet,
+            srcSet,
         };
     }, [src, width, height]);
 

--- a/data/mediaConfig.ts
+++ b/data/mediaConfig.ts
@@ -342,22 +342,48 @@ export const generateResponsiveSrcSets = (
 
 /**
  * Generate srcset for responsive images using the active media provider.
+ *
+ * Standalone helper: when all three srcsets are needed for a single element,
+ * prefer {@link generateResponsiveSrcSets} so the per-size base URL is computed
+ * once instead of recomputed by each generator.
  */
-export const generateSrcSet = (url: string, sizes: number[] = DEFAULT_SRCSET_SIZES): string =>
-    generateResponsiveSrcSets(url, sizes).srcSet;
+export const generateSrcSet = (url: string, sizes: number[] = DEFAULT_SRCSET_SIZES): string => {
+    if (!url) return '';
+    const entries: string[] = [];
+    for (const size of sizes) {
+        entries.push(`${optimizeRemoteImageUrl(url, size)} ${size}w`);
+    }
+    return entries.join(', ');
+};
 
 /**
  * Generate an AVIF srcset for use inside a <picture> <source> element.
  * Returns an empty string when Cloudflare transforms are not enabled, preventing
  * browsers from requesting JPEG/PNG origins with type="image/avif".
  */
-export const generateAvifSrcSet = (url: string, sizes: number[] = DEFAULT_SRCSET_SIZES): string =>
-    generateResponsiveSrcSets(url, sizes).avifSrcSet;
+export const generateAvifSrcSet = (url: string, sizes: number[] = DEFAULT_SRCSET_SIZES): string => {
+    if (!url) return '';
+    const entries: string[] = [];
+    for (const size of sizes) {
+        const formatted = optimizeRemoteImageUrl(url, size, undefined, 'avif');
+        const unformatted = optimizeRemoteImageUrl(url, size);
+        if (formatted !== unformatted) entries.push(`${formatted} ${size}w`);
+    }
+    return entries.join(', ');
+};
 
 /**
  * Generate a WebP srcset for use inside a <picture> <source> element.
  * Returns an empty string when Cloudflare transforms are not enabled, preventing
  * browsers from requesting JPEG/PNG origins with type="image/webp".
  */
-export const generateWebpSrcSet = (url: string, sizes: number[] = DEFAULT_SRCSET_SIZES): string =>
-    generateResponsiveSrcSets(url, sizes).webpSrcSet;
+export const generateWebpSrcSet = (url: string, sizes: number[] = DEFAULT_SRCSET_SIZES): string => {
+    if (!url) return '';
+    const entries: string[] = [];
+    for (const size of sizes) {
+        const formatted = optimizeRemoteImageUrl(url, size, undefined, 'webp');
+        const unformatted = optimizeRemoteImageUrl(url, size);
+        if (formatted !== unformatted) entries.push(`${formatted} ${size}w`);
+    }
+    return entries.join(', ');
+};

--- a/data/mediaConfig.ts
+++ b/data/mediaConfig.ts
@@ -285,39 +285,79 @@ export const optimizeCloudinaryUrl = (
     format: 'auto' | 'webp' | 'avif' = 'auto',
 ): string => optimizeRemoteImageUrl(url, width, undefined, format);
 
+const DEFAULT_SRCSET_SIZES = [400, 800, 1200];
+
+export interface ResponsiveSrcSets {
+    /** Base srcset (provider default-format negotiation). */
+    srcSet: string;
+    /** AVIF srcset for a <picture> <source>; empty when transforms are off. */
+    avifSrcSet: string;
+    /** WebP srcset for a <picture> <source>; empty when transforms are off. */
+    webpSrcSet: string;
+}
+
+/**
+ * Build the base, AVIF and WebP srcsets in a single pass.
+ *
+ * PERFORMANCE: the base (unformatted) URL for each size is computed once and
+ * reused as the comparison baseline for AVIF/WebP transform detection, instead
+ * of being recomputed independently inside three separate generators. A
+ * LazyImage that emits all three srcsets previously triggered 16
+ * optimizeImageUrl() calls per image (regex + URL parsing); sharing the base
+ * brings that down to 10 (~37% fewer), which adds up across image-heavy lists
+ * and galleries.
+ */
+export const generateResponsiveSrcSets = (
+    url: string,
+    sizes: number[] = DEFAULT_SRCSET_SIZES,
+): ResponsiveSrcSets => {
+    if (!url) {
+        return { srcSet: '', avifSrcSet: '', webpSrcSet: '' };
+    }
+
+    const baseEntries: string[] = [];
+    const avifEntries: string[] = [];
+    const webpEntries: string[] = [];
+
+    for (const size of sizes) {
+        // Compute the base URL once; the format-specific variants only differ
+        // from it when Cloudflare transforms are active for this URL, so the
+        // shared baseline doubles as the "transforms enabled?" detector.
+        const base = optimizeRemoteImageUrl(url, size);
+        baseEntries.push(`${base} ${size}w`);
+
+        const avif = optimizeRemoteImageUrl(url, size, undefined, 'avif');
+        if (avif !== base) avifEntries.push(`${avif} ${size}w`);
+
+        const webp = optimizeRemoteImageUrl(url, size, undefined, 'webp');
+        if (webp !== base) webpEntries.push(`${webp} ${size}w`);
+    }
+
+    return {
+        srcSet: baseEntries.join(', '),
+        avifSrcSet: avifEntries.join(', '),
+        webpSrcSet: webpEntries.join(', '),
+    };
+};
+
 /**
  * Generate srcset for responsive images using the active media provider.
  */
-export const generateSrcSet = (url: string, sizes: number[] = [400, 800, 1200]): string => {
-    return sizes
-        .map(size => `${optimizeRemoteImageUrl(url, size)} ${size}w`)
-        .join(', ');
-};
+export const generateSrcSet = (url: string, sizes: number[] = DEFAULT_SRCSET_SIZES): string =>
+    generateResponsiveSrcSets(url, sizes).srcSet;
 
 /**
  * Generate an AVIF srcset for use inside a <picture> <source> element.
  * Returns an empty string when Cloudflare transforms are not enabled, preventing
  * browsers from requesting JPEG/PNG origins with type="image/avif".
  */
-export const generateAvifSrcSet = (url: string, sizes: number[] = [400, 800, 1200]): string => {
-    const entries = sizes.flatMap(size => {
-        const formatted = optimizeRemoteImageUrl(url, size, undefined, 'avif');
-        const unformatted = optimizeRemoteImageUrl(url, size);
-        return formatted !== unformatted ? [`${formatted} ${size}w`] : [];
-    });
-    return entries.join(', ');
-};
+export const generateAvifSrcSet = (url: string, sizes: number[] = DEFAULT_SRCSET_SIZES): string =>
+    generateResponsiveSrcSets(url, sizes).avifSrcSet;
 
 /**
  * Generate a WebP srcset for use inside a <picture> <source> element.
  * Returns an empty string when Cloudflare transforms are not enabled, preventing
  * browsers from requesting JPEG/PNG origins with type="image/webp".
  */
-export const generateWebpSrcSet = (url: string, sizes: number[] = [400, 800, 1200]): string => {
-    const entries = sizes.flatMap(size => {
-        const formatted = optimizeRemoteImageUrl(url, size, undefined, 'webp');
-        const unformatted = optimizeRemoteImageUrl(url, size);
-        return formatted !== unformatted ? [`${formatted} ${size}w`] : [];
-    });
-    return entries.join(', ');
-};
+export const generateWebpSrcSet = (url: string, sizes: number[] = DEFAULT_SRCSET_SIZES): string =>
+    generateResponsiveSrcSets(url, sizes).webpSrcSet;

--- a/tests/media-config.test.ts
+++ b/tests/media-config.test.ts
@@ -5,8 +5,10 @@ import { AUTHORS } from '../data/blogData.ts';
 import {
     getMediaRuntimeConfig,
     HERO_VIDEOS,
+    generateSrcSet,
     generateAvifSrcSet,
     generateWebpSrcSet,
+    generateResponsiveSrcSets,
     optimizeCloudinaryUrl,
 } from '../data/mediaConfig.ts';
 import { BLOG_POST_MANIFEST } from '../data/blogManifest.ts';
@@ -128,6 +130,32 @@ test('generateAvifSrcSet should return empty string when transforms are not enab
 test('generateWebpSrcSet should return empty string when transforms are not enabled', () => {
     const result = generateWebpSrcSet('https://media.anhanga.tur.br/images/destinations/paris.jpg');
     assert.equal(result, '');
+});
+
+test('generateResponsiveSrcSets should match the standalone generators in one pass', () => {
+    // The combined generator shares each size's base URL across all three
+    // srcsets, so its output must stay identical to calling the individual
+    // generators that LazyImage previously used.
+    const url = 'https://media.anhanga.tur.br/images/destinations/paris.jpg';
+    const combined = generateResponsiveSrcSets(url);
+
+    assert.equal(combined.srcSet, generateSrcSet(url));
+    assert.equal(combined.avifSrcSet, generateAvifSrcSet(url));
+    assert.equal(combined.webpSrcSet, generateWebpSrcSet(url));
+
+    // Base srcset always lists every requested width descriptor.
+    assert.deepEqual(
+        combined.srcSet.split(', ').map((entry) => entry.split(' ').pop()),
+        ['400w', '800w', '1200w'],
+    );
+});
+
+test('generateResponsiveSrcSets should return empty strings for an empty url', () => {
+    assert.deepEqual(generateResponsiveSrcSets(''), {
+        srcSet: '',
+        avifSrcSet: '',
+        webpSrcSet: '',
+    });
 });
 
 test('optimizeCloudinaryUrl should pass format to the underlying helper (not silently ignore it)', () => {


### PR DESCRIPTION
## ⚡ Bolt: LazyImage srcset single-pass generation

### 💡 What
`LazyImage` (the render hot path for nearly every image on the site — destination grids, blog, galleries) generated its responsive srcsets by calling three independent helpers: `generateSrcSet`, `generateAvifSrcSet`, and `generateWebpSrcSet`. The AVIF and WebP generators each **recomputed the same unformatted base URL per size** in order to detect whether a Cloudflare transform was actually applied (`formatted !== unformatted`). The base URL was therefore computed three separate times per size.

This PR introduces `generateResponsiveSrcSets(url, sizes)`, which walks the sizes **once**, computes each size's base URL a single time, and reuses it as the comparison baseline for the AVIF/WebP variants. The three original functions are kept as thin wrappers so the public API and existing tests are unchanged.

### 🎯 Why
Per image, the old path issued **16** `optimizeImageUrl()` calls (each doing regex tests + `new URL()` parsing):
- 1 main `optimizedSrc`
- 3 base (`generateSrcSet`)
- 6 (`generateAvifSrcSet`: 3 avif + 3 redundant base)
- 6 (`generateWebpSrcSet`: 3 webp + 3 redundant base)

Production runs with `VITE_MEDIA_ENABLE_TRANSFORMS=true` (`wrangler.toml`), so this redundancy hit real users, not just dev.

### 📊 Impact
- **~37% fewer** `optimizeImageUrl()` calls per `LazyImage`: **16 → 10**.
- Eliminates **6 redundant** base-URL computations (regex + URL parsing) per rendered image.
- Scales linearly with image count — e.g. a 20-image gallery drops ~120 redundant calls.
- **Behavior-preserving:** the base srcset and the AVIF/WebP transform-detection results are byte-for-byte identical; only the duplicate work is removed.

### 🔬 Measurement / Verification
- `tests/media-config.test.ts` — new tests assert `generateResponsiveSrcSets` output is identical to the standalone generators and that the base srcset emits every width descriptor (`400w/800w/1200w`), plus empty-URL handling.
- `pnpm typecheck` ✅
- Related suites: `media-config`, `mdx-image-cls`, `media-url`, `image-optimization` — **46 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFiJ2Gv1TykMvqLxUQMrdC)_