### PR TITLE
fix(dev): pré-bundla globe.gl em optimizeDeps p/ estabilizar e2e do /corporativo (#979)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -211,6 +211,16 @@ export default defineConfig(({ mode, isSsrBuild }) => {
       host: devHost,
       strictPort: devStrictPort,
     },
+    // globe.gl é um dynamic import alcançado só em /corporativo, então o scan
+    // inicial do Vite não o descobre. Sem isto, o primeiro acesso descobre
+    // globe.gl + three + three-globe e dispara uma re-otimização que invalida
+    // node_modules/.vite/deps em pleno carregamento → "Failed to fetch
+    // dynamically imported module". Pré-bundlar de forma estável elimina a
+    // flakiness no e2e do /corporativo. Dev-only; em build o globe entra no
+    // grafo normal de chunks.
+    optimizeDeps: {
+      include: ['globe.gl', 'three', 'three-globe'],
+    },
     plugins: [
       stripMdxFrontmatterPlugin(),
       {


### PR DESCRIPTION
Resolve #979.

## Problema
Durante a suíte e2e (dev server do Vite), o console acusava repetidamente `Failed to load globe.gl: TypeError: Failed to fetch dynamically imported module`, desestabilizando `tests/e2e/corporativo.spec.ts` em webkit/firefox.

## Causa raiz
`globe.gl` é um dynamic import alcançado só em `/corporativo`, fora do scan inicial do Vite. No primeiro acesso, o dev server descobria `globe.gl` + `three` + `three-globe` e disparava uma re-otimização do pré-bundler, invalidando `node_modules/.vite/deps/globe__gl.js` em pleno carregamento → o import falhava. Problema **dev/test-only** (em build o globe entra no grafo normal de chunks).

## Remédio
Adiciona `optimizeDeps.include = ['globe.gl', 'three', 'three-globe']` no `vite.config.ts`, forçando o pré-bundling estável dessas deps no dev server (sem re-otimização em runtime).

## Critério de aceite
- [x] Sem erros "Failed to load globe.gl" no console durante `pnpm test:e2e` (exceto o teste de fallback, que aborta o globe **de propósito**).
- [x] `tests/e2e/corporativo.spec.ts` estável em chromium/firefox/webkit.

## Verificação
Com `node_modules/.vite` limpo (força o cenário de otimização do zero):
- `corporativo.spec.ts --repeat-each=2` (todos os testes, todos os navegadores) — ✅ **76 passed, 4 skipped**, hash do dep estável (`?v=669f2d3a` em todas as ocorrências, sem re-otimização).
- `corporativo.spec.ts --repeat-each=3 --grep-invert "fallback when globe"` — ✅ **105/105**, **zero** erros "Failed to load globe.gl" no console.
- O teste `should show fallback when globe.gl fails to load` continua válido (aborta `globe(\.|__)gl|three-globe` e verifica o fallback).
- `pnpm typecheck` — ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)