### PR TITLE
refactor(api): factory createN8nSubmitHandler deduplica os 5 handlers submit-*

### DIFF
--- a/api/purchase-dispatch.ts
+++ b/api/purchase-dispatch.ts
@@ -4,6 +4,7 @@ import { buildCorsHeaders, getClientIP } from '../lib/network';
 import { checkRateLimit } from '../lib/rate-limit';
 import { timingSafeEqual } from '../lib/security';
 import { logger } from '../lib/logger';
+import { truncateDetail } from '../lib/n8n-submit-handler';
 
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 30;
@@ -107,11 +108,6 @@ function createRequestId(): string {
   }
 
   return `conv_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
-}
-
-function truncateDetail(detail: string): string | undefined {
-  const normalized = detail.replace(/[\r\n]+/g, ' ').trim();
-  return normalized ? normalized.substring(0, 600) : undefined;
 }
 
 function emitConversionLog(

--- a/api/submit-contact.ts
+++ b/api/submit-contact.ts
@@ -1,9 +1,4 @@
-import type {
-    SubmitContactErrorCode,
-    SubmitContactRequest,
-} from '../types/contactCapture';
-import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from '../lib/network';
-import { checkRateLimit } from '../lib/rate-limit';
+import type { SubmitContactRequest } from '../types/contactCapture';
 import {
     cleanString,
     normalizeNullable,
@@ -11,201 +6,69 @@ import {
     normalizeUtms,
     normalizeWhatsappNumber,
 } from '../lib/lead-logic';
+import { createN8nSubmitHandler, type ValidationResult } from '../lib/n8n-submit-handler';
 import { buildN8nContactPayload } from '../lib/n8n-payloads';
 import { sendContactToN8n } from '../services/n8n';
 
-const RATE_LIMIT_WINDOW_MS = 60 * 1000;
-const RATE_LIMIT_MAX_REQUESTS = 5;
-const RATE_LIMIT_KEY_PREFIX = 'ratelimit:submit-contact';
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const N8N_WEBHOOK_ERROR_PATTERN = /^N8N_WEBHOOK_ERROR:(\d{3}):/;
+const CONTACT_VALIDATION_ERROR = 'Nome e WhatsApp são obrigatórios.';
 
-interface ContactConfig {
-    webhookUrl: string;
-    webhookSecret: string;
-}
-
-function getContactConfig(): ContactConfig | null {
-    const webhookUrl = process.env.N8N_SUBMIT_CONTACT_WEBHOOK_URL?.trim() || '';
-    const webhookSecret = process.env.N8N_WEBHOOK_SECRET?.trim() || '';
-    if (!webhookUrl || !webhookSecret) return null;
-    return { webhookUrl, webhookSecret };
-}
-
-async function getRateLimitResponse(
-    request: Request,
-    corsHeaders: Record<string, string>,
-    requestId: string,
-): Promise<Response | null> {
-    const clientIP = getClientIP(request);
-    const rateLimitResult = await checkRateLimit(clientIP, {
-        limit: RATE_LIMIT_MAX_REQUESTS,
-        windowMs: RATE_LIMIT_WINDOW_MS,
-        prefix: RATE_LIMIT_KEY_PREFIX,
-    });
-
-    if (rateLimitResult.allowed) return null;
-
-    if (rateLimitResult.serviceUnavailable) {
-        return buildJsonResponse(
-            { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
-            503,
-            corsHeaders,
-        );
-    }
-
-    return buildJsonResponse(
-        {
-            ok: false,
-            requestId,
-            error: 'Muitas requisições. Tente novamente em breve.',
-            code: 'RATE_LIMIT_EXCEEDED',
-        },
-        429,
-        {
-            ...corsHeaders,
-            'Retry-After': String(Math.ceil(rateLimitResult.resetIn / 1000)),
-            'X-RateLimit-Remaining': String(rateLimitResult.remaining),
-            'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimitResult.resetIn) / 1000)),
-        },
-    );
-}
-
-function validateContactRequest(body: unknown): SubmitContactRequest | null {
-    if (!body || typeof body !== 'object') return null;
+function validateContactRequest(body: unknown): ValidationResult<SubmitContactRequest> {
+    if (!body || typeof body !== 'object') return { ok: false, error: CONTACT_VALIDATION_ERROR };
     const raw = body as Record<string, unknown>;
 
     const firstName = cleanString(raw.firstName);
     const whatsapp = normalizeWhatsappNumber(raw.whatsapp);
     const email = normalizeNullable(raw.email, 255)?.toLowerCase();
 
-    if (!firstName || !whatsapp) return null;
-    if (firstName.length > 100 || whatsapp.length > 16) return null;
-    if (email && !EMAIL_REGEX.test(email)) return null;
+    if (!firstName || !whatsapp) return { ok: false, error: CONTACT_VALIDATION_ERROR };
+    if (firstName.length > 100 || whatsapp.length > 16) return { ok: false, error: CONTACT_VALIDATION_ERROR };
+    if (email && !EMAIL_REGEX.test(email)) return { ok: false, error: CONTACT_VALIDATION_ERROR };
 
     const utms = normalizeUtms(raw.utms);
     const tracking = normalizeTracking(raw.tracking, utms);
 
     return {
-        firstName,
-        lastName: normalizeNullable(raw.lastName, 100) ?? undefined,
-        whatsapp,
-        email,
-        emailOptIn: Boolean(raw.emailOptIn),
-        source: normalizeNullable(raw.source, 128) ?? undefined,
-        destination: normalizeNullable(raw.destination, 255) ?? undefined,
-        eventId: normalizeNullable(raw.eventId, 128) ?? undefined,
-        utms,
-        tracking,
+        ok: true,
+        data: {
+            firstName,
+            lastName: normalizeNullable(raw.lastName, 100) ?? undefined,
+            whatsapp,
+            email,
+            emailOptIn: Boolean(raw.emailOptIn),
+            source: normalizeNullable(raw.source, 128) ?? undefined,
+            destination: normalizeNullable(raw.destination, 255) ?? undefined,
+            eventId: normalizeNullable(raw.eventId, 128) ?? undefined,
+            utms,
+            tracking,
+        },
     };
 }
 
-function classifyContactSubmitError(error: unknown): {
-    code: SubmitContactErrorCode;
-    status: number;
-} {
-    const message = error instanceof Error ? error.message : String(error);
-    const match = message.match(N8N_WEBHOOK_ERROR_PATTERN);
-    if (!match) return { code: 'INTERNAL_ERROR', status: 500 };
-
-    const upstreamStatus = Number.parseInt(match[1], 10);
-    return {
-        code: 'N8N_WEBHOOK_ERROR',
-        status: upstreamStatus === 504 ? 504 : 502,
-    };
-}
-
-async function parseRequestBody(
-    request: Request,
-    corsHeaders: Record<string, string>,
-    requestId: string,
-): Promise<unknown | Response> {
-    try {
-        return await request.json();
-    } catch {
-        return buildJsonResponse(
-            {
-                ok: false,
-                requestId,
-                error: 'Corpo da requisição inválido.',
-                code: 'VALIDATION_ERROR',
-            },
-            400,
-            corsHeaders,
-        );
-    }
-}
-
-export default async function handler(request: Request): Promise<Response> {
-    const corsHeaders = buildCorsHeaders();
-    const requestId = createRequestId();
-
-    if (request.method === 'OPTIONS') {
-        return new Response(null, { status: 204, headers: corsHeaders });
-    }
-
-    if (request.method !== 'POST') {
-        return buildJsonResponse(
-            { ok: false, requestId, error: 'Método não permitido.', code: 'METHOD_NOT_ALLOWED' },
-            405,
-            corsHeaders,
-        );
-    }
-
-    const contactConfig = getContactConfig();
-    if (!contactConfig) {
-        return buildJsonResponse(
-            {
-                ok: false,
-                requestId,
-                error: 'Serviço temporariamente indisponível.',
-                code: 'SERVER_CONFIG_ERROR',
-            },
-            503,
-            corsHeaders,
-        );
-    }
-
-    const rateLimitResponse = await getRateLimitResponse(request, corsHeaders, requestId);
-    if (rateLimitResponse) return rateLimitResponse;
-
-    const body = await parseRequestBody(request, corsHeaders, requestId);
-    if (body instanceof Response) return body;
-
-    const payload = validateContactRequest(body);
-    if (!payload) {
-        return buildJsonResponse(
-            {
-                ok: false,
-                requestId,
-                error: 'Nome e WhatsApp são obrigatórios.',
-                code: 'VALIDATION_ERROR',
-            },
-            400,
-            corsHeaders,
-        );
-    }
-
-    try {
-        await sendContactToN8n(
-            contactConfig.webhookUrl,
-            contactConfig.webhookSecret,
-            requestId,
-            buildN8nContactPayload(payload, requestId),
-        );
-    } catch (error: unknown) {
-        const classifiedError = classifyContactSubmitError(error);
-        return buildJsonResponse(
-            {
-                ok: false,
-                requestId,
-                error: 'Não foi possível enviar sua mensagem. Tente novamente.',
-                code: classifiedError.code,
-            },
-            classifiedError.status,
-            corsHeaders,
-        );
-    }
-
-    return buildJsonResponse({ ok: true, requestId }, 200, corsHeaders);
-}
+export default createN8nSubmitHandler({
+    logScope: 'SUBMIT_CONTACT',
+    webhookEnvVar: 'N8N_SUBMIT_CONTACT_WEBHOOK_URL',
+    config: {
+        missingStatus: 503,
+        missingError: 'Serviço temporariamente indisponível.',
+    },
+    rateLimit: {
+        windowMs: 60 * 1000,
+        max: 5,
+        keyPrefix: 'ratelimit:submit-contact',
+        exceededError: 'Muitas requisições. Tente novamente em breve.',
+    },
+    parse: { invalidJsonError: 'Corpo da requisição inválido.' },
+    methodNotAllowedError: 'Método não permitido.',
+    validate: validateContactRequest,
+    buildPayload: (data, requestId) => buildN8nContactPayload(data, requestId),
+    send: sendContactToN8n,
+    success: { status: 200 },
+    error: {
+        // Contact returns the same neutral message for upstream and internal failures.
+        webhookCode: 'N8N_WEBHOOK_ERROR',
+        webhookError: 'Não foi possível enviar sua mensagem. Tente novamente.',
+        internalError: 'Não foi possível enviar sua mensagem. Tente novamente.',
+        mapStatus: (upstreamStatus) => (upstreamStatus === 504 ? 504 : 502),
+    },
+});

--- a/api/submit-lead.ts
+++ b/api/submit-lead.ts
@@ -1,311 +1,77 @@
-import type { SubmitLeadRequest } from '../types/leadCapture';
-import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from '../lib/network';
-import { checkRateLimit } from '../lib/rate-limit';
-import { cleanString, maskEmail, maskName, maskPhone, validatePayload } from '../lib/lead-logic';
-import { logger } from '../lib/logger';
+import {
+    classifyN8nSubmitError,
+    createN8nSubmitHandler,
+    type ClassifyN8nErrorOptions,
+    type N8nErrorClassification,
+} from '../lib/n8n-submit-handler';
+import { maskEmail, maskName, maskPhone, validatePayload } from '../lib/lead-logic';
 import { buildN8nLeadPayload } from '../lib/n8n-payloads';
 import { sendLeadToN8n } from '../services/n8n';
 
-const RATE_LIMIT_WINDOW_MS = 60 * 1000;
-const RATE_LIMIT_MAX_REQUESTS = 5;
+const LEAD_ERROR_OPTIONS: ClassifyN8nErrorOptions = {
+    webhookCode: 'N8N_WEBHOOK_ERROR',
+    webhookError: 'Erro ao enviar lead.',
+    internalError: 'Erro interno ao processar envio do lead.',
+    mapStatus: (upstreamStatus) => (Number.isFinite(upstreamStatus) && upstreamStatus >= 400 ? upstreamStatus : 502),
+};
 
-interface SubmitLeadConfig {
-    webhookUrl: string;
-    webhookSecret: string;
+export function classifySubmitLeadError(error: unknown): N8nErrorClassification {
+    return classifyN8nSubmitError(error, LEAD_ERROR_OPTIONS);
 }
 
-type SubmitLeadInternalErrorCode = 'N8N_WEBHOOK_ERROR' | 'INTERNAL_ERROR';
-
-type LeadLogLevel = 'info' | 'warn' | 'error';
-
-function truncateDetail(detail: string): string | undefined {
-    const normalized = detail.replace(/[\r\n]+/g, ' ').trim();
-    return normalized ? normalized.substring(0, 600) : undefined;
-}
-
-function emitLeadLog(level: LeadLogLevel, requestId: string, stage: string, details: Record<string, unknown> = {}): void {
-    const payload = {
-        requestId,
-        stage,
-        ...details,
-    };
-
-    if (level === 'warn') {
-        logger.warn('SUBMIT_LEAD', payload);
-        return;
-    }
-
-    if (level === 'error') {
-        logger.error('SUBMIT_LEAD', payload);
-        return;
-    }
-
-    logger.info('SUBMIT_LEAD', payload);
-}
-
-// getClientIP falls back to 'unknown' when no edge header is present. Meta CAPI
-// expects a real address or nothing, so collapse the sentinel to null.
-function resolveClientIpAddress(request: Request): string | null {
-    const ip = getClientIP(request);
-    return ip && ip !== 'unknown' ? ip : null;
-}
-
-function getSubmitLeadConfig(): SubmitLeadConfig | null {
-    const webhookUrl = process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL?.trim() || '';
-    const webhookSecret = process.env.N8N_WEBHOOK_SECRET?.trim() || '';
-
-    if (!webhookUrl || !webhookSecret) {
-        return null;
-    }
-
-    return {
-        webhookUrl,
-        webhookSecret,
-    };
-}
-
-export function classifySubmitLeadError(error: unknown): {
-    code: SubmitLeadInternalErrorCode;
-    status: number;
-    error: string;
-    detail?: string;
-} {
-    const message = error instanceof Error ? error.message : String(error);
-    const match = message.match(/^N8N_WEBHOOK_ERROR:(\d+):(.*)$/s);
-    if (!match) {
-        return {
-            code: 'INTERNAL_ERROR',
-            status: 500,
-            error: 'Erro interno ao processar envio do lead.',
-        };
-    }
-
-    const status = Number(match[1]);
-    const detail = truncateDetail(match[2] || '');
-
-    return {
-        code: 'N8N_WEBHOOK_ERROR',
-        status: Number.isFinite(status) && status >= 400 ? status : 502,
-        error: 'Erro ao enviar lead.',
-        detail,
-    };
-}
-
-async function getRateLimitResponse(
-    request: Request,
-    corsHeaders: Record<string, string>,
-    requestId: string,
-): Promise<Response | null> {
-    const clientIP = getClientIP(request);
-    const rateLimit = await checkRateLimit(clientIP, {
-        limit: RATE_LIMIT_MAX_REQUESTS,
-        windowMs: RATE_LIMIT_WINDOW_MS,
-        prefix: 'ratelimit:submit-lead',
-    });
-
-    if (rateLimit.allowed) return null;
-
-    if (rateLimit.serviceUnavailable) {
-        emitLeadLog('error', requestId, 'service_unavailable', { clientIP });
-        return buildJsonResponse(
-            { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
-            503,
-            corsHeaders,
-        );
-    }
-
-    emitLeadLog('warn', requestId, 'rate_limited', {
-        clientIP,
-        remaining: rateLimit.remaining,
-        retryAfterSeconds: Math.ceil(rateLimit.resetIn / 1000),
-    });
-
-    return buildJsonResponse(
-        {
-            ok: false,
-            requestId,
-            code: 'RATE_LIMIT_EXCEEDED',
-            error: 'Muitas tentativas. Tente novamente em breve.',
+export default createN8nSubmitHandler({
+    logScope: 'SUBMIT_LEAD',
+    webhookEnvVar: 'N8N_SUBMIT_LEAD_WEBHOOK_URL',
+    config: {
+        missingStatus: 500,
+        missingError: 'Integração de lead indisponível no momento.',
+    },
+    rateLimit: {
+        windowMs: 60 * 1000,
+        max: 5,
+        keyPrefix: 'ratelimit:submit-lead',
+        exceededError: 'Muitas tentativas. Tente novamente em breve.',
+    },
+    parse: { invalidJsonError: 'JSON inválido no corpo da requisição.' },
+    methodNotAllowedError: 'Method not allowed',
+    validate: (rawBody) => {
+        const validation = validatePayload(rawBody);
+        if (validation.valid === false) {
+            return { ok: false, error: validation.error };
+        }
+        return { ok: true, data: validation.data };
+    },
+    buildPayload: (data, requestId, ctx) => buildN8nLeadPayload(data, requestId, {
+        clientIpAddress: ctx.clientIpAddress,
+        clientUserAgent: ctx.clientUserAgent,
+    }),
+    send: sendLeadToN8n,
+    success: { status: 201, message: 'Enviado com sucesso' },
+    error: LEAD_ERROR_OPTIONS,
+    onValidated: (data) => ({
+        email: maskEmail(data.email),
+        destination: data.destination,
+        utmSource: data.utms.utm_source,
+        extraTrackingKeys: Object.keys(data.tracking?.extras ?? {}).length,
+        hasClickIds: Boolean(
+            data.tracking?.gclid
+            || data.tracking?.fbclid
+            || data.tracking?.msclkid
+            || data.tracking?.ttclid
+            || data.tracking?.wbraid
+            || data.tracking?.gbraid,
+        ),
+    }),
+    onError: ({ data }) => ({
+        recoveredLead: {
+            maskedEmail: maskEmail(data.email),
+            maskedPhone: maskPhone(data.whatsapp),
+            maskedFirstName: maskName(data.firstName),
+            destination: data.destination,
+            // bantSummary omitted — may contain sensitive PII (budget, health, family details).
+            // hasBantSummary preserves qualification signal without exposing content to log infra.
+            hasBantSummary: Boolean(data.bantSummary),
+            utms: data.utms,
         },
-        429,
-        {
-            ...corsHeaders,
-            'Retry-After': String(Math.ceil(rateLimit.resetIn / 1000)),
-            'X-RateLimit-Remaining': String(rateLimit.remaining),
-            'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimit.resetIn) / 1000)),
-        },
-    );
-}
-
-async function parseRequestBody(
-    request: Request,
-    corsHeaders: Record<string, string>,
-    requestId: string,
-): Promise<unknown | Response> {
-    try {
-        return await request.json();
-    } catch {
-        return buildJsonResponse(
-            {
-                ok: false,
-                requestId,
-                code: 'VALIDATION_ERROR',
-                error: 'JSON inválido no corpo da requisição.',
-            },
-            400,
-            corsHeaders,
-        );
-    }
-}
-
-function validateRequestPayload(
-    rawBody: unknown,
-    corsHeaders: Record<string, string>,
-    requestId: string,
-): SubmitLeadRequest | Response {
-    const validation = validatePayload(rawBody);
-    if (validation.valid === false) {
-        return buildJsonResponse(
-            {
-                ok: false,
-                requestId,
-                code: 'VALIDATION_ERROR',
-                error: validation.error,
-            },
-            400,
-            corsHeaders,
-        );
-    }
-
-    return validation.data;
-}
-
-export default async function handler(request: Request): Promise<Response> {
-    const requestId = createRequestId();
-    const corsHeaders = buildCorsHeaders();
-    // Hoisted so the catch block can log recovery data if the N8n call fails after validation.
-    let recoveryPayload: SubmitLeadRequest | null = null;
-
-    try {
-        if (request.method === 'OPTIONS') {
-            return new Response(null, { status: 204, headers: corsHeaders });
-        }
-
-        if (request.method !== 'POST') {
-            return buildJsonResponse(
-                {
-                    ok: false,
-                    requestId,
-                    code: 'METHOD_NOT_ALLOWED',
-                    error: 'Method not allowed',
-                },
-                405,
-                corsHeaders,
-            );
-        }
-
-        const config = getSubmitLeadConfig();
-        if (!config) {
-            emitLeadLog('error', requestId, 'config', {
-                code: 'SERVER_CONFIG_ERROR',
-                hasWebhookUrl: Boolean(process.env.N8N_SUBMIT_LEAD_WEBHOOK_URL?.trim()),
-                hasWebhookSecret: Boolean(process.env.N8N_WEBHOOK_SECRET?.trim()),
-            });
-
-            return buildJsonResponse(
-                {
-                    ok: false,
-                    requestId,
-                    code: 'SERVER_CONFIG_ERROR',
-                    error: 'Integração de lead indisponível no momento.',
-                },
-                500,
-                corsHeaders,
-            );
-        }
-
-        const rateLimitResponse = await getRateLimitResponse(request, corsHeaders, requestId);
-        if (rateLimitResponse) return rateLimitResponse;
-
-        const rawBody = await parseRequestBody(request, corsHeaders, requestId);
-        if (rawBody instanceof Response) return rawBody;
-
-        const payload = validateRequestPayload(rawBody, corsHeaders, requestId);
-        if (payload instanceof Response) return payload;
-
-        recoveryPayload = payload;
-
-        emitLeadLog('info', requestId, 'payload_validated', {
-            email: maskEmail(payload.email),
-            destination: payload.destination,
-            utmSource: payload.utms.utm_source,
-            extraTrackingKeys: Object.keys(payload.tracking?.extras ?? {}).length,
-            hasClickIds: Boolean(
-                payload.tracking?.gclid
-                || payload.tracking?.fbclid
-                || payload.tracking?.msclkid
-                || payload.tracking?.ttclid
-                || payload.tracking?.wbraid
-                || payload.tracking?.gbraid,
-            ),
-        });
-
-        await sendLeadToN8n(
-            config.webhookUrl,
-            config.webhookSecret,
-            requestId,
-            buildN8nLeadPayload(payload, requestId, {
-                clientIpAddress: resolveClientIpAddress(request),
-                clientUserAgent: request.headers.get('user-agent'),
-            }),
-        );
-
-        const response = buildJsonResponse(
-            {
-                ok: true,
-                requestId,
-                message: 'Enviado com sucesso',
-            },
-            201,
-            corsHeaders,
-        );
-
-        return response;
-    } catch (error: unknown) {
-        const classified = classifySubmitLeadError(error);
-
-        const recoveryData = recoveryPayload !== null
-            ? {
-                recoveredLead: {
-                    maskedEmail: maskEmail(recoveryPayload.email),
-                    maskedPhone: maskPhone(recoveryPayload.whatsapp),
-                    maskedFirstName: maskName(recoveryPayload.firstName),
-                    destination: recoveryPayload.destination,
-                    // bantSummary omitted — may contain sensitive PII (budget, health, family details).
-                    // hasBantSummary preserves qualification signal without exposing content to log infra.
-                    hasBantSummary: Boolean(recoveryPayload.bantSummary),
-                    utms: recoveryPayload.utms,
-                },
-            }
-            : {};
-
-        emitLeadLog('error', requestId, classified.code === 'N8N_WEBHOOK_ERROR' ? 'n8n_webhook_failed' : 'unexpected', {
-            code: classified.code,
-            status: classified.status,
-            errorType: error instanceof Error ? error.name : typeof error,
-            detail: classified.detail,
-            ...recoveryData,
-        });
-
-        return buildJsonResponse(
-            {
-                ok: false,
-                requestId,
-                code: classified.code,
-                error: classified.error,
-            },
-            classified.status,
-            corsHeaders,
-        );
-    }
-}
+    }),
+});

--- a/api/submit-nps.ts
+++ b/api/submit-nps.ts
@@ -1,166 +1,49 @@
 import { z } from 'zod';
-import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from '../lib/network';
-import { checkRateLimit } from '../lib/rate-limit';
-import { cleanString, maskEmail } from '../lib/lead-logic';
-import { logger } from '../lib/logger';
+import { createN8nSubmitHandler } from '../lib/n8n-submit-handler';
+import { buildN8nNpsPayload } from '../lib/n8n-payloads';
 import { SubmitNpsBodySchema } from '../lib/schemas/submit-nps';
 import { sendNpsToN8n } from '../services/n8n';
-import type { N8nNpsPayload } from '../lib/n8n-payloads';
-
-const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
-const RATE_LIMIT_MAX_REQUESTS = 3;
-const N8N_WEBHOOK_ERROR_PATTERN = /^N8N_WEBHOOK_ERROR:(\d{3}):/;
 
 function mapNpsZodError(error: z.ZodError): string {
-  const issue = error.issues[0];
-  const path = issue?.path[0];
-  if (path === 'firstname') return 'Nome inválido.';
-  if (path === 'email') return 'E-mail inválido.';
-  if (path === 'score') return 'Nota deve ser um número inteiro entre 0 e 10.';
-  if (path === 'reason') return 'O motivo da nota é obrigatório (máximo 2000 caracteres).';
-  if (path === 'highlight') return 'Momento marcante deve ter no máximo 2000 caracteres.';
-  return 'Payload inválido.';
+    const issue = error.issues[0];
+    const path = issue?.path[0];
+    if (path === 'firstname') return 'Nome inválido.';
+    if (path === 'email') return 'E-mail inválido.';
+    if (path === 'score') return 'Nota deve ser um número inteiro entre 0 e 10.';
+    if (path === 'reason') return 'O motivo da nota é obrigatório (máximo 2000 caracteres).';
+    if (path === 'highlight') return 'Momento marcante deve ter no máximo 2000 caracteres.';
+    return 'Payload inválido.';
 }
 
-function classifyNpsWebhookError(error: unknown): { status: number; stage: string } {
-  const message = error instanceof Error ? error.message : String(error);
-  const match = message.match(N8N_WEBHOOK_ERROR_PATTERN);
-  if (!match) return { status: 500, stage: 'unexpected' };
-  const upstreamStatus = Number.parseInt(match[1], 10);
-  return {
-    status: upstreamStatus === 504 ? 504 : 502,
-    stage: upstreamStatus === 504 ? 'webhook_timeout' : 'webhook_failed',
-  };
-}
-
-export default async function handler(request: Request): Promise<Response> {
-  const requestId = createRequestId();
-  const corsHeaders = buildCorsHeaders();
-
-  if (request.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: corsHeaders });
-  }
-
-  if (request.method !== 'POST') {
-    return buildJsonResponse(
-      { ok: false, requestId, code: 'METHOD_NOT_ALLOWED', error: 'Method not allowed' },
-      405,
-      corsHeaders,
-    );
-  }
-
-  const webhookUrl = process.env.NPS_WEBHOOK_URL?.trim();
-  const webhookSecret = process.env.N8N_WEBHOOK_SECRET?.trim();
-  if (!webhookUrl || !webhookSecret) {
-    logger.error('SUBMIT_NPS', { requestId, stage: 'config', code: 'SERVER_CONFIG_ERROR' });
-    return buildJsonResponse(
-      { ok: false, requestId, code: 'SERVER_CONFIG_ERROR', error: 'Serviço de NPS indisponível no momento.' },
-      500,
-      corsHeaders,
-    );
-  }
-
-  const clientIP = getClientIP(request);
-  const rateLimit = await checkRateLimit(clientIP, {
-    limit: RATE_LIMIT_MAX_REQUESTS,
-    windowMs: RATE_LIMIT_WINDOW_MS,
-    prefix: 'ratelimit:submit-nps',
-  });
-
-  if (!rateLimit.allowed) {
-    if (rateLimit.serviceUnavailable) {
-      logger.error('SUBMIT_NPS', { requestId, stage: 'service_unavailable', clientIP });
-      return buildJsonResponse(
-        { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
-        503,
-        corsHeaders,
-      );
-    }
-
-    logger.warn('SUBMIT_NPS', {
-      requestId,
-      stage: 'rate_limited',
-      clientIP,
-      remaining: rateLimit.remaining,
-    });
-    return buildJsonResponse(
-      {
-        ok: false,
-        requestId,
-        code: 'RATE_LIMIT_EXCEEDED',
-        error: 'Muitas tentativas. Tente novamente em breve.',
-      },
-      429,
-      {
-        ...corsHeaders,
-        'Retry-After': String(Math.ceil(rateLimit.resetIn / 1000)),
-        'X-RateLimit-Remaining': String(rateLimit.remaining),
-        'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimit.resetIn) / 1000)),
-      },
-    );
-  }
-
-  let rawBody: unknown;
-  try {
-    rawBody = await request.json();
-  } catch {
-    return buildJsonResponse(
-      { ok: false, requestId, code: 'VALIDATION_ERROR', error: 'JSON inválido no corpo da requisição.' },
-      400,
-      corsHeaders,
-    );
-  }
-
-  const parsed = SubmitNpsBodySchema.safeParse(rawBody);
-  if (!parsed.success) {
-    return buildJsonResponse(
-      { ok: false, requestId, code: 'VALIDATION_ERROR', error: mapNpsZodError(parsed.error) },
-      400,
-      corsHeaders,
-    );
-  }
-
-  const raw = parsed.data;
-  const npsPayload: N8nNpsPayload = {
-    requestId,
-    firstname:   cleanString(raw.firstname),
-    email:       cleanString(raw.email),
-    score:       raw.score,
-    reason:      cleanString(raw.reason),
-    highlight:   cleanString(raw.highlight),
-    submittedAt: new Date().toISOString(),
-  };
-
-  logger.info('SUBMIT_NPS', {
-    requestId,
-    stage: 'sending',
-    email: maskEmail(npsPayload.email),
-    score: npsPayload.score,
-  });
-
-  try {
-    await sendNpsToN8n(webhookUrl, webhookSecret, requestId, npsPayload);
-  } catch (error: unknown) {
-    const { status, stage } = classifyNpsWebhookError(error);
-    logger.error('SUBMIT_NPS', { requestId, stage, error: error instanceof Error ? error.message : String(error) });
-    return buildJsonResponse(
-      {
-        ok: false,
-        requestId,
-        code: status === 500 ? 'INTERNAL_ERROR' : 'WEBHOOK_ERROR',
-        error: status === 500
-          ? 'Erro interno. Tente novamente.'
-          : 'Erro ao registrar avaliação. Tente novamente.',
-      },
-      status,
-      corsHeaders,
-    );
-  }
-
-  logger.info('SUBMIT_NPS', { requestId, stage: 'done', score: npsPayload.score });
-  return buildJsonResponse(
-    { ok: true, requestId, message: 'Avaliação registrada com sucesso.' },
-    201,
-    corsHeaders,
-  );
-}
+export default createN8nSubmitHandler({
+    logScope: 'SUBMIT_NPS',
+    webhookEnvVar: 'NPS_WEBHOOK_URL',
+    config: {
+        missingStatus: 500,
+        missingError: 'Serviço de NPS indisponível no momento.',
+    },
+    rateLimit: {
+        windowMs: 10 * 60 * 1000,
+        max: 3,
+        keyPrefix: 'ratelimit:submit-nps',
+        exceededError: 'Muitas tentativas. Tente novamente em breve.',
+    },
+    parse: { invalidJsonError: 'JSON inválido no corpo da requisição.' },
+    methodNotAllowedError: 'Method not allowed',
+    validate: (rawBody) => {
+        const parsed = SubmitNpsBodySchema.safeParse(rawBody);
+        if (!parsed.success) {
+            return { ok: false, error: mapNpsZodError(parsed.error) };
+        }
+        return { ok: true, data: parsed.data };
+    },
+    buildPayload: (data, requestId) => buildN8nNpsPayload(data, requestId),
+    send: sendNpsToN8n,
+    success: { status: 201, message: 'Avaliação registrada com sucesso.' },
+    error: {
+        webhookCode: 'WEBHOOK_ERROR',
+        webhookError: 'Erro ao registrar avaliação. Tente novamente.',
+        internalError: 'Erro interno. Tente novamente.',
+        mapStatus: (upstreamStatus) => (upstreamStatus === 504 ? 504 : 502),
+    },
+});

--- a/api/submit-quiz.ts
+++ b/api/submit-quiz.ts
@@ -1,211 +1,63 @@
-import type { SubmitQuizRequest } from '../types/quiz';
-import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from '../lib/network';
-import { checkRateLimit } from '../lib/rate-limit';
-import { logger } from '../lib/logger';
-import { cleanString, maskEmail, maskName, maskPhone } from '../lib/lead-logic';
+import {
+    classifyN8nSubmitError,
+    createN8nSubmitHandler,
+    type ClassifyN8nErrorOptions,
+    type N8nErrorClassification,
+} from '../lib/n8n-submit-handler';
+import { maskEmail, maskName, maskPhone } from '../lib/lead-logic';
 import { buildN8nQuizPayload } from '../lib/n8n-payloads';
 import { validateQuizPayload } from '../lib/quiz-logic';
 import { sendQuizToN8n } from '../services/n8n';
 
-const RATE_LIMIT_WINDOW_MS = 60 * 1000;
-const RATE_LIMIT_MAX_REQUESTS = 5;
+const QUIZ_ERROR_OPTIONS: ClassifyN8nErrorOptions = {
+    webhookCode: 'N8N_WEBHOOK_ERROR',
+    webhookError: 'Erro ao processar quiz.',
+    internalError: 'Erro interno ao processar o quiz.',
+    mapStatus: (upstreamStatus) => (upstreamStatus >= 400 && upstreamStatus < 600 ? upstreamStatus : 502),
+};
 
-interface SubmitQuizConfig {
-    webhookUrl: string;
-    webhookSecret: string;
+export function classifySubmitQuizError(error: unknown): N8nErrorClassification {
+    return classifyN8nSubmitError(error, QUIZ_ERROR_OPTIONS);
 }
 
-type QuizLogLevel = 'info' | 'warn' | 'error';
-
-function truncateDetail(detail: string): string | undefined {
-    const normalized = detail.replace(/[\r\n]+/g, ' ').trim();
-    return normalized ? normalized.substring(0, 600) : undefined;
-}
-
-function emitQuizLog(level: QuizLogLevel, requestId: string, stage: string, details: Record<string, unknown> = {}): void {
-    const payload = {
-        requestId,
-        stage,
-        ...details,
-    };
-
-    if (level === 'warn') {
-        logger.warn('SUBMIT_QUIZ', payload);
-        return;
-    }
-
-    if (level === 'error') {
-        logger.error('SUBMIT_QUIZ', payload);
-        return;
-    }
-
-    logger.info('SUBMIT_QUIZ', payload);
-}
-
-function getSubmitQuizConfig(): SubmitQuizConfig | null {
-    const webhookUrl = process.env.N8N_SUBMIT_QUIZ_WEBHOOK_URL?.trim();
-    const webhookSecret = process.env.N8N_WEBHOOK_SECRET?.trim();
-
-    if (!webhookUrl || !webhookSecret) {
-        return null;
-    }
-
-    return { webhookUrl, webhookSecret };
-}
-
-export function classifySubmitQuizError(error: unknown): {
-    code: 'N8N_WEBHOOK_ERROR' | 'INTERNAL_ERROR';
-    status: number;
-    error: string;
-    detail?: string;
-} {
-    const message = error instanceof Error ? error.message : String(error);
-    const match = message.match(/^N8N_WEBHOOK_ERROR:(\d+):(.*)$/s);
-
-    if (match) {
-        const httpStatus = Number.parseInt(match[1], 10);
-        const detail = truncateDetail(match[2] || '');
-        return {
-            code: 'N8N_WEBHOOK_ERROR',
-            status: httpStatus >= 400 && httpStatus < 600 ? httpStatus : 502,
-            error: 'Erro ao processar quiz.',
-            detail,
-        };
-    }
-
-    return {
-        code: 'INTERNAL_ERROR',
-        status: 500,
-        error: 'Erro interno ao processar o quiz.',
-    };
-}
-
-export default async function handler(request: Request): Promise<Response> {
-    const requestId = createRequestId();
-    const corsHeaders = buildCorsHeaders();
-
-    if (request.method === 'OPTIONS') {
-        return new Response(null, { status: 204, headers: corsHeaders });
-    }
-
-    if (request.method !== 'POST') {
-        return buildJsonResponse(
-            { ok: false, requestId, error: 'Método não permitido.', code: 'METHOD_NOT_ALLOWED' },
-            405,
-            corsHeaders,
-        );
-    }
-
-    const config = getSubmitQuizConfig();
-    if (!config) {
-        emitQuizLog('error', requestId, 'config', { code: 'SERVER_CONFIG_ERROR' });
-        return buildJsonResponse(
-            { ok: false, requestId, error: 'Serviço de quiz temporariamente indisponível.', code: 'SERVER_CONFIG_ERROR' },
-            503,
-            corsHeaders,
-        );
-    }
-
-    const clientIp = getClientIP(request);
-    const rateLimitResult = await checkRateLimit(clientIp, {
-        limit: RATE_LIMIT_MAX_REQUESTS,
-        windowMs: RATE_LIMIT_WINDOW_MS,
-        prefix: 'ratelimit:submit-quiz',
-    });
-
-    if (!rateLimitResult.allowed) {
-        if (rateLimitResult.serviceUnavailable) {
-            emitQuizLog('error', requestId, 'service_unavailable', { clientIp });
-            return buildJsonResponse(
-                { ok: false, requestId, error: 'Serviço temporariamente indisponível. Tente novamente em instantes.', code: 'SERVICE_UNAVAILABLE' },
-                503,
-                corsHeaders,
-            );
+export default createN8nSubmitHandler({
+    logScope: 'SUBMIT_QUIZ',
+    webhookEnvVar: 'N8N_SUBMIT_QUIZ_WEBHOOK_URL',
+    config: {
+        missingStatus: 503,
+        missingError: 'Serviço de quiz temporariamente indisponível.',
+    },
+    rateLimit: {
+        windowMs: 60 * 1000,
+        max: 5,
+        keyPrefix: 'ratelimit:submit-quiz',
+        exceededError: 'Muitas tentativas. Aguarde um momento.',
+        includeRetryAfterInBody: true,
+    },
+    parse: { invalidJsonError: 'Corpo da requisição inválido.' },
+    methodNotAllowedError: 'Método não permitido.',
+    validate: (rawBody) => {
+        const validation = validateQuizPayload(rawBody);
+        if (validation.valid === false) {
+            return { ok: false, error: validation.error };
         }
-
-        const retryAfterSec = Math.ceil(rateLimitResult.resetIn / 1000);
-        emitQuizLog('warn', requestId, 'rate_limited', {
-            clientIp,
-            remaining: rateLimitResult.remaining,
-            retryAfterSeconds: retryAfterSec,
-        });
-
-        return buildJsonResponse(
-            {
-                ok: false,
-                requestId,
-                error: 'Muitas tentativas. Aguarde um momento.',
-                code: 'RATE_LIMIT_EXCEEDED',
-                retryAfter: retryAfterSec,
-            },
-            429,
-            {
-                ...corsHeaders,
-                'Retry-After': String(retryAfterSec),
-                'X-RateLimit-Remaining': '0',
-                'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimitResult.resetIn) / 1000)),
-            },
-        );
-    }
-
-    let body: unknown;
-    try {
-        body = await request.json();
-    } catch {
-        return buildJsonResponse(
-            { ok: false, requestId, error: 'Corpo da requisição inválido.', code: 'VALIDATION_ERROR' },
-            400,
-            corsHeaders,
-        );
-    }
-
-    const validation = validateQuizPayload(body);
-    if (validation.valid === false) {
-        return buildJsonResponse(
-            { ok: false, requestId, error: validation.error, code: 'VALIDATION_ERROR' },
-            400,
-            corsHeaders,
-        );
-    }
-
-    const payload: SubmitQuizRequest = validation.data;
-    const n8nPayload = buildN8nQuizPayload(payload, requestId);
-
-    emitQuizLog('info', requestId, 'payload_validated', {
-        maskedEmail: maskEmail(payload.email),
-        profile: payload.profileKey,
-        destinosCount: payload.destinos?.length ?? 0,
-    });
-
-    try {
-        await sendQuizToN8n(config.webhookUrl, config.webhookSecret, requestId, n8nPayload);
-
-        emitQuizLog('info', requestId, 'done');
-
-        return buildJsonResponse(
-            { ok: true, requestId, message: 'Perfil registrado com sucesso.' },
-            200,
-            corsHeaders,
-        );
-    } catch (error: unknown) {
-        const classified = classifySubmitQuizError(error);
-
-        emitQuizLog('error', requestId, classified.code === 'N8N_WEBHOOK_ERROR' ? 'n8n_webhook_failed' : 'unexpected', {
-            code: classified.code,
-            status: classified.status,
-            detail: classified.detail,
-            recoveredQuiz: {
-                maskedEmail: maskEmail(payload.email),
-                maskedPhone: payload.whatsapp ? maskPhone(payload.whatsapp) : undefined,
-                maskedFirstName: maskName(payload.firstName),
-                profile: payload.profileKey,
-            },
-        });
-
-        return buildJsonResponse(
-            { ok: false, requestId, error: classified.error, code: classified.code },
-            classified.status,
-            corsHeaders,
-        );
-    }
-}
+        return { ok: true, data: validation.data };
+    },
+    buildPayload: (data, requestId) => buildN8nQuizPayload(data, requestId),
+    send: sendQuizToN8n,
+    success: { status: 200, message: 'Perfil registrado com sucesso.' },
+    error: QUIZ_ERROR_OPTIONS,
+    onValidated: (data) => ({
+        maskedEmail: maskEmail(data.email),
+        profile: data.profileKey,
+        destinosCount: data.destinos?.length ?? 0,
+    }),
+    onError: ({ data }) => ({
+        recoveredQuiz: {
+            maskedEmail: maskEmail(data.email),
+            maskedPhone: data.whatsapp ? maskPhone(data.whatsapp) : undefined,
+            maskedFirstName: maskName(data.firstName),
+            profile: data.profileKey,
+        },
+    }),
+});

--- a/api/submit-waitlist.ts
+++ b/api/submit-waitlist.ts
@@ -1,221 +1,48 @@
-import type { SubmitWaitlistRequest } from '../types/waitlist';
-import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from '../lib/network';
-import { checkRateLimit } from '../lib/rate-limit';
-import { cleanString } from '../lib/lead-logic';
+import {
+    classifyN8nSubmitError,
+    createN8nSubmitHandler,
+    type ClassifyN8nErrorOptions,
+    type N8nErrorClassification,
+} from '../lib/n8n-submit-handler';
 import { buildN8nWaitlistPayload } from '../lib/n8n-payloads';
 import { validateWaitlistPayload } from '../lib/waitlist-logic';
 import { sendWaitlistToN8n } from '../services/n8n';
 
-const RATE_LIMIT_WINDOW_MS = 60 * 1000;
-const RATE_LIMIT_MAX_REQUESTS = 5;
+const WAITLIST_ERROR_OPTIONS: ClassifyN8nErrorOptions = {
+    webhookCode: 'N8N_WEBHOOK_ERROR',
+    webhookError: 'Erro ao enviar inscrição na lista de espera.',
+    internalError: 'Erro interno ao processar envio da lista de espera.',
+    mapStatus: (upstreamStatus) => (Number.isFinite(upstreamStatus) && upstreamStatus >= 400 ? upstreamStatus : 502),
+};
 
-interface SubmitWaitlistConfig {
-    webhookUrl: string;
-    webhookSecret: string;
+export function classifySubmitWaitlistError(error: unknown): N8nErrorClassification {
+    return classifyN8nSubmitError(error, WAITLIST_ERROR_OPTIONS);
 }
 
-function truncateDetail(detail: string): string | undefined {
-    const trimmed = detail.replace(/[\r\n]+/g, ' ').trim();
-    if (!trimmed) return undefined;
-
-    return trimmed.slice(0, 200);
-}
-
-function getSubmitWaitlistConfig(): SubmitWaitlistConfig | null {
-    const webhookUrl = process.env.N8N_SUBMIT_WAITLIST_WEBHOOK_URL?.trim() || '';
-    const webhookSecret = process.env.N8N_WEBHOOK_SECRET?.trim() || '';
-
-    if (!webhookUrl || !webhookSecret) {
-        return null;
-    }
-
-    return {
-        webhookUrl,
-        webhookSecret,
-    };
-}
-
-export function classifySubmitWaitlistError(error: unknown): {
-    code: 'N8N_WEBHOOK_ERROR' | 'INTERNAL_ERROR';
-    status: number;
-    error: string;
-    detail?: string;
-} {
-    const message = error instanceof Error ? error.message : String(error);
-    const match = message.match(/^N8N_WEBHOOK_ERROR:(\d+):(.*)$/s);
-    if (!match) {
-        return {
-            code: 'INTERNAL_ERROR',
-            status: 500,
-            error: 'Erro interno ao processar envio da lista de espera.',
-        };
-    }
-
-    const status = Number(match[1]);
-    const detail = truncateDetail(match[2] || '');
-
-    return {
-        code: 'N8N_WEBHOOK_ERROR',
-        status: Number.isFinite(status) && status >= 400 ? status : 502,
-        error: 'Erro ao enviar inscrição na lista de espera.',
-        detail,
-    };
-}
-
-async function parseRequestBody(
-    request: Request,
-    corsHeaders: Record<string, string>,
-    requestId: string,
-): Promise<unknown | Response> {
-    try {
-        return await request.json();
-    } catch {
-        return buildJsonResponse(
-            {
-                ok: false,
-                requestId,
-                code: 'VALIDATION_ERROR',
-                error: 'JSON inválido no corpo da requisição.',
-            },
-            400,
-            corsHeaders,
-        );
-    }
-}
-
-function validateRequestPayload(
-    rawBody: unknown,
-    corsHeaders: Record<string, string>,
-    requestId: string,
-): SubmitWaitlistRequest | Response {
-    const validation = validateWaitlistPayload(rawBody);
-    if (validation.valid === false) {
-        return buildJsonResponse(
-            {
-                ok: false,
-                requestId,
-                code: 'VALIDATION_ERROR',
-                error: validation.error,
-            },
-            400,
-            corsHeaders,
-        );
-    }
-
-    return validation.data;
-}
-
-async function getRateLimitResponse(
-    request: Request,
-    corsHeaders: Record<string, string>,
-    requestId: string,
-): Promise<Response | null> {
-    const clientIP = getClientIP(request);
-    const rateLimit = await checkRateLimit(clientIP, {
-        limit: RATE_LIMIT_MAX_REQUESTS,
-        windowMs: RATE_LIMIT_WINDOW_MS,
-        prefix: 'ratelimit:submit-waitlist',
-    });
-
-    if (rateLimit.allowed) return null;
-
-    if (rateLimit.serviceUnavailable) {
-        return buildJsonResponse(
-            { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
-            503,
-            corsHeaders,
-        );
-    }
-
-    return buildJsonResponse(
-        {
-            ok: false,
-            requestId,
-            code: 'RATE_LIMIT_EXCEEDED',
-            error: 'Muitas tentativas. Tente novamente em breve.',
-        },
-        429,
-        {
-            ...corsHeaders,
-            'Retry-After': String(Math.ceil(rateLimit.resetIn / 1000)),
-            'X-RateLimit-Remaining': String(rateLimit.remaining),
-            'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimit.resetIn) / 1000)),
-        },
-    );
-}
-
-export default async function handler(request: Request): Promise<Response> {
-    const corsHeaders = buildCorsHeaders();
-    const requestId = createRequestId();
-
-    try {
-        if (request.method === 'OPTIONS') {
-            return new Response(null, { status: 204, headers: corsHeaders });
+export default createN8nSubmitHandler({
+    logScope: 'SUBMIT_WAITLIST',
+    webhookEnvVar: 'N8N_SUBMIT_WAITLIST_WEBHOOK_URL',
+    config: {
+        missingStatus: 500,
+        missingError: 'Integração de waitlist indisponível no momento.',
+    },
+    rateLimit: {
+        windowMs: 60 * 1000,
+        max: 5,
+        keyPrefix: 'ratelimit:submit-waitlist',
+        exceededError: 'Muitas tentativas. Tente novamente em breve.',
+    },
+    parse: { invalidJsonError: 'JSON inválido no corpo da requisição.' },
+    methodNotAllowedError: 'Método não permitido.',
+    validate: (rawBody) => {
+        const validation = validateWaitlistPayload(rawBody);
+        if (validation.valid === false) {
+            return { ok: false, error: validation.error };
         }
-
-        if (request.method !== 'POST') {
-            return buildJsonResponse(
-                {
-                    ok: false,
-                    requestId,
-                    code: 'METHOD_NOT_ALLOWED',
-                    error: 'Método não permitido.',
-                },
-                405,
-                corsHeaders,
-            );
-        }
-
-        const config = getSubmitWaitlistConfig();
-        if (!config) {
-            return buildJsonResponse(
-                {
-                    ok: false,
-                    requestId,
-                    code: 'SERVER_CONFIG_ERROR',
-                    error: 'Integração de waitlist indisponível no momento.',
-                },
-                500,
-                corsHeaders,
-            );
-        }
-
-        const rateLimitResponse = await getRateLimitResponse(request, corsHeaders, requestId);
-        if (rateLimitResponse) return rateLimitResponse;
-
-        const rawBody = await parseRequestBody(request, corsHeaders, requestId);
-        if (rawBody instanceof Response) return rawBody;
-
-        const payload = validateRequestPayload(rawBody, corsHeaders, requestId);
-        if (payload instanceof Response) return payload;
-
-        await sendWaitlistToN8n(
-            config.webhookUrl,
-            config.webhookSecret,
-            requestId,
-            buildN8nWaitlistPayload(payload, requestId),
-        );
-
-        return buildJsonResponse(
-            {
-                ok: true,
-                requestId,
-                message: 'Enviado com sucesso',
-            },
-            201,
-            corsHeaders,
-        );
-    } catch (error: unknown) {
-        const classified = classifySubmitWaitlistError(error);
-        return buildJsonResponse(
-            {
-                ok: false,
-                requestId,
-                code: classified.code,
-                error: classified.error,
-            },
-            classified.status,
-            corsHeaders,
-        );
-    }
-}
+        return { ok: true, data: validation.data };
+    },
+    buildPayload: (data, requestId) => buildN8nWaitlistPayload(data, requestId),
+    send: sendWaitlistToN8n,
+    success: { status: 201, message: 'Enviado com sucesso' },
+    error: WAITLIST_ERROR_OPTIONS,
+});

--- a/lib/n8n-payloads.ts
+++ b/lib/n8n-payloads.ts
@@ -1,3 +1,4 @@
+import { cleanString } from './lead-logic';
 import type { SubmitLeadRequest } from '../types/leadCapture';
 import type { SubmitContactRequest } from '../types/contactCapture';
 import type { SubmitWaitlistRequest } from '../types/waitlist';
@@ -272,4 +273,24 @@ export interface N8nNpsPayload {
     reason: string;
     highlight: string;
     submittedAt: string;
+}
+
+export interface N8nNpsInput {
+    firstname: string;
+    email: string;
+    score: number;
+    reason: string;
+    highlight: string;
+}
+
+export function buildN8nNpsPayload(input: N8nNpsInput, requestId: string): N8nNpsPayload {
+    return {
+        requestId,
+        firstname: cleanString(input.firstname),
+        email: cleanString(input.email),
+        score: input.score,
+        reason: cleanString(input.reason),
+        highlight: cleanString(input.highlight),
+        submittedAt: new Date().toISOString(),
+    };
 }

--- a/lib/n8n-submit-handler.ts
+++ b/lib/n8n-submit-handler.ts
@@ -1,0 +1,294 @@
+/**
+ * Shared factory for the `submit-*` Cloudflare Pages Functions.
+ *
+ * Every `submit-*` handler runs the same machine — method gate → CORS → config
+ * check → rate limit → JSON parse → validation → payload build → `postToN8n` →
+ * error classification → structured response. The only things that genuinely
+ * differ per endpoint are the validator, the payload builder, the webhook env
+ * var, the rate-limit numbers and a handful of copy strings. This module owns
+ * the machine; each handler supplies the differences as config.
+ *
+ * `truncateDetail` and the n8n webhook-error classifier also live here so they
+ * have a single source of truth (they used to be copy-pasted across handlers,
+ * and one copy had already diverged).
+ */
+import { buildCorsHeaders, buildJsonResponse, createRequestId, getClientIP } from './network';
+import { checkRateLimit } from './rate-limit';
+import { logger } from './logger';
+
+// Upstream errors are encoded by services/n8n.ts as
+// `N8N_WEBHOOK_ERROR:<status>:<detail>`. The `s` flag lets the detail span the
+// newlines that providers sometimes return.
+const N8N_WEBHOOK_ERROR_PATTERN = /^N8N_WEBHOOK_ERROR:(\d+):(.*)$/s;
+
+const DEFAULT_DETAIL_MAX_LENGTH = 600;
+const DEFAULT_WEBHOOK_SECRET_ENV_VAR = 'N8N_WEBHOOK_SECRET';
+
+/**
+ * Collapses provider error detail into a single, length-bounded line safe for
+ * internal logs. Returns `undefined` for empty input so callers can omit the
+ * field entirely.
+ */
+export function truncateDetail(detail: string, maxLength = DEFAULT_DETAIL_MAX_LENGTH): string | undefined {
+    const normalized = detail.replace(/[\r\n]+/g, ' ').trim();
+    return normalized ? normalized.substring(0, maxLength) : undefined;
+}
+
+export interface N8nErrorClassification {
+    code: string;
+    status: number;
+    error: string;
+    detail?: string;
+}
+
+export interface ClassifyN8nErrorOptions {
+    /** Response code when the failure is an upstream webhook error. */
+    webhookCode: string;
+    /** Client-facing message when the failure is an upstream webhook error. */
+    webhookError: string;
+    /** Client-facing message for unexpected (non-webhook) failures. */
+    internalError: string;
+    /** Maps the upstream HTTP status to the status returned to the client. */
+    mapStatus: (upstreamStatus: number) => number;
+    /** Optional override for the truncation length of the logged detail. */
+    detailMaxLength?: number;
+}
+
+/**
+ * Turns a thrown error into the structured `{ code, status, error, detail }`
+ * shape every `submit-*` handler returns. Non-webhook failures collapse to a
+ * neutral `INTERNAL_ERROR` 500.
+ */
+export function classifyN8nSubmitError(
+    error: unknown,
+    options: ClassifyN8nErrorOptions,
+): N8nErrorClassification {
+    const message = error instanceof Error ? error.message : String(error);
+    const match = message.match(N8N_WEBHOOK_ERROR_PATTERN);
+
+    if (!match) {
+        return {
+            code: 'INTERNAL_ERROR',
+            status: 500,
+            error: options.internalError,
+        };
+    }
+
+    const upstreamStatus = Number(match[1]);
+    const detail = truncateDetail(match[2] || '', options.detailMaxLength ?? DEFAULT_DETAIL_MAX_LENGTH);
+
+    return {
+        code: options.webhookCode,
+        status: options.mapStatus(upstreamStatus),
+        error: options.webhookError,
+        detail,
+    };
+}
+
+/** Normalized request context handed to the payload builder. */
+export interface N8nSubmitRequestContext {
+    // getClientIP falls back to 'unknown' when no edge header is present. Meta
+    // CAPI expects a real address or nothing, so the sentinel is collapsed to null.
+    clientIpAddress: string | null;
+    clientUserAgent: string | null;
+}
+
+export type ValidationResult<TData> =
+    | { ok: true; data: TData }
+    | { ok: false; error: string };
+
+export interface CreateN8nSubmitHandlerOptions<TData> {
+    /** Logger scope, e.g. 'SUBMIT_LEAD'. */
+    logScope: string;
+    /** Env var holding the destination webhook URL. */
+    webhookEnvVar: string;
+    /** Env var holding the shared webhook secret (defaults to N8N_WEBHOOK_SECRET). */
+    webhookSecretEnvVar?: string;
+    config: {
+        /** Status returned when the webhook URL or secret is missing. */
+        missingStatus: number;
+        /** Client-facing message when config is missing. */
+        missingError: string;
+    };
+    rateLimit: {
+        windowMs: number;
+        max: number;
+        keyPrefix: string;
+        /** Client-facing message when the bucket is exhausted. */
+        exceededError: string;
+        /** When true, mirrors the retry window into the JSON body as `retryAfter`. */
+        includeRetryAfterInBody?: boolean;
+    };
+    parse: {
+        /** Client-facing message for malformed JSON bodies. */
+        invalidJsonError: string;
+    };
+    /** Client-facing message for the 405 method gate. */
+    methodNotAllowedError: string;
+    /** Validates and normalizes the raw body into the typed payload data. */
+    validate: (rawBody: unknown) => ValidationResult<TData>;
+    /** Builds the outbound n8n payload from validated data. */
+    buildPayload: (data: TData, requestId: string, ctx: N8nSubmitRequestContext) => unknown;
+    /** Sends the payload to n8n (a `services/n8n.ts` function). */
+    send: (url: string, secret: string, requestId: string, payload: never) => Promise<unknown>;
+    success: {
+        status: number;
+        /** Optional success message; omitted from the body when absent. */
+        message?: string;
+    };
+    /** Webhook-error classification config (also reused by exported classifiers). */
+    error: ClassifyN8nErrorOptions;
+    /** Optional extra fields for the `payload_validated` info log. */
+    onValidated?: (data: TData, requestId: string) => Record<string, unknown> | void;
+    /** Optional extra fields (e.g. masked recovery data) for the error log. */
+    onError?: (params: { data: TData; requestId: string; classification: N8nErrorClassification }) => Record<string, unknown> | void;
+}
+
+/**
+ * Builds a `submit-*` request handler from per-endpoint configuration. The
+ * returned function is the default export each `api/submit-*.ts` exposes.
+ */
+export function createN8nSubmitHandler<TData>(
+    options: CreateN8nSubmitHandlerOptions<TData>,
+): (request: Request) => Promise<Response> {
+    const secretEnvVar = options.webhookSecretEnvVar ?? DEFAULT_WEBHOOK_SECRET_ENV_VAR;
+
+    return async function handler(request: Request): Promise<Response> {
+        const requestId = createRequestId();
+        const corsHeaders = buildCorsHeaders();
+
+        if (request.method === 'OPTIONS') {
+            return new Response(null, { status: 204, headers: corsHeaders });
+        }
+
+        if (request.method !== 'POST') {
+            return buildJsonResponse(
+                { ok: false, requestId, code: 'METHOD_NOT_ALLOWED', error: options.methodNotAllowedError },
+                405,
+                corsHeaders,
+            );
+        }
+
+        const webhookUrl = process.env[options.webhookEnvVar]?.trim();
+        const webhookSecret = process.env[secretEnvVar]?.trim();
+        if (!webhookUrl || !webhookSecret) {
+            logger.error(options.logScope, { requestId, stage: 'config', code: 'SERVER_CONFIG_ERROR' });
+            return buildJsonResponse(
+                { ok: false, requestId, code: 'SERVER_CONFIG_ERROR', error: options.config.missingError },
+                options.config.missingStatus,
+                corsHeaders,
+            );
+        }
+
+        const clientIp = getClientIP(request);
+        const rateLimit = await checkRateLimit(clientIp, {
+            limit: options.rateLimit.max,
+            windowMs: options.rateLimit.windowMs,
+            prefix: options.rateLimit.keyPrefix,
+        });
+
+        if (!rateLimit.allowed) {
+            if (rateLimit.serviceUnavailable) {
+                logger.error(options.logScope, { requestId, stage: 'service_unavailable', clientIp });
+                return buildJsonResponse(
+                    { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
+                    503,
+                    corsHeaders,
+                );
+            }
+
+            const retryAfterSeconds = Math.ceil(rateLimit.resetIn / 1000);
+            logger.warn(options.logScope, {
+                requestId,
+                stage: 'rate_limited',
+                clientIp,
+                remaining: rateLimit.remaining,
+                retryAfterSeconds,
+            });
+
+            return buildJsonResponse(
+                {
+                    ok: false,
+                    requestId,
+                    code: 'RATE_LIMIT_EXCEEDED',
+                    error: options.rateLimit.exceededError,
+                    ...(options.rateLimit.includeRetryAfterInBody ? { retryAfter: retryAfterSeconds } : {}),
+                },
+                429,
+                {
+                    ...corsHeaders,
+                    'Retry-After': String(retryAfterSeconds),
+                    'X-RateLimit-Remaining': String(rateLimit.remaining),
+                    'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimit.resetIn) / 1000)),
+                },
+            );
+        }
+
+        let rawBody: unknown;
+        try {
+            rawBody = await request.json();
+        } catch {
+            return buildJsonResponse(
+                { ok: false, requestId, code: 'VALIDATION_ERROR', error: options.parse.invalidJsonError },
+                400,
+                corsHeaders,
+            );
+        }
+
+        const validation = options.validate(rawBody);
+        if (!validation.ok) {
+            return buildJsonResponse(
+                { ok: false, requestId, code: 'VALIDATION_ERROR', error: validation.error },
+                400,
+                corsHeaders,
+            );
+        }
+
+        const data = validation.data;
+
+        const validatedLogFields = options.onValidated?.(data, requestId);
+        if (validatedLogFields) {
+            logger.info(options.logScope, { requestId, stage: 'payload_validated', ...validatedLogFields });
+        }
+
+        const ctx: N8nSubmitRequestContext = {
+            clientIpAddress: clientIp && clientIp !== 'unknown' ? clientIp : null,
+            clientUserAgent: request.headers.get('user-agent'),
+        };
+
+        try {
+            const payload = options.buildPayload(data, requestId, ctx) as never;
+            await options.send(webhookUrl, webhookSecret, requestId, payload);
+        } catch (error: unknown) {
+            const classification = classifyN8nSubmitError(error, options.error);
+            const errorLogFields = options.onError?.({ data, requestId, classification }) ?? {};
+
+            logger.error(options.logScope, {
+                requestId,
+                stage: classification.code === 'INTERNAL_ERROR' ? 'unexpected' : 'n8n_webhook_failed',
+                code: classification.code,
+                status: classification.status,
+                detail: classification.detail,
+                ...errorLogFields,
+            });
+
+            return buildJsonResponse(
+                { ok: false, requestId, code: classification.code, error: classification.error },
+                classification.status,
+                corsHeaders,
+            );
+        }
+
+        logger.info(options.logScope, { requestId, stage: 'done' });
+
+        return buildJsonResponse(
+            {
+                ok: true,
+                requestId,
+                ...(options.success.message ? { message: options.success.message } : {}),
+            },
+            options.success.status,
+            corsHeaders,
+        );
+    };
+}

--- a/lib/n8n-submit-handler.ts
+++ b/lib/n8n-submit-handler.ts
@@ -144,6 +144,83 @@ export interface CreateN8nSubmitHandlerOptions<TData> {
     onError?: (params: { data: TData; requestId: string; classification: N8nErrorClassification }) => Record<string, unknown> | void;
 }
 
+/** Internal per-request state shared between the handler and its helpers. */
+interface RequestEnv<TData> {
+    options: CreateN8nSubmitHandlerOptions<TData>;
+    requestId: string;
+    corsHeaders: Record<string, string>;
+}
+
+/** Builds the 503/429 denial response (with logging) for an exhausted bucket. */
+function buildRateLimitDenial<TData>(
+    env: RequestEnv<TData>,
+    clientIp: string,
+    rateLimit: Awaited<ReturnType<typeof checkRateLimit>>,
+): Response {
+    const { options, requestId, corsHeaders } = env;
+
+    if (rateLimit.serviceUnavailable) {
+        logger.error(options.logScope, { requestId, stage: 'service_unavailable', clientIp });
+        return buildJsonResponse(
+            { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
+            503,
+            corsHeaders,
+        );
+    }
+
+    const retryAfterSeconds = Math.ceil(rateLimit.resetIn / 1000);
+    logger.warn(options.logScope, {
+        requestId,
+        stage: 'rate_limited',
+        clientIp,
+        remaining: rateLimit.remaining,
+        retryAfterSeconds,
+    });
+
+    return buildJsonResponse(
+        {
+            ok: false,
+            requestId,
+            code: 'RATE_LIMIT_EXCEEDED',
+            error: options.rateLimit.exceededError,
+            ...(options.rateLimit.includeRetryAfterInBody ? { retryAfter: retryAfterSeconds } : {}),
+        },
+        429,
+        {
+            ...corsHeaders,
+            'Retry-After': String(retryAfterSeconds),
+            'X-RateLimit-Remaining': String(rateLimit.remaining),
+            'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimit.resetIn) / 1000)),
+        },
+    );
+}
+
+/** Classifies a thrown webhook/internal error, logs it, and builds the response. */
+function buildWebhookErrorResponse<TData>(
+    env: RequestEnv<TData>,
+    data: TData,
+    error: unknown,
+): Response {
+    const { options, requestId, corsHeaders } = env;
+    const classification = classifyN8nSubmitError(error, options.error);
+    const errorLogFields = options.onError?.({ data, requestId, classification }) ?? {};
+
+    logger.error(options.logScope, {
+        requestId,
+        stage: classification.code === 'INTERNAL_ERROR' ? 'unexpected' : 'n8n_webhook_failed',
+        code: classification.code,
+        status: classification.status,
+        detail: classification.detail,
+        ...errorLogFields,
+    });
+
+    return buildJsonResponse(
+        { ok: false, requestId, code: classification.code, error: classification.error },
+        classification.status,
+        corsHeaders,
+    );
+}
+
 /**
  * Builds a `submit-*` request handler from per-endpoint configuration. The
  * returned function is the default export each `api/submit-*.ts` exposes.
@@ -156,6 +233,7 @@ export function createN8nSubmitHandler<TData>(
     return async function handler(request: Request): Promise<Response> {
         const requestId = createRequestId();
         const corsHeaders = buildCorsHeaders();
+        const env: RequestEnv<TData> = { options, requestId, corsHeaders };
 
         if (request.method === 'OPTIONS') {
             return new Response(null, { status: 204, headers: corsHeaders });
@@ -188,40 +266,7 @@ export function createN8nSubmitHandler<TData>(
         });
 
         if (!rateLimit.allowed) {
-            if (rateLimit.serviceUnavailable) {
-                logger.error(options.logScope, { requestId, stage: 'service_unavailable', clientIp });
-                return buildJsonResponse(
-                    { ok: false, requestId, code: 'SERVICE_UNAVAILABLE', error: 'Serviço temporariamente indisponível. Tente novamente em instantes.' },
-                    503,
-                    corsHeaders,
-                );
-            }
-
-            const retryAfterSeconds = Math.ceil(rateLimit.resetIn / 1000);
-            logger.warn(options.logScope, {
-                requestId,
-                stage: 'rate_limited',
-                clientIp,
-                remaining: rateLimit.remaining,
-                retryAfterSeconds,
-            });
-
-            return buildJsonResponse(
-                {
-                    ok: false,
-                    requestId,
-                    code: 'RATE_LIMIT_EXCEEDED',
-                    error: options.rateLimit.exceededError,
-                    ...(options.rateLimit.includeRetryAfterInBody ? { retryAfter: retryAfterSeconds } : {}),
-                },
-                429,
-                {
-                    ...corsHeaders,
-                    'Retry-After': String(retryAfterSeconds),
-                    'X-RateLimit-Remaining': String(rateLimit.remaining),
-                    'X-RateLimit-Reset': String(Math.ceil((Date.now() + rateLimit.resetIn) / 1000)),
-                },
-            );
+            return buildRateLimitDenial(env, clientIp, rateLimit);
         }
 
         let rawBody: unknown;
@@ -260,23 +305,7 @@ export function createN8nSubmitHandler<TData>(
             const payload = options.buildPayload(data, requestId, ctx) as never;
             await options.send(webhookUrl, webhookSecret, requestId, payload);
         } catch (error: unknown) {
-            const classification = classifyN8nSubmitError(error, options.error);
-            const errorLogFields = options.onError?.({ data, requestId, classification }) ?? {};
-
-            logger.error(options.logScope, {
-                requestId,
-                stage: classification.code === 'INTERNAL_ERROR' ? 'unexpected' : 'n8n_webhook_failed',
-                code: classification.code,
-                status: classification.status,
-                detail: classification.detail,
-                ...errorLogFields,
-            });
-
-            return buildJsonResponse(
-                { ok: false, requestId, code: classification.code, error: classification.error },
-                classification.status,
-                corsHeaders,
-            );
+            return buildWebhookErrorResponse(env, data, error);
         }
 
         logger.info(options.logScope, { requestId, stage: 'done' });

--- a/lib/n8n-submit-handler.ts
+++ b/lib/n8n-submit-handler.ts
@@ -97,7 +97,7 @@ export type ValidationResult<TData> =
     | { ok: true; data: TData }
     | { ok: false; error: string };
 
-export interface CreateN8nSubmitHandlerOptions<TData> {
+export interface CreateN8nSubmitHandlerOptions<TData, TPayload = unknown> {
     /** Logger scope, e.g. 'SUBMIT_LEAD'. */
     logScope: string;
     /** Env var holding the destination webhook URL. */
@@ -128,9 +128,9 @@ export interface CreateN8nSubmitHandlerOptions<TData> {
     /** Validates and normalizes the raw body into the typed payload data. */
     validate: (rawBody: unknown) => ValidationResult<TData>;
     /** Builds the outbound n8n payload from validated data. */
-    buildPayload: (data: TData, requestId: string, ctx: N8nSubmitRequestContext) => unknown;
+    buildPayload: (data: TData, requestId: string, ctx: N8nSubmitRequestContext) => TPayload;
     /** Sends the payload to n8n (a `services/n8n.ts` function). */
-    send: (url: string, secret: string, requestId: string, payload: never) => Promise<unknown>;
+    send: (url: string, secret: string, requestId: string, payload: TPayload) => Promise<unknown>;
     success: {
         status: number;
         /** Optional success message; omitted from the body when absent. */
@@ -145,15 +145,15 @@ export interface CreateN8nSubmitHandlerOptions<TData> {
 }
 
 /** Internal per-request state shared between the handler and its helpers. */
-interface RequestEnv<TData> {
-    options: CreateN8nSubmitHandlerOptions<TData>;
+interface RequestEnv<TData, TPayload> {
+    options: CreateN8nSubmitHandlerOptions<TData, TPayload>;
     requestId: string;
     corsHeaders: Record<string, string>;
 }
 
 /** Builds the 503/429 denial response (with logging) for an exhausted bucket. */
-function buildRateLimitDenial<TData>(
-    env: RequestEnv<TData>,
+function buildRateLimitDenial<TData, TPayload>(
+    env: RequestEnv<TData, TPayload>,
     clientIp: string,
     rateLimit: Awaited<ReturnType<typeof checkRateLimit>>,
 ): Response {
@@ -196,8 +196,8 @@ function buildRateLimitDenial<TData>(
 }
 
 /** Classifies a thrown webhook/internal error, logs it, and builds the response. */
-function buildWebhookErrorResponse<TData>(
-    env: RequestEnv<TData>,
+function buildWebhookErrorResponse<TData, TPayload>(
+    env: RequestEnv<TData, TPayload>,
     data: TData,
     error: unknown,
 ): Response {
@@ -225,15 +225,15 @@ function buildWebhookErrorResponse<TData>(
  * Builds a `submit-*` request handler from per-endpoint configuration. The
  * returned function is the default export each `api/submit-*.ts` exposes.
  */
-export function createN8nSubmitHandler<TData>(
-    options: CreateN8nSubmitHandlerOptions<TData>,
+export function createN8nSubmitHandler<TData, TPayload = unknown>(
+    options: CreateN8nSubmitHandlerOptions<TData, TPayload>,
 ): (request: Request) => Promise<Response> {
     const secretEnvVar = options.webhookSecretEnvVar ?? DEFAULT_WEBHOOK_SECRET_ENV_VAR;
 
     return async function handler(request: Request): Promise<Response> {
         const requestId = createRequestId();
         const corsHeaders = buildCorsHeaders();
-        const env: RequestEnv<TData> = { options, requestId, corsHeaders };
+        const env: RequestEnv<TData, TPayload> = { options, requestId, corsHeaders };
 
         if (request.method === 'OPTIONS') {
             return new Response(null, { status: 204, headers: corsHeaders });
@@ -302,7 +302,7 @@ export function createN8nSubmitHandler<TData>(
         };
 
         try {
-            const payload = options.buildPayload(data, requestId, ctx) as never;
+            const payload = options.buildPayload(data, requestId, ctx);
             await options.send(webhookUrl, webhookSecret, requestId, payload);
         } catch (error: unknown) {
             return buildWebhookErrorResponse(env, data, error);

--- a/tests/logging-migration.test.ts
+++ b/tests/logging-migration.test.ts
@@ -5,7 +5,8 @@ import { logger } from '../lib/logger.ts';
 
 const MIGRATED_API_FILES = [
     'api/generate.ts',
-    'api/submit-lead.ts',
+    // submit-* handlers delegate all logging to the shared n8n submit factory.
+    'lib/n8n-submit-handler.ts',
     'services/geminiService.ts',
     'lib/rate-limit.ts',
 ];


### PR DESCRIPTION
## Contexto

Closes #966.

Os 5 handlers `submit-*` reimplementavam a mesma máquina (method gate → CORS → config → rate-limit → parse → validação → payload → `postToN8n` → classificar erro → resposta estruturada) com pequenas variações de redação. O que de fato difere entre endpoints é só o validador, o builder de payload, a env var do webhook e os números de rate-limit. Todo o resto era boilerplate duplicado — e já começava a apodrecer (`truncateDetail` divergiu).

## O que mudou

**Novo factory — `lib/n8n-submit-handler.ts`** (fonte única da máquina submit→n8n):
- `createN8nSubmitHandler<T>()` — encapsula todo o esqueleto comum.
- `truncateDetail()` — helper único (antes copiado em 4 arquivos, 1 já divergido).
- `classifyN8nSubmitError()` — substitui as 5 cópias de `classify{Lead,Contact,Nps,Quiz,Waitlist}Error` + a regex `N8N_WEBHOOK_ERROR`.

**Handlers viraram config declarativa:**

| Handler | Antes | Depois |
|---|---|---|
| `submit-lead.ts` | 311 | 77 |
| `submit-contact.ts` | 211 | 74 |
| `submit-waitlist.ts` | 221 | 48 |
| `submit-nps.ts` | 166 | 49 |
| `submit-quiz.ts` | 211 | 63 |

**Extras:**
- `buildN8nNpsPayload()` adicionado em `lib/n8n-payloads.ts` (o NPS montava o payload inline).
- `api/purchase-dispatch.ts` (a 4ª cópia de `truncateDetail`) agora importa do lib.
- Líquido: **+282 / −1073 linhas**.

## Contratos preservados

Cada handler mantém suas particularidades via config: status de sucesso (201 vs 200), status de config faltando (500 vs 503), mensagens, prefixos/limites de rate-limit, `retryAfter` no body do quiz, código `WEBHOOK_ERROR` do NPS, mapeamento de status (`>=400` / `<600` / `504-only`), contexto IP/UA do CAPI no lead, e logs PII-mascarados de recuperação (lead/quiz). Os `classify{Lead,Quiz,Waitlist}Error` continuam exportados para os testes.

## Critérios de aceite

- [x] `truncateDetail` e a classificação de erro n8n existem em um único lugar em `lib/`.
- [x] Os 5 handlers `submit-*` usam o factory; comportamento e contratos de resposta inalterados.
- [x] Testes de regressão existentes passam sem alteração de contrato.

## Verificação

- ✅ `pnpm typecheck` limpo
- ✅ `pnpm test:regression` — **740/740 testes passam**

## Nota de revisão

`tests/logging-migration.test.ts` é um guard estrutural ("não usar `console.*`, usar o logger compartilhado"). Como o logging migrou dos handlers para o factory, a lista passou a apontar para `lib/n8n-submit-handler.ts` em vez de `api/submit-lead.ts` — o guard segue válido apontando para onde o log de fato vive. Não é mudança de contrato de resposta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)