### PR TITLE
fix(links): aplica design system, corrige contraste e alinhamento da /links

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "av-site-dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/.impeccable/critique/2026-06-28T02-56-53Z__pages-linkspage-tsx.md
+++ b/.impeccable/critique/2026-06-28T02-56-53Z__pages-linkspage-tsx.md
@@ -1,0 +1,78 @@
+---
+target: links
+total_score: 30
+p0_count: 0
+p1_count: 3
+timestamp: 2026-06-28T02-56-53Z
+slug: pages-linkspage-tsx
+---
+# Critique — Página de Links na Bio (`/links`)
+
+## Design Health Score
+
+| # | Heurística | Nota | Problema-chave |
+|---|-----------|-------|----------------|
+| 1 | Visibilidade do status | 3 | Sem affordance de "abre WhatsApp/nova aba"; resto ok (focus ring, active:scale) |
+| 2 | Match com o mundo real | 4 | PT-BR claro, ordem quente→frio, ícone do WhatsApp reconhecível |
+| 3 | Controle e liberdade | 3 | Lista de links, baixo risco; externos abrem em nova aba |
+| 4 | Consistência e padrões | 2 | Ícones desalinhados (label em x=109–163px), alturas mistas (56/72px), não usa hard-shadow/press-down do sistema |
+| 5 | Prevenção de erro | 3 | n/a — sem formulários |
+| 6 | Reconhecer vs. lembrar | 4 | Tudo visível e rotulado, zero carga de memória |
+| 7 | Flexibilidade/eficiência | 3 | Ação primária a 1 toque; sem aceleradores (não precisa) |
+| 8 | Estético e minimalista | 2 | 12 botões brancos idênticos empilhados; banner disputa com o CTA; dois amarelos; FABs cobrindo conteúdo |
+| 9 | Recuperação de erro | 3 | n/a |
+| 10 | Ajuda e documentação | 3 | A própria página é um hub de navegação; selos dão reforço |
+| **Total** | | **30/40** | **Bom — base sólida, mas fora do sistema e com falhas de polimento** |
+
+## Anti-Patterns Verdict
+
+**Parece feito por IA?** Em parte, sim — pelo *template*, não pelos detalhes.
+
+**Avaliação LLM:** a página é uma pilha vertical de ~12 cartões brancos arredondados idênticos sobre gradiente azul. Isso é literalmente o visual padrão do Linktree — exatamente o que o DESIGN.md bane ("cards idênticos em grade repetida") e o que a marca lista como anti-referência ("grades de cards idênticos, frieza transacional"). A identidade "O Diário de Bordo" (peso físico, hard-shadow, press-down tipo carimbo) está **ausente**: os botões usam `shadow-sm` + `active:scale`, genérico. A paleta está certa; o *sistema* não foi aplicado.
+
+**Scan determinístico:** `detect.mjs` rodou em `LinksPage.tsx`, `LinkButton.tsx`, `TrustSeals.tsx` → **0 achados** (exit 0). Nenhum dos tells automatizados (gradient text, side-stripe, eyebrow) está presente. Os problemas aqui são de sistema/composição/contraste, que o detector não pega.
+
+**Evidência de browser:** renderizado em viewport mobile (375×812), rota `/links` confirmada, 12 botões, altura total 1308px. Medições reais: gradiente `#003B8E → #0ea5e9`; sublabels em `#003B8E` a 70% opacidade; selos do rodapé em branco a 80% sobre a base clara do gradiente (`#0ea5e9`).
+
+## Overall Impression
+
+Funciona e está na cor da marca, mas se entrega como Linktree, não como Anhangá. O maior ganho não é corrigir bugs — é **fazer a página parecer da marca**: trazer o peso tátil (hard-shadow/press-down) e quebrar a monotonia dos 12 cartões iguais. Em segundo lugar, dois bugs reais: contraste do rodapé reprova AA e o AIChat aparece numa página que o spec definiu como standalone sem ele.
+
+## What's Working
+
+- **Ordem de prioridade e hierarquia de intenção:** quente→frio (WhatsApp → quiz → site → landings) é a decisão certa para tráfego de bio. WhatsApp em destaque amarelo no topo é o instinto correto.
+- **Tokens e copy on-brand:** `anhanga-*` canônico, Poppins, PT-BR caloroso e direto ("Atendimento humano e rápido"), selos de confiança (Cadastur/ABAV/Google) — reforço real para um público que decide por confiança.
+- **Acessibilidade de base:** `focus-visible:ring`, `aria-label` na nav, ícones `aria-hidden`, touch targets generosos (56–72px). O alicerce está lá.
+
+## Priority Issues
+
+- **[P1] Cara de Linktree, não de Anhangá.** Pilha de 12 cartões brancos idênticos; o sistema tátil "Diário de Bordo" (hard-shadow, press-down de carimbo, âmbar como assinatura de press) não foi aplicado. *Por que importa:* a marca se define por "não parecer OTA/template frio"; a primeira impressão da bio é justamente o lugar onde a promessa precisa aparecer. *Fix:* aplicar `shadow-hard`/`shadow-hard-yellow` e a sequência rest→hover→active nos botões; variar peso/dimensão para que a pilha não seja uniforme (o WhatsApp e o quiz merecem mais peso que "Lollapalooza"). *Comando:* `/impeccable bolder` (depois `/impeccable delight`).
+
+- **[P1] Rodapé reprova contraste WCAG AA.** Selos (Cadastur, Membro ABAV, Nota 5.0, "ANHANGA TURISMO LTDA") em branco a 80% sobre a base clara do gradiente (`#0ea5e9`) → ~2.8:1, abaixo do piso de 4.5:1 para texto pequeno. *Por que importa:* informação legal/confiança ilegível, e o PRODUCT.md fixa AA como piso. *Fix:* escurecer o fim do gradiente, colocar o rodapé sobre faixa escura, ou usar texto em `anhanga-darkBlue`. *Comando:* `/impeccable colorize` ou `/impeccable audit`.
+
+- **[P1] Ícones e rótulos desalinhados.** Com `justify-center` + `gap-3`, a borda esquerda dos rótulos varia muito (medido: 109, 117, 163, 155, 136px) e as alturas alternam 56/72px. *Por que importa:* leitura em ziguezague, ritmo quebrado, reforça o ar de "montado às pressas". *Fix:* ancorar ícone à esquerda com largura fixa e alinhar rótulos a uma coluna comum (ou centralizar tudo de forma consistente); padronizar altura mínima. *Comando:* `/impeccable layout`.
+
+- **[P2] Dois amarelos competindo.** O CTA do banner ("Fazer o quiz", pílula amarela) e o botão WhatsApp (preenchido amarelo) aparecem na mesma dobra, violando a "Regra do Âmbar" (máx. 1 por tela) e dividindo o foco primário. *Por que importa:* o sistema reserva o âmbar para 1 ação dominante; dois neutralizam o sinal. *Fix:* escolher um dono do amarelo (o WhatsApp, ação de maior valor) e rebaixar o CTA do banner para variante secundária. *Comando:* `/impeccable distill`.
+
+- **[P2] AIChat + BackToTop flutuam numa página standalone.** O spec define `/links` "sem Header, Footer, AIChat", mas `ClientFeatures` (AIChat, ContactModal, BackToTop) renderiza no `AppLayout` para todas as rotas — o FAB "Abrir assistente virtual" e o "Voltar ao topo" aparecem no canto inferior direito e **cobrem o último botão (Lollapalooza) e os selos**. *Por que importa:* adiciona um CTA concorrente numa página cujo trabalho é encaminhar para 1 dos destinos listados, e oculta conteúdo/confiança. *Fix:* condicionar `ClientFeatures` (ou só o AIChat) a não renderizar em `/links`, ou reposicionar os FABs. *Comando:* `/impeccable harden`.
+
+## Persona Red Flags
+
+**Casey (mobile distraído, polegar):** os destinos primários (WhatsApp, quiz) estão no topo, longe da zona do polegar; o FAB de chat sobreposto compete justamente na zona alcançável. Os 12 botões exigem scroll longo (1308px) sem agrupamento — "landings" e "utilidades" (seguro, chip) misturados.
+
+**Jordan (primeira vez):** links externos (Seguro = afiliado; Site; ABAV) não sinalizam que abrem em nova aba/saem do site — pode achar que "saiu" da Anhangá. "Chip / eSIM internacional" não deixa claro que leva ao WhatsApp (o sublabel ajuda, mas o ícone de SIM sugere página própria).
+
+**Dona Marisa (melhor idade, celular à noite — persona do projeto):** o contraste fraco do rodapé e os sublabels a 70% de opacidade penalizam exatamente quem o PRODUCT.md prioriza (leitura noturna, baixa carga). Botões grandes ajudam; o texto secundário, não.
+
+## Minor Observations
+
+- Sublabels em `text-xs` (12px) a `opacity-70` sobre branco ≈ 3.7:1 — abaixo de AA para texto pequeno. Subir para ~85% ou usar `anhanga-action`/`darkBlue` cheio.
+- Sem agrupamento: utilidades (seguro, chip) e landings de destino estão na mesma lista contínua; um divisor sutil ou eyebrow único separaria intenções.
+- Links externos sem indicador visual de "↗ nova aba".
+- Criei `.claude/launch.json` (config `av-site-dev`, porta 3000) para renderizar/inspecionar a página; mantive porque habilita futuros `preview`/`critique`. Remova se não quiser versioná-lo.
+
+## Questions to Consider
+
+- E se a pilha não fosse uniforme — WhatsApp e quiz com peso físico (hard-shadow) e os destinos como uma lista mais leve abaixo? Isso comunicaria curadoria em vez de catálogo.
+- Os 12 links precisam estar todos visíveis de uma vez, ou "Destinos" poderia ser um grupo recolhido depois das 3 ações principais?
+- Como seria a versão *confiante* desta página — uma que ninguém confundiria com um Linktree genérico?

--- a/App.tsx
+++ b/App.tsx
@@ -43,7 +43,10 @@ const ROUTES_WITHOUT_AICHAT = ['/links'];
 
 const ClientFeatures: React.FC = () => {
   const { pathname } = useLocation();
-  const showAIChat = !ROUTES_WITHOUT_AICHAT.includes(pathname);
+  // Normaliza trailing slash (ex.: /links/ vindo da bio) antes de comparar — o React Router
+  // casa a rota com ou sem a barra, mas location.pathname preserva a barra.
+  const normalizedPath = pathname === '/' ? '/' : pathname.replace(/\/$/, '');
+  const showAIChat = !ROUTES_WITHOUT_AICHAT.includes(normalizedPath);
   return (
     <ClientOnly>
       {showAIChat ? <AIChat /> : null}

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, lazy } from 'react';
 import { LazyMotion, domAnimation } from 'framer-motion';
-import { BrowserRouter, MemoryRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import Header from './components/Header/Header';
 import Footer from './components/Footer';
 import AIChat from './components/AIChat';
@@ -38,13 +38,20 @@ const LinksPage = lazy(() => import('./pages/LinksPage'));
 const MainRouteFallback: React.FC = () => <section className="min-h-[40vh] bg-white" aria-hidden="true" />;
 const LandingRouteFallback: React.FC = () => <div className="min-h-screen bg-white" aria-hidden="true" />;
 
-const ClientFeatures: React.FC = () => (
-  <ClientOnly>
-    <AIChat />
-    <ContactModal />
-    <BackToTop />
-  </ClientOnly>
-);
+// Rotas standalone que não devem carregar o assistente virtual (página de bio, etc.)
+const ROUTES_WITHOUT_AICHAT = ['/links'];
+
+const ClientFeatures: React.FC = () => {
+  const { pathname } = useLocation();
+  const showAIChat = !ROUTES_WITHOUT_AICHAT.includes(pathname);
+  return (
+    <ClientOnly>
+      {showAIChat ? <AIChat /> : null}
+      <ContactModal />
+      <BackToTop />
+    </ClientOnly>
+  );
+};
 
 const MainSiteShell: React.FC = () => {
   return (

--- a/components/links/LinkButton.tsx
+++ b/components/links/LinkButton.tsx
@@ -17,25 +17,44 @@ interface LinkButtonProps {
     item: LinkItem;
 }
 
+// Slot de ícone com largura fixa garante que todos os rótulos alinhem na mesma coluna,
+// com ou sem ícone — o que evita o efeito "ziguezague" de bordas esquerdas desiguais.
 const baseClasses =
-    'flex w-full items-center justify-center gap-3 rounded-2xl px-6 py-4 text-base font-semibold shadow-sm transition-transform duration-150 active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-anhanga-yellow focus-visible:ring-offset-2 focus-visible:ring-offset-anhanga-darkBlue';
+    'flex w-full items-center gap-4 rounded-2xl px-5 text-left font-semibold transition-[transform,box-shadow] duration-150 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-anhanga-yellow focus-visible:ring-offset-2 focus-visible:ring-offset-anhanga-darkBlue';
 
-function variantClasses(highlight?: boolean): string {
-    return highlight
-        ? 'bg-anhanga-yellow text-anhanga-darkBlue hover:brightness-95'
-        : 'bg-white/95 text-anhanga-darkBlue hover:bg-white';
+// Press-down físico (assinatura "O Diário de Bordo"): rest → hover → active, como um carimbo.
+const pressPrimary =
+    'shadow-hard hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0_0_rgba(15,23,42,1)] active:translate-x-1 active:translate-y-1 active:shadow-none';
+const pressSecondary =
+    'shadow-[2px_2px_0_0_rgba(15,23,42,0.5)] hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[1px_1px_0_0_rgba(15,23,42,0.5)] active:translate-x-0.5 active:translate-y-0.5 active:shadow-none';
+
+// Dois níveis de peso quebram a monotonia da pilha: ações (WhatsApp/quiz/utilidades) com
+// peso físico cheio; destinos "secos" ficam mais leves e compactos, como uma lista de apoio.
+function tierClasses(item: LinkItem): string {
+    const isPrimary = item.highlight || Boolean(item.icon) || Boolean(item.sublabel);
+    if (item.highlight) {
+        return `min-h-[4.5rem] py-4 text-base bg-anhanga-yellow text-anhanga-darkBlue ${pressPrimary}`;
+    }
+    if (isPrimary) {
+        return `min-h-[4.5rem] py-4 text-base bg-white text-anhanga-darkBlue ${pressPrimary}`;
+    }
+    return `min-h-[3.25rem] py-3 text-[0.95rem] bg-white/90 text-anhanga-darkBlue ${pressSecondary}`;
 }
 
 export const LinkButton: React.FC<LinkButtonProps> = ({ item }) => {
-    const className = `${baseClasses} ${variantClasses(item.highlight)}`;
+    const className = `${baseClasses} ${tierClasses(item)}`;
     const IconComponent = item.icon ? ICON_MAP[item.icon] : undefined;
 
     const content = (
         <>
-            {IconComponent ? <IconComponent size={22} weight="fill" aria-hidden="true" /> : null}
-            <span className="flex flex-col text-left">
-                <span>{item.label}</span>
-                {item.sublabel ? <span className="text-xs font-normal opacity-70">{item.sublabel}</span> : null}
+            <span className="flex w-6 shrink-0 items-center justify-center" aria-hidden="true">
+                {IconComponent ? <IconComponent size={22} weight="fill" /> : null}
+            </span>
+            <span className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate">{item.label}</span>
+                {item.sublabel ? (
+                    <span className="text-xs font-normal text-anhanga-darkBlue/80">{item.sublabel}</span>
+                ) : null}
             </span>
         </>
     );

--- a/components/links/TrustSeals.tsx
+++ b/components/links/TrustSeals.tsx
@@ -9,7 +9,7 @@ export const TrustSeals: React.FC = () => {
     const rating = googleReviews.averageRating ? googleReviews.averageRating.toFixed(1) : '5.0';
 
     return (
-        <footer className="mt-10 flex flex-col items-center gap-1 text-center text-xs text-white/80">
+        <footer className="mt-10 flex flex-col items-center gap-1 text-center text-xs text-white">
             <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
                 <a href="https://cadastur.turismo.gov.br/hotsite/" target="_blank" rel="noopener noreferrer"
                    className="underline underline-offset-2 hover:text-anhanga-yellow transition-colors">
@@ -23,7 +23,7 @@ export const TrustSeals: React.FC = () => {
                 <span aria-hidden="true">·</span>
                 <span>Nota {rating} no Google</span>
             </div>
-            <p className="mt-1 opacity-70">ANHANGA TURISMO LTDA</p>
+            <p className="mt-1 text-white/85">ANHANGA TURISMO LTDA</p>
         </footer>
     );
 };

--- a/pages/LinksPage.tsx
+++ b/pages/LinksPage.tsx
@@ -24,7 +24,7 @@ const LinksPage: React.FC = () => {
                 robots="noindex, follow"
                 noHreflang
             />
-            <main className="min-h-screen bg-gradient-to-b from-anhanga-darkBlue to-anhanga-action px-5 py-10 font-sans">
+            <main className="min-h-screen bg-gradient-to-b from-anhanga-darkBlue via-anhanga-action to-anhanga-darkBlue px-5 py-10 font-sans">
                 <div className="mx-auto flex w-full max-w-md flex-col items-center">
                     <img
                         src={BRAND_LOGO_WHITE_URL}

--- a/tests/e2e/links-page.spec.ts
+++ b/tests/e2e/links-page.spec.ts
@@ -52,6 +52,11 @@ test('não renderiza o assistente virtual (AIChat) na página standalone', async
     // /links é página de bio standalone — o FAB do AIChat não deve aparecer (cobriria os selos
     // e competiria com os destinos curados). Ver ROUTES_WITHOUT_AICHAT em App.tsx.
     await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toHaveCount(0);
+
+    // Também não deve renderizar com barra no final (trailing slash, comum em links de bio).
+    await page.goto('/links/');
+    await expect(page.getByTestId('link-whatsapp')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toHaveCount(0);
 });
 
 test('botão WhatsApp aponta para wa.me com texto', async ({ page }) => {

--- a/tests/e2e/links-page.spec.ts
+++ b/tests/e2e/links-page.spec.ts
@@ -46,6 +46,14 @@ test('clique dispara links_page_click com o label correto', async ({ page }) => 
     expect(clicks.some((c) => c.label === 'orlando')).toBe(true);
 });
 
+test('não renderiza o assistente virtual (AIChat) na página standalone', async ({ page }) => {
+    await page.goto('/links');
+    await expect(page.getByTestId('link-whatsapp')).toBeVisible();
+    // /links é página de bio standalone — o FAB do AIChat não deve aparecer (cobriria os selos
+    // e competiria com os destinos curados). Ver ROUTES_WITHOUT_AICHAT em App.tsx.
+    await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toHaveCount(0);
+});
+
 test('botão WhatsApp aponta para wa.me com texto', async ({ page }) => {
     await page.goto('/links');
     const href = await page.getByTestId('link-whatsapp').getAttribute('href');


### PR DESCRIPTION
## O que mudou

Crítica `/impeccable critique links` da página de bio (`/links`) apontou que ela se entregava como **Linktree genérico, não como Anhangá**, além de dois bugs reais (acessibilidade + arquitetura). Este PR corrige os 3 P1 e remove o AIChat da página. Tudo verificado no browser mobile (375×812).

### 1. Identidade da marca — `components/links/LinkButton.tsx`
- Sistema tátil "O Diário de Bordo": troca `shadow-sm`/`active:scale` pelo **press-down físico** (rest→hover→active com `shadow-hard`, como carimbo).
- **Dois níveis de peso**: ações (WhatsApp/quiz/utilidades) como cartões com peso cheio (72px); destinos "secos" (Orlando, Beto, etc.) mais leves e compactos (52px, `white/90`). Quebra a monotonia da pilha de 12 cartões idênticos.

### 2. Contraste do rodapé (a11y) — `pages/LinksPage.tsx` + `components/links/TrustSeals.tsx`
- Gradiente passa a `from-darkBlue via-action to-darkBlue`: base escura no rodapé. Selos de confiança saem de **~2.8:1 (reprova WCAG AA)** para **~9.8:1 (AAA)**. PRODUCT.md fixa AA como piso.

### 3. Alinhamento e ritmo — `components/links/LinkButton.tsx`
- Slot de ícone de largura fixa + coluna de rótulos `text-left`: todas as bordas esquerdas alinham em **x=80px** (antes variava 109–163px). Sublabels em `darkBlue/80`.

### 4. AIChat na `/links` — `App.tsx`
- `ROUTES_WITHOUT_AICHAT` impede o FAB do assistente de renderizar em `/links`, alinhando com o spec de página standalone. O FAB cobria os selos e competia com os destinos curados.

## Por quê
A `/links` é o destino único da bio do Instagram — a primeira impressão da promessa da marca. Estava na cor certa, mas fora do design system e com texto legal ilegível no rodapé.

## Testes
- Novo e2e (`links-page.spec.ts`) garante ausência do AIChat na `/links`.
- `pnpm typecheck` ✅
- Regression (`links-page-data`, `links-tracking`, `internal-link-trailing-slash`): 14/14 ✅
- E2E Chromium + Mobile Chrome: 10/10 ✅ (firefox/webkit/safari não instalados localmente; rodam no CI).

## Notas para o reviewer
- Fora de escopo (P2/menores, deixados de propósito): dois amarelos competindo (banner + WhatsApp), indicador "↗ nova aba" em links externos, agrupamento "Destinos".
- Inclui `.claude/launch.json` (config de preview para render/inspeção da página) e o snapshot da crítica em `.impeccable/critique/` (mesma convenção do snapshot do corporativo já versionado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)