### PR TITLE
fix(quiz): previne duplo envio do lead da PreLeadScreen (#975)

### DIFF
--- a/components/landings/quiz/PreLeadScreen.tsx
+++ b/components/landings/quiz/PreLeadScreen.tsx
@@ -6,9 +6,10 @@ interface PreLeadScreenProps {
     profile: TravelerProfile;
     onSubmit: (form: LeadForm) => void;
     onBack: () => void;
+    isSubmitting: boolean;
 }
 
-export function PreLeadScreen({ profile, onSubmit, onBack }: PreLeadScreenProps) {
+export function PreLeadScreen({ profile, onSubmit, onBack, isSubmitting }: PreLeadScreenProps) {
     const [form, setForm] = useState<LeadForm>({ nome: '', sobrenome: '', email: '', aceite: false });
     const [errors, setErrors] = useState<Partial<Record<keyof LeadForm, string>>>({});
 
@@ -117,8 +118,8 @@ export function PreLeadScreen({ profile, onSubmit, onBack }: PreLeadScreenProps)
                         </Link>.
                     </p>
 
-                    <button type="submit" className="quiz-btn quiz-btn-primary quiz-btn-lg">
-                        Revelar meu perfil
+                    <button type="submit" className="quiz-btn quiz-btn-primary quiz-btn-lg" disabled={isSubmitting}>
+                        {isSubmitting ? 'Enviando...' : 'Revelar meu perfil'}
                         <span className="quiz-arrow">→</span>
                     </button>
                 </form>

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, useReducer } from 'react';
+import { useMemo, useCallback, useReducer, useRef } from 'react';
 import { Seo } from '../../components/Seo';
 import { BreadcrumbSchema } from '../../components/schemas/BreadcrumbSchema';
 import { useQuizCapture } from '../../hooks/useQuizCapture';
@@ -61,6 +61,7 @@ interface StageContentProps {
     leadForm: LeadForm | null;
     baseWaUrl: string;
     submitFailed: boolean;
+    isSubmitting: boolean;
     onStart: () => void;
     onAnswerQ: (qId: string, value: string[]) => void;
     onNextQ: (currentIndex: number) => void;
@@ -72,7 +73,7 @@ interface StageContentProps {
 }
 
 function StageContent({
-    stage, answers, profileKey, leadForm, baseWaUrl, submitFailed,
+    stage, answers, profileKey, leadForm, baseWaUrl, submitFailed, isSubmitting,
     onStart, onAnswerQ, onNextQ, onBackQ, onLeadSubmit, onRestart, onGo, onPhoneSubmit,
 }: StageContentProps) {
     if (stage.kind === 'hero') return <HeroScreen onStart={onStart} />;
@@ -98,6 +99,7 @@ function StageContent({
                 profile={TRAVELER_PROFILES[leadProfileKey]}
                 onSubmit={onLeadSubmit}
                 onBack={() => onGo({ kind: 'question', index: QUIZ_QUESTIONS.length - 1 }, 'back')}
+                isSubmitting={isSubmitting}
             />
         );
     }
@@ -195,7 +197,13 @@ export default function QuizAnhangaLanding() {
     const urlParams = useQuizUrlParams();
     const [state, dispatch] = useReducer(quizReducer, QUIZ_INITIAL_STATE);
     const { stage, direction, answers, leadForm, profileKey, baseWaUrl, submitFailed } = state;
-    const { submitQuiz } = useQuizCapture();
+    const { submitQuiz, isSubmitting } = useQuizCapture();
+
+    // Synchronous re-entrancy guard: handleLeadSubmit navigates to the result
+    // screen before awaiting submitQuiz, so the disabled button can race with the
+    // unmount. This ref blocks a second submit fired in the same tick, preventing
+    // duplicate leads in the CRM.
+    const submittingRef = useRef(false);
 
     const go = useCallback((next: Stage, dir: 'forward' | 'back' = 'forward') => {
         dispatch({ type: 'GO', stage: next, direction: dir });
@@ -230,6 +238,9 @@ export default function QuizAnhangaLanding() {
     }
 
     async function handleLeadSubmit(form: LeadForm, skipped = false) {
+        if (submittingRef.current) return;
+        submittingRef.current = true;
+
         const pKey = matchProfile(answers);
         const profile = TRAVELER_PROFILES[pKey];
         const mainDest = selectMainDestination(pKey, answers.destino ?? []);
@@ -242,6 +253,7 @@ export default function QuizAnhangaLanding() {
         go({ kind: 'result' });
 
         const result = await submitQuiz(buildQuizSubmitInput(form, pKey, answers, { skipped }));
+        submittingRef.current = false;
 
         if (!result.ok) {
             dispatch({ type: 'SUBMIT_FAILED' });
@@ -292,6 +304,7 @@ export default function QuizAnhangaLanding() {
                                 leadForm={leadForm}
                                 baseWaUrl={baseWaUrl}
                                 submitFailed={submitFailed}
+                                isSubmitting={isSubmitting}
                                 onStart={start}
                                 onAnswerQ={answerQ}
                                 onNextQ={nextQ}

--- a/tests/e2e/quiz-double-submit.spec.ts
+++ b/tests/e2e/quiz-double-submit.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * Regression for #975: rapid double clicks on "Revelar meu perfil" must not
+ * fire two lead submissions to /api/submit-quiz (which would create duplicate
+ * leads in the CRM). Protected by the disabled submit button plus a synchronous
+ * re-entrancy guard in the quiz orchestrator.
+ */
+
+async function answerSingle(page: Page, name: RegExp) {
+    const option = page.getByRole('button', { name });
+    await expect(option).toBeVisible();
+    await option.click();
+}
+
+test.describe('Quiz — proteção contra duplo envio do lead', () => {
+    test('dois cliques rápidos em "Revelar meu perfil" disparam apenas um envio inicial', async ({ page }) => {
+        const initialSubmits: Array<Record<string, unknown>> = [];
+
+        await page.route('**/api/submit-quiz', async route => {
+            const body = JSON.parse(route.request().postData() || '{}') as Record<string, unknown>;
+            // The reveal submit carries no whatsapp; the later enrichment submit does.
+            if (typeof body.whatsapp !== 'string' || body.whatsapp.length === 0) {
+                initialSubmits.push(body);
+            }
+            // Hold the request open to widen the in-flight window the guard covers.
+            await new Promise(resolve => setTimeout(resolve, 400));
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ ok: true, requestId: 'req-quiz-dup-e2e', message: 'ok' }),
+            });
+        });
+
+        // Salesforce mirror is fire-and-forget; stub it so it never errors in CI.
+        await page.route('**/api/submit-lead-sf', async route => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ ok: true }),
+            });
+        });
+
+        await page.goto('/quiz');
+
+        await page.getByRole('button', { name: /bora começar/i }).click();
+
+        // Q1 (destino) — múltipla escolha, exige "Próxima".
+        await page.getByRole('button', { name: /Europa/ }).click();
+        await page.getByRole('button', { name: /Próxima/ }).click();
+
+        // Q2–Q6 — escolha única, avançam sozinhas.
+        await answerSingle(page, /Aventura & autenticidade/);
+        await answerSingle(page, /Só eu/);
+        await answerSingle(page, /Multidão/);
+        await answerSingle(page, /Dinheiro\./);
+        await answerSingle(page, /Semi-planejado/);
+
+        // Tela de lead.
+        await expect(page.locator('#quiz-nome')).toBeVisible();
+        await page.locator('#quiz-nome').fill('Maria');
+        await page.locator('#quiz-sobrenome').fill('Silva');
+        await page.locator('#quiz-email').fill('maria@example.com');
+
+        // Dispara dois cliques no mesmo tick, antes de qualquer re-render do React.
+        await page.evaluate(() => {
+            const btn = document.querySelector<HTMLButtonElement>(
+                'form.quiz-lead-form button[type="submit"]',
+            );
+            btn?.click();
+            btn?.click();
+        });
+
+        // Avança para o resultado (passo de WhatsApp), confirmando que o fluxo seguiu.
+        await expect(page.getByLabel(/número de whatsapp/i)).toBeVisible();
+
+        // Mesmo com o duplo clique, só um envio inicial (sem whatsapp) pode ocorrer.
+        await expect.poll(() => initialSubmits.length).toBe(1);
+    });
+});


### PR DESCRIPTION
Resolve #975.

## Problema
O botão "Revelar meu perfil" da `PreLeadScreen` não era desabilitado durante a submissão. Cliques rápidos repetidos podiam disparar múltiplas requisições para `/api/submit-quiz` e Salesforce, gerando **leads duplicados** no CRM. Comportamento pré-existente, apontado em review do PR #972.

## O que muda
- **`useQuizCapture`** já expunha `isSubmitting` — agora ele é consumido pelo orquestrador.
- **`QuizAnhangaLanding`** repassa `isSubmitting` (via `StageContent`) à `PreLeadScreen`.
- **`PreLeadScreen`** desabilita o botão e troca o rótulo para `Enviando...` durante a requisição.
- **Guard síncrono (`useRef`)** em `handleLeadSubmit`: como `handleLeadSubmit` navega para o resultado **antes** do `await submitQuiz` (desmontando a `PreLeadScreen`), o `disabled` pode perder a corrida com o unmount. O ref bloqueia, de forma determinística, um segundo submit disparado no mesmo tick — fechando a janela residual de duplo envio. O ref é resetado ao fim da requisição.

## Critérios de aceite
- [x] Botão desabilitado + estado de envio (`Enviando...`) enquanto a submissão está em andamento.
- [x] Envio via tecla **Enter** continua funcionando (o botão só desabilita durante a requisição em voo).
- [x] Teste cobrindo o caminho de captura: `tests/e2e/quiz-double-submit.spec.ts` — duplo clique no mesmo tick dispara **apenas um** envio inicial.

## Verificação
- `pnpm typecheck` — ✅
- `pnpm test:e2e quiz-double-submit + quiz-whatsapp` — ✅ 10/10 (5 navegadores × 2 testes)
- Regressão do quiz (`node:test`) — ✅ 58/58

## Nota
O hook do impeccable sinalizou 40 achados em `pages/landings/quiz-anhanga.css` (bounce-easing etc.) — arquivo não tocado nesta mudança; achados pré-existentes e fora de escopo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)