### PR TITLE
feat(crm): destino do site vira tag category_id no Odoo

### DIFF
--- a/lib/destination-region.ts
+++ b/lib/destination-region.ts
@@ -138,9 +138,15 @@ function escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function matchesKeyword(haystack: string, keyword: string): boolean {
-    return new RegExp(`\\b${escapeRegExp(keyword)}\\b`).test(haystack);
-}
+// One alternation regex per region, compiled once at module load (avoids
+// recompiling a RegExp per keyword on every submit). Word boundaries keep short
+// tokens from matching inside longer words (e.g. "usa" inside "jerusalem").
+const REGION_RULES: Array<{ tag: RegionTagId; regex: RegExp }> = REGION_KEYWORDS.map(
+    ({ tag, keywords }) => ({
+        tag,
+        regex: new RegExp(`\\b(?:${keywords.map(escapeRegExp).join('|')})\\b`),
+    }),
+);
 
 /** Quiz answer ids → region tags (structured, exact lookup). */
 export function resolveQuizDestinoTags(destinos: string[] | undefined | null): RegionTagId[] {
@@ -160,8 +166,8 @@ export function resolveRegionTagsFromText(text: string | null | undefined): Regi
     if (!normalized) return [];
 
     const tags = new Set<RegionTagId>();
-    for (const { tag, keywords } of REGION_KEYWORDS) {
-        if (keywords.some((kw) => matchesKeyword(normalized, kw))) {
+    for (const { tag, regex } of REGION_RULES) {
+        if (regex.test(normalized)) {
             tags.add(tag);
         }
     }

--- a/lib/destination-region.ts
+++ b/lib/destination-region.ts
@@ -1,0 +1,169 @@
+/**
+ * Maps a travel destination to Odoo `res.partner.category` tags under the parent
+ * "Destino de Interesse" (id 2). Two intake shapes feed this:
+ *  - Quiz: structured answer ids (`europa`, `america-norte`, …) → direct lookup.
+ *  - Chatbot/contato: free text ("Orlando", "Lisboa") → keyword heuristic.
+ *
+ * Unrecognized destinations return no tag (the raw text still lands in the
+ * crm.lead description), so a miss degrades gracefully instead of mis-tagging.
+ */
+
+// res.partner.category record ids (contract §, validated against the instance).
+export const REGION_TAG = {
+    europa: 3,
+    asia: 4,
+    americaLatina: 5,
+    americaNorte: 6,
+    oceania: 7,
+    brasil: 8,
+    africaOriente: 9,
+    caribe: 10,
+    cruzeiros: 11,
+    abertoSurpresa: 12,
+} as const;
+
+export type RegionTagId = (typeof REGION_TAG)[keyof typeof REGION_TAG];
+
+// Quiz `destino` answer ids (data/quiz.ts) → region tag. The quiz has no Brasil,
+// Oceania or Cruzeiros options; those only arise from free text.
+const QUIZ_DESTINO_TO_TAG: Record<string, RegionTagId> = {
+    'europa': REGION_TAG.europa,
+    'america-norte': REGION_TAG.americaNorte,
+    'latam': REGION_TAG.americaLatina,
+    'caribe': REGION_TAG.caribe,
+    'asia': REGION_TAG.asia,
+    'africa-oriente': REGION_TAG.africaOriente,
+    'surpresa': REGION_TAG.abertoSurpresa,
+};
+
+// Free-text keywords per region, normalized (lowercase, no diacritics). Matched
+// on word boundaries so short tokens (eua) don't hit inside longer words. Order
+// is irrelevant: all matching regions are returned, deduped.
+const REGION_KEYWORDS: Array<{ tag: RegionTagId; keywords: string[] }> = [
+    {
+        tag: REGION_TAG.cruzeiros,
+        keywords: ['cruzeiro', 'cruzeiros', 'navio'],
+    },
+    {
+        tag: REGION_TAG.brasil,
+        keywords: [
+            'brasil', 'rio de janeiro', 'sao paulo', 'nordeste', 'bahia', 'salvador',
+            'fernando de noronha', 'noronha', 'gramado', 'florianopolis', 'fortaleza',
+            'recife', 'natal', 'maceio', 'jericoacoara', 'porto de galinhas',
+            'foz do iguacu', 'amazonia', 'pantanal', 'chapada', 'bonito', 'buzios',
+            'paraty', 'ilha grande', 'maragogi', 'lencois',
+        ],
+    },
+    {
+        tag: REGION_TAG.americaNorte,
+        keywords: [
+            'estados unidos', 'eua', 'usa', 'orlando', 'miami', 'nova york', 'new york',
+            'los angeles', 'las vegas', 'california', 'disney', 'universal', 'canada',
+            'toronto', 'vancouver', 'montreal', 'washington', 'chicago', 'boston',
+            'san francisco', 'havai', 'hawaii', 'alasca', 'seattle',
+        ],
+    },
+    {
+        tag: REGION_TAG.americaLatina,
+        keywords: [
+            'mexico', 'cidade do mexico', 'argentina', 'buenos aires', 'bariloche',
+            'chile', 'santiago', 'atacama', 'peru', 'lima', 'cusco', 'machu picchu',
+            'colombia', 'bogota', 'cartagena', 'uruguai', 'montevideu', 'punta del este',
+            'bolivia', 'equador', 'paraguai', 'costa rica', 'panama', 'guatemala',
+        ],
+    },
+    {
+        tag: REGION_TAG.caribe,
+        keywords: [
+            'caribe', 'cancun', 'riviera maya', 'punta cana', 'republica dominicana',
+            'aruba', 'bahamas', 'jamaica', 'cuba', 'havana', 'curacao', 'barbados',
+            'porto rico', 'maldivas', 'st marten', 'sao martinho',
+        ],
+    },
+    {
+        tag: REGION_TAG.europa,
+        keywords: [
+            'europa', 'portugal', 'lisboa', 'porto', 'espanha', 'madri', 'madrid',
+            'barcelona', 'franca', 'paris', 'italia', 'roma', 'veneza', 'florenca',
+            'milao', 'londres', 'inglaterra', 'reino unido', 'alemanha', 'berlim',
+            'munique', 'amsterda', 'holanda', 'paises baixos', 'grecia', 'atenas',
+            'santorini', 'suica', 'austria', 'viena', 'irlanda', 'dublin', 'escocia',
+            'praga', 'budapeste', 'croacia', 'noruega', 'suecia', 'estocolmo',
+            'dinamarca', 'copenhague', 'finlandia', 'belgica', 'polonia', 'islandia',
+        ],
+    },
+    {
+        tag: REGION_TAG.asia,
+        keywords: [
+            'asia', 'japao', 'toquio', 'quioto', 'osaka', 'china', 'pequim', 'xangai',
+            'hong kong', 'tailandia', 'bangkok', 'phuket', 'vietna', 'india', 'indonesia',
+            'bali', 'singapura', 'coreia', 'seul', 'filipinas', 'camboja', 'nepal',
+            'sri lanka', 'taiwan', 'malasia',
+        ],
+    },
+    {
+        tag: REGION_TAG.oceania,
+        keywords: [
+            'oceania', 'australia', 'sydney', 'melbourne', 'nova zelandia', 'auckland',
+            'fiji', 'tahiti', 'polinesia', 'bora bora',
+        ],
+    },
+    {
+        tag: REGION_TAG.africaOriente,
+        keywords: [
+            'africa', 'africa do sul', 'cidade do cabo', 'egito', 'cairo', 'marrocos',
+            'marrakech', 'quenia', 'safari', 'tanzania', 'zanzibar', 'dubai', 'abu dhabi',
+            'emirados', 'catar', 'qatar', 'israel', 'jerusalem', 'jordania', 'petra',
+            'namibia', 'mauricio', 'seychelles',
+        ],
+    },
+    {
+        tag: REGION_TAG.abertoSurpresa,
+        keywords: [
+            'surpresa', 'me surpreenda', 'qualquer lugar', 'indeciso', 'nao sei',
+            'destino aberto', 'aberto', 'tanto faz',
+        ],
+    },
+];
+
+function normalize(value: string): string {
+    return value
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .trim();
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function matchesKeyword(haystack: string, keyword: string): boolean {
+    return new RegExp(`\\b${escapeRegExp(keyword)}\\b`).test(haystack);
+}
+
+/** Quiz answer ids → region tags (structured, exact lookup). */
+export function resolveQuizDestinoTags(destinos: string[] | undefined | null): RegionTagId[] {
+    if (!destinos || destinos.length === 0) return [];
+    const tags = new Set<RegionTagId>();
+    for (const id of destinos) {
+        const tag = QUIZ_DESTINO_TO_TAG[id];
+        if (tag) tags.add(tag);
+    }
+    return [...tags];
+}
+
+/** Free-text destination → region tags (heuristic). Empty when unrecognized. */
+export function resolveRegionTagsFromText(text: string | null | undefined): RegionTagId[] {
+    if (!text) return [];
+    const normalized = normalize(text);
+    if (!normalized) return [];
+
+    const tags = new Set<RegionTagId>();
+    for (const { tag, keywords } of REGION_KEYWORDS) {
+        if (keywords.some((kw) => matchesKeyword(normalized, kw))) {
+            tags.add(tag);
+        }
+    }
+    return [...tags];
+}

--- a/lib/odoo-lead-mapping.ts
+++ b/lib/odoo-lead-mapping.ts
@@ -16,6 +16,11 @@ import type { LeadTracking, LeadUtms, SubmitLeadRequest } from '../types/leadCap
 import type { SubmitContactRequest } from '../types/contactCapture';
 import type { SubmitQuizRequest } from '../types/quiz';
 import type { SubmitWaitlistRequest } from '../types/waitlist';
+import {
+    type RegionTagId,
+    resolveQuizDestinoTags,
+    resolveRegionTagsFromText,
+} from './destination-region';
 
 // utm.source / utm.medium record IDs (see contract §3, validated against instance).
 const SOURCE = { referral: 8, googleAds: 17, metaAds: 18, quiz: 16, whatsapp: 19, site: 15 } as const;
@@ -55,6 +60,8 @@ export interface OdooLeadInput {
     marketingOptIn: boolean;
     /** Quiz ProfileKey → x_perfil_do_viajante (selection). */
     profileKey?: string | null;
+    /** "Destino de Interesse" tags (res.partner.category) → category_id. */
+    destinationTagIds?: RegionTagId[];
     destination?: string | null;
     bantSummary?: string | null;
     referred?: string | null;
@@ -100,6 +107,8 @@ function fullName(firstName: string, lastName: string): string {
  * Builds the `res.partner` create/write dict. Only includes fields with content:
  * `x_lgpd_consent` is written only when opting in (we never revoke consent on an
  * update), and `x_perfil_do_viajante` only for a recognized quiz profile.
+ * `category_id` uses link commands `(4, id)` so tags are added without removing
+ * any existing ones on a deduped partner.
  */
 export function buildPartnerFields(input: OdooLeadInput): Record<string, unknown> {
     const fields: Record<string, unknown> = { name: fullName(input.firstName, input.lastName) };
@@ -109,6 +118,9 @@ export function buildPartnerFields(input: OdooLeadInput): Record<string, unknown
     if (input.marketingOptIn) fields.x_lgpd_consent = true;
     if (input.profileKey && VALID_PROFILE_KEYS.has(input.profileKey)) {
         fields.x_perfil_do_viajante = input.profileKey;
+    }
+    if (input.destinationTagIds && input.destinationTagIds.length > 0) {
+        fields.category_id = input.destinationTagIds.map((id) => [4, id]);
     }
     if (input.contextNote) fields.comment = input.contextNote;
 
@@ -188,6 +200,7 @@ export function leadInputFromSubmitLead(data: SubmitLeadRequest): OdooLeadInput 
         phone: data.whatsapp || null,
         marketingOptIn: data.marketingOptIn === true,
         destination: data.destination,
+        destinationTagIds: resolveRegionTagsFromText(data.destination),
         bantSummary: data.bantSummary,
         eventId: data.event_id ?? null,
         utms: data.utms,
@@ -206,6 +219,7 @@ export function leadInputFromSubmitContact(data: SubmitContactRequest): OdooLead
         phone: data.whatsapp || null,
         marketingOptIn: data.emailOptIn === true,
         destination: data.destination ?? null,
+        destinationTagIds: resolveRegionTagsFromText(data.destination ?? null),
         eventId: data.eventId ?? null,
         utms: data.utms,
         tracking: data.tracking,
@@ -236,6 +250,7 @@ export function leadInputFromSubmitQuiz(data: SubmitQuizRequest): OdooLeadInput 
         phone: data.whatsapp || null,
         marketingOptIn: data.newsletterOptIn === true,
         profileKey: data.profileKey,
+        destinationTagIds: resolveQuizDestinoTags(data.destinos),
         utms: data.utms,
         tracking: data.tracking,
         originSignal: 'quiz',

--- a/tests/destination-region.test.ts
+++ b/tests/destination-region.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    REGION_TAG,
+    resolveQuizDestinoTags,
+    resolveRegionTagsFromText,
+} from '../lib/destination-region.ts';
+
+test('resolveQuizDestinoTags — mapeia ids estruturados do quiz para tags', () => {
+    assert.deepEqual(resolveQuizDestinoTags(['europa']), [REGION_TAG.europa]);
+    assert.deepEqual(resolveQuizDestinoTags(['america-norte']), [REGION_TAG.americaNorte]);
+    assert.deepEqual(resolveQuizDestinoTags(['latam']), [REGION_TAG.americaLatina]);
+    assert.deepEqual(resolveQuizDestinoTags(['caribe']), [REGION_TAG.caribe]);
+    assert.deepEqual(resolveQuizDestinoTags(['asia']), [REGION_TAG.asia]);
+    assert.deepEqual(resolveQuizDestinoTags(['africa-oriente']), [REGION_TAG.africaOriente]);
+    assert.deepEqual(resolveQuizDestinoTags(['surpresa']), [REGION_TAG.abertoSurpresa]);
+});
+
+test('resolveQuizDestinoTags — múltiplos destinos, deduplicados, ignora desconhecido', () => {
+    assert.deepEqual(
+        resolveQuizDestinoTags(['europa', 'asia', 'europa', 'inexistente']).sort((a, b) => a - b),
+        [REGION_TAG.europa, REGION_TAG.asia].sort((a, b) => a - b),
+    );
+});
+
+test('resolveQuizDestinoTags — vazio/nulo retorna []', () => {
+    assert.deepEqual(resolveQuizDestinoTags([]), []);
+    assert.deepEqual(resolveQuizDestinoTags(undefined), []);
+    assert.deepEqual(resolveQuizDestinoTags(null), []);
+});
+
+test('resolveRegionTagsFromText — destino livre do chatbot vira tag de região', () => {
+    assert.deepEqual(resolveRegionTagsFromText('Orlando'), [REGION_TAG.americaNorte]);
+    assert.deepEqual(resolveRegionTagsFromText('Orlando, Estados Unidos'), [REGION_TAG.americaNorte]);
+    assert.deepEqual(resolveRegionTagsFromText('Lisboa'), [REGION_TAG.europa]);
+    assert.deepEqual(resolveRegionTagsFromText('Tóquio'), [REGION_TAG.asia]);
+    assert.deepEqual(resolveRegionTagsFromText('Sydney'), [REGION_TAG.oceania]);
+    assert.deepEqual(resolveRegionTagsFromText('Rio de Janeiro'), [REGION_TAG.brasil]);
+    assert.deepEqual(resolveRegionTagsFromText('Dubai'), [REGION_TAG.africaOriente]);
+});
+
+test('resolveRegionTagsFromText — insensível a acento e caixa', () => {
+    assert.deepEqual(resolveRegionTagsFromText('MÉXICO'), [REGION_TAG.americaLatina]);
+    assert.deepEqual(resolveRegionTagsFromText('cancun'), [REGION_TAG.caribe]);
+    assert.deepEqual(resolveRegionTagsFromText('Cancún'), [REGION_TAG.caribe]);
+});
+
+test('resolveRegionTagsFromText — cruzeiro e surpresa', () => {
+    assert.deepEqual(resolveRegionTagsFromText('Cruzeiro pelo Mediterrâneo'), [REGION_TAG.cruzeiros]);
+    assert.deepEqual(resolveRegionTagsFromText('Me surpreenda'), [REGION_TAG.abertoSurpresa]);
+});
+
+test('resolveRegionTagsFromText — fallback: destino não reconhecido retorna []', () => {
+    assert.deepEqual(resolveRegionTagsFromText('Marte'), []);
+    assert.deepEqual(resolveRegionTagsFromText(''), []);
+    assert.deepEqual(resolveRegionTagsFromText(null), []);
+    assert.deepEqual(resolveRegionTagsFromText('   '), []);
+});
+
+test('resolveRegionTagsFromText — token curto não casa dentro de palavra maior', () => {
+    // "jerusalem" contém o substring "usa": sem boundary casaria América do Norte.
+    // Deve casar só África/Oriente (keyword "jerusalem"), não América do Norte.
+    assert.deepEqual(resolveRegionTagsFromText('Jerusalém'), [REGION_TAG.africaOriente]);
+    assert.deepEqual(resolveRegionTagsFromText('EUA'), [REGION_TAG.americaNorte]);
+});

--- a/tests/odoo-lead-mapping.test.ts
+++ b/tests/odoo-lead-mapping.test.ts
@@ -10,6 +10,7 @@ import {
     leadInputFromSubmitWaitlist,
     type OdooLeadInput,
 } from '../lib/odoo-lead-mapping.ts';
+import { REGION_TAG } from '../lib/destination-region.ts';
 import type { LeadUtms } from '../types/leadCapture.ts';
 
 const EMPTY_UTMS: LeadUtms = { utm_source: null, utm_medium: null, utm_campaign: null, utm_term: null, utm_content: null };
@@ -89,6 +90,18 @@ test('buildPartnerFields — ignores an unrecognized profileKey', () => {
     assert.equal('x_perfil_do_viajante' in fields, false);
 });
 
+test('buildPartnerFields — emite category_id com comandos de link (4, id) por tag', () => {
+    const fields = buildPartnerFields(
+        baseInput({ destinationTagIds: [REGION_TAG.americaNorte, REGION_TAG.caribe] }),
+    );
+    assert.deepEqual(fields.category_id, [[4, 6], [4, 10]]);
+});
+
+test('buildPartnerFields — omite category_id quando não há tag (fallback)', () => {
+    assert.equal('category_id' in buildPartnerFields(baseInput({ destinationTagIds: [] })), false);
+    assert.equal('category_id' in buildPartnerFields(baseInput({})), false);
+});
+
 // --- buildLeadFields ---------------------------------------------------------
 
 test('buildLeadFields — opportunity shape with partner_id and resolved source/medium', () => {
@@ -127,6 +140,16 @@ test('leadInputFromSubmitLead — creates a lead, maps marketingOptIn', () => {
     assert.equal(input.createsLead, true);
     assert.equal(input.marketingOptIn, true);
     assert.equal(input.destination, 'Orlando');
+    assert.deepEqual(input.destinationTagIds, [REGION_TAG.americaNorte]);
+});
+
+test('leadInputFromSubmitLead — destino livre não reconhecido não gera tag (fallback)', () => {
+    const input = leadInputFromSubmitLead({
+        firstName: 'Ana', lastName: 'Silva', email: 'ana@example.com', whatsapp: '+5511999990000',
+        bantSummary: 'Need: X', destination: 'Marte', marketingOptIn: true,
+        utms: EMPTY_UTMS, tracking: undefined,
+    } as never);
+    assert.deepEqual(input.destinationTagIds, []);
 });
 
 test('leadInputFromSubmitContact — creates a lead, emailOptIn → marketingOptIn', () => {
@@ -142,13 +165,14 @@ test('leadInputFromSubmitQuiz — partner only (no lead), carries profileKey + q
     const input = leadInputFromSubmitQuiz({
         firstName: 'Ana', lastName: 'Silva', email: 'ana@example.com',
         profileKey: 'escapista', profileName: 'Escapista', bantSummary: 'Quiz', sourcePage: '/quiz',
-        destinos: ['Maldivas'], newsletterOptIn: true, utms: EMPTY_UTMS,
+        destinos: ['europa', 'asia'], newsletterOptIn: true, utms: EMPTY_UTMS,
     } as never);
     assert.equal(input.createsLead, false);
     assert.equal(input.profileKey, 'escapista');
     assert.equal(input.originSignal, 'quiz');
     assert.equal(input.marketingOptIn, true);
-    assert.match(String(input.contextNote), /Destinos: Maldivas/);
+    assert.deepEqual(input.destinationTagIds, [REGION_TAG.europa, REGION_TAG.asia]);
+    assert.match(String(input.contextNote), /Destinos: europa, asia/);
 });
 
 test('leadInputFromSubmitWaitlist — partner only, splits name, emailOptIn → marketingOptIn', () => {


### PR DESCRIPTION
## Decisão (issue #1007)

Closes #1007. A issue pedia uma **decisão de mapeamento**: (a) mapear destino → tag de região nos dois fluxos, (b) só no quiz, ou (a') só no chatbot. **Escolhida: (a) — mapear nos dois, com fallback seguro.**

Antes, o destino do chatbot ficava só como texto na `description` do `crm.lead`. Agora a região de interesse também vira **tag estruturada** em `res.partner.category` (pai "Destino de Interesse", id 2).

## Como funciona

Novo módulo puro `lib/destination-region.ts`:

- **Quiz** (`destinos: string[]`): ids estruturados da UI (`europa`, `america-norte`, `latam`, `caribe`, `asia`, `africa-oriente`, `surpresa`) → lookup direto.
- **Chatbot / contato** (texto livre, ex. "Orlando"): heurística por palavra-chave (país/cidade → continente), **insensível a acento e caixa**, com match por **word boundary** (`\bkw\b`) pra evitar falso positivo — ex.: "Jerusalém" contém o substring "usa" mas casa só África/Oriente, não América do Norte.
- **Fallback**: destino não reconhecido → **sem tag** (o texto continua na description). Degrada com elegância, nunca mis-tagga.

`buildPartnerFields` emite `category_id: [[4, id], …]` — comando de **link** many2many, **append-safe**: adiciona tags sem remover as que já existem no partner deduplicado (mesma filosofia do `comment` concatenado no `upsertPartner`).

### Tabela de tags (instância `anhanga`)

| Tag | id | | Tag | id |
|---|---|---|---|---|
| Europa | 3 | | Brasil | 8 |
| Ásia | 4 | | África / Oriente Médio | 9 |
| América Latina | 5 | | Caribe / Ilhas | 10 |
| América do Norte | 6 | | Cruzeiros | 11 |
| Oceania | 7 | | Destino Aberto / Surpresa | 12 |

> Nota: o quiz não tem opções de Brasil, Oceania ou Cruzeiros — essas tags só surgem do texto livre do chatbot.

## Testes

- `tests/destination-region.test.ts` (novo): quiz ids, texto livre, acento/caixa, cruzeiro/surpresa, fallback, word boundary.
- `tests/odoo-lead-mapping.test.ts`: `category_id` com comandos de link, omissão no fallback, adapters (chatbot "Orlando"→[6], "Marte"→[], quiz ['europa','asia']→[3,4]).

## Verificação

- `pnpm test:regression` → **734 testes ✅**
- `pnpm exec tsc --noEmit` ✅

## Critério de aceite (issue)

Lead do chatbot com destino reconhecível → `res.partner.category_id` contém a tag de região. Conferir via MCP após deploy:
`odoo_search_read res.partner [["email","=","<email-teste>"]] fields=["category_id"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)