### PR TITLE
feat(redirects): link curto /indica → home com UTM de indicação (NPS promotor)

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -10,6 +10,11 @@
 /brazil-promotion-day    /corporativo    301
 /brazil-promotion-day/   /corporativo    301
 
+# Link curto de indicação (e-mail #14 NPS promotor → WhatsApp share)
+# 302 (temporário) para permitir ajustar os UTMs depois sem cache de 301.
+/indica    /?utm_source=indicacao&utm_medium=whatsapp&utm_campaign=nps_promotor    302
+/indica/   /?utm_source=indicacao&utm_medium=whatsapp&utm_campaign=nps_promotor    302
+
 # Exclusão de dados trailing-slash normalisation
 /exclusao-de-dados  /exclusao-de-dados/  301
 

--- a/tests/cloudflare-config.test.ts
+++ b/tests/cloudflare-config.test.ts
@@ -117,6 +117,25 @@ test('Cloudflare redirects should use supported status codes', async () => {
   assert.doesNotMatch(redirects, /(?:^|\s)(?:301|302|303|307|308)!(?:\s|$)/);
 });
 
+test('Cloudflare redirects should expose the /indica short link with NPS referral UTMs', async () => {
+  const redirects = await readFile(new URL('../public/_redirects', import.meta.url), 'utf8');
+  const rules = collectRedirectRules(redirects)
+    .map((line) => line.split(/\s+/))
+    .filter(([from]) => from === '/indica' || from === '/indica/');
+
+  assert.ok(rules.length >= 1, 'expected at least one /indica redirect rule');
+
+  for (const [, target, status] of rules) {
+    assert.equal(status, '302', '/indica must use a temporary 302 redirect');
+
+    const url = new URL(target, 'https://www.anhanga.tur.br');
+    assert.equal(url.pathname, '/', '/indica must redirect to the home route');
+    assert.equal(url.searchParams.get('utm_source'), 'indicacao');
+    assert.equal(url.searchParams.get('utm_medium'), 'whatsapp');
+    assert.equal(url.searchParams.get('utm_campaign'), 'nps_promotor');
+  }
+});
+
 test('Cloudflare redirects should avoid redundant SPA fallback rewrites', async () => {
   const redirects = await readFile(new URL('../public/_redirects', import.meta.url), 'utf8');
 

--- a/tests/cloudflare-config.test.ts
+++ b/tests/cloudflare-config.test.ts
@@ -123,7 +123,7 @@ test('Cloudflare redirects should expose the /indica short link with NPS referra
     .map((line) => line.split(/\s+/))
     .filter(([from]) => from === '/indica' || from === '/indica/');
 
-  assert.ok(rules.length >= 1, 'expected at least one /indica redirect rule');
+  assert.equal(rules.length, 2, 'expected exactly two /indica redirect rules (with and without trailing slash)');
 
   for (const [, target, status] of rules) {
     assert.equal(status, '302', '/indica must use a temporary 302 redirect');


### PR DESCRIPTION
## Contexto

Fecha #955. O e-mail Mautic **#14 "[NPS] Indicação — Promotores"** tem um botão **"Indicar pelo WhatsApp"** que compartilha uma mensagem pronta com o link do site. Para **medir** a indicação (`lead_source` no ledger `attribution_events`), o link precisa carregar UTMs — mas a URL completa deixa a mensagem longa e com cara de rastreador, desincentivando o envio.

**Solução:** link curto branded que aplica os UTMs por trás. A mensagem mostra `anhanga.tur.br/indica` (limpo); o GA4 recebe a atribuição completa.

## Mudança

`public/_redirects` — nova regra no bloco de redirects de campanha:

```
/indica    /?utm_source=indicacao&utm_medium=whatsapp&utm_campaign=nps_promotor    302
/indica/   /?utm_source=indicacao&utm_medium=whatsapp&utm_campaign=nps_promotor    302
```

- **302** (temporário) para permitir ajustar os UTMs depois sem cache de 301.
- Variante com trailing slash (`/indica/`) espelha o padrão de normalização do arquivo.
- Destino = home; `utils/whatsapp.ts` captura os UTMs no load → lead entra marcado como indicação.
- Slug `/indica` confirmado livre (sem conflito com rotas do `App.tsx`; o `_redirects` é processado pelo Cloudflare antes do SPA fallback).

## Testes

`tests/cloudflare-config.test.ts` — novo caso valida: regra existe, status 302, destino é a home (`/`) e os 3 UTMs corretos.

```
pnpm exec tsx --test tests/cloudflare-config.test.ts  →  14/14 passam
```

## Aceite

- [x] Regra adicionada ao `public/_redirects`.
- [x] `/indica` (e `www`, via Redirect Rule host-based já existente) redireciona para a home com os 3 UTMs.
- [x] Caso de teste adicionado para `/indica`.

## ⚠️ Coordenação

Fazer o **deploy deste redirect ANTES de publicar/enviar o e-mail #14** — senão o botão cai em 404 enquanto a regra não está live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)