### PR TITLE
🎨 Palette: associate ChatLeadForm validation errors with their inputs

### DIFF
--- a/components/ChatLeadForm.tsx
+++ b/components/ChatLeadForm.tsx
@@ -132,7 +132,7 @@ function openWhatsAppWindow(url: string): void {
   }
 }
 
-function TextField({
+export function TextField({
   id,
   label,
   type,
@@ -142,6 +142,7 @@ function TextField({
   onChange,
   inputMode,
 }: TextFieldProps) {
+  const errorId = `${id}-error`;
   return (
     <div className="space-y-1">
       <label htmlFor={id} className="sr-only">{label}</label>
@@ -152,9 +153,11 @@ function TextField({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : undefined}
         className={`w-full bg-white border ${error ? 'border-red-500' : 'border-zinc-200'} rounded-xl px-4 py-3 text-sm text-zinc-700 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-brand-vibrant/30 focus:border-brand-vibrant transition shadow-sm`}
       />
-      {error && <span className="text-[10px] text-red-500 font-bold ml-1 uppercase">{error}</span>}
+      {error && <span id={errorId} role="alert" className="text-[10px] text-red-500 font-bold ml-1 uppercase">{error}</span>}
     </div>
   );
 }
@@ -311,6 +314,8 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
                   type="checkbox"
                   checked={acceptedLGPD}
                   onChange={(e) => setAcceptedLGPD(e.target.checked)}
+                  aria-invalid={fieldErrors.lgpd ? true : undefined}
+                  aria-describedby={fieldErrors.lgpd ? 'lead-lgpd-error' : undefined}
                   className="peer size-4 cursor-pointer appearance-none rounded border border-zinc-300 bg-white checked:bg-brand-vibrant checked:border-brand-vibrant transition focus:ring-2 focus:ring-brand-vibrant/20"
                 />
                 <CheckCircle2 className="absolute size-3 text-white opacity-0 peer-checked:opacity-100 left-0.5 pointer-events-none transition-opacity" />
@@ -319,7 +324,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
                 Aceito receber comunicações e autorizo o tratamento dos meus dados conforme a <a href="/politica-privacidade/" target="_blank" rel="noopener noreferrer" className="underline hover:text-brand-vibrant">Política de Privacidade</a>.
               </span>
             </label>
-            {fieldErrors.lgpd && <span className="text-[10px] text-red-500 font-bold ml-7 uppercase">{fieldErrors.lgpd}</span>}
+            {fieldErrors.lgpd && <span id="lead-lgpd-error" role="alert" className="text-[10px] text-red-500 font-bold ml-7 uppercase">{fieldErrors.lgpd}</span>}
           </div>
         </div>
 

--- a/tests/chat-lead-form-a11y.test.ts
+++ b/tests/chat-lead-form-a11y.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { TextField } from '../components/ChatLeadForm.tsx';
+
+const baseProps = {
+  id: 'lead-email',
+  label: 'E-mail',
+  type: 'email' as const,
+  value: '',
+  placeholder: 'E-mail',
+  onChange: () => {},
+};
+
+test('TextField com erro associa a mensagem ao input via aria-describedby', () => {
+  const html = renderToStaticMarkup(
+    React.createElement(TextField, { ...baseProps, error: 'E-mail inválido' })
+  );
+
+  // Input is flagged invalid and points at the error message id.
+  assert.ok(html.includes('aria-invalid="true"'), 'input deve ter aria-invalid="true"');
+  assert.ok(
+    html.includes('aria-describedby="lead-email-error"'),
+    'input deve referenciar o id da mensagem de erro'
+  );
+  // Error message carries the matching id and is exposed to assistive tech.
+  assert.ok(html.includes('id="lead-email-error"'), 'mensagem de erro deve ter o id correspondente');
+  assert.ok(html.includes('role="alert"'), 'mensagem de erro deve ter role="alert"');
+  assert.ok(html.includes('E-mail inválido'), 'mensagem de erro deve ser renderizada');
+});
+
+test('TextField sem erro não adiciona atributos de erro', () => {
+  const html = renderToStaticMarkup(React.createElement(TextField, baseProps));
+
+  assert.ok(!html.includes('aria-invalid'), 'não deve ter aria-invalid sem erro');
+  assert.ok(!html.includes('aria-describedby'), 'não deve ter aria-describedby sem erro');
+  assert.ok(!html.includes('role="alert"'), 'não deve ter role="alert" sem erro');
+});


### PR DESCRIPTION
## 💡 What
Linked the lead-capture form's validation errors to the fields they describe. Text inputs and the LGPD checkbox now carry `aria-invalid` + `aria-describedby`, and each error message has a matching `id` and `role="alert"`.

## 🎯 Why
The form already rendered field-level errors visually (red border + small red text), but the errors were invisible to assistive technology — there was no `aria-invalid`, no `aria-describedby`, and the messages weren't in the accessibility tree. A screen-reader user could submit, hear nothing change, and have no idea *which* field failed or *why* ("Campo obrigatório", "E-mail inválido", etc.). This is the chatbot's primary lead-conversion form, so the gap mattered.

## ♿ Accessibility
- `aria-invalid="true"` on inputs/checkbox when their field has an error
- `aria-describedby` points each input at its error message `id`
- Each error message gets a stable `id` + `role="alert"` so it is announced the moment it appears
- No visual change — purely additive semantics; clears cleanly when the field becomes valid

## ✅ Verify
- `pnpm typecheck` — passes
- New regression test `tests/chat-lead-form-a11y.test.ts` (renders `TextField` via `renderToStaticMarkup`, asserts the error-association attributes appear with an error and stay absent without one) — passes

Scope: ~11 lines of component change + a focused test. No layout, styling, or backend logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AFjPVzS6GiXwf64ZHvU3C

---
_Generated by [Claude Code](https://claude.ai/code/session_013AFjPVzS6GiXwf64ZHvU3C)_