### PR TITLE
docs(security): corrige nota do GHSA-h67p-54hq-rp68 (js-yaml) — override viável após cooldown

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,13 +24,21 @@ overrides:
   # injeção de header/cookie). Transitivo via wrangler > miniflare.
   # 7.28.0 corrige; pinado em ^7.28.0 (mesma major).
   undici: "^7.28.0"
-  # NOTA: GHSA-h67p-54hq-rp68 (moderate, DoS quadrático em merge keys do
-  # js-yaml <= 4.1.1) NÃO é corrigível por override aqui. O patch exige
-  # js-yaml >= 4.1.2, mas o gray-matter (build-time, scripts/blog-manifest)
-  # depende de js-yaml 3.x e usa a API yaml.safeLoad, removida na 4.x — forçar
-  # a 4.x quebra a geração do manifest. Não há release de gray-matter sobre
-  # js-yaml 4. O risco é build/dev-time apenas e já existe na main; revisitar
-  # se/quando o gray-matter for substituído ou migrar para js-yaml 4.
+  # PENDENTE: GHSA-h67p-54hq-rp68 (moderate, DoS quadrático em merge keys do
+  # js-yaml via aliases repetidos). Transitivo build/dev-time via gray-matter
+  # (scripts/blog-manifest) e bundlesize2 > cosmiconfig — ambos na linha 3.x,
+  # que usa a API yaml.safeLoad. Resolvido instalado: js-yaml@3.14.2 (vulnerável).
+  #
+  # CORREÇÃO conhecida (atualiza nota anterior que dizia ser inviável): existe o
+  # backport js-yaml@3.15.0 (dist-tag v3-legacy, publicado 2026-06-26) que corrige
+  # NA PRÓPRIA linha 3.x e preserva safeLoad — logo NÃO quebra o gray-matter.
+  # O override correto é:  js-yaml: "^3.15.0"  (>=3.15.0 <4, mantém major 3.x).
+  #
+  # BLOQUEIO temporário: 3.15.0 ainda está dentro da janela `minimumReleaseAge`
+  # (10080 min / 7 dias) desta config — `pnpm install` rejeita com
+  # ERR_PNPM_NO_MATURE_MATCHING_VERSION até ~2026-07-03. Adotar o override acima
+  # quando a versão amadurecer (não burlar o cooldown via exclude para um release
+  # de poucos dias). Risco até lá: build/dev-time apenas, moderate, já na main.
 
 legacyPeerDeps: true
 nodeLinker: hoisted


### PR DESCRIPTION
## Resumo

- **O que muda:** Reescreve a nota de `GHSA-h67p-54hq-rp68` (js-yaml) em `pnpm-workspace.yaml`. A nota anterior afirmava que a advisory **não era corrigível por override**. Isso está desatualizado.
- **Por quê:** Existe o backport **`js-yaml@3.15.0`** (dist-tag `v3-legacy`, publicado 2026-06-26) que corrige o DoS quadrático **na própria linha 3.x** e preserva a API `safeLoad` — logo **não** quebra o `gray-matter` (a justificativa da nota antiga de que "só 4.1.2 corrige" não vale mais). O override correto passa a ser `js-yaml: "^3.15.0"`.
- **Impacto para o usuário:** Nenhum em runtime. Mudança somente de comentário; o lockfile não é alterado.
- **Nível de risco:** baixo

### Por que só a nota (e não o override de fato)

O override `js-yaml: "^3.15.0"` foi validado localmente e **falha o `pnpm install` hoje** por causa da trava de supply-chain do próprio repo:

```text
[ERR_PNPM_NO_MATURE_MATCHING_VERSION] js-yaml@3.15.0 was published at
2026-06-26T23:12:41Z, within the minimumReleaseAge cutoff (2026-06-22T18:43Z)
```

`minimumReleaseAge: 10080` (7 dias) rejeita a 3.15.0 até **~2026-07-03**. Aplicar o override agora deixaria o lockfile dessincronizado e quebraria o CI. A opção de burlar o cooldown (`minimumReleaseAgeExclude`) instalaria um release de ~2 dias — exatamente o risco que a trava protege —, então **não** foi feita sem aprovação.

**Plano:** adotar o override `js-yaml: "^3.15.0"` quando a versão amadurecer (~03/07). Posso abrir o PR funcional nessa data. Até lá o risco é build/dev-time apenas, moderate, e já existente na `main`.

### Contexto do scan de dependências

Rodada de auditoria (`pnpm audit` / `pnpm outdated`) deste repositório:
- **Segurança:** 1 moderate — este `js-yaml` (transitivo, dev/build-time via `gray-matter` e `bundlesize2 > cosmiconfig`). Sem `high`/`critical`.
- **Desatualizados sem CVE:** `@types/node` 25→26 (major), `@google/genai` 2.8→2.9, `@sentry/{cloudflare,react}` 10.58→10.59, `lucide-react` 1.18→1.21, `react-router-dom` 7.17→7.18, `wrangler` 4.100→4.103, `@aws-sdk/client-s3`, `react-doctor`, `sharp` (patch). Não incluídos aqui.

## Issue relacionada

Sem issue. Acompanhamento da advisory `GHSA-h67p-54hq-rp68` levantada pelo `pnpm audit`.

## Tipo de mudança

- [x] 📚 Documentação

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only) — docs-only (comentário em `pnpm-workspace.yaml`).
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível) — N/A.

Comandos executados:

```text
pnpm audit            # 1 moderate (js-yaml), 0 high/critical
pnpm outdated         # levantamento de versões
pnpm install --lockfile-only  # validou o bloqueio do override pela minimumReleaseAge
git diff --stat       # confirma: só comentário alterado, lockfile intacto
```

## API & Segurança

- [x] Não se aplica — não toca handlers de `api/` nem fluxos com input externo.

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`docs:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

- Mudança intencionalmente **docs-only**: o override funcional está bloqueado pela `minimumReleaseAge` até ~2026-07-03. Esta correção evita que a nota antiga (factualmente errada) leve a vuln a ser tratada como "não corrigível" indefinidamente, e deixa o plano de adoção documentado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtbBaTAKgiCthdVRZLWEbY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtbBaTAKgiCthdVRZLWEbY)_