### PR TITLE
test(e2e): estabiliza contact-form e destructive-lolla cross-browser (#980)

### DIFF
--- a/tests/e2e/contact-form.spec.ts
+++ b/tests/e2e/contact-form.spec.ts
@@ -118,14 +118,16 @@ test.describe('CallToAction inline form', () => {
   });
 
   test('expande formulário ao clicar em "Solicitar meu Orçamento"', async ({ page }) => {
-    await page.locator('#contato').scrollIntoViewIfNeeded();
+    // O click do Playwright já rola até o alvo e aguarda actionability/estabilidade.
+    // Rolar o container #contato antes desacopla o elemento se a seção re-renderiza
+    // entre o scroll e a ação (flaky em firefox/webkit) — agir direto no botão evita
+    // a janela de detach.
     await page.getByRole('button', { name: /solicitar meu orçamento/i }).click();
 
     await expect(page.locator('#cta-firstName')).toBeVisible();
   });
 
   test('exibe confirmação após "Me chamem"', async ({ page }) => {
-    await page.locator('#contato').scrollIntoViewIfNeeded();
     await page.getByRole('button', { name: /solicitar meu orçamento/i }).click();
 
     await page.locator('#cta-firstName').fill('João');

--- a/tests/e2e/pages/LollapaloozaPage.ts
+++ b/tests/e2e/pages/LollapaloozaPage.ts
@@ -21,7 +21,11 @@ export class LollapaloozaPage {
 
   async goto() {
     await this.page.goto('/lollapalooza');
-    await this.page.waitForLoadState('networkidle');
+    // networkidle é flaky em firefox/webkit: timers de analytics e o vídeo de
+    // fundo mantêm conexões abertas e a página nunca atinge idle dentro do
+    // timeout. Espera o formulário da waitlist renderizar — sinal observável e
+    // determinístico de que a página hidratou e está interativa.
+    await this.nameInput.waitFor({ state: 'visible' });
   }
 
   async fillForm(data: { name: string; email: string; acceptLgpd?: boolean }) {


### PR DESCRIPTION
Resolve #980.

## Problema
Na suíte e2e completa, `contact-form.spec.ts` e `destructive-lolla.spec.ts` falhavam apenas em **firefox/webkit** (chromium passava) por timing/flakiness — não por regressão. Pré-existente em `main`.

## Causas e remédios

**1. `contact-form.spec.ts` (CallToAction inline)** — `locator.scrollIntoViewIfNeeded: Element is not attached to the DOM`
A seção `#contato` re-renderiza (hidratação/troca de estado) entre o `scrollIntoViewIfNeeded` no container e a ação seguinte, desanexando o elemento. Removido o scroll no container: o `.click()` do Playwright já rola até o botão e aguarda actionability/estabilidade, eliminando a janela de detach.

**2. `destructive-lolla.spec.ts` (Lollapalooza waitlist)** — `page.waitForLoadState: Test timeout of 30000ms exceeded`
O timeout vinha do `beforeEach → goto() → waitForLoadState('networkidle')`. `networkidle` é flaky em firefox/webkit: timers de analytics e o vídeo de fundo mantêm conexões abertas e a página nunca atinge idle dentro do timeout. Trocado por `nameInput.waitFor({ state: 'visible' })` — sinal observável e determinístico de que a página hidratou.

## Critério de aceite
- [x] `contact-form.spec.ts` e `destructive-lolla.spec.ts` estáveis em chromium, firefox e webkit.

## Verificação
- Ambos os specs, todos os navegadores (incl. projetos mobile), `--repeat-each=3` → ✅ **210/210, 0 flaky** (sem "not attached", sem "Test timeout").
- `pnpm typecheck` — ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)