### PR TITLE
feat(corporativo): a11y de motion (reduced-motion) + visibilidade sem JS

### DIFF
--- a/.impeccable/critique/2026-06-28T03-29-21Z__pages-landings-corporativolanding-tsx.md
+++ b/.impeccable/critique/2026-06-28T03-29-21Z__pages-landings-corporativolanding-tsx.md
@@ -1,0 +1,93 @@
+---
+target: a página corporativo
+total_score: 32
+p0_count: 0
+p1_count: 0
+timestamp: 2026-06-28T03-29-21Z
+slug: pages-landings-corporativolanding-tsx
+---
+## Design Health Score — /corporativo (pós-polish)
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Form cobre submitting/success/error; globo sem loading state |
+| 2 | Match System / Real World | 4 | PT-BR claro, sem jargão |
+| 3 | User Control and Freedom | 3 | Dois caminhos (WhatsApp/form); globo auto-rotaciona sem controle |
+| 4 | Consistency and Standards | 3 | Botões coesos; ainda 4 eyebrows + acentos pastel azul/sky/âmbar |
+| 5 | Error Prevention | 3 | Validação + LGPD obrigatório |
+| 6 | Recognition Rather Than Recall | 4 | Fluxo simples |
+| 7 | Flexibility and Efficiency | 3 | Atalho WhatsApp + form |
+| 8 | Aesthetic and Minimalist Design | 3 | Hero disciplinado agora; resta ruído (noise+dot-grid+2 widgets fixos) |
+| 9 | Error Recovery | 3 | Mensagens presentes, genéricas |
+| 10 | Help and Documentation | 3 | Contato visível; launcher global |
+| **Total** | | **32/40** | **Bom — hero resolvido, teto agora em consistência de cor + a11y de motion** |
+
+## Anti-Patterns Verdict
+
+**Não parece "feito por IA".** Identidade própria e comprometida: botões neo-brutalistas com sombra dura, eyebrow do hero agora em pill de vidro com avião âmbar (sem o oliva anterior), globo com arcos amarelo/ciano legíveis (brilho reduzido para 1.45), pilares scrapbook (fita washi + rotação + ordinal atrás) e processo numerado real (01/02/03 = sequência genuína, não andaime).
+
+**Scan determinístico (detect.mjs):** 1 ocorrência — `LandingPillars.tsx:29`, cor `#94a3b8` não documentada no DESIGN.md (cor dos pontos do fundo). Nenhum gradient-text, side-stripe, glassmorphism decorativo ou hero-metric.
+
+**Evidência de browser:** screenshots desktop (1440×900) e mobile (390px) de todas as seções, com banner de cookies dispensado e reveals disparados via scroll. Hero, pilares, processo, banda e contato renderizam sem overflow.
+
+## Overall Impression
+
+O polish resolveu o que travava a página: o hero agora respira (CTAs na dobra, globo contido com cor de marca, eyebrow limpo). Subiu de 31→32. O teto restante não é mais cosmético de hero — é **disciplina de cor** (pastéis azul/sky/âmbar diluindo o navy+amarelo) e **acessibilidade de motion** (zero guard de `prefers-reduced-motion` num projeto cujo PRODUCT.md diz que isso "não é opcional").
+
+## What's Working
+
+1. **Hero coeso e disciplinado.** Eyebrow de vidro unificado com os badges, CTA âmbar como único grito, globo com arcos amarelo/ciano contando "conectamos sua empresa a destinos". A primeira ação cabe na dobra em desktop e mobile.
+2. **Sistema de botão neo-brutalista.** Sombra dura com press-down consistente em nav, hero, banda e form. Assinatura, não enfeite.
+3. **Processo numerado legítimo.** "Como funciona em 3 passos" usa 01/02/03 porque É uma sequência ordenada — números carregam informação, não são scaffolding.
+
+## Priority Issues
+
+### [P2] Sem guard de prefers-reduced-motion
+- **O que:** Globo `controls.autoRotate = true` incondicional (`CorpGlobe.tsx:76`) e animações de entrada framer (`fadeUp`, springs dos pilares) rodam sempre. Nenhum `useReducedMotion`/`MotionConfig`/media query em toda a landing.
+- **Por que importa:** PRODUCT.md: "Reduced motion não é opcional." Usuários com vestibular disorder recebem rotação contínua + reveals sem alternativa.
+- **Fix:** `MotionConfig reducedMotion="user"` no wrapper da landing e desligar `autoRotate` quando `useReducedMotion()` for true.
+- **Comando sugerido:** `/impeccable harden`
+
+### [P2] Pastéis azul/sky/âmbar diluem o navy+amarelo
+- **O que:** Pilares e processo usam `blue-100/sky-100/amber-100` por item; a identidade forte é navy + amarelo + ciano.
+- **Por que importa:** O acúmulo de pastéis "amigáveis" puxa para o genérico-SaaS-simpático e enfraquece a voz que o hero estabelece.
+- **Fix:** Restringir a 2–3 cores próprias (navy/ciano/amarelo) ou um único acento por seção.
+- **Comando sugerido:** `/impeccable colorize`
+
+### [P2] Conteúdo escondido atrás de whileInView (risco prerender/no-JS)
+- **O que:** Pilares e processo usam `initial="hidden"` (opacity 0) + `whileInView`. Em render real com scroll funciona; mas o HTML prerenderizado sai com `opacity:0` e, sem JS, as seções ficam invisíveis.
+- **Por que importa:** O guia: "reveals devem enriquecer um default já visível." Afeta SEO/no-JS e mora em `components/landings/shared/` (4 landings).
+- **Fix:** Default visível + animar só com JS ativo (ou via IntersectionObserver com fallback).
+- **Comando sugerido:** `/impeccable harden`
+
+### [P3] Eyebrow ainda como cadência de seção
+- **O que:** Hero, pilares, banda e contato abrem com o mesmo micro-label skewed (4×). Processo já entra direto pelo H2 — bom.
+- **Por que importa:** 4 em sequência ainda lê como andaime; o guia trata eyebrow recorrente como gramática de IA.
+- **Fix:** Manter o eyebrow só onde carrega informação (hero, contato); pilares/banda entram pelo H2.
+- **Comando sugerido:** `/impeccable distill`
+
+### [P3] Cor #94a3b8 fora do DESIGN.md + globo via CDN de terceiros
+- **O que:** Detector aponta `#94a3b8` (pontos do fundo dos pilares) não documentada. Globo carrega textura de `//unpkg.com` (dependência externa no caminho do hero).
+- **Por que importa:** Higiene de token e resiliência. Baixo impacto direto no usuário.
+- **Fix:** Tokenizar a cor dos pontos; hospedar `earth-night.jpg` no R2 próprio.
+- **Comando sugerido:** `/impeccable polish`
+
+## Persona Red Flags
+
+**Sam (acessibilidade, reduced motion):** o globo gira sem parar e os reveals disparam mesmo com "reduzir movimento" ativo no SO — desconforto real, sem alternativa. Pior red flag atual.
+
+**Jordan (primeira vez, desktop):** experiência clara — headline, dois CTAs visíveis, badges de prova. Sem fricção. O launcher global "Roteiro IA" no canto soma uma 3ª chamada de ação, mas não confunde.
+
+**Casey (mobile, com pressa):** hero encaixa, CTAs grandes no polegar, form com autocomplete e labels. Único ruído: launcher de chat + seta voltar-ao-topo sobrepõem o canto inferior.
+
+## Minor Observations
+
+- Dois widgets fixos globais (launcher "Roteiro IA" + back-to-top) competem visualmente com os CTAs da página e usam z-index arbitrário; idealmente escala semântica de z-index.
+- Texto de corpo cinza (`zinc-500`) sobre a superfície quente `#fffdf5` está no limite do 4.5:1 — vale conferir o contraste nas descrições de pilares/processo.
+- Banda WhatsApp: "Chama no WhatsApp" em ciano sobre navy fica vivo e legível — bom uso da cor de marca.
+
+## Questions to Consider
+
+- A página tem 3–4 canais de ação (WhatsApp no nav, hero, "ser contatado", launcher global). Qual deve converter 80% — e os outros estão ajudando ou competindo?
+- O globo precisa girar sempre, ou poderia pausar em reduced-motion e no hover, ganhando acessibilidade sem perder o efeito?
+- Se pilares e processo usassem só navy/ciano/amarelo, a página ganharia foco ou perderia o tom "amigável"?

--- a/components/landings/corporativo/CorpGlobe.tsx
+++ b/components/landings/corporativo/CorpGlobe.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { prefersReducedMotion } from '../shared/motion';
 
 const SP = { lat: -23.5505, lng: -46.6333 };
 
@@ -39,6 +40,8 @@ export function CorpGlobe() {
         const el = containerRef.current;
         if (!el) return;
 
+        const reduced = prefersReducedMotion();
+
         import('globe.gl').then(({ default: Globe }) => {
             if (cancelled || !el) return;
 
@@ -54,7 +57,7 @@ export function CorpGlobe() {
                 .arcColor(() => ['rgba(255,214,0,0.85)', 'rgba(56,189,248,0.95)'])
                 .arcDashLength(0.5)
                 .arcDashGap(0.5)
-                .arcDashAnimateTime(3500)
+                .arcDashAnimateTime(reduced ? 0 : 3500)
                 .arcStroke(0.35)
                 .arcAltitude(0.18)
                 // Destination dots
@@ -71,9 +74,9 @@ export function CorpGlobe() {
                 renderer.setSize(el.clientWidth, el.clientHeight);
             }
 
-            // Camera controls
+            // Camera controls — auto-rotation is motion; respect reduced-motion
             const controls = globe.controls();
-            controls.autoRotate = true;
+            controls.autoRotate = !reduced;
             controls.autoRotateSpeed = 0.1;
             controls.enableZoom = false;
             controls.enablePan = false;
@@ -81,6 +84,14 @@ export function CorpGlobe() {
             controls.dampingFactor = 0.08;
 
             globe.pointOfView({ lat: -18, lng: -48, altitude: 1.55 }, 0);
+
+            // React to live changes of the reduced-motion preference
+            const motionQuery = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+            const onMotionChange = (e: MediaQueryListEvent) => {
+                controls.autoRotate = !e.matches;
+                globe.arcDashAnimateTime(e.matches ? 0 : 3500);
+            };
+            motionQuery?.addEventListener('change', onMotionChange);
 
             const resizeObserver = new ResizeObserver(() => {
                 if (el) {
@@ -92,6 +103,7 @@ export function CorpGlobe() {
 
             cleanup = () => {
                 try {
+                    motionQuery?.removeEventListener('change', onMotionChange);
                     resizeObserver.disconnect();
                     const r = globe.renderer();
                     if (r) {

--- a/components/landings/corporativo/CorpGlobe.tsx
+++ b/components/landings/corporativo/CorpGlobe.tsx
@@ -91,7 +91,7 @@ export function CorpGlobe() {
                 controls.autoRotate = !e.matches;
                 globe.arcDashAnimateTime(e.matches ? 0 : 3500);
             };
-            motionQuery?.addEventListener('change', onMotionChange);
+            motionQuery?.addEventListener?.('change', onMotionChange);
 
             const resizeObserver = new ResizeObserver(() => {
                 if (el) {
@@ -103,7 +103,7 @@ export function CorpGlobe() {
 
             cleanup = () => {
                 try {
-                    motionQuery?.removeEventListener('change', onMotionChange);
+                    motionQuery?.removeEventListener?.('change', onMotionChange);
                     resizeObserver.disconnect();
                     const r = globe.renderer();
                     if (r) {

--- a/components/landings/shared/motion.ts
+++ b/components/landings/shared/motion.ts
@@ -1,0 +1,13 @@
+/**
+ * Reads the user's OS-level "reduce motion" preference at call time.
+ *
+ * SSR-safe: returns false when `window`/`matchMedia` are unavailable (prerender,
+ * Node test runner). Callers that need to react to live changes should also
+ * subscribe to the media query; this helper is a point-in-time read.
+ */
+export function prefersReducedMotion(): boolean {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+        return false;
+    }
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches === true;
+}

--- a/docs/design/corporativo-critique-followup.md
+++ b/docs/design/corporativo-critique-followup.md
@@ -1,0 +1,35 @@
+# /corporativo — follow-up do critique (impeccable)
+
+Handoff para continuar a melhoria da landing `/corporativo` em outra sessão.
+
+- **Critique completo (snapshot):** `.impeccable/critique/2026-06-28T03-29-21Z__pages-landings-corporativolanding-tsx.md`
+- **Nota atual:** 32/40 (sem P0/P1). Trend: 31 → 32.
+- **Como retomar:** rode `/impeccable polish corporativo` (lê o snapshot como backlog) ou os comandos abaixo direto.
+
+## Já feito
+
+- **Polish** (PR #961, mergeado): eyebrow do hero (oliva → vidro com âmbar) e brilho do globo (`brightness` 2 → 1.45, arcos amarelo/ciano legíveis).
+- **Harden** (PR #963): a11y de motion (`MotionConfig reducedMotion="user"` + globo respeita `prefers-reduced-motion` + helper `prefersReducedMotion()`) e visibilidade sem JS (`<noscript>` para o `opacity:0` que o framer serializa no prerender). Cobertura: unit + e2e reduced-motion.
+
+## Pendências (em ordem de impacto)
+
+### 1. Cor — `/impeccable colorize corporativo` · P2 (maior ganho)
+Pilares e processo usam `blue-100 / sky-100 / amber-100` por item, diluindo a identidade navy + ciano + amarelo para um genérico "SaaS simpático".
+- **Onde:** `components/landings/corporativo/constants.ts` (PILLARS) e `components/landings/corporativo/CorpProcess.tsx` (STEPS); tape colors em `components/landings/shared/LandingPillars.tsx:21` (`bg-emerald-100/90` destoa do acento âmbar do 3º card).
+- **Fix:** restringir a 2–3 cores da marca ou 1 acento por seção.
+
+### 2. Cadência de eyebrow — `/impeccable distill corporativo` · P3
+4 eyebrows skewed em sequência (hero, pilares, banda, contato) lê como andaime. O processo já entra direto pelo H2 — bom.
+- **Fix:** manter o eyebrow só no hero e no contato; pilares e banda entram pelo H2.
+
+### 3. Higiene final — `/impeccable polish corporativo` · P3
+- Cor `#94a3b8` fora do DESIGN.md (único achado do `detect.mjs`) — pontos do fundo em `LandingPillars.tsx:29`. Tokenizar.
+- Globo carrega `earth-night.jpg` de `//unpkg.com` (`CorpGlobe.tsx`) — hospedar no R2 próprio.
+- Reconferir contraste do corpo `zinc-500` sobre `#fffdf5` (limite de 4.5:1).
+
+## Observações menores (do critique)
+
+- Dois widgets fixos globais (launcher "Roteiro IA" + back-to-top) competem com os CTAs e usam z-index arbitrário.
+- Globo sem loading state.
+
+Após as pendências, re-rodar `/impeccable critique corporativo` para confirmar a nota subindo.

--- a/pages/landings/CorporativoLanding.tsx
+++ b/pages/landings/CorporativoLanding.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { MotionConfig } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { Seo } from '@/components/Seo';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
@@ -34,7 +35,18 @@ const CorporativoLanding: React.FC = () => {
                     { name: 'Corporativo', item: 'https://www.anhanga.tur.br/corporativo/' },
                 ]}
             />
-            <div className="bg-brand-surface min-h-screen font-sans">
+            {/*
+              No-JS / pre-hydration fallback: framer-motion serializes `initial`
+              styles (opacity:0) into the prerendered HTML. Without JS the reveal
+              never fires, so the sections would ship blank. This forces them
+              visible when scripts are disabled; with JS it's inert and the
+              entrances animate normally.
+            */}
+            <noscript>
+                <style>{`[data-corp-landing] [style*="opacity"]{opacity:1!important;transform:none!important}`}</style>
+            </noscript>
+            <MotionConfig reducedMotion="user">
+            <div data-corp-landing className="bg-brand-surface min-h-screen font-sans">
                 <CorpNav />
                 <CorpHero />
                 <CorpPillars />
@@ -59,6 +71,7 @@ const CorporativoLanding: React.FC = () => {
                 </nav>
                 <CorpFooter />
             </div>
+            </MotionConfig>
         </>
     );
 };

--- a/pages/landings/CorporativoLanding.tsx
+++ b/pages/landings/CorporativoLanding.tsx
@@ -43,7 +43,7 @@ const CorporativoLanding: React.FC = () => {
               entrances animate normally.
             */}
             <noscript>
-                <style>{`[data-corp-landing] [style*="opacity"]{opacity:1!important;transform:none!important}`}</style>
+                <style>{`[data-corp-landing] [style*="opacity"]{opacity:1!important}`}</style>
             </noscript>
             <MotionConfig reducedMotion="user">
             <div data-corp-landing className="bg-brand-surface min-h-screen font-sans">

--- a/tests/corp-reduced-motion.test.ts
+++ b/tests/corp-reduced-motion.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { prefersReducedMotion } from '../components/landings/shared/motion';
+
+// Guards the corporativo globe auto-rotation / arc animation gate. The helper is
+// the single source of truth read by CorpGlobe to honor the OS reduced-motion
+// setting (PRODUCT.md: "Reduced motion não é opcional").
+
+const originalWindow = (globalThis as { window?: unknown }).window;
+
+function setWindow(value: unknown) {
+    (globalThis as { window?: unknown }).window = value;
+}
+
+test.afterEach(() => {
+    if (originalWindow === undefined) {
+        delete (globalThis as { window?: unknown }).window;
+    } else {
+        setWindow(originalWindow);
+    }
+});
+
+test('returns false when window is unavailable (SSR / prerender / node)', () => {
+    setWindow(undefined);
+    assert.equal(prefersReducedMotion(), false);
+});
+
+test('returns false when matchMedia is not a function', () => {
+    setWindow({});
+    assert.equal(prefersReducedMotion(), false);
+});
+
+test('returns true when the user prefers reduced motion', () => {
+    setWindow({
+        matchMedia: (query: string) => ({ matches: query.includes('reduce') }),
+    });
+    assert.equal(prefersReducedMotion(), true);
+});
+
+test('returns false when the user has no reduced-motion preference', () => {
+    setWindow({
+        matchMedia: () => ({ matches: false }),
+    });
+    assert.equal(prefersReducedMotion(), false);
+});

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -208,9 +208,22 @@ test.describe('Corporativo Landing Page', () => {
     const pillarsHeading = page.getByRole('heading', { name: /escolhem a Anhangá/i });
     await pillarsHeading.scrollIntoViewIfNeeded();
     await expect(pillarsHeading).toBeVisible();
+    // opacity isn't inherited, so walk every ancestor and take the minimum —
+    // a framer-hidden wrapper higher up would otherwise pass a single-level check.
     await expect
       .poll(() =>
-        pillarsHeading.evaluate(el => Number(getComputedStyle(el.closest('div') || el).opacity))
+        pillarsHeading.evaluate(el => {
+          let current: HTMLElement | null = el as HTMLElement;
+          let minOpacity = 1;
+          while (current) {
+            const opacity = parseFloat(getComputedStyle(current).opacity);
+            if (!Number.isNaN(opacity)) {
+              minOpacity = Math.min(minOpacity, opacity);
+            }
+            current = current.parentElement;
+          }
+          return minOpacity;
+        })
       )
       .toBeGreaterThan(0.95);
 

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -194,6 +194,31 @@ test.describe('Corporativo Landing Page', () => {
     await expect(page.getByTestId('corp-globe-fallback')).toBeVisible();
   });
 
+  test('should keep section content visible under reduced motion', async ({ page }) => {
+    // PRODUCT.md: "Reduced motion não é opcional." Reveal-on-scroll must not
+    // gate visibility — with motion reduced, sections should read immediately.
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+
+    const landing = new CorporativoPage(page);
+    await landing.goto();
+
+    const heroHeading = page.getByRole('heading', { level: 1 });
+    await expect(heroHeading).toBeVisible();
+
+    const pillarsHeading = page.getByRole('heading', { name: /escolhem a Anhangá/i });
+    await pillarsHeading.scrollIntoViewIfNeeded();
+    await expect(pillarsHeading).toBeVisible();
+    await expect
+      .poll(() =>
+        pillarsHeading.evaluate(el => Number(getComputedStyle(el.closest('div') || el).opacity))
+      )
+      .toBeGreaterThan(0.95);
+
+    const processHeading = page.getByRole('heading', { name: /3 passos/i });
+    await processHeading.scrollIntoViewIfNeeded();
+    await expect(processHeading).toBeVisible();
+  });
+
   test('should handle navigation to #contato anchor', async ({ page, isMobile }) => {
     const landing = new CorporativoPage(page);
     await landing.goto();


### PR DESCRIPTION
## O que

Hardening da landing `/corporativo` a partir do critique pós-polish (frentes P2 #1 e #2). Não toca a identidade visual — só resiliência.

## Frente 1 — Acessibilidade de motion

PRODUCT.md: *"Reduced motion não é opcional."* A landing não tinha nenhum guard.

- `MotionConfig reducedMotion="user"` no root: entradas framer respeitam o SO (transform reduzido; crossfade de opacidade mantido — a alternativa sancionada).
- Globo (`CorpGlobe.tsx`) desliga `autoRotate` e a animação de arcos sob `prefers-reduced-motion`, com listener para mudança da preferência em runtime.
- Helper puro `prefersReducedMotion()` (SSR-safe) como fonte única da decisão.

## Frente 2 — Visibilidade sem JS / prerender

O framer serializa `initial` (`opacity:0`) no HTML prerenderizado; sem JS o reveal nunca dispara e pilares/processo sairiam em branco.

- Fallback `<noscript>` força as seções visíveis quando scripts estão desabilitados — inerte quando há JS (animações intactas).

## Testes

- **Unit** (`node:test`): `prefersReducedMotion` cobrindo SSR e os dois estados de preferência.
- **E2e**: conteúdo das seções permanece visível sob reduced motion.
- Regressão completa: 740/740 ✓ · suíte e2e corporativo: 8/8 ✓ · typecheck ✓.

## Notas

- `LandingPillars` é consumido só pela corporativo, então o blast radius é local.
- Fica para rodadas seguintes do plano do critique: `/colorize` (pastéis), `/distill` (cadência de eyebrow), `/polish` (cor `#94a3b8` + textura do globo via CDN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)