### PR TITLE
fix(crm): envia consentimento LGPD do chatbot/corporativo pro Odoo

### DIFF
--- a/components/ChatLeadForm.tsx
+++ b/components/ChatLeadForm.tsx
@@ -53,6 +53,8 @@ type ValidationResult =
   | {
       ok: true;
       payload: LeadFinalizePayload;
+      /** LGPD checkbox is mandatory, so a valid submit always carries consent. */
+      marketingOptIn: boolean;
     }
   | {
       ok: false;
@@ -71,7 +73,7 @@ type TextFieldProps = {
   inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode'];
 };
 
-function validateLeadForm(values: LeadFormValues): ValidationResult {
+export function validateLeadForm(values: LeadFormValues): ValidationResult {
   const normalizedFirstName = values.firstName.trim();
   const normalizedLastName = values.lastName.trim();
   const normalizedEmail = values.email.trim().toLowerCase();
@@ -122,6 +124,7 @@ function validateLeadForm(values: LeadFormValues): ValidationResult {
       bantSummary: values.defaultBantSummary || 'Não informado',
       destination: normalizedDestination,
     },
+    marketingOptIn: values.acceptedLGPD,
   };
 }
 
@@ -211,12 +214,17 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
       isProcessingRef.current = false;
       return;
     }
-    const { payload } = validation;
+    const { payload, marketingOptIn } = validation;
 
     void triggerHaptic('medium');
 
     const eventId = createLeadEventId();
-    const submitPayload = prepareLeadSubmitPayload(payload, eventId);
+    // Forward the LGPD/marketing consent so the handler sets x_lgpd_consent on
+    // the Odoo res.partner; prepareLeadSubmitPayload only maps draft + tracking.
+    const submitPayload: SubmitLeadRequest = {
+      ...prepareLeadSubmitPayload(payload, eventId),
+      marketingOptIn,
+    };
     pushGenerateLeadDataLayerEvent(submitPayload);
 
     // Open WhatsApp synchronously in the click handler to prevent popup blockers on mobile/Safari

--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -47,6 +47,8 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                     eventId,
                     pushDataLayerEvent: true,
                     formType: 'corporate_lead',
+                    // Mandatory LGPD checkbox → Odoo x_lgpd_consent on the partner.
+                    marketingOptIn: state.acceptedLGPD,
                 },
             );
 

--- a/tests/chat-lead-form-a11y.test.ts
+++ b/tests/chat-lead-form-a11y.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { TextField } from '../components/ChatLeadForm.tsx';
+import { TextField, validateLeadForm } from '../components/ChatLeadForm.tsx';
 
 const baseProps = {
   id: 'lead-email',
@@ -36,4 +36,28 @@ test('TextField sem erro não adiciona atributos de erro', () => {
   assert.ok(!html.includes('aria-invalid'), 'não deve ter aria-invalid sem erro');
   assert.ok(!html.includes('aria-describedby'), 'não deve ter aria-describedby sem erro');
   assert.ok(!html.includes('role="alert"'), 'não deve ter role="alert" sem erro');
+});
+
+const validLeadValues = {
+  firstName: 'Ana',
+  lastName: 'Silva',
+  email: 'ana@example.com',
+  whatsapp: '11999998888',
+  countryCode: '+55',
+  destination: 'Orlando',
+  defaultBantSummary: 'Need: Disney',
+};
+
+test('validateLeadForm — lead válido carrega o consentimento de marketing (→ x_lgpd_consent)', () => {
+  const result = validateLeadForm({ ...validLeadValues, acceptedLGPD: true });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.marketingOptIn, true);
+});
+
+test('validateLeadForm — sem aceite de LGPD a submissão é bloqueada', () => {
+  const result = validateLeadForm({ ...validLeadValues, acceptedLGPD: false });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.ok === false && result.fieldErrors?.lgpd, 'Você deve aceitar os termos');
 });

--- a/tests/chat-lead-form-a11y.test.ts
+++ b/tests/chat-lead-form-a11y.test.ts
@@ -52,12 +52,17 @@ test('validateLeadForm — lead válido carrega o consentimento de marketing (�
   const result = validateLeadForm({ ...validLeadValues, acceptedLGPD: true });
 
   assert.equal(result.ok, true);
-  assert.equal(result.ok && result.marketingOptIn, true);
+  if (result.ok) {
+    assert.equal(result.marketingOptIn, true);
+  }
 });
 
 test('validateLeadForm — sem aceite de LGPD a submissão é bloqueada', () => {
   const result = validateLeadForm({ ...validLeadValues, acceptedLGPD: false });
 
   assert.equal(result.ok, false);
-  assert.equal(result.ok === false && result.fieldErrors?.lgpd, 'Você deve aceitar os termos');
+  if (!result.ok) {
+    assert.ok(result.fieldErrors);
+    assert.equal(result.fieldErrors.lgpd, 'Você deve aceitar os termos');
+  }
 });


### PR DESCRIPTION
## Problema

Closes #1006. No cut-over Site → Odoo, o lead de teste do chatbot entrou correto (`res.partner` + `crm.lead`), mas `x_lgpd_consent = false` — deixando o contato fora do segmento **"Base Email Ativa"** do funil.

## Causa raiz

Tanto `ChatLeadForm` (chatbot) quanto `CorpContactForm` (landing corporativa) já têm um **checkbox de aceite obrigatório**:

> _"Aceito receber comunicações e autorizo o tratamento dos meus dados conforme a Política de Privacidade."_

Mas o valor (`acceptedLGPD`) era usado **apenas na validação** e nunca era propagado ao payload. Resultado: `marketingOptIn` chegava `undefined` em `/api/submit-lead`, e `buildPartnerFields` só grava `x_lgpd_consent` quando o opt-in é `true`.

## Decisão de produto/legal (item aberto na issue)

A issue perguntava "o que conta como aceite no chatbot". **Já existe** um checkbox LGPD explícito e **obrigatório** no `ChatLeadForm` — não há aceite implícito. Esse checkbox É o opt-in de e-mail marketing + consentimento LGPD. Como é obrigatório para enviar, todo lead submetido com sucesso consentiu. Nenhuma UI nova foi necessária.

## Mudanças

- **`ChatLeadForm.tsx`** — `validateLeadForm` agora expõe `marketingOptIn` (= aceite obrigatório); o submit injeta o sinal no `SubmitLeadRequest` antes do `onFinalizeLead`.
- **`CorpContactForm.tsx`** — encaminha `state.acceptedLGPD` como `marketingOptIn` nas opções do `submitLead`.
- **`tests/chat-lead-form-a11y.test.ts`** — regressão: `validateLeadForm` carrega o consentimento no caso válido e bloqueia o submit sem aceite.

O backend (schema → `leadInputFromSubmitLead` → `buildPartnerFields`) já mapeava `marketingOptIn → x_lgpd_consent`; faltava só o cliente enviar.

## Verificação

- `pnpm exec tsc --noEmit` ✅
- `tests/chat-lead-form-a11y.test.ts`, `submit-lead.test.ts`, `odoo-lead-mapping.test.ts`, `corp-form-reducer.test.ts` ✅ (44 testes)

## Critério de aceite (issue)

Lead novo pelo chatbot → `res.partner.x_lgpd_consent = true`. Conferir via MCP:
`odoo_search_read res.partner [["email","=","<email-teste>"]] fields=["x_lgpd_consent"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)