### PR TITLE
fix(corporativo): polir eyebrow do hero e brilho do globo

### DIFF
--- a/components/landings/corporativo/CorpGlobe.tsx
+++ b/components/landings/corporativo/CorpGlobe.tsx
@@ -141,7 +141,7 @@ export function CorpGlobe() {
         <div
             ref={containerRef}
             className="w-full h-full"
-            style={{ filter: 'brightness(2) contrast(1.05) saturate(1.35)' }}
+            style={{ filter: 'brightness(1.45) contrast(1.08) saturate(1.5)' }}
         />
     );
 }

--- a/components/landings/corporativo/CorpHero.tsx
+++ b/components/landings/corporativo/CorpHero.tsx
@@ -62,9 +62,9 @@ export function CorpHero() {
                         custom={0}
                         className="inline-block relative mb-6"
                     >
-                        <span className="absolute inset-0 bg-brand-yellow/30 transform -skew-x-12 rounded-lg" />
+                        <span className="absolute inset-0 bg-white/10 border border-white/15 transform -skew-x-12 rounded-lg" />
                         <span className="relative px-4 py-1.5 text-white font-black uppercase tracking-widest text-xs flex items-center gap-2">
-                            <AirplaneTilt className="size-4" weight="fill" />
+                            <AirplaneTilt className="size-4 text-brand-yellow" weight="fill" />
                             Viagens para Empresas
                         </span>
                     </m.div>


### PR DESCRIPTION
## O que

Polish final da landing `/corporativo`. A maior parte do critique anterior (31/40) já fora resolvida no #951; este PR fecha os **dois defeitos cosméticos reais que restavam**, verificados visualmente (screenshots antes/depois) em desktop e mobile.

## Mudanças

- **Eyebrow do hero** (`CorpHero.tsx`): `bg-brand-yellow/30` sobre o navy renderizava um oliva opaco e duplicava o âmbar (que já é o CTA). Trocado por um pill de vidro (`bg-white/10` + borda sutil) com o ícone de avião em âmbar — limpo, unificado com os badges e respeitando a Regra do Âmbar (CTA segue como o único âmbar dominante).
- **Arcos do globo** (`CorpGlobe.tsx`): `brightness(2)` lavava o amarelo/ciano para quase-branco e criava um limbo solar competindo com o título. Reduzido para `brightness(1.45)` + `saturate(1.5)` — arcos com cor de marca de volta e Terra noturna legível.

## Fora de escopo (follow-up)

- Reveal `whileInView`/`opacity:0` nos pilares/processo: render real (com scroll) funciona; o risco é só prerender/no-JS e vive em `components/landings/shared/` usado por 4 landings — merece um `harden` dedicado.
- Proliferação de pastéis e cadência de eyebrows: roteados pelo critique para `/colorize` e `/distill`.

## Verificação

- `pnpm typecheck` — sem erros
- detector determinístico do impeccable — `[]` (zero padrões de slop)
- Inspeção visual desktop + mobile + scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)