### PR TITLE
[codex] Add corporate lead fields to Odoo mapping

### DIFF
--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -3,6 +3,7 @@ import { m } from 'framer-motion';
 import { AirplaneTilt, PaperPlaneTilt, SpinnerGap } from '@phosphor-icons/react';
 import { useLeadCapture, createLeadEventId } from '@/hooks/useLeadCapture';
 import { useCorpFormReducer, validateCorpForm } from './useCorpFormReducer';
+import { buildCorporateLeadDraft } from './CorpLeadDraft';
 import { CorpFormFields } from './CorpFormFields';
 import { CorpLgpdConsent } from './CorpLgpdConsent';
 import { CorpSuccessState } from './CorpSuccessState';
@@ -31,18 +32,9 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
 
         try {
             const eventId = createLeadEventId();
-            const empresa = state.form.empresa.trim() || 'Não informado';
-            const cargo = state.form.cargo.trim() || 'Não informado';
 
             const result = await submitLead(
-                {
-                    firstName: state.form.firstName,
-                    lastName: state.form.lastName,
-                    email: state.form.email,
-                    whatsapp: state.form.whatsapp,
-                    destination: 'Corporativo',
-                    bantSummary: `Lead corporativo captado via landing /corporativo. Empresa: ${empresa}. Cargo: ${cargo}.`,
-                },
+                buildCorporateLeadDraft(state.form),
                 {
                     eventId,
                     pushDataLayerEvent: true,

--- a/components/landings/corporativo/CorpLeadDraft.ts
+++ b/components/landings/corporativo/CorpLeadDraft.ts
@@ -2,8 +2,8 @@ import type { LeadDraftPartial } from '@/hooks/useLeadCapture';
 import type { FormFields } from './useCorpFormReducer';
 
 export function buildCorporateLeadDraft(form: FormFields): LeadDraftPartial {
-    const empresa = form.empresa.trim();
-    const cargo = form.cargo.trim();
+    const empresa = form.empresa?.trim() ?? '';
+    const cargo = form.cargo?.trim() ?? '';
 
     return {
         firstName: form.firstName,

--- a/components/landings/corporativo/CorpLeadDraft.ts
+++ b/components/landings/corporativo/CorpLeadDraft.ts
@@ -1,0 +1,18 @@
+import type { LeadDraftPartial } from '@/hooks/useLeadCapture';
+import type { FormFields } from './useCorpFormReducer';
+
+export function buildCorporateLeadDraft(form: FormFields): LeadDraftPartial {
+    const empresa = form.empresa.trim();
+    const cargo = form.cargo.trim();
+
+    return {
+        firstName: form.firstName,
+        lastName: form.lastName,
+        email: form.email,
+        whatsapp: form.whatsapp,
+        destination: 'Corporativo',
+        empresa: empresa || undefined,
+        cargo: cargo || undefined,
+        bantSummary: `Lead corporativo captado via landing /corporativo. Empresa: ${empresa || 'Não informado'}. Cargo: ${cargo || 'Não informado'}.`,
+    };
+}

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -13,6 +13,8 @@ export interface LeadDraft {
     destination: string;
     dates: string;
     baggagePreference: string;
+    empresa?: string;
+    cargo?: string;
 }
 
 export type LeadDraftPartial = Partial<LeadDraft>;
@@ -51,9 +53,11 @@ const EMPTY_LEAD_DRAFT: LeadDraft = {
     destination: '',
     dates: '',
     baggagePreference: '',
+    empresa: '',
+    cargo: '',
 };
 
-function cleanValue(value: string): string {
+function cleanValue(value: unknown): string {
     return cleanString(value);
 }
 
@@ -211,8 +215,7 @@ function buildSubmitLeadPayload(
     eventId?: string,
 ): SubmitLeadRequest {
     const merged = mergeLeadDraft(leadDraft, overrides);
-
-    return {
+    const payload: SubmitLeadRequest = {
         firstName: cleanValue(merged.firstName),
         lastName: cleanValue(merged.lastName),
         email: cleanValue(merged.email).toLowerCase(),
@@ -226,6 +229,13 @@ function buildSubmitLeadPayload(
             ...latestUtms,
         },
     };
+    const empresa = cleanValue(merged.empresa);
+    const cargo = cleanValue(merged.cargo);
+
+    if (empresa) payload.empresa = empresa;
+    if (cargo) payload.cargo = cargo;
+
+    return payload;
 }
 
 export function isPreparedSubmitLeadRequest(value: LeadDraftPartial | SubmitLeadRequest): value is SubmitLeadRequest {

--- a/lib/lead-logic.ts
+++ b/lib/lead-logic.ts
@@ -197,6 +197,8 @@ export function validatePayload(payload: unknown): { valid: true; data: SubmitLe
     const eventId = normalizeNullable(raw.event_id, 128) ?? undefined;
     const bantSummary = cleanString(raw.bantSummary);
     const destination = cleanString(raw.destination);
+    const empresa = normalizeNullable(raw.empresa) ?? undefined;
+    const cargo = normalizeNullable(raw.cargo) ?? undefined;
 
     // normalizeWhatsappNumber can still fail for strings Zod accepted (e.g. non-digit-only content)
     if (!whatsapp) {
@@ -209,7 +211,14 @@ export function validatePayload(payload: unknown): { valid: true; data: SubmitLe
     }
 
     // Safety net: cleanString expands HTML entities which can push lengths past the Zod-checked raw limits
-    if (firstName.length > 100 || lastName.length > 100 || bantSummary.length > 5000 || destination.length > 255) {
+    if (
+        firstName.length > 100
+        || lastName.length > 100
+        || bantSummary.length > 5000
+        || destination.length > 255
+        || (empresa && empresa.length > 255)
+        || (cargo && cargo.length > 255)
+    ) {
         return { valid: false, error: 'Entrada muito longa.' };
     }
 
@@ -226,6 +235,8 @@ export function validatePayload(payload: unknown): { valid: true; data: SubmitLe
             event_id: eventId,
             bantSummary,
             destination,
+            empresa,
+            cargo,
             marketingOptIn: raw.marketingOptIn === true,
             utms,
             tracking,

--- a/lib/odoo-lead-mapping.ts
+++ b/lib/odoo-lead-mapping.ts
@@ -212,6 +212,8 @@ export function leadInputFromSubmitLead(data: SubmitLeadRequest): OdooLeadInput 
         destination: data.destination,
         destinationTagIds: resolveRegionTagsFromText(data.destination),
         bantSummary: data.bantSummary,
+        empresa: data.empresa ?? null,
+        cargo: data.cargo ?? null,
         eventId: data.event_id ?? null,
         utms: data.utms,
         tracking: data.tracking,

--- a/lib/schemas/submit-lead.ts
+++ b/lib/schemas/submit-lead.ts
@@ -22,8 +22,9 @@ export const SubmitLeadBodySchema = z.object({
     event_id:    z.string().max(128).optional(),
     bantSummary: z.string().min(1).max(5000),
     destination: z.string().min(1).max(255),
+    empresa:     z.string().max(255).optional(),
+    cargo:       z.string().max(255).optional(),
     marketingOptIn: z.boolean().optional(),
     utms:        LeadUtmsSchema,
     tracking:    LeadTrackingSchema,
 });
-

--- a/tests/corp-form-reducer.test.ts
+++ b/tests/corp-form-reducer.test.ts
@@ -94,11 +94,25 @@ describe('validateCorpForm', () => {
 
     it('should build a lead draft with empresa/cargo as structured fields', () => {
         const draft = buildCorporateLeadDraft(VALID_FORM);
+        assert.ok(draft, 'Expected draft to be defined');
         assert.equal(draft.destination, 'Corporativo');
         assert.equal(draft.empresa, 'Empresa Teste');
         assert.equal(draft.cargo, 'Sócia');
-        if (!draft.bantSummary) assert.fail('Expected corporate draft to include bantSummary');
+        assert.ok(draft.bantSummary, 'Expected corporate draft to include bantSummary');
         assert.match(draft.bantSummary, /Empresa: Empresa Teste/);
         assert.match(draft.bantSummary, /Cargo: Sócia/);
+    });
+
+    it('should build a lead draft when optional empresa/cargo are missing at runtime', () => {
+        const { empresa: _empresa, cargo: _cargo, ...partialForm } = VALID_FORM;
+        const draft = buildCorporateLeadDraft(partialForm as FormFields);
+
+        assert.ok(draft, 'Expected draft to be defined');
+        assert.equal(draft.destination, 'Corporativo');
+        assert.equal(draft.empresa, undefined);
+        assert.equal(draft.cargo, undefined);
+        assert.ok(draft.bantSummary, 'Expected corporate draft to include bantSummary');
+        assert.match(draft.bantSummary, /Empresa: Não informado/);
+        assert.match(draft.bantSummary, /Cargo: Não informado/);
     });
 });

--- a/tests/corp-form-reducer.test.ts
+++ b/tests/corp-form-reducer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { validateCorpForm } from '../components/landings/corporativo/useCorpFormReducer';
+import { buildCorporateLeadDraft } from '../components/landings/corporativo/CorpLeadDraft';
 import type { FormFields } from '../components/landings/corporativo/useCorpFormReducer';
 
 const VALID_FORM: FormFields = {
@@ -89,5 +90,15 @@ describe('validateCorpForm', () => {
     it('should accept form without optional empresa and cargo', () => {
         const result = validateCorpForm({ ...VALID_FORM, empresa: '', cargo: '' }, true);
         assert.deepStrictEqual(result, { ok: true });
+    });
+
+    it('should build a lead draft with empresa/cargo as structured fields', () => {
+        const draft = buildCorporateLeadDraft(VALID_FORM);
+        assert.equal(draft.destination, 'Corporativo');
+        assert.equal(draft.empresa, 'Empresa Teste');
+        assert.equal(draft.cargo, 'Sócia');
+        if (!draft.bantSummary) assert.fail('Expected corporate draft to include bantSummary');
+        assert.match(draft.bantSummary, /Empresa: Empresa Teste/);
+        assert.match(draft.bantSummary, /Cargo: Sócia/);
     });
 });

--- a/tests/odoo-lead-mapping.test.ts
+++ b/tests/odoo-lead-mapping.test.ts
@@ -143,6 +143,17 @@ test('leadInputFromSubmitLead — creates a lead, maps marketingOptIn', () => {
     assert.deepEqual(input.destinationTagIds, [REGION_TAG.americaNorte]);
 });
 
+test('leadInputFromSubmitLead — carries empresa/cargo into Odoo lead input', () => {
+    const input = leadInputFromSubmitLead({
+        firstName: 'Ana', lastName: 'Silva', email: 'ana@example.com', whatsapp: '+5511999990000',
+        bantSummary: 'Lead corporativo', destination: 'Corporativo', marketingOptIn: true,
+        empresa: 'Acme Viagens', cargo: 'Diretora de Pessoas',
+        utms: EMPTY_UTMS, tracking: undefined,
+    } as never);
+    assert.equal(input.empresa, 'Acme Viagens');
+    assert.equal(input.cargo, 'Diretora de Pessoas');
+});
+
 test('leadInputFromSubmitLead — destino livre não reconhecido não gera tag (fallback)', () => {
     const input = leadInputFromSubmitLead({
         firstName: 'Ana', lastName: 'Silva', email: 'ana@example.com', whatsapp: '+5511999990000',

--- a/tests/submit-lead.test.ts
+++ b/tests/submit-lead.test.ts
@@ -106,6 +106,19 @@ test('validatePayload should map marketingOptIn from the request body', () => {
     assert.equal(result.data.marketingOptIn, true);
 });
 
+test('validatePayload should accept optional empresa/cargo as structured lead fields', () => {
+    const result = validatePayload({
+        firstName: 'Felipe', lastName: 'William', email: 'felipe@example.com', whatsapp: '+5511988314487',
+        bantSummary: 'Lead corporativo', destination: 'Corporativo',
+        empresa: '  Acme Viagens  ', cargo: '  Diretora de Pessoas  ',
+        utms: {}, tracking: {},
+    });
+    assert.equal(result.valid, true);
+    if (!result.valid) return;
+    assert.equal(result.data.empresa, 'Acme Viagens');
+    assert.equal(result.data.cargo, 'Diretora de Pessoas');
+});
+
 // --- handler integration (Odoo) ---------------------------------------------
 
 test('submit-lead upserts a partner and creates a linked crm.lead opportunity', async (t) => {
@@ -131,6 +144,25 @@ test('submit-lead upserts a partner and creates a linked crm.lead opportunity', 
     assert.equal(lead.source_id, 17); // google + cpc → Google Ads
     assert.equal(lead.medium_id, 7);
     assert.match(String(lead.name), /^Lead Site — Felipe William \(Rio de Janeiro\)$/);
+});
+
+test('submit-lead maps corporate empresa/cargo to crm.lead partner_name/function', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    const mock = createOdooMock({ newPartnerId: 101, leadId: 555 });
+    global.fetch = mock.fetch;
+
+    const response = await handler(buildRequest({
+        ...buildLeadPayloadFixture(),
+        destination: 'Corporativo',
+        empresa: 'Acme Viagens',
+        cargo: 'Diretora de Pessoas',
+    }));
+    assert.equal(response.status, 201);
+
+    const lead = mock.leadFields()!;
+    assert.equal(lead.partner_name, 'Acme Viagens');
+    assert.equal(lead.function, 'Diretora de Pessoas');
 });
 
 test('submit-lead sends sanitized values into the Odoo records', async (t) => {

--- a/types/leadCapture.ts
+++ b/types/leadCapture.ts
@@ -35,7 +35,8 @@ export interface SubmitLeadRequest {
     tracking?: LeadTracking;
     bantSummary: string;
     destination: string;
+    empresa?: string;
+    cargo?: string;
     /** E-mail-marketing opt-in → Odoo x_lgpd_consent. */
     marketingOptIn?: boolean;
 }
-


### PR DESCRIPTION
## Summary
- Accept optional `empresa` and `cargo` on `/api/submit-lead` and preserve them through validation/normalization.
- Send corporate landing company/title as discrete lead fields instead of only embedding them in `bantSummary`.
- Map those values through `leadInputFromSubmitLead` so Odoo `crm.lead.partner_name` and `crm.lead.function` are populated.

Closes #1011

## Test Plan
- [x] `pnpm exec tsx --test tests/odoo-lead-mapping.test.ts tests/submit-lead.test.ts tests/corp-form-reducer.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm exec react-doctor --verbose --diff`
- [x] `pnpm test:regression`

## Notes
- The canonical `npx react-doctor@latest --verbose --diff` could not run inside the sandbox due DNS/network restrictions, and external execution was rejected because it would download and run fresh third-party code. I used the repository-pinned `react-doctor` via `pnpm exec` instead.
- Odoo live MCP validation was not available in this session, so the PR validates the Odoo mapping through the existing mocked submit-lead integration tests.