### PR TITLE
test(e2e): skip "aceitar carrega Mautic" por host, não por env CI (#978)

### DIFF
--- a/tests/e2e/cookie-consent.spec.ts
+++ b/tests/e2e/cookie-consent.spec.ts
@@ -169,10 +169,16 @@ test.describe('Cookie Consent Banner (CMP)', () => {
 
   // --- Aceitar com Mautic ---
 
-  test('aceitar carrega Mautic', async ({ page }) => {
-    // Em CI o hostname é 127.0.0.1; loadMautic() tem guard que retorna cedo nesse caso.
-    // A lógica de despacho do evento e a gate de consentimento são cobertas por consent.test.ts.
-    test.skip(!!process.env.CI, 'loadMautic retorna cedo em 127.0.0.1 em CI — coberto por testes unitários');
+  test('aceitar carrega Mautic', async ({ page, baseURL }) => {
+    // loadMautic() (index.html) retorna cedo em hosts locais — localhost, 127.0.0.1,
+    // .local e .test — então mtc.js nunca é solicitado nesses hosts. O webServer do
+    // Playwright roda em 127.0.0.1 por padrão (local e CI), logo o skip precisa
+    // depender do host real, não só de process.env.CI. A lógica de despacho e a gate
+    // de consentimento já são cobertas por consent.test.ts e index-third-party-scripts.test.ts.
+    const host = baseURL ? new URL(baseURL).hostname : '127.0.0.1';
+    const isMauticGatedHost =
+      host === 'localhost' || host === '127.0.0.1' || host.endsWith('.local') || host.endsWith('.test');
+    test.skip(isMauticGatedHost, `loadMautic retorna cedo em ${host} — coberto por testes unitários`);
 
     // Interceptar o script do Mautic para confirmar que foi solicitado
     let mauticRequested = false;

--- a/tests/e2e/cookie-consent.spec.ts
+++ b/tests/e2e/cookie-consent.spec.ts
@@ -175,7 +175,16 @@ test.describe('Cookie Consent Banner (CMP)', () => {
     // Playwright roda em 127.0.0.1 por padrão (local e CI), logo o skip precisa
     // depender do host real, não só de process.env.CI. A lógica de despacho e a gate
     // de consentimento já são cobertas por consent.test.ts e index-third-party-scripts.test.ts.
-    const host = baseURL ? new URL(baseURL).hostname : '127.0.0.1';
+    let host = '127.0.0.1';
+    if (baseURL) {
+      try {
+        host = new URL(baseURL).hostname;
+      } catch {
+        // baseURL sem protocolo (ex.: sobrescrito via CLI) — usa o valor cru,
+        // que ainda casa com os sufixos .local/.test do gate abaixo.
+        host = baseURL;
+      }
+    }
     const isMauticGatedHost =
       host === 'localhost' || host === '127.0.0.1' || host.endsWith('.local') || host.endsWith('.test');
     test.skip(isMauticGatedHost, `loadMautic retorna cedo em ${host} — coberto por testes unitários`);


### PR DESCRIPTION
Resolve #978.

## Problema
`tests/e2e/cookie-consent.spec.ts` ("aceitar carrega Mautic") falhava em **todos os navegadores localmente** (`expect(mauticRequested).toBe(true)` recebia `false`).

## Causa raiz
`loadMautic()` (em `index.html`) retorna cedo quando o hostname é `localhost`, `127.0.0.1`, `.local` ou `.test` — então `mtc.js` nunca é solicitado nesses hosts. O `webServer` do Playwright roda em `127.0.0.1` por padrão (local **e** CI), mas o skip do teste só checava `process.env.CI`. A condição estava incompleta: localmente o host é gated mas `CI` é falso → o teste roda e falha de forma garantida.

## Remédio
Deriva o host da fixture `baseURL` e pula quando ele dispara o gate do `loadMautic`, espelhando exatamente a condição de `index.html`. A lógica de despacho do evento e a gate de consentimento já são cobertas por `consent.test.ts` e `index-third-party-scripts.test.ts`, então pular no host local é seguro. Em um host não-gated (ex.: domínio real ou `0.0.0.0`), o teste volta a rodar normalmente.

## Critério de aceite
- [x] `pnpm test:e2e tests/e2e/cookie-consent.spec.ts` passa/pula determinístico localmente em todos os navegadores.

## Verificação
- `pnpm test:e2e tests/e2e/cookie-consent.spec.ts` — ✅ **60 passed, 5 skipped** (o teste do Mautic pula determinístico nos 5 navegadores em `127.0.0.1`; antes falhava em todos).
- `pnpm typecheck` — ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)