### PR TITLE
fix(security): restrict Claude automation to trusted actors only [#1015]

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,21 +12,31 @@ on:
 
 jobs:
   claude:
+    # Security: Restrict to trusted users only (OWNER, MEMBER, COLLABORATOR).
+    # This prevents untrusted/external GitHub users from invoking Claude automation
+    # via @claude mentions on public repositories. Fixes: acl-check (HIGH severity).
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event.sender.login == github.repository_owner ||
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) ||
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      ) &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -47,4 +57,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## 🔐 Security Fix — HIGH Severity

Closes #1015

### Problema
Qualquer usuário externo num repositório público podia mencionar `@claude` em issues ou comentários de PR e acionar automação Claude com permissões `write` (contents, pull-requests, issues, id-token). Isso permitia **prompt injection** por atores não confiáveis com efeitos colaterais no repositório.

### Solução

#### ✅ Allowlist de `author_association`
Apenas usuários com associação `OWNER`, `MEMBER` ou `COLLABORATOR` podem acionar o workflow. Usuários externos recebem `NONE`, `FIRST_TIME_CONTRIBUTOR` ou `CONTRIBUTOR` — todos bloqueados.

```yaml
github.event.sender.login == github.repository_owner ||
contains(["OWNER","MEMBER","COLLABORATOR"], author_association)
```

#### ✅ Removido `id-token: write`
Permissão desnecessária eliminada. O Claude Code usa OAuth token, não OIDC.

#### ✅ Pinado `actions/checkout@v4`
Versão anterior (`@v7`) era inválida; corrigida para `@v4` (estável).

### Arquivos alterados
- `.github/workflows/claude.yml`

### Referências
- [OWASP A01: Broken Access Control](https://owasp.org/Top10/A01_2021-Broken_Access_Control/)
- [GitHub author_association docs](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation)