### PR TITLE
refactor(search): unifica estado dos painéis em openPanel e decompõe SearchForm (#967)

### DIFF
--- a/components/SearchForm.tsx
+++ b/components/SearchForm.tsx
@@ -1,8 +1,5 @@
-import React, { useEffect, useMemo, useRef, useState, memo, useCallback } from 'react';
-import { Search, MapPin, ChevronDown, Plus, Minus, X, ChevronLeft, ChevronRight, Loader2, Calendar, User, Briefcase, Wallet } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState, memo, useCallback } from 'react';
 import {
-  MONTH_NAMES,
-  WEEK_DAYS,
   normalizeStr,
   PRE_NORMALIZED_DB,
   TRIP_OPTIONS,
@@ -10,653 +7,34 @@ import {
   getDaysInMonth
 } from '../data/destinations';
 import { openAiChat } from '../utils/aiChat';
+import DestinationField from './search/DestinationField';
+import DateField from './search/DateField';
+import GuestsField from './search/GuestsField';
+import TripTypeField from './search/TripTypeField';
+import BudgetField from './search/BudgetField';
+import SearchButton from './search/SearchButton';
+import { buildSearchMessage, getGuestSummary, isDateInPast } from './search/helpers';
+import { useSearchFormDismiss, type PanelRegistryEntry } from './search/useSearchFormDismiss';
+import type { DestinationOption, OpenPanel } from './search/types';
+
+type ActivePanel = Exclude<OpenPanel, null>;
 
 interface SearchFormProps {
   onDestinationMatch: (city: string | null) => void;
 }
 
-type DestinationOption = typeof PRE_NORMALIZED_DB[number];
-type TripOption = typeof TRIP_OPTIONS[number];
-type BudgetTier = typeof BUDGET_TIERS[number];
-type SearchPanelRefs = {
-  destRef: React.RefObject<HTMLDivElement | null>;
-  calendarRef: React.RefObject<HTMLDivElement | null>;
-  guestDropdownRef: React.RefObject<HTMLDivElement | null>;
-  tripTypeRef: React.RefObject<HTMLDivElement | null>;
-  budgetRef: React.RefObject<HTMLDivElement | null>;
-};
-
-type CloseHandlers = {
-  closeDestSuggestions: () => void;
-  closeCalendar: () => void;
-  closeGuestDropdown: () => void;
-  closeTripTypeDropdown: () => void;
-  closeBudgetDropdown: () => void;
-};
-
-const closeAllPanels = (handlers: CloseHandlers): void => {
-  handlers.closeDestSuggestions();
-  handlers.closeCalendar();
-  handlers.closeGuestDropdown();
-  handlers.closeTripTypeDropdown();
-  handlers.closeBudgetDropdown();
-};
-
-const isDateInPast = (date: Date): boolean => {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  return date < today;
-};
-
-const formatDateDisplay = (date: Date | null): string => {
-  if (!date) return '';
-  return date.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit' });
-};
-
-const getGuestSummary = (adults: number, children: number): string => {
-  return `${adults} Adulto${adults !== 1 ? 's' : ''}${children > 0 ? `, ${children} Chd` : ''}`;
-};
-
-const buildSearchMessage = (params: {
-  inputValue: string;
-  startDate: Date;
-  endDate: Date | null;
-  adults: number;
-  children: number;
-  childAges: string[];
-  tripType: string;
-  budget: string;
-}): string => {
-  const startStr = params.startDate.toLocaleDateString('pt-BR');
-  const endStr = params.endDate ? params.endDate.toLocaleDateString('pt-BR') : 'A definir';
-  const childAgesStr = params.children > 0
-    ? ` (${params.childAges.map((age) => age ? `${age} anos` : 'Idade N/I').join(', ')})`
-    : '';
-
-  let message = 'Olá! Gostaria de um orçamento para minha próxima viagem:\n\n';
-  message += `📍 *Destino:* ${params.inputValue}\n`;
-  message += `📅 *Ida:* ${startStr}\n`;
-  message += `📅 *Volta:* ${endStr}\n`;
-  message += `👥 *Viajantes:* ${params.adults} Adt, ${params.children} Chd${childAgesStr}\n`;
-
-  if (params.tripType) {
-    message += `🎭 *Tipo de Viagem:* ${params.tripType}\n`;
-  }
-
-  if (params.budget) {
-    const selectedBudget = BUDGET_TIERS.find((tier) => tier.label === params.budget);
-    message += `💰 *Orçamento:* ${selectedBudget?.range || params.budget}\n`;
-  }
-
-  return message;
-};
-
-function useSearchFormDismiss(refs: SearchPanelRefs, handlers: CloseHandlers): void {
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-
-      if (refs.destRef.current && !refs.destRef.current.contains(target)) {
-        handlers.closeDestSuggestions();
-      }
-      if (refs.calendarRef.current && !refs.calendarRef.current.contains(target)) {
-        handlers.closeCalendar();
-      }
-      if (refs.guestDropdownRef.current && !refs.guestDropdownRef.current.contains(target)) {
-        handlers.closeGuestDropdown();
-      }
-      if (refs.tripTypeRef.current && !refs.tripTypeRef.current.contains(target)) {
-        handlers.closeTripTypeDropdown();
-      }
-      if (refs.budgetRef.current && !refs.budgetRef.current.contains(target)) {
-        handlers.closeBudgetDropdown();
-      }
-    };
-
-    const handleEsc = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        closeAllPanels(handlers);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleEsc);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEsc);
-    };
-  }, [handlers, refs]);
-}
-
-interface DestinationFieldProps {
-  destRef: React.RefObject<HTMLDivElement | null>;
-  inputRef: React.RefObject<HTMLInputElement | null>;
-  inputValue: string;
-  showDestSuggestions: boolean;
-  filteredDestinations: DestinationOption[];
-  activeSuggestionIndex: number;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  onFocus: () => void;
-  onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
-  onSelect: (destination: DestinationOption) => void;
-  onClear: () => void;
-}
-
-const DestinationField = memo(({
-  destRef,
-  inputRef,
-  inputValue,
-  showDestSuggestions,
-  filteredDestinations,
-  activeSuggestionIndex,
-  onChange,
-  onFocus,
-  onKeyDown,
-  onSelect,
-  onClear,
-}: DestinationFieldProps) => {
-  const hasSuggestions = filteredDestinations.length > 0;
-  const shouldShowEmptyState = showDestSuggestions && inputValue.length > 1 && !hasSuggestions;
-
-  return (
-    <div
-      className="w-full md:flex-[1.5] p-3 md:p-6 relative group text-left cursor-text hover:bg-zinc-50/80 transition duration-300 rounded-t-[2rem] md:rounded-tl-[2rem] md:rounded-tr-none"
-      ref={destRef}
-    >
-      <label htmlFor="destination-input" className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-focus-within:text-brand-cyan transition-colors">
-        <MapPin className="size-3" /> Para onde?
-      </label>
-      <div className="relative flex items-center">
-        <input
-          id="destination-input"
-          ref={inputRef}
-          type="text"
-          data-testid="destination-input"
-          value={inputValue}
-          onChange={onChange}
-          onFocus={onFocus}
-          onKeyDown={onKeyDown}
-          placeholder="Ex: Orlando, Paris, Brasil..."
-          className="w-full outline-none text-zinc-800 font-bold placeholder-zinc-300 bg-transparent text-lg md:text-xl truncate transition-colors pr-8"
-          autoComplete="off"
-          role="combobox"
-          aria-autocomplete="list"
-          aria-expanded={showDestSuggestions && hasSuggestions}
-          aria-haspopup="listbox"
-          aria-controls="destination-results"
-          aria-activedescendant={activeSuggestionIndex >= 0 ? `suggestion-${activeSuggestionIndex}` : undefined}
-        />
-        {inputValue && (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              onClear();
-            }}
-            className="absolute right-0 p-1 text-zinc-400 hover:text-brand-vibrant transition-colors rounded-full focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-brand-vibrant"
-            aria-label="Limpar destino"
-          >
-            <X className="size-4" />
-          </button>
-        )}
-      </div>
-      {showDestSuggestions && hasSuggestions && (
-        <div className="absolute top-full left-0 w-full bg-white rounded-2xl shadow-xl border-2 border-zinc-100 mt-4 overflow-hidden z-[60] animate-pop-in origin-top">
-          <div id="destination-results" role="listbox" className="max-h-60 overflow-y-auto custom-scrollbar">
-            {filteredDestinations.map((dest, index) => (
-              <div
-                key={dest.label}
-                id={`suggestion-${index}`}
-                role="option"
-                tabIndex={-1}
-                aria-selected={index === activeSuggestionIndex}
-                onClick={() => onSelect(dest)}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onSelect(dest); }}
-                className={`px-6 py-3 cursor-pointer text-left text-sm font-medium border-b border-zinc-50 last:border-0 flex items-center gap-2 transition-colors ${
-                  index === activeSuggestionIndex ? 'bg-brand-light text-brand-cyan' : 'hover:bg-brand-light text-zinc-700'
-                }`}
-              >
-                <MapPin className={`size-4 shrink-0 ${index === activeSuggestionIndex ? 'text-brand-cyan' : 'text-brand-cyan/50'}`} />
-                <span className="truncate">{dest.label}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-      {shouldShowEmptyState && (
-        <div className="absolute top-full left-0 w-full bg-white rounded-2xl shadow-xl border-2 border-zinc-100 mt-4 p-4 z-[60] animate-pop-in origin-top">
-          <p className="text-zinc-400 text-sm font-medium text-center">Nenhum destino encontrado. Tente outra cidade ou país.</p>
-        </div>
-      )}
-    </div>
-  );
-});
-DestinationField.displayName = 'DestinationField';
-
-interface DateFieldProps {
-  calendarRef: React.RefObject<HTMLDivElement | null>;
-  showCalendar: boolean;
-  startDate: Date | null;
-  endDate: Date | null;
-  currentMonth: Date;
-  calendarDays: Array<Date | null>;
-  canGoToPreviousMonth: boolean;
-  onToggle: () => void;
-  onChangeMonth: (offset: number) => void;
-  onDateClick: (date: Date) => void;
-  isDateSelected: (date: Date) => boolean;
-  isDateInRange: (date: Date) => boolean;
-}
-
-const DateField = memo(({
-  calendarRef,
-  showCalendar,
-  startDate,
-  endDate,
-  currentMonth,
-  calendarDays,
-  canGoToPreviousMonth,
-  onToggle,
-  onChangeMonth,
-  onDateClick,
-  isDateSelected,
-  isDateInRange,
-}: DateFieldProps) => (
-  <div className="w-full md:flex-1 relative group" ref={calendarRef}>
-    <button
-      type="button"
-      onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
-      aria-expanded={showCalendar}
-      aria-haspopup="grid"
-      data-testid="dates-filter-btn"
-    >
-      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
-        <Calendar className="size-3" /> Quando?
-      </span>
-      <div className="flex items-center justify-between">
-        <span className={`text-lg md:text-xl font-bold truncate transition-colors ${startDate ? "text-zinc-800" : "text-zinc-300"}`}>
-          {startDate ? `${formatDateDisplay(startDate)} - ${endDate ? formatDateDisplay(endDate) : '...'}` : "Definir datas"}
-        </span>
-        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${showCalendar ? 'rotate-180' : ''}`} />
-      </div>
-    </button>
-
-    {showCalendar && (
-      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 md:left-auto md:right-0 bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-4 p-6 z-[60] w-full md:w-80 cursor-default animate-pop-in origin-top">
-        <div className="flex items-center justify-between mb-4">
-          <button
-            type="button"
-            onClick={() => onChangeMonth(-1)}
-            disabled={!canGoToPreviousMonth}
-            className={`p-1 rounded-full transition-colors ${canGoToPreviousMonth ? 'hover:bg-zinc-100 text-zinc-600' : 'text-zinc-300 cursor-not-allowed'}`}
-            aria-label="Mês anterior"
-          >
-            <ChevronLeft className="size-5" />
-          </button>
-          <span className="font-bold text-zinc-800">{MONTH_NAMES[currentMonth.getMonth()]} {currentMonth.getFullYear()}</span>
-          <button type="button" onClick={() => onChangeMonth(1)} className="p-1 hover:bg-zinc-100 rounded-full text-zinc-600 transition-colors" aria-label="Próximo mês">
-            <ChevronRight className="size-5" />
-          </button>
-        </div>
-        <div className="grid grid-cols-7 mb-2 text-center text-xs font-bold text-zinc-400">
-          {WEEK_DAYS.map((day) => <div key={day}>{day}</div>)}
-        </div>
-        <div className="grid grid-cols-7 gap-y-1">
-          {calendarDays.map((date, slot) => {
-            if (!date) return <div key={`empty-${slot}`} />;
-
-            const selected = isDateSelected(date);
-            const inRange = isDateInRange(date);
-            const past = isDateInPast(date);
-
-            return (
-              <button
-                key={date.toISOString()}
-                type="button"
-                onClick={() => onDateClick(date)}
-                disabled={past}
-                aria-disabled={past}
-                className={`size-9 mx-auto flex items-center justify-center text-sm rounded-full transition duration-200 border-2
-                  ${past ? 'border-transparent text-zinc-300 cursor-not-allowed' : selected ? 'bg-brand-cyan border-brand-cyan text-white font-bold scale-110' : inRange ? 'bg-brand-light border-transparent text-brand-cyan font-bold' : 'border-transparent text-zinc-600 hover:bg-zinc-100'}`}
-              >
-                {date.getDate()}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-    )}
-  </div>
-));
-DateField.displayName = 'DateField';
-
-interface GuestsFieldProps {
-  guestDropdownRef: React.RefObject<HTMLDivElement | null>;
-  showGuestDropdown: boolean;
-  guestSummary: string;
-  adults: number;
-  childrenCount: number;
-  childAges: string[];
-  onToggle: () => void;
-  onAdultsChange: (nextValue: number) => void;
-  onChildCountChange: (operation: 'add' | 'remove') => void;
-  onChildAgeChange: (index: number, value: string) => void;
-  onClose: () => void;
-}
-
-const GuestsField = memo(({
-  guestDropdownRef,
-  showGuestDropdown,
-  guestSummary,
-  adults,
-  childrenCount,
-  childAges,
-  onToggle,
-  onAdultsChange,
-  onChildCountChange,
-  onChildAgeChange,
-  onClose,
-}: GuestsFieldProps) => (
-  <div className="w-full md:flex-1 relative group" ref={guestDropdownRef}>
-    <button
-      type="button"
-      onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 md:rounded-tr-[2rem] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
-      aria-expanded={showGuestDropdown}
-      aria-haspopup="true"
-      data-testid="guests-filter-btn"
-    >
-      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
-        <User className="size-3" /> Quem vai?
-      </span>
-      <div className="flex items-center justify-between">
-        <span className="text-lg md:text-xl font-bold text-zinc-800 truncate transition-colors">{guestSummary}</span>
-        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${showGuestDropdown ? 'rotate-180' : ''}`} />
-      </div>
-    </button>
-
-    {showGuestDropdown && (
-      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 md:left-auto md:right-0 bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-4 p-6 z-[60] w-full md:w-72 cursor-default animate-pop-in origin-top">
-        <div className="flex justify-between items-center mb-4">
-          <p className="font-bold text-zinc-800">Adultos</p>
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={(event) => { event.preventDefault(); event.stopPropagation(); onAdultsChange(Math.max(1, adults - 1)); }}
-              disabled={adults <= 1}
-              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition disabled:opacity-40 disabled:cursor-not-allowed"
-              aria-label="Remover um adulto"
-            >
-              <Minus className="size-4" />
-            </button>
-            <span className="font-bold w-8 text-center text-zinc-900" aria-live="polite">{adults}</span>
-            <button
-              type="button"
-              onClick={(event) => { event.preventDefault(); event.stopPropagation(); onAdultsChange(adults + 1); }}
-              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition"
-              aria-label="Adicionar um adulto"
-            >
-              <Plus className="size-4" />
-            </button>
-          </div>
-        </div>
-        <div className="flex justify-between items-center mb-4">
-          <p className="font-bold text-zinc-800">Crianças</p>
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={(event) => { event.preventDefault(); event.stopPropagation(); onChildCountChange('remove'); }}
-              disabled={childrenCount <= 0}
-              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition disabled:opacity-40 disabled:cursor-not-allowed"
-              aria-label="Remover uma criança"
-            >
-              <Minus className="size-4" />
-            </button>
-            <span className="font-bold w-8 text-center text-zinc-900" aria-live="polite">{childrenCount}</span>
-            <button
-              type="button"
-              onClick={(event) => { event.preventDefault(); event.stopPropagation(); onChildCountChange('add'); }}
-              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition"
-              aria-label="Adicionar uma criança"
-            >
-              <Plus className="size-4" />
-            </button>
-          </div>
-        </div>
-
-        {childrenCount > 0 && (
-          <div className="mb-4 grid grid-cols-2 gap-2 max-h-32 overflow-y-auto pr-1 custom-scrollbar animate-fade-in-up">
-            {childAges.map((age, i) => (
-              <div key={`child-age-${i + 1}`} className="flex flex-col">
-                <label htmlFor={`child-age-input-${i + 1}`} className="text-[10px] text-zinc-400 font-bold mb-1">Idade Criança {i + 1}</label>
-                <input
-                  id={`child-age-input-${i + 1}`}
-                  type="number"
-                  min="0"
-                  max="17"
-                  value={age}
-                  onClick={(event) => event.stopPropagation()}
-                  onChange={(event) => onChildAgeChange(i, event.target.value)}
-                  className="w-full border-2 border-zinc-100 rounded-lg px-2 py-1 text-sm font-bold text-zinc-700 outline-none focus:border-brand-cyan transition-colors"
-                  placeholder="Ex: 5"
-                />
-              </div>
-            ))}
-          </div>
-        )}
-
-        <button type="button" onClick={onClose} className="w-full mt-2 bg-brand-cyan text-white rounded-xl py-3 font-bold hover:bg-brand-cyanDark transition active:scale-95 shadow-[0_4px_0px_#0284c7] hover:shadow-[0_2px_0px_#0284c7] hover:translate-y-[2px]">Pronto</button>
-      </div>
-    )}
-  </div>
-));
-GuestsField.displayName = 'GuestsField';
-
-interface TripTypeFieldProps {
-  tripTypeRef: React.RefObject<HTMLDivElement | null>;
-  showTripTypeDropdown: boolean;
-  tripType: string;
-  selectedTripObj?: TripOption;
-  onToggle: () => void;
-  onSelect: (label: string) => void;
-}
-
-const TripTypeField = memo(({
-  tripTypeRef,
-  showTripTypeDropdown,
-  tripType,
-  selectedTripObj,
-  onToggle,
-  onSelect,
-}: TripTypeFieldProps) => (
-  <div className="w-full md:flex-1 relative group" ref={tripTypeRef}>
-    <button
-      type="button"
-      onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
-      aria-expanded={showTripTypeDropdown}
-      aria-haspopup="true"
-      data-testid="trip-type-filter-btn"
-    >
-      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
-        <Briefcase className="size-3" /> Tipo de Viagem
-      </span>
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 overflow-hidden">
-          {selectedTripObj && (
-            <selectedTripObj.icon className={`size-5 ${selectedTripObj.color}`} />
-          )}
-          <span className={`text-lg md:text-lg font-bold truncate transition-colors ${tripType ? "text-zinc-800" : "text-zinc-300"}`}>
-            {tripType || "Lazer, Lua de Mel..."}
-          </span>
-        </div>
-        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${showTripTypeDropdown ? 'rotate-180' : ''}`} />
-      </div>
-    </button>
-
-    {showTripTypeDropdown && (
-      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 w-full md:w-[400px] bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-2 z-[60] animate-pop-in origin-top overflow-hidden p-4">
-        <div className="grid grid-cols-2 gap-3">
-          {TRIP_OPTIONS.map((type) => (
-            <button
-              key={type.label}
-              type="button"
-              onClick={() => onSelect(type.label)}
-              className={`flex flex-col items-start gap-2 p-3 rounded-2xl border-2 transition duration-200 text-left
-                ${tripType === type.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-zinc-50 hover:border-zinc-100'}`}
-            >
-              <div className={`p-2 rounded-xl ${type.bg} ${type.color}`}>
-                <type.icon className="size-5" />
-              </div>
-              <span className={`font-bold text-base ${tripType === type.label ? 'text-brand-dark' : 'text-zinc-600'}`}>
-                {type.label}
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
-    )}
-  </div>
-));
-TripTypeField.displayName = 'TripTypeField';
-
-interface BudgetFieldProps {
-  budgetRef: React.RefObject<HTMLDivElement | null>;
-  showBudgetDropdown: boolean;
-  budget: string;
-  selectedBudgetObj?: BudgetTier;
-  onToggle: () => void;
-  onSelect: (label: string) => void;
-}
-
-const BudgetField = memo(({
-  budgetRef,
-  showBudgetDropdown,
-  budget,
-  selectedBudgetObj,
-  onToggle,
-  onSelect,
-}: BudgetFieldProps) => (
-  <div className="w-full md:flex-1 relative group" ref={budgetRef}>
-    <button
-      type="button"
-      onClick={onToggle}
-      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
-      aria-expanded={showBudgetDropdown}
-      aria-haspopup="true"
-      data-testid="budget-filter-btn"
-    >
-      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
-        <Wallet className="size-3" /> Orçamento Aprox.
-      </span>
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 overflow-hidden">
-          {selectedBudgetObj && (
-            <div className="flex text-green-600 font-bold text-xs bg-green-50 px-1.5 py-0.5 rounded-md">
-              <span>{'$'.repeat(selectedBudgetObj.level)}</span>
-            </div>
-          )}
-          <span className={`text-lg md:text-lg font-bold truncate transition-colors ${budget ? "text-zinc-800" : "text-zinc-300"}`}>
-            {budget || "Definir padrão"}
-          </span>
-        </div>
-        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${showBudgetDropdown ? 'rotate-180' : ''}`} />
-      </div>
-    </button>
-
-    {showBudgetDropdown && (
-      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 w-full md:w-[320px] bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-2 z-[60] animate-pop-in origin-top overflow-hidden p-3">
-        {BUDGET_TIERS.map((option) => (
-          <button
-            key={option.label}
-            type="button"
-            onClick={() => onSelect(option.label)}
-            className={`w-full flex items-center gap-4 p-3 rounded-2xl border-2 transition duration-200 mb-2 last:mb-0
-              ${budget === option.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-zinc-50 hover:border-zinc-100'}`}
-          >
-            <div className={`p-2 rounded-xl bg-zinc-100 text-zinc-600 ${budget === option.label ? 'bg-brand-vibrant text-white' : ''}`}>
-              <option.icon className="size-5" />
-            </div>
-            <div className="text-left">
-              <div className="flex items-center gap-2">
-                <span className={`font-bold text-base ${budget === option.label ? 'text-brand-dark' : 'text-zinc-800'}`}>
-                  {option.label}
-                </span>
-                <div className="flex text-[10px] font-black text-green-600 bg-green-50 px-1.5 rounded">
-                  <span>{'$'.repeat(option.level)}</span>
-                </div>
-              </div>
-              <div className="flex items-center gap-2 mt-1">
-                <span className="text-sm text-zinc-400 font-medium">{option.desc}</span>
-                <span className="text-xs text-zinc-500 font-semibold">•</span>
-                <span className="text-sm text-zinc-600 font-semibold">{option.range}</span>
-              </div>
-            </div>
-          </button>
-        ))}
-      </div>
-    )}
-  </div>
-));
-BudgetField.displayName = 'BudgetField';
-
-interface SearchButtonProps {
-  isSearchLoading: boolean;
-  validationError?: string | null;
-}
-
-const SearchButton = memo(({ isSearchLoading, validationError }: SearchButtonProps) => (
-  <div className="p-2 w-full md:w-auto flex-shrink-0 relative">
-    {validationError && (
-      <div
-        role="alert"
-        className="absolute -top-6 left-1/2 -translate-x-1/2 w-full text-center text-red-600 text-xs font-black animate-fade-in-down whitespace-nowrap bg-white/90 backdrop-blur-sm py-1 px-2 rounded-full shadow-sm border border-red-100 z-10"
-      >
-        {validationError}
-      </div>
-    )}
-    <button
-      type="submit"
-      disabled={isSearchLoading}
-      data-testid="submit-search-btn"
-      className="btn-specialist w-full md:w-auto h-full min-h-[70px] bg-brand-yellow hover:bg-anhanga-yellowHover text-brand-dark rounded-2xl md:rounded-[1.5rem] shadow-lg flex items-center justify-center gap-2 px-6 transition duration-300 ease-spring hover:scale-105 hover:shadow-xl active:scale-90 group border-2 border-transparent whitespace-nowrap"
-      data-tracking="hero-home"
-    >
-      {isSearchLoading ? (
-        <>
-          <Loader2 className="size-6 animate-spin" />
-          <span className="font-black text-lg">Planejando…</span>
-        </>
-      ) : (
-        <>
-          <Search className="size-6 group-hover:rotate-12 transition-transform duration-300 ease-spring" strokeWidth={2.5} />
-          <span className="font-black text-lg">Planejar Viagem</span>
-        </>
-      )}
-    </button>
-  </div>
-));
-SearchButton.displayName = 'SearchButton';
-
 const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
   const [inputValue, setInputValue] = useState('');
-  const [showDestSuggestions, setShowDestSuggestions] = useState(false);
   const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
-  const [showCalendar, setShowCalendar] = useState(false);
+  const [openPanel, setOpenPanel] = useState<OpenPanel>(null);
   const [startDate, setStartDate] = useState<Date | null>(null);
   const [endDate, setEndDate] = useState<Date | null>(null);
   const [currentMonth, setCurrentMonth] = useState(new Date());
-  const [showGuestDropdown, setShowGuestDropdown] = useState(false);
   const [adults, setAdults] = useState(2);
   const [children, setChildren] = useState(0);
   const [childAges, setChildAges] = useState<string[]>([]);
   const [tripType, setTripType] = useState('');
-  const [showTripTypeDropdown, setShowTripTypeDropdown] = useState(false);
   const [budget, setBudget] = useState('');
-  const [showBudgetDropdown, setShowBudgetDropdown] = useState(false);
   const [isSearchLoading, setIsSearchLoading] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
   const errorTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -676,23 +54,26 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
   const tripTypeRef = useRef<HTMLDivElement>(null);
   const budgetRef = useRef<HTMLDivElement>(null);
 
-  const panelRefs = useMemo<SearchPanelRefs>(() => ({
-    destRef,
-    calendarRef,
-    guestDropdownRef,
-    tripTypeRef,
-    budgetRef,
-  }), []);
+  const closePanel = useCallback((panel: ActivePanel) => {
+    setOpenPanel((prev) => (prev === panel ? null : prev));
+  }, []);
 
-  const closeHandlers = useMemo<CloseHandlers>(() => ({
-    closeDestSuggestions: () => setShowDestSuggestions(false),
-    closeCalendar: () => setShowCalendar(false),
-    closeGuestDropdown: () => setShowGuestDropdown(false),
-    closeTripTypeDropdown: () => setShowTripTypeDropdown(false),
-    closeBudgetDropdown: () => setShowBudgetDropdown(false),
-  }), []);
+  const closeAllPanels = useCallback(() => setOpenPanel(null), []);
 
-  useSearchFormDismiss(panelRefs, closeHandlers);
+  const togglePanel = useCallback((panel: ActivePanel) => {
+    setOpenPanel((prev) => (prev === panel ? null : panel));
+    import('../utils/haptics').then(m => m.triggerHaptic('light'));
+  }, []);
+
+  const panelRegistry = useMemo<PanelRegistryEntry[]>(() => ([
+    { panel: 'dest', ref: destRef },
+    { panel: 'calendar', ref: calendarRef },
+    { panel: 'guests', ref: guestDropdownRef },
+    { panel: 'trip', ref: tripTypeRef },
+    { panel: 'budget', ref: budgetRef },
+  ]), []);
+
+  useSearchFormDismiss(panelRegistry, closePanel, closeAllPanels);
 
   const calendarDays = useMemo(() => getDaysInMonth(currentMonth), [currentMonth]);
 
@@ -709,7 +90,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
   const handleDestinationChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
     setInputValue(value);
-    setShowDestSuggestions(true);
+    setOpenPanel('dest');
     setActiveSuggestionIndex(-1);
 
     const search = normalizeStr(value);
@@ -723,12 +104,12 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
   const handleDestinationSelect = useCallback((destination: DestinationOption) => {
     setInputValue(destination.label);
     onDestinationMatch(destination.city);
-    setShowDestSuggestions(false);
+    closePanel('dest');
     setActiveSuggestionIndex(-1);
-  }, [onDestinationMatch]);
+  }, [onDestinationMatch, closePanel]);
 
   const handleDestinationKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!showDestSuggestions || filteredDestinations.length === 0) return;
+    if (openPanel !== 'dest' || filteredDestinations.length === 0) return;
 
     if (event.key === 'ArrowDown') {
       event.preventDefault();
@@ -744,21 +125,21 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
         handleDestinationSelect(filteredDestinations[activeSuggestionIndex]);
       }
     } else if (event.key === 'Escape') {
-      setShowDestSuggestions(false);
+      closePanel('dest');
       setActiveSuggestionIndex(-1);
     }
-  }, [showDestSuggestions, filteredDestinations, activeSuggestionIndex, handleDestinationSelect]);
+  }, [openPanel, filteredDestinations, activeSuggestionIndex, handleDestinationSelect, closePanel]);
 
   const handleClearDestination = useCallback(() => {
     setInputValue('');
     onDestinationMatch(null);
-    setShowDestSuggestions(false);
+    closePanel('dest');
     setActiveSuggestionIndex(-1);
     if (destinationInputRef.current) {
       destinationInputRef.current.focus();
     }
     import('../utils/haptics').then(m => m.triggerHaptic('light'));
-  }, [onDestinationMatch]);
+  }, [onDestinationMatch, closePanel]);
 
   const handleAdultsChange = useCallback((nextValue: number) => {
     setAdults(nextValue);
@@ -802,8 +183,8 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
     }
 
     setEndDate(date);
-    setShowCalendar(false);
-  }, [startDate, endDate]);
+    closePanel('calendar');
+  }, [startDate, endDate, closePanel]);
 
   const isDateSelected = useCallback((date: Date) => {
     if (!startDate) return false;
@@ -843,13 +224,13 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
 
   const handleTripTypeSelect = useCallback((label: string) => {
     setTripType(label);
-    setShowTripTypeDropdown(false);
-  }, []);
+    closePanel('trip');
+  }, [closePanel]);
 
   const handleBudgetSelect = useCallback((label: string) => {
     setBudget(label);
-    setShowBudgetDropdown(false);
-  }, []);
+    closePanel('budget');
+  }, [closePanel]);
 
   const handleSearch = useCallback(() => {
     if (!inputValue.trim()) {
@@ -864,7 +245,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
       if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current);
       setValidationError("Por favor, selecione a data de ida.");
       import('../utils/haptics').then(m => m.triggerHaptic('medium'));
-      setShowCalendar(true);
+      setOpenPanel('calendar');
       errorTimeoutRef.current = setTimeout(() => setValidationError(null), 4000);
       return;
     }
@@ -897,25 +278,13 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
     handleSearch();
   }, [handleSearch]);
 
-  const toggleCalendar = useCallback(() => {
-    setShowCalendar((prev) => !prev);
-    import('../utils/haptics').then(m => m.triggerHaptic('light'));
-  }, []);
-  const toggleGuestDropdown = useCallback(() => {
-    setShowGuestDropdown((prev) => !prev);
-    import('../utils/haptics').then(m => m.triggerHaptic('light'));
-  }, []);
-  const closeGuestDropdown = useCallback(() => setShowGuestDropdown(false), []);
-  const toggleTripTypeDropdown = useCallback(() => {
-    setShowTripTypeDropdown((prev) => !prev);
-    import('../utils/haptics').then(m => m.triggerHaptic('light'));
-  }, []);
-  const toggleBudgetDropdown = useCallback(() => {
-    setShowBudgetDropdown((prev) => !prev);
-    import('../utils/haptics').then(m => m.triggerHaptic('light'));
-  }, []);
+  const toggleCalendar = useCallback(() => togglePanel('calendar'), [togglePanel]);
+  const toggleGuestDropdown = useCallback(() => togglePanel('guests'), [togglePanel]);
+  const closeGuestDropdown = useCallback(() => closePanel('guests'), [closePanel]);
+  const toggleTripTypeDropdown = useCallback(() => togglePanel('trip'), [togglePanel]);
+  const toggleBudgetDropdown = useCallback(() => togglePanel('budget'), [togglePanel]);
   const onDestinationFocus = useCallback(() => {
-    setShowDestSuggestions(true);
+    setOpenPanel('dest');
     setActiveSuggestionIndex(-1);
   }, []);
 
@@ -931,7 +300,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
           destRef={destRef}
           inputRef={destinationInputRef}
           inputValue={inputValue}
-          showDestSuggestions={showDestSuggestions}
+          isOpen={openPanel === 'dest'}
           filteredDestinations={filteredDestinations}
           activeSuggestionIndex={activeSuggestionIndex}
           onChange={handleDestinationChange}
@@ -942,7 +311,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
         />
         <DateField
           calendarRef={calendarRef}
-          showCalendar={showCalendar}
+          isOpen={openPanel === 'calendar'}
           startDate={startDate}
           endDate={endDate}
           currentMonth={currentMonth}
@@ -956,7 +325,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
         />
         <GuestsField
           guestDropdownRef={guestDropdownRef}
-          showGuestDropdown={showGuestDropdown}
+          isOpen={openPanel === 'guests'}
           guestSummary={guestSummary}
           adults={adults}
           childrenCount={children}
@@ -977,7 +346,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
       <div className="flex flex-col md:flex-row items-stretch w-full divide-y md:divide-y-0 md:divide-x divide-zinc-100">
         <TripTypeField
           tripTypeRef={tripTypeRef}
-          showTripTypeDropdown={showTripTypeDropdown}
+          isOpen={openPanel === 'trip'}
           tripType={tripType}
           selectedTripObj={selectedTripObj}
           onToggle={toggleTripTypeDropdown}
@@ -985,7 +354,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
         />
         <BudgetField
           budgetRef={budgetRef}
-          showBudgetDropdown={showBudgetDropdown}
+          isOpen={openPanel === 'budget'}
           budget={budget}
           selectedBudgetObj={selectedBudgetObj}
           onToggle={toggleBudgetDropdown}

--- a/components/SearchForm.tsx
+++ b/components/SearchForm.tsx
@@ -73,7 +73,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
     { panel: 'budget', ref: budgetRef },
   ]), []);
 
-  useSearchFormDismiss(panelRegistry, closePanel, closeAllPanels);
+  useSearchFormDismiss(panelRegistry, openPanel, closePanel, closeAllPanels);
 
   const calendarDays = useMemo(() => getDaysInMonth(currentMonth), [currentMonth]);
 

--- a/components/search/BudgetField.tsx
+++ b/components/search/BudgetField.tsx
@@ -1,0 +1,86 @@
+import { memo } from 'react';
+import { ChevronDown, Wallet } from 'lucide-react';
+import { BUDGET_TIERS } from '../../data/destinations';
+import type { BudgetTier } from './types';
+
+interface BudgetFieldProps {
+  budgetRef: React.RefObject<HTMLDivElement | null>;
+  isOpen: boolean;
+  budget: string;
+  selectedBudgetObj?: BudgetTier;
+  onToggle: () => void;
+  onSelect: (label: string) => void;
+}
+
+const BudgetField = memo(({
+  budgetRef,
+  isOpen,
+  budget,
+  selectedBudgetObj,
+  onToggle,
+  onSelect,
+}: BudgetFieldProps) => (
+  <div className="w-full md:flex-1 relative group" ref={budgetRef}>
+    <button
+      type="button"
+      onClick={onToggle}
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      aria-expanded={isOpen}
+      aria-haspopup="true"
+      data-testid="budget-filter-btn"
+    >
+      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
+        <Wallet className="size-3" /> Orçamento Aprox.
+      </span>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 overflow-hidden">
+          {selectedBudgetObj && (
+            <div className="flex text-green-600 font-bold text-xs bg-green-50 px-1.5 py-0.5 rounded-md">
+              <span>{'$'.repeat(selectedBudgetObj.level)}</span>
+            </div>
+          )}
+          <span className={`text-lg md:text-lg font-bold truncate transition-colors ${budget ? "text-zinc-800" : "text-zinc-300"}`}>
+            {budget || "Definir padrão"}
+          </span>
+        </div>
+        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`} />
+      </div>
+    </button>
+
+    {isOpen && (
+      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 w-full md:w-[320px] bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-2 z-[60] animate-pop-in origin-top overflow-hidden p-3">
+        {BUDGET_TIERS.map((option) => (
+          <button
+            key={option.label}
+            type="button"
+            onClick={() => onSelect(option.label)}
+            className={`w-full flex items-center gap-4 p-3 rounded-2xl border-2 transition duration-200 mb-2 last:mb-0
+              ${budget === option.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-zinc-50 hover:border-zinc-100'}`}
+          >
+            <div className={`p-2 rounded-xl bg-zinc-100 text-zinc-600 ${budget === option.label ? 'bg-brand-vibrant text-white' : ''}`}>
+              <option.icon className="size-5" />
+            </div>
+            <div className="text-left">
+              <div className="flex items-center gap-2">
+                <span className={`font-bold text-base ${budget === option.label ? 'text-brand-dark' : 'text-zinc-800'}`}>
+                  {option.label}
+                </span>
+                <div className="flex text-[10px] font-black text-green-600 bg-green-50 px-1.5 rounded">
+                  <span>{'$'.repeat(option.level)}</span>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-sm text-zinc-400 font-medium">{option.desc}</span>
+                <span className="text-xs text-zinc-500 font-semibold">•</span>
+                <span className="text-sm text-zinc-600 font-semibold">{option.range}</span>
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+    )}
+  </div>
+));
+BudgetField.displayName = 'BudgetField';
+
+export default BudgetField;

--- a/components/search/DateField.tsx
+++ b/components/search/DateField.tsx
@@ -1,0 +1,104 @@
+import { memo } from 'react';
+import { ChevronDown, ChevronLeft, ChevronRight, Calendar } from 'lucide-react';
+import { MONTH_NAMES, WEEK_DAYS } from '../../data/destinations';
+import { formatDateDisplay, isDateInPast } from './helpers';
+
+interface DateFieldProps {
+  calendarRef: React.RefObject<HTMLDivElement | null>;
+  isOpen: boolean;
+  startDate: Date | null;
+  endDate: Date | null;
+  currentMonth: Date;
+  calendarDays: Array<Date | null>;
+  canGoToPreviousMonth: boolean;
+  onToggle: () => void;
+  onChangeMonth: (offset: number) => void;
+  onDateClick: (date: Date) => void;
+  isDateSelected: (date: Date) => boolean;
+  isDateInRange: (date: Date) => boolean;
+}
+
+const DateField = memo(({
+  calendarRef,
+  isOpen,
+  startDate,
+  endDate,
+  currentMonth,
+  calendarDays,
+  canGoToPreviousMonth,
+  onToggle,
+  onChangeMonth,
+  onDateClick,
+  isDateSelected,
+  isDateInRange,
+}: DateFieldProps) => (
+  <div className="w-full md:flex-1 relative group" ref={calendarRef}>
+    <button
+      type="button"
+      onClick={onToggle}
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      aria-expanded={isOpen}
+      aria-haspopup="grid"
+      data-testid="dates-filter-btn"
+    >
+      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
+        <Calendar className="size-3" /> Quando?
+      </span>
+      <div className="flex items-center justify-between">
+        <span className={`text-lg md:text-xl font-bold truncate transition-colors ${startDate ? "text-zinc-800" : "text-zinc-300"}`}>
+          {startDate ? `${formatDateDisplay(startDate)} - ${endDate ? formatDateDisplay(endDate) : '...'}` : "Definir datas"}
+        </span>
+        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`} />
+      </div>
+    </button>
+
+    {isOpen && (
+      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 md:left-auto md:right-0 bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-4 p-6 z-[60] w-full md:w-80 cursor-default animate-pop-in origin-top">
+        <div className="flex items-center justify-between mb-4">
+          <button
+            type="button"
+            onClick={() => onChangeMonth(-1)}
+            disabled={!canGoToPreviousMonth}
+            className={`p-1 rounded-full transition-colors ${canGoToPreviousMonth ? 'hover:bg-zinc-100 text-zinc-600' : 'text-zinc-300 cursor-not-allowed'}`}
+            aria-label="Mês anterior"
+          >
+            <ChevronLeft className="size-5" />
+          </button>
+          <span className="font-bold text-zinc-800">{MONTH_NAMES[currentMonth.getMonth()]} {currentMonth.getFullYear()}</span>
+          <button type="button" onClick={() => onChangeMonth(1)} className="p-1 hover:bg-zinc-100 rounded-full text-zinc-600 transition-colors" aria-label="Próximo mês">
+            <ChevronRight className="size-5" />
+          </button>
+        </div>
+        <div className="grid grid-cols-7 mb-2 text-center text-xs font-bold text-zinc-400">
+          {WEEK_DAYS.map((day, index) => <div key={`weekday-${index}`}>{day}</div>)}
+        </div>
+        <div className="grid grid-cols-7 gap-y-1">
+          {calendarDays.map((date, slot) => {
+            if (!date) return <div key={`empty-${slot}`} />;
+
+            const selected = isDateSelected(date);
+            const inRange = isDateInRange(date);
+            const past = isDateInPast(date);
+
+            return (
+              <button
+                key={date.toISOString()}
+                type="button"
+                onClick={() => onDateClick(date)}
+                disabled={past}
+                aria-disabled={past}
+                className={`size-9 mx-auto flex items-center justify-center text-sm rounded-full transition duration-200 border-2
+                  ${past ? 'border-transparent text-zinc-300 cursor-not-allowed' : selected ? 'bg-brand-cyan border-brand-cyan text-white font-bold scale-110' : inRange ? 'bg-brand-light border-transparent text-brand-cyan font-bold' : 'border-transparent text-zinc-600 hover:bg-zinc-100'}`}
+              >
+                {date.getDate()}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    )}
+  </div>
+));
+DateField.displayName = 'DateField';
+
+export default DateField;

--- a/components/search/DestinationField.tsx
+++ b/components/search/DestinationField.tsx
@@ -63,6 +63,9 @@ const DestinationField = memo(({
         {inputValue && (
           <button
             type="button"
+            // Prevent the input from blurring on press so the mobile keyboard
+            // stays open when clearing the destination.
+            onMouseDown={(e) => e.preventDefault()}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();

--- a/components/search/DestinationField.tsx
+++ b/components/search/DestinationField.tsx
@@ -1,0 +1,111 @@
+import { memo } from 'react';
+import { MapPin, X } from 'lucide-react';
+import type { DestinationOption } from './types';
+
+interface DestinationFieldProps {
+  destRef: React.RefObject<HTMLDivElement | null>;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  inputValue: string;
+  isOpen: boolean;
+  filteredDestinations: DestinationOption[];
+  activeSuggestionIndex: number;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onFocus: () => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  onSelect: (destination: DestinationOption) => void;
+  onClear: () => void;
+}
+
+const DestinationField = memo(({
+  destRef,
+  inputRef,
+  inputValue,
+  isOpen,
+  filteredDestinations,
+  activeSuggestionIndex,
+  onChange,
+  onFocus,
+  onKeyDown,
+  onSelect,
+  onClear,
+}: DestinationFieldProps) => {
+  const hasSuggestions = filteredDestinations.length > 0;
+  const shouldShowEmptyState = isOpen && inputValue.length > 1 && !hasSuggestions;
+
+  return (
+    <div
+      className="w-full md:flex-[1.5] p-3 md:p-6 relative group text-left cursor-text hover:bg-zinc-50/80 transition duration-300 rounded-t-[2rem] md:rounded-tl-[2rem] md:rounded-tr-none"
+      ref={destRef}
+    >
+      <label htmlFor="destination-input" className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-focus-within:text-brand-cyan transition-colors">
+        <MapPin className="size-3" /> Para onde?
+      </label>
+      <div className="relative flex items-center">
+        <input
+          id="destination-input"
+          ref={inputRef}
+          type="text"
+          data-testid="destination-input"
+          value={inputValue}
+          onChange={onChange}
+          onFocus={onFocus}
+          onKeyDown={onKeyDown}
+          placeholder="Ex: Orlando, Paris, Brasil..."
+          className="w-full outline-none text-zinc-800 font-bold placeholder-zinc-300 bg-transparent text-lg md:text-xl truncate transition-colors pr-8"
+          autoComplete="off"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={isOpen && hasSuggestions}
+          aria-haspopup="listbox"
+          aria-controls="destination-results"
+          aria-activedescendant={activeSuggestionIndex >= 0 ? `suggestion-${activeSuggestionIndex}` : undefined}
+        />
+        {inputValue && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onClear();
+            }}
+            className="absolute right-0 p-1 text-zinc-400 hover:text-brand-vibrant transition-colors rounded-full focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-brand-vibrant"
+            aria-label="Limpar destino"
+          >
+            <X className="size-4" />
+          </button>
+        )}
+      </div>
+      {isOpen && hasSuggestions && (
+        <div className="absolute top-full left-0 w-full bg-white rounded-2xl shadow-xl border-2 border-zinc-100 mt-4 overflow-hidden z-[60] animate-pop-in origin-top">
+          <div id="destination-results" role="listbox" className="max-h-60 overflow-y-auto custom-scrollbar">
+            {filteredDestinations.map((dest, index) => (
+              <div
+                key={dest.label}
+                id={`suggestion-${index}`}
+                role="option"
+                tabIndex={-1}
+                aria-selected={index === activeSuggestionIndex}
+                onClick={() => onSelect(dest)}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onSelect(dest); }}
+                className={`px-6 py-3 cursor-pointer text-left text-sm font-medium border-b border-zinc-50 last:border-0 flex items-center gap-2 transition-colors ${
+                  index === activeSuggestionIndex ? 'bg-brand-light text-brand-cyan' : 'hover:bg-brand-light text-zinc-700'
+                }`}
+              >
+                <MapPin className={`size-4 shrink-0 ${index === activeSuggestionIndex ? 'text-brand-cyan' : 'text-brand-cyan/50'}`} />
+                <span className="truncate">{dest.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {shouldShowEmptyState && (
+        <div className="absolute top-full left-0 w-full bg-white rounded-2xl shadow-xl border-2 border-zinc-100 mt-4 p-4 z-[60] animate-pop-in origin-top">
+          <p className="text-zinc-400 text-sm font-medium text-center">Nenhum destino encontrado. Tente outra cidade ou país.</p>
+        </div>
+      )}
+    </div>
+  );
+});
+DestinationField.displayName = 'DestinationField';
+
+export default DestinationField;

--- a/components/search/GuestsField.tsx
+++ b/components/search/GuestsField.tsx
@@ -1,0 +1,126 @@
+import { memo } from 'react';
+import { ChevronDown, Plus, Minus, User } from 'lucide-react';
+
+interface GuestsFieldProps {
+  guestDropdownRef: React.RefObject<HTMLDivElement | null>;
+  isOpen: boolean;
+  guestSummary: string;
+  adults: number;
+  childrenCount: number;
+  childAges: string[];
+  onToggle: () => void;
+  onAdultsChange: (nextValue: number) => void;
+  onChildCountChange: (operation: 'add' | 'remove') => void;
+  onChildAgeChange: (index: number, value: string) => void;
+  onClose: () => void;
+}
+
+const GuestsField = memo(({
+  guestDropdownRef,
+  isOpen,
+  guestSummary,
+  adults,
+  childrenCount,
+  childAges,
+  onToggle,
+  onAdultsChange,
+  onChildCountChange,
+  onChildAgeChange,
+  onClose,
+}: GuestsFieldProps) => (
+  <div className="w-full md:flex-1 relative group" ref={guestDropdownRef}>
+    <button
+      type="button"
+      onClick={onToggle}
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 md:rounded-tr-[2rem] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      aria-expanded={isOpen}
+      aria-haspopup="true"
+      data-testid="guests-filter-btn"
+    >
+      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
+        <User className="size-3" /> Quem vai?
+      </span>
+      <div className="flex items-center justify-between">
+        <span className="text-lg md:text-xl font-bold text-zinc-800 truncate transition-colors">{guestSummary}</span>
+        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`} />
+      </div>
+    </button>
+
+    {isOpen && (
+      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 md:left-auto md:right-0 bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-4 p-6 z-[60] w-full md:w-72 cursor-default animate-pop-in origin-top">
+        <div className="flex justify-between items-center mb-4">
+          <p className="font-bold text-zinc-800">Adultos</p>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={(event) => { event.preventDefault(); event.stopPropagation(); onAdultsChange(Math.max(1, adults - 1)); }}
+              disabled={adults <= 1}
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition disabled:opacity-40 disabled:cursor-not-allowed"
+              aria-label="Remover um adulto"
+            >
+              <Minus className="size-4" />
+            </button>
+            <span className="font-bold w-8 text-center text-zinc-900" aria-live="polite">{adults}</span>
+            <button
+              type="button"
+              onClick={(event) => { event.preventDefault(); event.stopPropagation(); onAdultsChange(adults + 1); }}
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition"
+              aria-label="Adicionar um adulto"
+            >
+              <Plus className="size-4" />
+            </button>
+          </div>
+        </div>
+        <div className="flex justify-between items-center mb-4">
+          <p className="font-bold text-zinc-800">Crianças</p>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={(event) => { event.preventDefault(); event.stopPropagation(); onChildCountChange('remove'); }}
+              disabled={childrenCount <= 0}
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition disabled:opacity-40 disabled:cursor-not-allowed"
+              aria-label="Remover uma criança"
+            >
+              <Minus className="size-4" />
+            </button>
+            <span className="font-bold w-8 text-center text-zinc-900" aria-live="polite">{childrenCount}</span>
+            <button
+              type="button"
+              onClick={(event) => { event.preventDefault(); event.stopPropagation(); onChildCountChange('add'); }}
+              className="size-8 rounded-full border-2 border-zinc-200 flex items-center justify-center text-zinc-600 hover:border-brand-cyan hover:text-brand-cyan transition"
+              aria-label="Adicionar uma criança"
+            >
+              <Plus className="size-4" />
+            </button>
+          </div>
+        </div>
+
+        {childrenCount > 0 && (
+          <div className="mb-4 grid grid-cols-2 gap-2 max-h-32 overflow-y-auto pr-1 custom-scrollbar animate-fade-in-up">
+            {childAges.map((age, i) => (
+              <div key={`child-age-${i + 1}`} className="flex flex-col">
+                <label htmlFor={`child-age-input-${i + 1}`} className="text-[10px] text-zinc-400 font-bold mb-1">Idade Criança {i + 1}</label>
+                <input
+                  id={`child-age-input-${i + 1}`}
+                  type="number"
+                  min="0"
+                  max="17"
+                  value={age}
+                  onClick={(event) => event.stopPropagation()}
+                  onChange={(event) => onChildAgeChange(i, event.target.value)}
+                  className="w-full border-2 border-zinc-100 rounded-lg px-2 py-1 text-sm font-bold text-zinc-700 outline-none focus:border-brand-cyan transition-colors"
+                  placeholder="Ex: 5"
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        <button type="button" onClick={onClose} className="w-full mt-2 bg-brand-cyan text-white rounded-xl py-3 font-bold hover:bg-brand-cyanDark transition active:scale-95 shadow-[0_4px_0px_#0284c7] hover:shadow-[0_2px_0px_#0284c7] hover:translate-y-[2px]">Pronto</button>
+      </div>
+    )}
+  </div>
+));
+GuestsField.displayName = 'GuestsField';
+
+export default GuestsField;

--- a/components/search/SearchButton.tsx
+++ b/components/search/SearchButton.tsx
@@ -1,0 +1,42 @@
+import { memo } from 'react';
+import { Search, Loader2 } from 'lucide-react';
+
+interface SearchButtonProps {
+  isSearchLoading: boolean;
+  validationError?: string | null;
+}
+
+const SearchButton = memo(({ isSearchLoading, validationError }: SearchButtonProps) => (
+  <div className="p-2 w-full md:w-auto flex-shrink-0 relative">
+    {validationError && (
+      <div
+        role="alert"
+        className="absolute -top-6 left-1/2 -translate-x-1/2 w-full text-center text-red-600 text-xs font-black animate-fade-in-down whitespace-nowrap bg-white/90 backdrop-blur-sm py-1 px-2 rounded-full shadow-sm border border-red-100 z-10"
+      >
+        {validationError}
+      </div>
+    )}
+    <button
+      type="submit"
+      disabled={isSearchLoading}
+      data-testid="submit-search-btn"
+      className="btn-specialist w-full md:w-auto h-full min-h-[70px] bg-brand-yellow hover:bg-anhanga-yellowHover text-brand-dark rounded-2xl md:rounded-[1.5rem] shadow-lg flex items-center justify-center gap-2 px-6 transition duration-300 ease-spring hover:scale-105 hover:shadow-xl active:scale-90 group border-2 border-transparent whitespace-nowrap"
+      data-tracking="hero-home"
+    >
+      {isSearchLoading ? (
+        <>
+          <Loader2 className="size-6 animate-spin" />
+          <span className="font-black text-lg">Planejando…</span>
+        </>
+      ) : (
+        <>
+          <Search className="size-6 group-hover:rotate-12 transition-transform duration-300 ease-spring" strokeWidth={2.5} />
+          <span className="font-black text-lg">Planejar Viagem</span>
+        </>
+      )}
+    </button>
+  </div>
+));
+SearchButton.displayName = 'SearchButton';
+
+export default SearchButton;

--- a/components/search/TripTypeField.tsx
+++ b/components/search/TripTypeField.tsx
@@ -1,0 +1,74 @@
+import { memo } from 'react';
+import { ChevronDown, Briefcase } from 'lucide-react';
+import { TRIP_OPTIONS } from '../../data/destinations';
+import type { TripOption } from './types';
+
+interface TripTypeFieldProps {
+  tripTypeRef: React.RefObject<HTMLDivElement | null>;
+  isOpen: boolean;
+  tripType: string;
+  selectedTripObj?: TripOption;
+  onToggle: () => void;
+  onSelect: (label: string) => void;
+}
+
+const TripTypeField = memo(({
+  tripTypeRef,
+  isOpen,
+  tripType,
+  selectedTripObj,
+  onToggle,
+  onSelect,
+}: TripTypeFieldProps) => (
+  <div className="w-full md:flex-1 relative group" ref={tripTypeRef}>
+    <button
+      type="button"
+      onClick={onToggle}
+      className="w-full p-3 md:p-6 text-left hover:bg-zinc-50/80 transition duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cyan"
+      aria-expanded={isOpen}
+      aria-haspopup="true"
+      data-testid="trip-type-filter-btn"
+    >
+      <span className="block text-[10px] font-black text-zinc-400 uppercase tracking-wider mb-1 flex items-center gap-1 group-hover:text-brand-cyan group-focus-within:text-brand-cyan transition-colors">
+        <Briefcase className="size-3" /> Tipo de Viagem
+      </span>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 overflow-hidden">
+          {selectedTripObj && (
+            <selectedTripObj.icon className={`size-5 ${selectedTripObj.color}`} />
+          )}
+          <span className={`text-lg md:text-lg font-bold truncate transition-colors ${tripType ? "text-zinc-800" : "text-zinc-300"}`}>
+            {tripType || "Lazer, Lua de Mel..."}
+          </span>
+        </div>
+        <ChevronDown className={`size-4 text-zinc-400 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`} />
+      </div>
+    </button>
+
+    {isOpen && (
+      <div onClick={(event) => event.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation" className="absolute top-full left-0 w-full md:w-[400px] bg-white rounded-3xl shadow-2xl border-2 border-zinc-100 mt-2 z-[60] animate-pop-in origin-top overflow-hidden p-4">
+        <div className="grid grid-cols-2 gap-3">
+          {TRIP_OPTIONS.map((type) => (
+            <button
+              key={type.label}
+              type="button"
+              onClick={() => onSelect(type.label)}
+              className={`flex flex-col items-start gap-2 p-3 rounded-2xl border-2 transition duration-200 text-left
+                ${tripType === type.label ? 'bg-brand-light border-brand-cyan shadow-sm' : 'bg-white border-transparent hover:bg-zinc-50 hover:border-zinc-100'}`}
+            >
+              <div className={`p-2 rounded-xl ${type.bg} ${type.color}`}>
+                <type.icon className="size-5" />
+              </div>
+              <span className={`font-bold text-base ${tripType === type.label ? 'text-brand-dark' : 'text-zinc-600'}`}>
+                {type.label}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    )}
+  </div>
+));
+TripTypeField.displayName = 'TripTypeField';
+
+export default TripTypeField;

--- a/components/search/helpers.ts
+++ b/components/search/helpers.ts
@@ -1,0 +1,50 @@
+import { BUDGET_TIERS } from '../../data/destinations';
+
+export const isDateInPast = (date: Date): boolean => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return date < today;
+};
+
+export const formatDateDisplay = (date: Date | null): string => {
+  if (!date) return '';
+  return date.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit' });
+};
+
+export const getGuestSummary = (adults: number, children: number): string => {
+  return `${adults} Adulto${adults !== 1 ? 's' : ''}${children > 0 ? `, ${children} Chd` : ''}`;
+};
+
+export const buildSearchMessage = (params: {
+  inputValue: string;
+  startDate: Date;
+  endDate: Date | null;
+  adults: number;
+  children: number;
+  childAges: string[];
+  tripType: string;
+  budget: string;
+}): string => {
+  const startStr = params.startDate.toLocaleDateString('pt-BR');
+  const endStr = params.endDate ? params.endDate.toLocaleDateString('pt-BR') : 'A definir';
+  const childAgesStr = params.children > 0
+    ? ` (${params.childAges.map((age) => age ? `${age} anos` : 'Idade N/I').join(', ')})`
+    : '';
+
+  let message = 'Olá! Gostaria de um orçamento para minha próxima viagem:\n\n';
+  message += `📍 *Destino:* ${params.inputValue}\n`;
+  message += `📅 *Ida:* ${startStr}\n`;
+  message += `📅 *Volta:* ${endStr}\n`;
+  message += `👥 *Viajantes:* ${params.adults} Adt, ${params.children} Chd${childAgesStr}\n`;
+
+  if (params.tripType) {
+    message += `🎭 *Tipo de Viagem:* ${params.tripType}\n`;
+  }
+
+  if (params.budget) {
+    const selectedBudget = BUDGET_TIERS.find((tier) => tier.label === params.budget);
+    message += `💰 *Orçamento:* ${selectedBudget?.range || params.budget}\n`;
+  }
+
+  return message;
+};

--- a/components/search/types.ts
+++ b/components/search/types.ts
@@ -1,0 +1,9 @@
+import type { PRE_NORMALIZED_DB, TRIP_OPTIONS, BUDGET_TIERS } from '../../data/destinations';
+
+export type DestinationOption = typeof PRE_NORMALIZED_DB[number];
+export type TripOption = typeof TRIP_OPTIONS[number];
+export type BudgetTier = typeof BUDGET_TIERS[number];
+
+// The five panels are mutually exclusive — only one can be open at a time —
+// so a single discriminated value models the UI state instead of five booleans.
+export type OpenPanel = 'dest' | 'calendar' | 'guests' | 'trip' | 'budget' | null;

--- a/components/search/useSearchFormDismiss.ts
+++ b/components/search/useSearchFormDismiss.ts
@@ -8,21 +8,23 @@ export type PanelRegistryEntry = {
   ref: React.RefObject<HTMLDivElement | null>;
 };
 
-// Click-outside + Escape dismissal for the search panels. Iterates over a
-// registry of { panel, ref } instead of branching per panel: a click outside
-// a panel's ref closes that panel (a no-op for panels that aren't open).
+// Click-outside + Escape dismissal for the search panels. Since the panels are
+// mutually exclusive, the listeners are only attached while a panel is open and
+// a click outside that one panel's ref closes it — no per-panel branching.
 export function useSearchFormDismiss(
   registry: PanelRegistryEntry[],
+  openPanel: OpenPanel,
   closePanel: (panel: ActivePanel) => void,
   closeAllPanels: () => void,
 ): void {
   useEffect(() => {
+    if (!openPanel) return;
+
     const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-      for (const { panel, ref } of registry) {
-        if (ref.current && !ref.current.contains(target)) {
-          closePanel(panel);
-        }
+      if (!(event.target instanceof Node)) return;
+      const activeEntry = registry.find((entry) => entry.panel === openPanel);
+      if (activeEntry?.ref.current && !activeEntry.ref.current.contains(event.target)) {
+        closePanel(openPanel);
       }
     };
 
@@ -39,5 +41,5 @@ export function useSearchFormDismiss(
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleEsc);
     };
-  }, [registry, closePanel, closeAllPanels]);
+  }, [registry, openPanel, closePanel, closeAllPanels]);
 }

--- a/components/search/useSearchFormDismiss.ts
+++ b/components/search/useSearchFormDismiss.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import type { OpenPanel } from './types';
+
+type ActivePanel = Exclude<OpenPanel, null>;
+
+export type PanelRegistryEntry = {
+  panel: ActivePanel;
+  ref: React.RefObject<HTMLDivElement | null>;
+};
+
+// Click-outside + Escape dismissal for the search panels. Iterates over a
+// registry of { panel, ref } instead of branching per panel: a click outside
+// a panel's ref closes that panel (a no-op for panels that aren't open).
+export function useSearchFormDismiss(
+  registry: PanelRegistryEntry[],
+  closePanel: (panel: ActivePanel) => void,
+  closeAllPanels: () => void,
+): void {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      for (const { panel, ref } of registry) {
+        if (ref.current && !ref.current.contains(target)) {
+          closePanel(panel);
+        }
+      }
+    };
+
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeAllPanels();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEsc);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [registry, closePanel, closeAllPanels]);
+}


### PR DESCRIPTION
## Resumo

Resolve #967. `components/SearchForm.tsx` tinha **1005 linhas** e o orquestrador carregava **5 booleans paralelos** (`showDestSuggestions`, `showCalendar`, `showGuestDropdown`, `showTripTypeDropdown`, `showBudgetDropdown`) para painéis que são **mutuamente exclusivos**.

## O que mudou

### 1. União discriminada para o painel aberto
```ts
type OpenPanel = 'dest' | 'calendar' | 'guests' | 'trip' | 'budget' | null;
const [openPanel, setOpenPanel] = useState<OpenPanel>(null);
```
- Toggles viram `setOpenPanel(p => p === x ? null : x)`.
- `closeAllPanels` vira `setOpenPanel(null)`; `closePanel(x)` fecha guardado (`p === x ? null : p`).
- O type `CloseHandlers` e o leque de `useCallback` de fechamento desaparecem.
- `useSearchFormDismiss` itera sobre um registry `{ panel, ref }[]` em vez de 5 branches idênticas de click-outside. Refs continuam por-painel (necessárias para click-outside).

### 2. Decomposição em `components/search/`
Movidos para arquivos próprios: `DestinationField`, `DateField`, `GuestsField`, `TripTypeField`, `BudgetField`, `SearchButton`, além de `helpers.ts`, `types.ts` e `useSearchFormDismiss.ts`. Cada campo recebe `isOpen` em vez do antigo `show*`.

`SearchForm.tsx`: **1005 → 374 linhas** (orquestrador + estado).

### 3. Fix incidental
Corrige warning de chave duplicada no header de dias da semana do calendário (Qua/Qui→`Q`, Seg/Sex/Sab→`S` colidiam) — código que passou a ser tocado nesta mudança.

## Critérios de aceite
- [x] `SearchForm.tsx` abaixo de 1k linhas (374).
- [x] Estado de painéis unificado em um único `openPanel`.
- [x] Comportamento de UI (abrir/fechar, click-outside, Esc) inalterado — coberto por `tests/e2e/hero_ux.spec.ts`.

## Verificação
- `pnpm typecheck` ✅
- `pnpm test:e2e tests/e2e/hero_ux.spec.ts --project=chromium` ✅ (3 passed; o warning de chave duplicada some)
- `pnpm test:regression` ✅ 739/740 (a única falha é `site-positioning.test.ts`, pré-existente e alheia — procura uma pasta "Design System" ausente localmente)
- `pnpm build` ✅ (prerender completo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)