### PR TITLE
Add referral intake through lead capture and Odoo mapping

### DIFF
--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -15,6 +15,7 @@ export interface LeadDraft {
     baggagePreference: string;
     empresa?: string;
     cargo?: string;
+    referred?: string;
 }
 
 export type LeadDraftPartial = Partial<LeadDraft>;
@@ -55,6 +56,7 @@ const EMPTY_LEAD_DRAFT: LeadDraft = {
     baggagePreference: '',
     empresa: '',
     cargo: '',
+    referred: '',
 };
 
 function cleanValue(value: unknown): string {
@@ -155,6 +157,10 @@ function captureInitialTracking(): LeadTracking {
     };
 }
 
+function referralFromTracking(tracking: LeadTracking): string {
+    return cleanValue(tracking.extras?.ref);
+}
+
 export function buildLeadWhatsAppMessage(lead: LeadDraft): string {
     const origin = cleanValue(lead.origin) || 'A definir';
     const destination = cleanValue(lead.destination) || 'A definir';
@@ -207,7 +213,7 @@ export function createLeadEventId(): string {
     return `lead_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
-function buildSubmitLeadPayload(
+export function buildSubmitLeadPayload(
     leadDraft: LeadDraft,
     overrides: LeadDraftPartial,
     latestTracking: LeadTracking,
@@ -231,9 +237,11 @@ function buildSubmitLeadPayload(
     };
     const empresa = cleanValue(merged.empresa);
     const cargo = cleanValue(merged.cargo);
+    const referred = cleanValue(merged.referred) || referralFromTracking(latestTracking);
 
     if (empresa) payload.empresa = empresa;
     if (cargo) payload.cargo = cargo;
+    if (referred) payload.referred = referred;
 
     return payload;
 }

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -157,8 +157,8 @@ function captureInitialTracking(): LeadTracking {
     };
 }
 
-function referralFromTracking(tracking: LeadTracking): string {
-    return cleanValue(tracking.extras?.ref);
+function referralFromTracking(tracking?: LeadTracking | null): string {
+    return cleanValue(tracking?.extras?.ref);
 }
 
 export function buildLeadWhatsAppMessage(lead: LeadDraft): string {

--- a/lib/api-catalog.ts
+++ b/lib/api-catalog.ts
@@ -155,6 +155,10 @@ const API_ENDPOINTS: readonly ApiEndpointDefinition[] = [
                             whatsapp: { type: 'string' },
                             bantSummary: { type: 'string' },
                             destination: { type: 'string' },
+                            referred: {
+                                type: 'string',
+                                description: 'Nome ou identificador de quem indicou o lead; aciona atribuição Odoo de indicação.',
+                            },
                             utms: {
                                 type: 'object',
                                 additionalProperties: true,

--- a/lib/lead-logic.ts
+++ b/lib/lead-logic.ts
@@ -199,6 +199,7 @@ export function validatePayload(payload: unknown): { valid: true; data: SubmitLe
     const destination = cleanString(raw.destination);
     const empresa = normalizeNullable(raw.empresa) ?? undefined;
     const cargo = normalizeNullable(raw.cargo) ?? undefined;
+    const referred = normalizeNullable(raw.referred) ?? undefined;
 
     // normalizeWhatsappNumber can still fail for strings Zod accepted (e.g. non-digit-only content)
     if (!whatsapp) {
@@ -218,6 +219,7 @@ export function validatePayload(payload: unknown): { valid: true; data: SubmitLe
         || destination.length > 255
         || (empresa && empresa.length > 255)
         || (cargo && cargo.length > 255)
+        || (referred && referred.length > 255)
     ) {
         return { valid: false, error: 'Entrada muito longa.' };
     }
@@ -237,6 +239,7 @@ export function validatePayload(payload: unknown): { valid: true; data: SubmitLe
             destination,
             empresa,
             cargo,
+            referred,
             marketingOptIn: raw.marketingOptIn === true,
             utms,
             tracking,

--- a/lib/odoo-lead-mapping.ts
+++ b/lib/odoo-lead-mapping.ts
@@ -201,6 +201,8 @@ export function buildLeadFields(input: OdooLeadInput, partnerId: number): Record
 // --- Per-form adapters: validated payload → OdooLeadInput ------------------
 
 export function leadInputFromSubmitLead(data: SubmitLeadRequest): OdooLeadInput {
+    const referred = data.referred?.trim() || null;
+
     return {
         formType: 'lead',
         createsLead: true,
@@ -214,11 +216,11 @@ export function leadInputFromSubmitLead(data: SubmitLeadRequest): OdooLeadInput 
         bantSummary: data.bantSummary,
         empresa: data.empresa ?? null,
         cargo: data.cargo ?? null,
-        referred: data.referred ?? null,
+        referred,
         eventId: data.event_id ?? null,
         utms: data.utms,
         tracking: data.tracking,
-        originSignal: data.referred ? 'referral' : null,
+        originSignal: referred ? 'referral' : null,
     };
 }
 

--- a/lib/odoo-lead-mapping.ts
+++ b/lib/odoo-lead-mapping.ts
@@ -214,10 +214,11 @@ export function leadInputFromSubmitLead(data: SubmitLeadRequest): OdooLeadInput 
         bantSummary: data.bantSummary,
         empresa: data.empresa ?? null,
         cargo: data.cargo ?? null,
+        referred: data.referred ?? null,
         eventId: data.event_id ?? null,
         utms: data.utms,
         tracking: data.tracking,
-        originSignal: null,
+        originSignal: data.referred ? 'referral' : null,
     };
 }
 

--- a/lib/schemas/submit-lead.ts
+++ b/lib/schemas/submit-lead.ts
@@ -24,6 +24,7 @@ export const SubmitLeadBodySchema = z.object({
     destination: z.string().min(1).max(255),
     empresa:     z.string().max(255).optional(),
     cargo:       z.string().max(255).optional(),
+    referred:    z.string().max(255).optional(),
     marketingOptIn: z.boolean().optional(),
     utms:        LeadUtmsSchema,
     tracking:    LeadTrackingSchema,

--- a/tests/hooks-useLeadCapture.test.ts
+++ b/tests/hooks-useLeadCapture.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
     isPreparedSubmitLeadRequest,
     extractUtms,
+    buildSubmitLeadPayload,
     buildLeadWhatsAppMessage,
     createLeadEventId,
     pushGenerateLeadDataLayerEvent,
@@ -143,6 +144,47 @@ test('extractUtms preserves null UTM values', () => {
 
     assert.equal(result.utm_source, null);
     assert.equal(result.utm_medium, null);
+});
+
+// ─── buildSubmitLeadPayload ─────────────────────────────────────────────────
+
+function validLeadDraft(overrides?: Partial<LeadDraft>): LeadDraft {
+    return {
+        firstName: 'Maria',
+        lastName: 'Silva',
+        email: 'maria@example.com',
+        whatsapp: '+5511988314487',
+        bantSummary: 'Need: praia | Authority: casal | Budget: 15k | Timeline: outubro',
+        origin: 'São Paulo',
+        destination: 'Porto de Galinhas',
+        dates: 'outubro',
+        baggagePreference: '',
+        ...overrides,
+    };
+}
+
+test('buildSubmitLeadPayload maps URL ref tracking into referred', () => {
+    const payload = buildSubmitLeadPayload(
+        validLeadDraft(),
+        {},
+        validPayload({ tracking: { ...validPayload().tracking!, extras: { ref: 'Maria Silva' } } }).tracking!,
+        validPayload().utms,
+        'lead_ref_test',
+    );
+
+    assert.equal(payload.referred, 'Maria Silva');
+});
+
+test('buildSubmitLeadPayload prefers explicit draft referred over URL ref tracking', () => {
+    const payload = buildSubmitLeadPayload(
+        validLeadDraft({ referred: 'João Souza' }),
+        {},
+        validPayload({ tracking: { ...validPayload().tracking!, extras: { ref: 'Maria Silva' } } }).tracking!,
+        validPayload().utms,
+        'lead_ref_test',
+    );
+
+    assert.equal(payload.referred, 'João Souza');
 });
 
 // ─── buildLeadWhatsAppMessage ─────────────────────────────────────────────────

--- a/tests/hooks-useLeadCapture.test.ts
+++ b/tests/hooks-useLeadCapture.test.ts
@@ -9,7 +9,7 @@ import {
     pushGenerateLeadDataLayerEvent,
     type LeadDraft,
 } from '../hooks/useLeadCapture.ts';
-import type { SubmitLeadRequest } from '../types/leadCapture.ts';
+import type { LeadTracking, SubmitLeadRequest } from '../types/leadCapture.ts';
 
 function validPayload(overrides?: Partial<SubmitLeadRequest>): SubmitLeadRequest {
     return {
@@ -185,6 +185,18 @@ test('buildSubmitLeadPayload prefers explicit draft referred over URL ref tracki
     );
 
     assert.equal(payload.referred, 'João Souza');
+});
+
+test('buildSubmitLeadPayload tolerates missing tracking while deriving referred', () => {
+    const payload = buildSubmitLeadPayload(
+        validLeadDraft(),
+        {},
+        null as unknown as LeadTracking,
+        validPayload().utms,
+        'lead_ref_test',
+    );
+
+    assert.equal(payload.referred, undefined);
 });
 
 // ─── buildLeadWhatsAppMessage ─────────────────────────────────────────────────

--- a/tests/lead-whatsapp.test.ts
+++ b/tests/lead-whatsapp.test.ts
@@ -7,6 +7,7 @@ import {
     pushGenerateLeadDataLayerEvent,
     type LeadDraft,
 } from '../hooks/useLeadCapture.ts';
+import { getTrackingDataObject } from '../utils/whatsapp.ts';
 
 type MockWindow = {
     location: {
@@ -123,6 +124,36 @@ test('buildLeadWhatsAppUrl should include origin, destination, dates, baggage an
     assert.match(message, /Dados: .*utm_source=google/);
     assert.match(message, /Dados: .*utm_medium=cpc/);
     assert.match(message, /Dados: .*gclid=test-gclid/);
+
+    restoreBrowserGlobals();
+});
+
+test('getTrackingDataObject should capture referral ref from URL params', () => {
+    const mockWindow: MockWindow = {
+        location: {
+            search: '?ref=Maria%20Silva',
+            hash: '',
+            href: 'https://www.anhanga.tur.br/?ref=Maria%20Silva',
+        },
+        dataLayer: [],
+    };
+
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: mockWindow,
+    });
+    Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        value: { cookie: '' },
+    });
+    Object.defineProperty(globalThis, 'sessionStorage', {
+        configurable: true,
+        value: createSessionStorage(),
+    });
+
+    const tracking = getTrackingDataObject();
+
+    assert.equal(tracking?.ref, 'Maria Silva');
 
     restoreBrowserGlobals();
 });

--- a/tests/odoo-lead-mapping.test.ts
+++ b/tests/odoo-lead-mapping.test.ts
@@ -165,6 +165,17 @@ test('leadInputFromSubmitLead — referred lead uses referral origin signal', ()
     assert.equal(input.originSignal, 'referral');
 });
 
+test('leadInputFromSubmitLead — blank referred is ignored', () => {
+    const input = leadInputFromSubmitLead({
+        firstName: 'Ana', lastName: 'Silva', email: 'ana@example.com', whatsapp: '+5511999990000',
+        bantSummary: 'Lead comum', destination: 'Orlando', marketingOptIn: true,
+        referred: '   ',
+        utms: EMPTY_UTMS, tracking: undefined,
+    } as never);
+    assert.equal(input.referred, null);
+    assert.equal(input.originSignal, null);
+});
+
 test('leadInputFromSubmitLead — destino livre não reconhecido não gera tag (fallback)', () => {
     const input = leadInputFromSubmitLead({
         firstName: 'Ana', lastName: 'Silva', email: 'ana@example.com', whatsapp: '+5511999990000',

--- a/tests/odoo-lead-mapping.test.ts
+++ b/tests/odoo-lead-mapping.test.ts
@@ -154,6 +154,17 @@ test('leadInputFromSubmitLead — carries empresa/cargo into Odoo lead input', (
     assert.equal(input.cargo, 'Diretora de Pessoas');
 });
 
+test('leadInputFromSubmitLead — referred lead uses referral origin signal', () => {
+    const input = leadInputFromSubmitLead({
+        firstName: 'Ana', lastName: 'Silva', email: 'ana@example.com', whatsapp: '+5511999990000',
+        bantSummary: 'Lead indicado', destination: 'Orlando', marketingOptIn: true,
+        referred: 'Maria Silva',
+        utms: EMPTY_UTMS, tracking: undefined,
+    } as never);
+    assert.equal(input.referred, 'Maria Silva');
+    assert.equal(input.originSignal, 'referral');
+});
+
 test('leadInputFromSubmitLead — destino livre não reconhecido não gera tag (fallback)', () => {
     const input = leadInputFromSubmitLead({
         firstName: 'Ana', lastName: 'Silva', email: 'ana@example.com', whatsapp: '+5511999990000',

--- a/tests/submit-lead.test.ts
+++ b/tests/submit-lead.test.ts
@@ -119,6 +119,18 @@ test('validatePayload should accept optional empresa/cargo as structured lead fi
     assert.equal(result.data.cargo, 'Diretora de Pessoas');
 });
 
+test('validatePayload should accept optional referred as a structured referral field', () => {
+    const result = validatePayload({
+        firstName: 'Felipe', lastName: 'William', email: 'felipe@example.com', whatsapp: '+5511988314487',
+        bantSummary: 'Lead indicado', destination: 'Orlando',
+        referred: '  Maria <Silva>  ',
+        utms: {}, tracking: {},
+    });
+    assert.equal(result.valid, true);
+    if (!result.valid) return;
+    assert.equal(result.data.referred, 'Maria &lt;Silva&gt;');
+});
+
 // --- handler integration (Odoo) ---------------------------------------------
 
 test('submit-lead upserts a partner and creates a linked crm.lead opportunity', async (t) => {
@@ -163,6 +175,27 @@ test('submit-lead maps corporate empresa/cargo to crm.lead partner_name/function
     const lead = mock.leadFields()!;
     assert.equal(lead.partner_name, 'Acme Viagens');
     assert.equal(lead.function, 'Diretora de Pessoas');
+});
+
+test('submit-lead maps referred leads to Indicação/indicacao in Odoo', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    const mock = createOdooMock({ newPartnerId: 101, leadId: 555 });
+    global.fetch = mock.fetch;
+
+    const response = await handler(buildRequest({
+        ...buildLeadPayloadFixture(),
+        utms: {},
+        tracking: {},
+        referred: 'Maria Silva',
+    }));
+    assert.equal(response.status, 201);
+
+    const lead = mock.leadFields()!;
+    assert.equal(lead.source_id, 8);
+    assert.equal(lead.medium_id, 6);
+    assert.equal(lead.referred, 'Maria Silva');
+    assert.match(String(lead.description), /<li>Indicado por: Maria Silva<\/li>/);
 });
 
 test('submit-lead sends sanitized values into the Odoo records', async (t) => {

--- a/types/leadCapture.ts
+++ b/types/leadCapture.ts
@@ -37,6 +37,7 @@ export interface SubmitLeadRequest {
     destination: string;
     empresa?: string;
     cargo?: string;
+    referred?: string;
     /** E-mail-marketing opt-in → Odoo x_lgpd_consent. */
     marketingOptIn?: boolean;
 }

--- a/utils/whatsapp.ts
+++ b/utils/whatsapp.ts
@@ -11,7 +11,8 @@ import { useState, useEffect } from 'react';
 
 const TRACKING_PARAMS = [
     'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term',
-    'gclid', 'fbclid', 'ttclid', 'wbraid', 'gbraid', 'msclkid'
+    'gclid', 'fbclid', 'ttclid', 'wbraid', 'gbraid', 'msclkid',
+    'ref',
 ];
 // Microsoft Ads (hsa_*) parameters are captured dynamically
 const HSA_PREFIX = 'hsa_';
@@ -321,4 +322,3 @@ export const useWhatsAppLink = (message: string, options: WhatsAppLinkOptions = 
 
     return whatsappUrl;
 };
-


### PR DESCRIPTION
## Summary
- Add a structured `referred` field to lead intake, validation, and schema mapping
- Capture `ref` URL tracking into lead payloads and propagate referral origin into Odoo
- Extend API catalog, types, and tests to cover referral handling end to end

## Testing
- Added unit tests for tracking capture, payload building, payload validation, and Odoo lead mapping
- Added integration-style submit-lead coverage for referral persistence and description rendering