### PR TITLE
feat(links): foco, página standalone e ritmo de tier na /links

### DIFF
--- a/.impeccable/critique/2026-06-28T15-24-29Z__pages-linkspage-tsx.md
+++ b/.impeccable/critique/2026-06-28T15-24-29Z__pages-linkspage-tsx.md
@@ -1,0 +1,79 @@
+---
+target: links
+total_score: 33
+p0_count: 0
+p1_count: 0
+timestamp: 2026-06-28T15-24-29Z
+slug: pages-linkspage-tsx
+---
+# Critique — Página de Links na Bio (`/links`) — reavaliação
+
+## Design Health Score
+
+| # | Heurística | Nota | Problema-chave |
+|---|-----------|-------|----------------|
+| 1 | Visibilidade do status | 3 | Externos não sinalizam "nova aba/sai do site"; resto ok (focus ring, press-down) |
+| 2 | Match com o mundo real | 4 | PT-BR claro, ordem quente→frio, ícones reconhecíveis |
+| 3 | Controle e liberdade | 3 | Lista de links, baixo risco; externos em nova aba |
+| 4 | Consistência e padrões | 4 | **Corrigido**: slot de ícone fixo, alturas padronizadas por tier, sistema tátil aplicado |
+| 5 | Prevenção de erro | 3 | n/a — sem formulários |
+| 6 | Reconhecer vs. lembrar | 4 | Tudo visível e rotulado |
+| 7 | Flexibilidade/eficiência | 3 | Ação primária a 1 toque; sem aceleradores (não precisa) |
+| 8 | Estético e minimalista | 3 | **Melhorou** (2 tiers quebram a pilha) mas: dois amarelos na 1ª dobra, /quiz duplicado, FAB BackToTop ainda cobre conteúdo |
+| 9 | Recuperação de erro | 3 | n/a |
+| 10 | Ajuda e documentação | 3 | A própria página é um hub; selos reforçam |
+| **Total** | | **33/40** | **Bom — saiu do "cara de Linktree", resta polimento P2/P3** |
+
+## Anti-Patterns Verdict
+
+**Parece feito por IA?** Já não. O commit #962 aplicou o sistema "O Diário de Bordo": `shadow-hard` + press-down (rest→hover→active, tipo carimbo) e **dois níveis de peso** — ações (WhatsApp/quiz/site/utilidades) cheias e os 7 destinos como lista de apoio mais leve/compacta. A pilha de 12 cartões brancos idênticos do Linktree foi quebrada.
+
+**Scan determinístico:** `detect.mjs` em `LinksPage.tsx`, `LinkButton.tsx`, `TrustSeals.tsx` → **0 achados** (exit 0). Nenhum tell automatizado.
+
+**O que o #962 resolveu (dos 3 P1 + 2 P2 do critique anterior):**
+- ✅ **Sistema tátil ausente** → aplicado (`shadow-hard`/press-down + tiers).
+- ✅ **Ícones/rótulos desalinhados** → slot de ícone `w-6 shrink-0`, alturas padronizadas (4.5rem / 3.25rem).
+- ✅ **Rodapé reprova AA** → gradiente agora `darkBlue → action → darkBlue`; o rodapé cai sobre o `#003B8E` escuro do fim (branco ≈ 8:1). Sublabels passaram a `darkBlue/80` sobre branco.
+- ✅ **AIChat em página standalone** → `ROUTES_WITHOUT_AICHAT = ['/links']` esconde o assistente.
+
+## Overall Impression
+
+A página deu um salto: de "Linktree na cor da marca" (30/40) para "Anhangá com peso tátil" (33/40). Não há mais P0/P1 — o que falta é polimento de foco e de saída. O maior ganho remanescente é **desfazer a competição de amarelos e a duplicação do /quiz na primeira dobra**, para a página comunicar curadoria (uma ação dominante) em vez de catálogo.
+
+## What's Working
+
+- **Sistema tátil aplicado com critério:** dois tiers de peso (`pressPrimary`/`pressSecondary`) comunicam hierarquia de intenção — exatamente "curadoria sobre catálogo".
+- **Ordem e copy on-brand:** quente→frio, PT-BR caloroso, selos de confiança (Cadastur/ABAV/Google) com contraste agora legível.
+- **Acessibilidade de base:** focus-visible ring com offset, `aria-label` na nav, ícones `aria-hidden`, touch targets 52–72px.
+
+## Priority Issues (o que falta)
+
+- **[P2] Três focos de amarelo na primeira dobra.** O banner empilha: container `bg-anhanga-yellow/15`, ring amarelo e pílula CTA `bg-anhanga-yellow` ("Fazer o quiz") — e logo abaixo o botão WhatsApp é amarelo cheio. A "Regra do Âmbar" (máx. 1 por tela) está violada e o foco primário se divide. *Fix:* eleger 1 dono do amarelo (o WhatsApp, ação de maior valor) e rebaixar o banner para superfície neutra/branca com CTA secundário. *Comando:* `/impeccable distill`.
+
+- **[P2] /quiz aparece duas vezes na 1ª dobra.** O banner ("Fazer o quiz" → `/quiz`) e o link primário "Planejar minha viagem" → `/quiz` levam ao mesmo lugar, encostados. Catálogo, não curadoria. *Fix:* manter o banner do quiz **ou** o link, não os dois; se manter o banner, remover o link `quiz` (ou vice-versa). *Comando:* `/impeccable distill`.
+
+- **[P2] BackToTop ainda flutua sobre o conteúdo em /links (fix parcial).** `ROUTES_WITHOUT_AICHAT` removeu só o AIChat; `ContactModal` e `BackToTop` continuam montando no `ClientFeatures`. Como a página tem ~1300px, o FAB "Voltar ao topo" (`fixed bottom-24 right-4 z-[9980]`) aparece após 400px de scroll e cobre os últimos destinos/selos. *Fix:* incluir `/links` numa lista que também suprima o BackToTop (ou condicionar todo o `ClientFeatures` a não renderizar em `/links`, já que o spec define a página como standalone). *Comando:* `/impeccable harden`.
+
+- **[P3] Externos não sinalizam saída do site.** "Seguro viagem" (afiliado), "Site oficial", Cadastur e ABAV abrem em nova aba sem indicador (↗) — Jordan pode achar que "saiu" da Anhangá. *Fix:* ícone/sufixo "↗" + `aria-label` "(abre em nova aba)" nos `type: 'external'`. *Comando:* `/impeccable clarify`.
+
+- **[P3] Sem agrupamento explícito ações × destinos.** Os tiers separam visualmente, mas os 7 destinos seguem como lista contínua sem rótulo. Um divisor sutil ou um único kicker ("Destinos") deixaria a intenção mais legível sem virar scaffolding. *Comando:* `/impeccable layout`.
+
+## Persona Red Flags
+
+**Casey (mobile, polegar):** ações primárias no topo, fora da zona do polegar; o FAB BackToTop ocupa a zona alcançável e cobre conteúdo. Scroll longo (~1300px) sem rótulo de seção entre utilidades e destinos.
+
+**Jordan (primeira vez):** externos (seguro afiliado, ABAV, Cadastur, site) não avisam que abrem nova aba. "Chip / eSIM" leva ao WhatsApp — o sublabel resolve, o ícone de SIM ainda sugere página própria.
+
+**Dona Marisa (melhor idade — persona do projeto):** muito melhor agora; sublabels em `darkBlue/80` e rodapé sobre fundo escuro são legíveis à noite. Resta o ruído dos amarelos competindo.
+
+## Minor Observations
+
+- `BackToTop` usa tokens legados `brand-cyan` e `z-[9980]` arbitrário — pré-existente, fora do escopo de `/links`, mas relevante se for tocado.
+- `isPrimary = highlight || icon || sublabel` faz 5 botões ganharem peso físico cheio; com `shadow-hard` em 5 cartões, o "peso reservado à ação" fica generoso. Aceitável, mas se quiser reforçar curadoria, dá para limitar o tier cheio a WhatsApp + quiz.
+- Verificar em viewport curta (conteúdo < tela): se o rodapé subir para a faixa `via-action #0ea5e9`, o branco cai para ~2.6:1. Com 12 links isso não ocorre, mas se a lista encolher por config, o contraste volta a reprovar.
+
+## Questions to Consider
+
+- A primeira dobra precisa de banner *e* link de quiz, ou uma única entrada confiante já basta?
+- O amarelo deveria ser exclusivo do WhatsApp (a conversa é o produto), deixando o quiz numa superfície neutra?
+- Os 7 destinos precisam estar todos abertos, ou caberia um agrupamento "Destinos" depois das ações?

--- a/App.tsx
+++ b/App.tsx
@@ -44,9 +44,10 @@ const STANDALONE_ROUTES = ['/links'];
 
 const ClientFeatures: React.FC = () => {
   const { pathname } = useLocation();
-  // Normaliza trailing slash (ex.: /links/ vindo da bio) antes de comparar — o React Router
-  // casa a rota com ou sem a barra, mas location.pathname preserva a barra.
-  const normalizedPath = pathname === '/' ? '/' : pathname.replace(/\/$/, '');
+  // Normaliza trailing slash e caixa antes de comparar: o React Router casa a rota com ou sem
+  // a barra E de forma case-insensitive (/LINKS renderiza LinksPage), mas location.pathname
+  // preserva ambos — sem normalizar, os overlays vazariam em /links/ ou /LINKS.
+  const normalizedPath = (pathname === '/' ? '/' : pathname.replace(/\/$/, '')).toLowerCase();
   if (STANDALONE_ROUTES.includes(normalizedPath)) return null;
   return (
     <ClientOnly>

--- a/App.tsx
+++ b/App.tsx
@@ -38,18 +38,19 @@ const LinksPage = lazy(() => import('./pages/LinksPage'));
 const MainRouteFallback: React.FC = () => <section className="min-h-[40vh] bg-white" aria-hidden="true" />;
 const LandingRouteFallback: React.FC = () => <div className="min-h-screen bg-white" aria-hidden="true" />;
 
-// Rotas standalone que não devem carregar o assistente virtual (página de bio, etc.)
-const ROUTES_WITHOUT_AICHAT = ['/links'];
+// Rotas standalone (página de bio, etc.): sem nenhum overlay flutuante — nem AIChat, nem
+// ContactModal, nem BackToTop. Esses FABs cobririam o conteúdo curado e os selos de confiança.
+const STANDALONE_ROUTES = ['/links'];
 
 const ClientFeatures: React.FC = () => {
   const { pathname } = useLocation();
   // Normaliza trailing slash (ex.: /links/ vindo da bio) antes de comparar — o React Router
   // casa a rota com ou sem a barra, mas location.pathname preserva a barra.
   const normalizedPath = pathname === '/' ? '/' : pathname.replace(/\/$/, '');
-  const showAIChat = !ROUTES_WITHOUT_AICHAT.includes(normalizedPath);
+  if (STANDALONE_ROUTES.includes(normalizedPath)) return null;
   return (
     <ClientOnly>
-      {showAIChat ? <AIChat /> : null}
+      <AIChat />
       <ContactModal />
       <BackToTop />
     </ClientOnly>

--- a/components/links/LinkButton.tsx
+++ b/components/links/LinkButton.tsx
@@ -15,6 +15,14 @@ const ICON_MAP: Record<string, Icon> = {
 
 interface LinkButtonProps {
     item: LinkItem;
+    /** classes extra (ex.: margem de ritmo na fronteira entre tiers) */
+    className?: string;
+}
+
+// Tier de peso: ações (WhatsApp/quiz/utilidades — com ícone ou sublabel) ganham peso físico cheio;
+// destinos "secos" ficam mais leves. Exportado para o LinksPage marcar a quebra de ritmo entre tiers.
+export function isPrimaryLink(item: LinkItem): boolean {
+    return Boolean(item.highlight) || Boolean(item.icon) || Boolean(item.sublabel);
 }
 
 // Slot de ícone com largura fixa garante que todos os rótulos alinhem na mesma coluna,
@@ -31,18 +39,17 @@ const pressSecondary =
 // Dois níveis de peso quebram a monotonia da pilha: ações (WhatsApp/quiz/utilidades) com
 // peso físico cheio; destinos "secos" ficam mais leves e compactos, como uma lista de apoio.
 function tierClasses(item: LinkItem): string {
-    const isPrimary = item.highlight || Boolean(item.icon) || Boolean(item.sublabel);
     if (item.highlight) {
         return `min-h-[4.5rem] py-4 text-base bg-anhanga-yellow text-anhanga-darkBlue ${pressPrimary}`;
     }
-    if (isPrimary) {
+    if (isPrimaryLink(item)) {
         return `min-h-[4.5rem] py-4 text-base bg-white text-anhanga-darkBlue ${pressPrimary}`;
     }
     return `min-h-[3.25rem] py-3 text-[0.95rem] bg-white/90 text-anhanga-darkBlue ${pressSecondary}`;
 }
 
-export const LinkButton: React.FC<LinkButtonProps> = ({ item }) => {
-    const className = `${baseClasses} ${tierClasses(item)}`;
+export const LinkButton: React.FC<LinkButtonProps> = ({ item, className: extraClassName }) => {
+    const className = `${baseClasses} ${tierClasses(item)}${extraClassName ? ` ${extraClassName}` : ''}`;
     const IconComponent = item.icon ? ICON_MAP[item.icon] : undefined;
 
     const content = (

--- a/data/linksPage.ts
+++ b/data/linksPage.ts
@@ -35,7 +35,10 @@ export interface LinksPageConfig {
 // ⚙️ EDITÁVEL: troque banner e links aqui sem mexer em componente.
 export const linksPageConfig: LinksPageConfig = {
     banner: {
-        visible: true,
+        // Desligado: o quiz já aparece como link "Planejar minha viagem" abaixo, então o banner
+        // duplicava o destino /quiz e somava um segundo amarelo na 1ª dobra (a "Regra do Âmbar"
+        // reserva o amarelo a 1 ação — o WhatsApp). Reative trocando para `true` se necessário.
+        visible: false,
         title: 'Descubra sua próxima viagem',
         subtitle: 'Responda 6 perguntas rápidas e receba ideias de roteiro personalizadas.',
         ctaLabel: 'Fazer o quiz',

--- a/pages/LinksPage.tsx
+++ b/pages/LinksPage.tsx
@@ -4,7 +4,7 @@ import { Seo } from '../components/Seo';
 import { BRAND_LOGO_WHITE_URL } from '../lib/media-assets';
 import { linksPageConfig } from '../data/linksPage';
 import { withTrackingParams, pushLinksPageView } from '../utils/linksTracking';
-import LinkButton from '../components/links/LinkButton';
+import LinkButton, { isPrimaryLink } from '../components/links/LinkButton';
 import TrustSeals from '../components/links/TrustSeals';
 
 const LinksPage: React.FC = () => {
@@ -48,10 +48,16 @@ const LinksPage: React.FC = () => {
                         </Link>
                     ) : null}
 
-                    <nav aria-label="Links Anhangá Viagens" className="mt-6 flex w-full flex-col gap-3">
-                        {visibleLinks.map((link) => (
-                            <LinkButton key={link.id} item={link} />
-                        ))}
+                    <nav aria-label="Links Anhangá Viagens" className="mt-8 flex w-full flex-col gap-3">
+                        {visibleLinks.map((link, index) => {
+                            // Quebra de ritmo na fronteira ações → destinos: um respiro a mais
+                            // marca a mudança de tier sem precisar de divisor ou rótulo.
+                            const previous = index > 0 ? visibleLinks[index - 1] : undefined;
+                            const startsDestinations = Boolean(previous && isPrimaryLink(previous) && !isPrimaryLink(link));
+                            return (
+                                <LinkButton key={link.id} item={link} className={startsDestinations ? 'mt-3' : undefined} />
+                            );
+                        })}
                     </nav>
 
                     <TrustSeals />

--- a/tests/e2e/links-page.spec.ts
+++ b/tests/e2e/links-page.spec.ts
@@ -9,12 +9,14 @@ test.beforeEach(async ({ page }) => {
     });
 });
 
-test('renderiza a página /links com banner, botões e selos', async ({ page }) => {
+test('renderiza a página /links com logo, botões e selos', async ({ page }) => {
     await page.goto('/links');
     await expect(page.getByRole('img', { name: 'Anhangá Viagens' })).toBeVisible();
-    await expect(page.getByTestId('links-banner')).toBeVisible();
     await expect(page.getByTestId('link-whatsapp')).toBeVisible();
     await expect(page.getByText('Membro ABAV')).toBeVisible();
+    // Banner do quiz está desligado (banner.visible=false): o quiz vive como link na lista,
+    // e o WhatsApp é o único amarelo na 1ª dobra. Ver data/linksPage.ts.
+    await expect(page.getByTestId('links-banner')).toHaveCount(0);
 });
 
 test('links_page_view é empurrado no dataLayer no load', async ({ page }) => {
@@ -46,17 +48,19 @@ test('clique dispara links_page_click com o label correto', async ({ page }) => 
     expect(clicks.some((c) => c.label === 'orlando')).toBe(true);
 });
 
-test('não renderiza o assistente virtual (AIChat) na página standalone', async ({ page }) => {
+test('não renderiza overlays flutuantes (AIChat / BackToTop) na página standalone', async ({ page }) => {
     await page.goto('/links');
     await expect(page.getByTestId('link-whatsapp')).toBeVisible();
-    // /links é página de bio standalone — o FAB do AIChat não deve aparecer (cobriria os selos
-    // e competiria com os destinos curados). Ver ROUTES_WITHOUT_AICHAT em App.tsx.
+    // /links é página de bio standalone — nenhum FAB deve aparecer (cobririam os selos de
+    // confiança e os destinos curados). Ver STANDALONE_ROUTES em App.tsx.
     await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Voltar ao topo' })).toHaveCount(0);
 
     // Também não deve renderizar com barra no final (trailing slash, comum em links de bio).
     await page.goto('/links/');
     await expect(page.getByTestId('link-whatsapp')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Voltar ao topo' })).toHaveCount(0);
 });
 
 test('botão WhatsApp aponta para wa.me com texto', async ({ page }) => {

--- a/tests/e2e/links-page.spec.ts
+++ b/tests/e2e/links-page.spec.ts
@@ -61,6 +61,13 @@ test('não renderiza overlays flutuantes (AIChat / BackToTop) na página standal
     await expect(page.getByTestId('link-whatsapp')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Voltar ao topo' })).toHaveCount(0);
+
+    // Nem em caixa alta: o React Router casa a rota case-insensitive, então STANDALONE_ROUTES
+    // normaliza para minúsculas — /LINKS também não deve carregar overlays.
+    await page.goto('/LINKS');
+    await expect(page.getByTestId('link-whatsapp')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Voltar ao topo' })).toHaveCount(0);
 });
 
 test('botão WhatsApp aponta para wa.me com texto', async ({ page }) => {


### PR DESCRIPTION
## O que muda

Curadoria do `/impeccable` (critique → distill → harden → polish) sobre a página de bio `/links`. O critique de hoje cedo (PR #962) já tinha aplicado o design system; esta passada fecha os P2 que sobraram e refina o ritmo.

### distill — foco da 1ª dobra
- Desliga o banner do quiz (`banner.visible=false` em `data/linksPage.ts`). Ele duplicava o destino `/quiz` (que já existe como o link "Planejar minha viagem") e somava um segundo amarelo na primeira dobra. Agora o **WhatsApp é o único âmbar** (Regra do Âmbar do DESIGN.md) e a dobra não repete o mesmo destino.

### harden — página standalone
- `/links` é página de bio standalone. `ClientFeatures` agora **não renderiza nenhum overlay flutuante** nessa rota (AIChat, ContactModal e BackToTop). Antes só o AIChat era suprimido; o FAB "Voltar ao topo" continuava montando e cobria os destinos finais e os selos de confiança. `ROUTES_WITHOUT_AICHAT` → `STANDALONE_ROUTES`.

### polish — ritmo de tier
- Quebra de ritmo na fronteira **ações → destinos** (24px vs 12px internos), só com espaçamento (sem divisor nem rótulo). Reforça "curadoria sobre catálogo".
- Regra de tier extraída para uma única fonte de verdade: `isPrimaryLink()` exportada de `LinkButton` e reusada no `LinksPage`. `LinkButton` ganhou um `className?` opcional para a margem de fronteira.

## Por quê
A marca se define por **não** parecer um Linktree/OTA frio. A página passou de 30→33 no critique (P1: 3→0) e, com esta passada, deve ficar ~37/40: WhatsApp como ação dominante, ações com peso físico, destinos como lista de apoio curada, sem FABs cobrindo conteúdo.

## Testes
- `tests/e2e/links-page.spec.ts` atualizado: banner ausente; nenhum FAB (AIChat **e** BackToTop), com e sem trailing slash.
- Unit `links-page-data` + `links-tracking`: 11/11 pass. `tsc --noEmit`: limpo.
- Verificação em browser real (mobile 375px): WhatsApp único elemento amarelo; `backToTop`/`aichat` ausentes do DOM; fronteira de tier 24px / interno 12px; sem erros no console.

## Notas para o reviewer
- Fora de escopo (P3, deliberado): indicador "↗ nova aba" nos links externos e rótulo/divisor de seção "Destinos".
- Inclui o snapshot de critique em `.impeccable/critique/` (mesmo padrão dos snapshots já versionados).
- Vale rodar `pnpm test:e2e tests/e2e/links-page.spec.ts` no CI para validar os specs num browser real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)