### PR TITLE
test(regression): site-positioning determinístico p/ pasta "* Design System" sem README (#977)

### DIFF
--- a/tests/site-positioning.test.ts
+++ b/tests/site-positioning.test.ts
@@ -48,14 +48,30 @@ async function collectTextFiles(targetPath: string): Promise<string[]> {
   return nestedFiles.flat();
 }
 
+async function isReadableFile(filePath: string): Promise<boolean> {
+  try {
+    return (await stat(filePath)).isFile();
+  } catch {
+    // Untracked local folders (e.g. an empty "* Design System" dir holding only
+    // .DS_Store) may match without a README — skip them so the test stays
+    // deterministic regardless of the local working tree.
+    return false;
+  }
+}
+
 async function collectDesignSystemReadmes(): Promise<string[]> {
   const entries = await readdir(ROOT_DIR, { withFileTypes: true });
-
-  return entries.flatMap((entry) =>
+  const candidates = entries.flatMap((entry) =>
     entry.isDirectory() && entry.name.endsWith('Design System')
       ? [path.join(ROOT_DIR, entry.name, 'README.md')]
       : []
   );
+
+  const existing = await Promise.all(
+    candidates.map(async (candidate) => ((await isReadableFile(candidate)) ? candidate : null)),
+  );
+
+  return existing.filter((candidate): candidate is string => candidate !== null);
 }
 
 test('site positioning content does not use boutique agency positioning', async () => {


### PR DESCRIPTION
Resolve #977.

## Problema
`tests/site-positioning.test.ts` falhava localmente com `ENOENT` ao abrir `Anhangá Viagens Design System/README.md`. A `collectDesignSystemReadmes()` listava pastas na raiz terminadas em `Design System` e assumia que cada uma tinha um `README.md`, chamando `readFile()` direto. Uma pasta local **não-trackeada** (`Anhangá Viagens Design System/`, com apenas `.DS_Store`) era encontrada mas sem README → quebrava o teste. No CI a pasta não existe, então só falhava nesta máquina — mas a fragilidade é real.

## Remédio
Adiciona guarda de existência (`stat` + `isFile`, já com `stat` importado) que filtra candidatos inexistentes antes do `readFile`. A verificação de READMEs reais é preservada; apenas caminhos ausentes são ignorados.

## Critério de aceite
- [x] `pnpm test:regression` passa mesmo com uma pasta `* Design System` sem README na raiz.

## Verificação
- Reproduzido o `ENOENT` localmente (pasta presente) antes do fix.
- `tests/site-positioning.test.ts` — ✅ passa com a pasta presente.
- `pnpm test:regression` — ✅ **745/745** (antes: 1 falha pré-existente que vínhamos contornando em PRs anteriores).
- `pnpm typecheck` — ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)