### PR TITLE
feat(corporativo): impeccable pass — cor, cadência, foco a11y e globo no R2

### DIFF
--- a/.impeccable/critique/2026-06-28T14-30-06Z__pages-landings-corporativolanding-tsx.md
+++ b/.impeccable/critique/2026-06-28T14-30-06Z__pages-landings-corporativolanding-tsx.md
@@ -1,0 +1,79 @@
+---
+target: a página corporativo
+total_score: 34
+p0_count: 0
+p1_count: 0
+timestamp: 2026-06-28T14-30-06Z
+slug: pages-landings-corporativolanding-tsx
+---
+## Design Health Score — /corporativo (pós colorize + distill + polish)
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Form cobre submitting/success/error; globo ainda sem loading state (Suspense fallback null) |
+| 2 | Match System / Real World | 4 | PT-BR claro, metáforas reais (bilhete de embarque, diário) |
+| 3 | User Control and Freedom | 3 | WhatsApp + form + âncora; globo auto-rotaciona mas respeita reduced-motion (sem pause-on-hover) |
+| 4 | Consistency and Standards | 4 | Paleta unificada navy→ciano; foco visível canônico em todos os interativos; 1 eyebrow só |
+| 5 | Error Prevention | 3 | Validação + LGPD obrigatório |
+| 6 | Recognition Rather Than Recall | 4 | Fluxo simples, opções visíveis |
+| 7 | Flexibility and Efficiency | 3 | Atalho WhatsApp + form; nav por teclado agora com foco visível |
+| 8 | Aesthetic and Minimalist Design | 4 | Hero disciplinado, pastéis e eyebrows removidos; resta textura (noise+dot-grid) + 2 widgets fixos globais |
+| 9 | Error Recovery | 3 | Mensagens presentes, genéricas |
+| 10 | Help and Documentation | 3 | Contato visível; launcher global |
+| **Total** | | **34/40** | **Bom — subiu em consistência e minimalismo; teto restante é infra (globo) + chrome global** |
+
+## Anti-Patterns Verdict
+
+**Não parece "feito por IA".** Identidade própria e comprometida, agora mais disciplinada: hero com globo de arcos amarelo/ciano, botões neo-brutalistas com sombra dura press-down, pilares scrapbook (fita washi + rotação + ordinal) e processo numerado legítimo (01/02/03 = sequência real). O colorize alinhou pilares e processo a uma rampa oceânica navy→sky→ciano (sem os pastéis azul/sky/âmbar genéricos e sem o emerald da fita); o âmbar virou exclusivo dos CTAs (Regra do Âmbar). O distill removeu a cadência de eyebrow — restou só o do hero, que identifica a página.
+
+**Scan determinístico (detect.mjs):** `[]` — zero ocorrências. O único achado anterior (`#94a3b8` indocumentado em `LandingPillars.tsx:29`) foi tokenizado para sapphire. Nenhum gradient-text, side-stripe, glassmorphism decorativo ou hero-metric.
+
+**Evidência de browser:** screenshots desktop (1280×900) e mobile (375px) de hero, pilares, processo, banda e contato, com reveals disparados via scroll. Sem overflow. CSS de foco confirmado ao vivo (`outline-color: #0ea5e9`, offset 2px). Foco por teclado não capturável em screenshot (`:focus-visible` exige eventos `isTrusted`).
+
+## Overall Impression
+
+A landing saiu de "boa com teto cosmético" para "sólida e disciplinada". Os três passos da sessão atacaram exatamente o que travava a nota: cor (rampa de marca em vez de pastel-rainbow), cadência (1 eyebrow em vez de 4) e acessibilidade (foco visível de 2 sinais em todo o caminho de conversão, que antes dependia do outline default do browser). 32 → 34. O teto restante não é mais do design da página em si — é o globo carregando textura de CDN de terceiros (infra) e os dois widgets fixos globais que competem com os CTAs.
+
+## What's Working
+
+1. **Disciplina cromática.** Pilares e processo num eixo navy→ciano coeso; o amarelo reservado ao grito de ação. A página tem 3 cores de marca com papéis claros, não 5 matizes diluídos.
+2. **Cadência limpa.** Sem eyebrow em toda seção. Hero abre com kicker informativo; pilares, processo, banda e contato entram pelo H2. Menos andaime, mais respiro.
+3. **Acessibilidade real.** Reduced-motion (harden) + foco visível canônico em nav, CTAs, form, links e social (polish). O caminho de conversão é navegável por teclado com sinal visível.
+
+## Priority Issues
+
+### [P3] Globo carrega textura de CDN de terceiros
+- **O que:** `CorpGlobe.tsx` usa `//unpkg.com/three-globe/example/img/earth-night.jpg` no caminho do hero.
+- **Por que importa:** Dependência externa e ponto único de falha visual (há fallback, mas o caminho feliz depende do unpkg). Resiliência e controle do asset.
+- **Fix:** Hospedar `earth-night.jpg` no R2 próprio (`media.anhanga.tur.br`). Tarefa de infra (upload no R2), fora do alcance de mudança só de código.
+- **Comando sugerido:** `/impeccable polish`
+
+### [P3] Globo sem loading state
+- **O que:** `Suspense fallback={null}` + import assíncrono de `globe.gl`; durante o load o lado direito do hero fica vazio.
+- **Por que importa:** É decorativo e `aria-hidden`, então o impacto é baixo, mas um shimmer/placeholder sutil suavizaria a chegada.
+- **Comando sugerido:** `/impeccable polish`
+
+### [P3] Dois widgets fixos globais competem com os CTAs
+- **O que:** Launcher "Roteiro IA" + back-to-top no canto inferior usam z-index arbitrário e somam chamadas de ação além dos CTAs da página.
+- **Por que importa:** Concorrência visual com o CTA dominante; escala de z-index não semântica. É chrome global, não específico da landing.
+- **Comando sugerido:** `/impeccable polish` (escopo global, fora da landing)
+
+## Persona Red Flags
+
+**Sam (acessibilidade):** principais red flags anteriores resolvidos — reduced-motion respeitado (globo para, reveals viram crossfade) e foco visível de 2 sinais em todo interativo. Restam: globo sem loading anunciado e contraste de alguns labels secundários `zinc-500` sobre creme no limite.
+
+**Jordan (primeira vez, desktop):** experiência clara — headline, dois CTAs visíveis, badges de prova, fluxo de 3 passos numerado. Sem fricção. O launcher global soma uma 3ª chamada mas não confunde.
+
+**Casey (mobile, com pressa):** hero encaixa na dobra, CTAs grandes no polegar, form com autocomplete e foco visível. Único ruído: launcher de chat + back-to-top sobrepõem o canto inferior.
+
+## Minor Observations
+
+- Labels secundários `text-zinc-500` sobre `#fffdf5` (ex.: "Nos siga nas redes") ficam no limite do 4.5:1 — corpo principal já foi para `zinc-600`.
+- Globo depende de `globe.gl` + three.js no caminho do hero (peso de bundle no `leaflet-vendor`/chunk — verificar custo de LCP em conexões lentas).
+- Os dois widgets fixos globais idealmente numa escala de z-index semântica (dropdown → sticky → modal → toast).
+
+## Questions to Consider
+
+- O globo precisa girar sempre, ou poderia pausar no hover além do reduced-motion, ganhando controle sem perder o efeito?
+- Vale hospedar a textura do globo no R2 agora (resiliência) ou deixar como dívida conhecida até a próxima janela de infra?
+- A página tem 3 canais de ação (WhatsApp no nav/hero, "ser contatado", launcher global). Qual deve converter 80% — e o launcher global ajuda ou compete?

--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -112,7 +112,7 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                         <button
                             type="submit"
                             disabled={busy}
-                            className="w-full flex items-center justify-center gap-3 bg-brand-dark text-white py-4 rounded-xl font-bold text-base shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition disabled:opacity-60 disabled:pointer-events-none"
+                            className="w-full flex items-center justify-center gap-3 bg-brand-dark text-white py-4 rounded-xl font-bold text-base shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition disabled:opacity-60 disabled:pointer-events-none focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
                             data-tracking="submit-form-corporativo"
                         >
                             {busy ? (

--- a/components/landings/corporativo/CorpContactInfo.tsx
+++ b/components/landings/corporativo/CorpContactInfo.tsx
@@ -44,7 +44,7 @@ export function CorpContactInfo({ whatsappUrl }: CorpContactInfoProps) {
                             <Icon className="size-5 text-blue-600" weight="fill" />
                         </div>
                         {href ? (
-                            <a href={href} className="font-semibold text-zinc-700 hover:text-brand-cyan transition-colors duration-150 pt-1.5">
+                            <a href={href} className="font-semibold text-zinc-700 hover:text-brand-cyan transition-colors duration-150 pt-1.5 rounded focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
                                 {label}
                             </a>
                         ) : (
@@ -69,7 +69,7 @@ export function CorpContactInfo({ whatsappUrl }: CorpContactInfoProps) {
                             href={href}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="size-11 rounded-xl bg-white border-2 border-zinc-200 flex items-center justify-center text-zinc-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-hard-yellow hover:-translate-y-1 transition duration-200"
+                            className="size-11 rounded-xl bg-white border-2 border-zinc-200 flex items-center justify-center text-zinc-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-hard-yellow hover:-translate-y-1 transition duration-200 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
                             aria-label={label}
                             {...(contact ? { 'data-contact-intent': true, 'data-tracking': 'social-whatsapp-corporativo' } : {})}
                         >

--- a/components/landings/corporativo/CorpContactSection.tsx
+++ b/components/landings/corporativo/CorpContactSection.tsx
@@ -10,7 +10,7 @@ export function CorpContactSection() {
         <section id="contato" className="py-24 bg-brand-surface relative overflow-hidden">
             <div
                 className="absolute inset-0 z-0 opacity-[0.3]"
-                style={{ backgroundImage: 'radial-gradient(#cbd5e1 1.5px, transparent 1.5px)', backgroundSize: '24px 24px' }}
+                style={{ backgroundImage: 'radial-gradient(#c2d3e8 1.5px, transparent 1.5px)', backgroundSize: '24px 24px' }}
             />
 
             <div className="container mx-auto px-6 relative z-10">

--- a/components/landings/corporativo/CorpGlobe.tsx
+++ b/components/landings/corporativo/CorpGlobe.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { GLOBE_EARTH_NIGHT_TEXTURE_URL } from '@/lib/media-assets';
 import { prefersReducedMotion } from '../shared/motion';
 
 const SP = { lat: -23.5505, lng: -46.6333 };
@@ -49,7 +50,7 @@ export function CorpGlobe() {
                 .backgroundColor('rgba(0,0,0,0)')
                 .width(el.clientWidth)
                 .height(el.clientHeight)
-                .globeImageUrl('//unpkg.com/three-globe/example/img/earth-night.jpg')
+                .globeImageUrl(GLOBE_EARTH_NIGHT_TEXTURE_URL)
                 .atmosphereColor('#60c8f5')
                 .atmosphereAltitude(0.22)
                 // Arcs — trajectórias suaves, altura moderada

--- a/components/landings/corporativo/CorpHero.tsx
+++ b/components/landings/corporativo/CorpHero.tsx
@@ -101,7 +101,7 @@ export function CorpHero() {
                         <button
                             type="button"
                             onClick={() => openContactModal({ source: 'corporativo' })}
-                            className="btn-whatsapp btn-specialist flex items-center justify-center gap-3 bg-brand-yellow text-brand-dark px-8 py-4 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(0,0,0,0.2)] hover:shadow-[2px_2px_0px_rgba(0,0,0,0.2)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
+                            className="btn-whatsapp btn-specialist flex items-center justify-center gap-3 bg-brand-yellow text-brand-dark px-8 py-4 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(0,0,0,0.2)] hover:shadow-[2px_2px_0px_rgba(0,0,0,0.2)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
                             data-contact-intent
                             data-tracking="hero-corporativo"
                         >
@@ -110,7 +110,7 @@ export function CorpHero() {
                         </button>
                         <a
                             href="#contato"
-                            className="btn-specialist flex items-center justify-center gap-2 border-2 border-white/40 text-white px-8 py-4 rounded-2xl font-bold text-lg hover:border-white hover:bg-white/10 transition duration-200"
+                            className="btn-specialist flex items-center justify-center gap-2 border-2 border-white/40 text-white px-8 py-4 rounded-2xl font-bold text-lg hover:border-white hover:bg-white/10 transition duration-200 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
                         >
                             Prefiro ser contatado
                             <ArrowRight className="size-5" />

--- a/components/landings/corporativo/CorpPillars.tsx
+++ b/components/landings/corporativo/CorpPillars.tsx
@@ -4,5 +4,5 @@ import { PILLARS } from './constants';
 const HEADING = <>Por que empresas <br /><span className="text-brand-cyan">escolhem a Anhangá.</span></>;
 
 export function CorpPillars() {
-    return <LandingPillars heading={HEADING} pillars={PILLARS} />;
+    return <LandingPillars heading={HEADING} pillars={PILLARS} eyebrow={null} />;
 }

--- a/components/landings/corporativo/CorpProcess.tsx
+++ b/components/landings/corporativo/CorpProcess.tsx
@@ -28,10 +28,10 @@ const STEPS = [
         Icon: AirplaneTilt,
         title: 'Você só embarca',
         description: 'Toda a burocracia fica com a gente. Faturamento no CNPJ, condições para grupo e atendimento durante a viagem. Você cuida da empresa, a gente cuida de tudo mais.',
-        iconBg: 'bg-amber-100',
-        iconColor: 'text-amber-700',
-        numberColor: 'text-amber-200',
-        border: 'border-amber-200',
+        iconBg: 'bg-cyan-100',
+        iconColor: 'text-cyan-700',
+        numberColor: 'text-cyan-200',
+        border: 'border-cyan-200',
     },
 ] as const;
 
@@ -40,7 +40,7 @@ export function CorpProcess() {
         <section className="py-24 bg-white relative overflow-hidden">
             <div
                 className="absolute inset-0 opacity-[0.35]"
-                style={{ backgroundImage: 'radial-gradient(#e2e8f0 1px, transparent 1px)', backgroundSize: '20px 20px' }}
+                style={{ backgroundImage: 'radial-gradient(#dbe6f4 1px, transparent 1px)', backgroundSize: '20px 20px' }}
             />
 
             <div className="container mx-auto px-6 relative z-10">
@@ -92,7 +92,7 @@ export function CorpProcess() {
                                 <h3 className="text-lg font-extrabold text-zinc-900 leading-snug mb-3">
                                     {step.title}
                                 </h3>
-                                <p className="text-zinc-500 font-medium leading-relaxed text-sm max-w-xs">
+                                <p className="text-zinc-600 font-medium leading-relaxed text-sm max-w-xs">
                                     {step.description}
                                 </p>
 

--- a/components/landings/corporativo/CorpSuccessState.tsx
+++ b/components/landings/corporativo/CorpSuccessState.tsx
@@ -25,7 +25,7 @@ export function CorpSuccessState({ whatsappUrl }: CorpSuccessStateProps) {
                 href={whatsappUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
+                className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
                 data-contact-intent
                 data-tracking="success-corporativo"
             >

--- a/components/landings/corporativo/CorpWhatsAppBand.tsx
+++ b/components/landings/corporativo/CorpWhatsAppBand.tsx
@@ -3,5 +3,5 @@ import { LandingWhatsAppBand } from '../shared/LandingWhatsAppBand';
 const HEADLINE = <>Quer uma proposta? <br /><span className="text-brand-cyan">Chama no WhatsApp.</span></>;
 
 export function CorpWhatsAppBand() {
-    return <LandingWhatsAppBand source="corporativo" subtitle="Bate-papo rápido" headline={HEADLINE} />;
+    return <LandingWhatsAppBand source="corporativo" headline={HEADLINE} />;
 }

--- a/components/landings/corporativo/constants.ts
+++ b/components/landings/corporativo/constants.ts
@@ -29,9 +29,9 @@ export const PILLARS: PillarItem[] = [
         icon: ClipboardText,
         title: 'Sem burocracia',
         description: 'Faturamento direto no CNPJ e condições pra grupo. Você cuida da empresa, a gente cuida da viagem.',
-        bg: 'bg-amber-100',
-        accent: 'border-amber-200',
-        iconColor: 'text-amber-700',
+        bg: 'bg-cyan-100',
+        accent: 'border-cyan-200',
+        iconColor: 'text-cyan-700',
         rotateDeg: -2,
     },
 ];

--- a/components/landings/shared/LandingNav.tsx
+++ b/components/landings/shared/LandingNav.tsx
@@ -11,7 +11,7 @@ export function LandingNav({ source }: LandingNavProps) {
     return (
         <nav className="bg-white/90 backdrop-blur-md border-b border-zinc-100 sticky top-0 z-50 px-6 py-2">
             <div className="container mx-auto flex items-center justify-between">
-                <Link to="/" aria-label="Voltar para o site principal">
+                <Link to="/" aria-label="Voltar para o site principal" className="inline-block rounded-lg focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
                     <img
                         src={BRAND_LOGO_BLUE_URL}
                         alt="Anhangá Viagens"
@@ -23,7 +23,7 @@ export function LandingNav({ source }: LandingNavProps) {
                 <button
                     type="button"
                     onClick={() => openContactModal({ source })}
-                    className="btn-whatsapp btn-specialist hidden sm:flex items-center gap-2 bg-brand-dark text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition"
+                    className="btn-whatsapp btn-specialist hidden sm:flex items-center gap-2 bg-brand-dark text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
                     data-contact-intent
                     data-tracking={`header-${source}`}
                 >

--- a/components/landings/shared/LandingPillars.tsx
+++ b/components/landings/shared/LandingPillars.tsx
@@ -18,7 +18,7 @@ interface LandingPillarsProps {
     pillars: PillarItem[];
 }
 
-const TAPE_COLORS = ['bg-brand-yellow/80', 'bg-sky-100/90', 'bg-emerald-100/90'];
+const TAPE_COLORS = ['bg-brand-yellow/80', 'bg-sky-100/90', 'bg-cyan-100/90'];
 
 export function LandingPillars({ heading, pillars }: LandingPillarsProps) {
     return (
@@ -26,7 +26,7 @@ export function LandingPillars({ heading, pillars }: LandingPillarsProps) {
 
             <div
                 className="absolute inset-0 z-0 opacity-[0.25]"
-                style={{ backgroundImage: 'radial-gradient(#94a3b8 1.5px, transparent 1.5px)', backgroundSize: '28px 28px' }}
+                style={{ backgroundImage: 'radial-gradient(#9fb8d4 1.5px, transparent 1.5px)', backgroundSize: '28px 28px' }}
             />
 
             <div className="container mx-auto px-6 relative z-10">
@@ -92,7 +92,7 @@ export function LandingPillars({ heading, pillars }: LandingPillarsProps) {
                                 <h3 className="text-xl font-extrabold text-zinc-900 mb-3 leading-tight group-hover:text-brand-cyan transition-colors duration-300 pr-10">
                                     {item.title}
                                 </h3>
-                                <p className="text-zinc-500 font-medium leading-relaxed text-sm">
+                                <p className="text-zinc-600 font-medium leading-relaxed text-sm">
                                     {item.description}
                                 </p>
                             </m.div>

--- a/components/landings/shared/LandingPillars.tsx
+++ b/components/landings/shared/LandingPillars.tsx
@@ -16,11 +16,23 @@ export interface PillarItem {
 interface LandingPillarsProps {
     heading: React.ReactNode;
     pillars: PillarItem[];
+    // Eyebrow kicker acima do H2. Passe `null` para suprimir (evita cadência
+    // de eyebrow repetida quando a landing já abre outras seções pelo H2).
+    eyebrow?: React.ReactNode;
 }
 
 const TAPE_COLORS = ['bg-brand-yellow/80', 'bg-sky-100/90', 'bg-cyan-100/90'];
 
-export function LandingPillars({ heading, pillars }: LandingPillarsProps) {
+const DEFAULT_EYEBROW = (
+    <div className="inline-block relative mb-5">
+        <span className="absolute inset-0 bg-brand-yellow/30 transform -skew-x-12 rounded-lg" />
+        <span className="relative px-4 py-1.5 text-brand-dark font-black uppercase tracking-widest text-xs flex items-center gap-2">
+            <Sparkle className="size-4" weight="fill" /> O Jeito Anhangá
+        </span>
+    </div>
+);
+
+export function LandingPillars({ heading, pillars, eyebrow = DEFAULT_EYEBROW }: LandingPillarsProps) {
     return (
         <section className="py-24 bg-brand-surface relative overflow-hidden">
 
@@ -39,12 +51,7 @@ export function LandingPillars({ heading, pillars }: LandingPillarsProps) {
                     custom={0}
                     className="text-center mb-16"
                 >
-                    <div className="inline-block relative mb-5">
-                        <span className="absolute inset-0 bg-brand-yellow/30 transform -skew-x-12 rounded-lg" />
-                        <span className="relative px-4 py-1.5 text-brand-dark font-black uppercase tracking-widest text-xs flex items-center gap-2">
-                            <Sparkle className="size-4" weight="fill" /> O Jeito Anhangá
-                        </span>
-                    </div>
+                    {eyebrow}
                     <h2 className="text-4xl md:text-5xl font-black text-brand-dark leading-tight">
                         {heading}
                     </h2>

--- a/components/landings/shared/LandingWhatsAppBand.tsx
+++ b/components/landings/shared/LandingWhatsAppBand.tsx
@@ -3,7 +3,9 @@ import { openContactModal } from '@/utils/contactForm';
 
 interface LandingWhatsAppBandProps {
     source: string;
-    subtitle: string;
+    // Eyebrow opcional acima do headline. Omita para a banda entrar direto
+    // pelo H2 (evita cadência de eyebrow repetida na landing).
+    subtitle?: string;
     headline: React.ReactNode;
 }
 
@@ -24,10 +26,12 @@ export function LandingWhatsAppBand({ source, subtitle, headline }: LandingWhats
             <div className="container mx-auto px-6 relative z-10">
                 <div className="max-w-5xl mx-auto flex flex-col md:flex-row items-center justify-between gap-8 bg-white/5 rounded-[2rem] p-10 border border-white/10">
                     <div>
-                        <p className="text-brand-yellow font-bold uppercase tracking-widest text-xs mb-3 flex items-center gap-2">
-                            <AirplaneTilt className="size-4" weight="fill" />
-                            {subtitle}
-                        </p>
+                        {subtitle && (
+                            <p className="text-brand-yellow font-bold uppercase tracking-widest text-xs mb-3 flex items-center gap-2">
+                                <AirplaneTilt className="size-4" weight="fill" />
+                                {subtitle}
+                            </p>
+                        )}
                         <h2 className="text-4xl md:text-5xl font-black text-white leading-tight">
                             {headline}
                         </h2>

--- a/components/landings/shared/LandingWhatsAppBand.tsx
+++ b/components/landings/shared/LandingWhatsAppBand.tsx
@@ -39,7 +39,7 @@ export function LandingWhatsAppBand({ source, subtitle, headline }: LandingWhats
                     <button
                         type="button"
                         onClick={() => openContactModal({ source })}
-                        className="btn-whatsapp btn-specialist shrink-0 flex items-center gap-3 bg-brand-yellow text-brand-dark px-10 py-5 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(255,255,255,0.15)] hover:shadow-[2px_2px_0px_rgba(255,255,255,0.15)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition whitespace-nowrap"
+                        className="btn-whatsapp btn-specialist shrink-0 flex items-center gap-3 bg-brand-yellow text-brand-dark px-10 py-5 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(255,255,255,0.15)] hover:shadow-[2px_2px_0px_rgba(255,255,255,0.15)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition whitespace-nowrap focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
                         data-contact-intent
                         data-tracking={`whatsapp-band-${source}`}
                     >

--- a/docs/design/corporativo-critique-followup.md
+++ b/docs/design/corporativo-critique-followup.md
@@ -12,12 +12,12 @@ Handoff para continuar a melhoria da landing `/corporativo` em outra sessão.
 - **Harden** (PR #963): a11y de motion (`MotionConfig reducedMotion="user"` + globo respeita `prefers-reduced-motion` + helper `prefersReducedMotion()`) e visibilidade sem JS (`<noscript>` para o `opacity:0` que o framer serializa no prerender). Cobertura: unit + e2e reduced-motion.
 - **Colorize**: rampa oceânica navy→sky→ciano nos pilares e no processo. 3º card/passo (`amber` → `cyan`) e fita washi (`emerald` → `cyan`); âmbar agora exclusivo dos CTAs (Regra do Âmbar). Dot-grids tintados para sapphire (sai o `#94a3b8` indocumentado) e corpo `text-sm` `zinc-500` → `zinc-600` (contraste ~7.5:1 sobre o creme). `text-emerald-500` mantido só no ícone de sucesso do form (verde = semântica de sucesso).
 - **Distill**: removidos os eyebrows de seção de pilares (`O Jeito Anhangá`) e banda (`Bate-papo rápido`) — ambas entram pelo H2. Resta só o eyebrow do hero (`Viagens para Empresas`), que identifica a página. Eyebrow virou prop opcional em `LandingPillars` (`eyebrow`, default preserva consumidores) e `subtitle` opcional em `LandingWhatsAppBand`. O header `✈ Contato / Corporativo` do form foi mantido (device de bilhete de embarque, não eyebrow).
+- **Polish**: foco visível de 2 sinais (`focus-visible:outline-2 outline-offset-2 outline-anhanga-action`, padrão do `components/ui/Button.tsx`) em todos os interativos que não tinham — nav (logo + botão), CTAs do hero, banda (`outline-white` sobre o navy), submit do form, links de contato/sociais, link do success e nav inferior "Conheça também". Antes só os campos do form tinham foco; os CTAs (caminho de conversão) dependiam do outline default do browser, violando o piso WCAG AA do PRODUCT.md.
 
 ## Pendências (em ordem de impacto)
 
-### 1. Higiene final — `/impeccable polish corporativo` · P3
-- Globo carrega `earth-night.jpg` de `//unpkg.com` (`CorpGlobe.tsx`) — hospedar no R2 próprio.
-- (resolvido no colorize: `#94a3b8` dos dots tintado para sapphire; contraste do corpo `zinc-500` → `zinc-600`.)
+### 1. Globo via CDN de terceiros — `/impeccable polish` · P3
+- `CorpGlobe.tsx` carrega `earth-night.jpg` de `//unpkg.com` (dependência externa no caminho do hero) — hospedar no R2 próprio. Tarefa de infra (upload no R2), fora do alcance de uma mudança só de código.
 
 ## Observações menores (do critique)
 

--- a/docs/design/corporativo-critique-followup.md
+++ b/docs/design/corporativo-critique-followup.md
@@ -10,22 +10,17 @@ Handoff para continuar a melhoria da landing `/corporativo` em outra sessão.
 
 - **Polish** (PR #961, mergeado): eyebrow do hero (oliva → vidro com âmbar) e brilho do globo (`brightness` 2 → 1.45, arcos amarelo/ciano legíveis).
 - **Harden** (PR #963): a11y de motion (`MotionConfig reducedMotion="user"` + globo respeita `prefers-reduced-motion` + helper `prefersReducedMotion()`) e visibilidade sem JS (`<noscript>` para o `opacity:0` que o framer serializa no prerender). Cobertura: unit + e2e reduced-motion.
+- **Colorize**: rampa oceânica navy→sky→ciano nos pilares e no processo. 3º card/passo (`amber` → `cyan`) e fita washi (`emerald` → `cyan`); âmbar agora exclusivo dos CTAs (Regra do Âmbar). Dot-grids tintados para sapphire (sai o `#94a3b8` indocumentado) e corpo `text-sm` `zinc-500` → `zinc-600` (contraste ~7.5:1 sobre o creme). `text-emerald-500` mantido só no ícone de sucesso do form (verde = semântica de sucesso).
 
 ## Pendências (em ordem de impacto)
 
-### 1. Cor — `/impeccable colorize corporativo` · P2 (maior ganho)
-Pilares e processo usam `blue-100 / sky-100 / amber-100` por item, diluindo a identidade navy + ciano + amarelo para um genérico "SaaS simpático".
-- **Onde:** `components/landings/corporativo/constants.ts` (PILLARS) e `components/landings/corporativo/CorpProcess.tsx` (STEPS); tape colors em `components/landings/shared/LandingPillars.tsx:21` (`bg-emerald-100/90` destoa do acento âmbar do 3º card).
-- **Fix:** restringir a 2–3 cores da marca ou 1 acento por seção.
-
-### 2. Cadência de eyebrow — `/impeccable distill corporativo` · P3
+### 1. Cadência de eyebrow — `/impeccable distill corporativo` · P3
 4 eyebrows skewed em sequência (hero, pilares, banda, contato) lê como andaime. O processo já entra direto pelo H2 — bom.
 - **Fix:** manter o eyebrow só no hero e no contato; pilares e banda entram pelo H2.
 
-### 3. Higiene final — `/impeccable polish corporativo` · P3
-- Cor `#94a3b8` fora do DESIGN.md (único achado do `detect.mjs`) — pontos do fundo em `LandingPillars.tsx:29`. Tokenizar.
+### 2. Higiene final — `/impeccable polish corporativo` · P3
 - Globo carrega `earth-night.jpg` de `//unpkg.com` (`CorpGlobe.tsx`) — hospedar no R2 próprio.
-- Reconferir contraste do corpo `zinc-500` sobre `#fffdf5` (limite de 4.5:1).
+- (resolvido no colorize: `#94a3b8` dos dots tintado para sapphire; contraste do corpo `zinc-500` → `zinc-600`.)
 
 ## Observações menores (do critique)
 

--- a/docs/design/corporativo-critique-followup.md
+++ b/docs/design/corporativo-critique-followup.md
@@ -13,15 +13,15 @@ Handoff para continuar a melhoria da landing `/corporativo` em outra sessão.
 - **Colorize**: rampa oceânica navy→sky→ciano nos pilares e no processo. 3º card/passo (`amber` → `cyan`) e fita washi (`emerald` → `cyan`); âmbar agora exclusivo dos CTAs (Regra do Âmbar). Dot-grids tintados para sapphire (sai o `#94a3b8` indocumentado) e corpo `text-sm` `zinc-500` → `zinc-600` (contraste ~7.5:1 sobre o creme). `text-emerald-500` mantido só no ícone de sucesso do form (verde = semântica de sucesso).
 - **Distill**: removidos os eyebrows de seção de pilares (`O Jeito Anhangá`) e banda (`Bate-papo rápido`) — ambas entram pelo H2. Resta só o eyebrow do hero (`Viagens para Empresas`), que identifica a página. Eyebrow virou prop opcional em `LandingPillars` (`eyebrow`, default preserva consumidores) e `subtitle` opcional em `LandingWhatsAppBand`. O header `✈ Contato / Corporativo` do form foi mantido (device de bilhete de embarque, não eyebrow).
 - **Polish**: foco visível de 2 sinais (`focus-visible:outline-2 outline-offset-2 outline-anhanga-action`, padrão do `components/ui/Button.tsx`) em todos os interativos que não tinham — nav (logo + botão), CTAs do hero, banda (`outline-white` sobre o navy), submit do form, links de contato/sociais, link do success e nav inferior "Conheça também". Antes só os campos do form tinham foco; os CTAs (caminho de conversão) dependiam do outline default do browser, violando o piso WCAG AA do PRODUCT.md.
+- **Globo no R2**: textura `earth-night.jpg` (4096×2048, 715KB) subida para `av-site-media/textures/earth-night.jpg`, servida em `https://media.anhanga.tur.br/textures/earth-night.jpg`. `CorpGlobe.tsx` agora usa `GLOBE_EARTH_NIGHT_TEXTURE_URL` (`lib/media-assets.ts`) — zero requests ao `unpkg`. Verificado: globo renderiza idêntico, sem erros.
 
-## Pendências (em ordem de impacto)
+## Pendências
 
-### 1. Globo via CDN de terceiros — `/impeccable polish` · P3
-- `CorpGlobe.tsx` carrega `earth-night.jpg` de `//unpkg.com` (dependência externa no caminho do hero) — hospedar no R2 próprio. Tarefa de infra (upload no R2), fora do alcance de uma mudança só de código.
+Nenhuma específica da landing. Nota atual **34/40** (sem P0/P1), detector limpo. Resta só chrome global (fora do escopo da landing):
 
 ## Observações menores (do critique)
 
-- Dois widgets fixos globais (launcher "Roteiro IA" + back-to-top) competem com os CTAs e usam z-index arbitrário.
-- Globo sem loading state.
+- Dois widgets fixos globais (launcher "Roteiro IA" + back-to-top) competem com os CTAs e usam z-index arbitrário — concern global, não da landing.
+- Globo sem loading state (Suspense fallback null) — decorativo/`aria-hidden`, impacto baixo.
 
 Após as pendências, re-rodar `/impeccable critique corporativo` para confirmar a nota subindo.

--- a/docs/design/corporativo-critique-followup.md
+++ b/docs/design/corporativo-critique-followup.md
@@ -11,14 +11,11 @@ Handoff para continuar a melhoria da landing `/corporativo` em outra sessão.
 - **Polish** (PR #961, mergeado): eyebrow do hero (oliva → vidro com âmbar) e brilho do globo (`brightness` 2 → 1.45, arcos amarelo/ciano legíveis).
 - **Harden** (PR #963): a11y de motion (`MotionConfig reducedMotion="user"` + globo respeita `prefers-reduced-motion` + helper `prefersReducedMotion()`) e visibilidade sem JS (`<noscript>` para o `opacity:0` que o framer serializa no prerender). Cobertura: unit + e2e reduced-motion.
 - **Colorize**: rampa oceânica navy→sky→ciano nos pilares e no processo. 3º card/passo (`amber` → `cyan`) e fita washi (`emerald` → `cyan`); âmbar agora exclusivo dos CTAs (Regra do Âmbar). Dot-grids tintados para sapphire (sai o `#94a3b8` indocumentado) e corpo `text-sm` `zinc-500` → `zinc-600` (contraste ~7.5:1 sobre o creme). `text-emerald-500` mantido só no ícone de sucesso do form (verde = semântica de sucesso).
+- **Distill**: removidos os eyebrows de seção de pilares (`O Jeito Anhangá`) e banda (`Bate-papo rápido`) — ambas entram pelo H2. Resta só o eyebrow do hero (`Viagens para Empresas`), que identifica a página. Eyebrow virou prop opcional em `LandingPillars` (`eyebrow`, default preserva consumidores) e `subtitle` opcional em `LandingWhatsAppBand`. O header `✈ Contato / Corporativo` do form foi mantido (device de bilhete de embarque, não eyebrow).
 
 ## Pendências (em ordem de impacto)
 
-### 1. Cadência de eyebrow — `/impeccable distill corporativo` · P3
-4 eyebrows skewed em sequência (hero, pilares, banda, contato) lê como andaime. O processo já entra direto pelo H2 — bom.
-- **Fix:** manter o eyebrow só no hero e no contato; pilares e banda entram pelo H2.
-
-### 2. Higiene final — `/impeccable polish corporativo` · P3
+### 1. Higiene final — `/impeccable polish corporativo` · P3
 - Globo carrega `earth-night.jpg` de `//unpkg.com` (`CorpGlobe.tsx`) — hospedar no R2 próprio.
 - (resolvido no colorize: `#94a3b8` dos dots tintado para sapphire; contraste do corpo `zinc-500` → `zinc-600`.)
 

--- a/lib/media-assets.ts
+++ b/lib/media-assets.ts
@@ -18,3 +18,8 @@ export const BETO_CARRERO_LANDING_IMAGE_URL =
 
 export const BETO_CARRERO_FIREWHIP_IMAGE_URL =
   'https://media.anhanga.tur.br/images/beto-carrero/landing/firewhip.webp';
+
+// Textura do globo do hero corporativo (CorpGlobe). Hospedada no R2 próprio
+// em vez do CDN público do three-globe (unpkg) para resiliência do hero.
+export const GLOBE_EARTH_NIGHT_TEXTURE_URL =
+  'https://media.anhanga.tur.br/textures/earth-night.jpg';

--- a/pages/landings/CorporativoLanding.tsx
+++ b/pages/landings/CorporativoLanding.tsx
@@ -57,13 +57,13 @@ const CorporativoLanding: React.FC = () => {
                     <div className="container mx-auto px-6 text-center">
                         <p className="text-sm text-zinc-500 font-medium mb-4">Conheça também</p>
                         <div className="flex flex-wrap justify-center gap-3">
-                            <Link to="/consultoria-de-viagem/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+                            <Link to="/consultoria-de-viagem/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
                                 Consultoria de Viagem
                             </Link>
-                            <Link to="/melhor-idade/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+                            <Link to="/melhor-idade/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
                                 Viagens Melhor Idade
                             </Link>
-                            <Link to="/curadoria-cruzeiros-brasil/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+                            <Link to="/curadoria-cruzeiros-brasil/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
                                 Cruzeiros pelo Brasil
                             </Link>
                         </div>


### PR DESCRIPTION
Sequência de melhorias na landing `/corporativo` via `/impeccable` (colorize → distill → polish → infra). Nota do critique subiu **32 → 34/40**, sem P0/P1, detector limpo.

## Mudanças

### 🎨 Colorize — disciplina cromática (`328b0a2`)
Pilares e processo usavam `blue-100 / sky-100 / amber-100` por item (+ fita `emerald`), diluindo a identidade navy+ciano+amarelo para um "SaaS simpático" genérico.
- Rampa oceânica **navy → sky → ciano** (3º card/passo `amber` → `cyan`; fita `emerald` → `cyan`)
- Âmbar agora exclusivo dos CTAs (Regra do Âmbar)
- Dot-grids tintados para sapphire (sai o `#94a3b8` indocumentado — único achado do detector)
- Corpo `text-sm` `zinc-500` → `zinc-600` (~7.5:1 sobre o creme)
- `text-emerald-500` mantido só no ícone de sucesso do form (semântica)

### ✂️ Distill — cadência de eyebrow (`8b75250`)
Pilares (`O Jeito Anhangá`) e banda (`Bate-papo rápido`) abriam com o mesmo micro-label do hero — eyebrow em toda seção lê como andaime de IA.
- Ambas entram pelo H2; resta só o eyebrow do hero, que identifica a página
- `eyebrow` vira prop opcional em `LandingPillars`; `subtitle` opcional em `LandingWhatsAppBand` (defaults preservam consumidores)

### ♿ Polish — foco visível de 2 sinais (`dcbfc6b`)
CTAs e links usavam `<button>`/`<a>` crus sem `:focus-visible` (`btn-specialist`/`btn-whatsapp` são só hooks de tracking). O foco dependia do outline default do browser, violando o piso WCAG AA do PRODUCT.md.
- Padrão canônico do `components/ui/Button.tsx` aplicado em nav, CTAs do hero, banda (`outline-white` sobre o navy), submit do form, links de contato/sociais, success e nav inferior
- Sem mudança no estado de repouso

### ⚡ Globo no R2 (`5b4c1f1`)
`CorpGlobe` carregava `earth-night.jpg` de `//unpkg.com` — CDN de terceiros no caminho do hero.
- Textura (4096×2048, 715KB) hospedada em `av-site-media/textures/earth-night.jpg`, servida via `media.anhanga.tur.br`
- Nova constante `GLOBE_EARTH_NIGHT_TEXTURE_URL` em `lib/media-assets.ts`; zero requests ao `unpkg`

## Verificação
- `pnpm typecheck` ✅
- Browser desktop (1280×900) + mobile (375px): hero, pilares, processo, banda, contato sem overflow
- Cores computadas conferidas (rampa hue 255→236→203); CSS de foco ao vivo (`outline-color #0ea5e9`)
- Globo: textura do R2, zero `unpkg`, console limpo
- `detect.mjs` → `[]` (limpo)

> ⚠️ As snapshots visuais de `tests/e2e/corporativo.spec.ts` podem precisar de `pnpm test:update-snapshots` (mudanças visuais de cor/eyebrow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)