### PR TITLE
fix(ci): validate workflow_dispatch branch input before shell use

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -13,6 +13,24 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
+    - name: Validate branch input
+      env:
+        # A entrada `branch` é livre (workflow_dispatch) e mais adiante entra num
+        # `git push` com o GITHUB_TOKEN presente. Expressões `${{ }}` são
+        # substituídas ANTES do shell interpretar o `run`, então um nome como
+        # `$(comando)` executaria comandos arbitrários no runner. Passamos a
+        # entrada por env var (sem interpolação no corpo do script) e validamos
+        # com allowlist estrita + git check-ref-format antes de qualquer uso.
+        BRANCH: ${{ github.event.inputs.branch }}
+      run: |
+        if ! printf '%s' "$BRANCH" | grep -qE '^[A-Za-z0-9._/-]+$'; then
+          echo "::error::Branch inválida: só são permitidos os caracteres [A-Za-z0-9._/-]."
+          exit 1
+        fi
+        if ! git check-ref-format "refs/heads/$BRANCH"; then
+          echo "::error::Branch inválida: falhou em git check-ref-format."
+          exit 1
+        fi
     - uses: actions/checkout@v7
       with:
         ref: ${{ github.event.inputs.branch }}
@@ -33,6 +51,9 @@ jobs:
     - name: Commit updated snapshots
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Branch validada no passo "Validate branch input"; usada como env var
+        # (nunca interpolada direto no corpo do script) para evitar injeção.
+        BRANCH: ${{ github.event.inputs.branch }}
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -41,5 +62,5 @@ jobs:
           echo "No snapshot changes to commit."
         else
           git commit -m "test: update visual regression baselines [skip ci]"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}" "HEAD:refs/heads/${{ github.event.inputs.branch }}"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" "HEAD:refs/heads/${BRANCH}"
         fi

--- a/tests/workflow-command-injection-guard.test.ts
+++ b/tests/workflow-command-injection-guard.test.ts
@@ -1,0 +1,138 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Guard de segurança para GitHub Actions: nenhum bloco `run:` pode interpolar
+// diretamente contexto controlável por terceiros — `${{ github.event.* }}`,
+// `${{ github.head_ref }}` ou `${{ inputs.* }}` — no corpo do shell. Expressões
+// `${{ }}` são substituídas ANTES do shell parsear o script, então um valor com
+// command substitution (ex.: um nome de branch `$(comando)`) executaria comandos
+// arbitrários no runner. Regressão do #1016 (update-snapshots.yml).
+//
+// O padrão SEGURO — e o que este guard permite — é mapear a entrada para uma env
+// var num bloco `env:` e referenciá-la como `${VAR}` (shell), nunca `${{ }}`.
+
+const WORKFLOWS_DIR = path.resolve(process.cwd(), '.github/workflows');
+
+// Contextos que um terceiro consegue influenciar. `github.event.*` cobre título
+// de issue, corpo de PR/comentário, inputs de dispatch, mensagens de commit etc.
+// O ponto final em `github.event.` é intencional: não casa `github.event_name`,
+// que é o tipo do evento (não controlável pelo atacante).
+const UNSAFE_CONTEXT = /\$\{\{[^}]*\b(github\.event\.|github\.head_ref\b|inputs\.)/;
+
+interface RunScript {
+  file: string;
+  line: number; // 1-based, onde a chave `run:` aparece
+  script: string;
+}
+
+// Extrai o corpo de cada passo `run:` de um workflow. Cobre block scalars
+// (`run: |`, `run: >`) e a forma inline (`run: cmd`). Não usa parser YAML: os
+// workflows deste repo são bem-formados e a estrutura por indentação é
+// suficiente para isolar o script do resto do mapeamento (env:, with:, etc.),
+// evitando falsos positivos no padrão seguro de env var.
+function extractRunScripts(yamlText: string, file: string): RunScript[] {
+  const lines = yamlText.split('\n');
+  const scripts: RunScript[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const match = /^(\s*)(- )?run:(\s*)(.*)$/.exec(lines[i]);
+    if (!match) continue;
+    const keyCol = match[1].length + (match[2] ? 2 : 0);
+    const rest = match[4];
+    if (/^[|>][+-]?\d*\s*$/.test(rest)) {
+      // Block scalar: coleta as linhas seguintes indentadas além da chave `run:`.
+      const body: string[] = [];
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        const bodyLine = lines[j];
+        if (bodyLine.trim() === '') {
+          body.push('');
+          continue;
+        }
+        const indent = bodyLine.length - bodyLine.trimStart().length;
+        if (indent > keyCol) {
+          body.push(bodyLine);
+        } else {
+          break;
+        }
+      }
+      scripts.push({ file, line: i + 1, script: body.join('\n') });
+      i = j - 1;
+    } else if (rest.trim() !== '') {
+      // Forma inline: `run: echo hi`.
+      scripts.push({ file, line: i + 1, script: rest });
+    }
+  }
+  return scripts;
+}
+
+function listWorkflowFiles(): string[] {
+  if (!fs.existsSync(WORKFLOWS_DIR)) return [];
+  return fs
+    .readdirSync(WORKFLOWS_DIR)
+    .filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'))
+    .map((file) => path.join(WORKFLOWS_DIR, file));
+}
+
+// Provas de que o detector funciona (um guard cujo detector está quebrado passa
+// vazio e não protege nada). O caso ruim reproduz a forma exata do #1016.
+test('detecta interpolação direta de input não confiável em bloco run (regressão #1016)', () => {
+  const vulnerable = [
+    'jobs:',
+    '  x:',
+    '    steps:',
+    '    - name: push',
+    '      run: |',
+    '        git push origin "HEAD:refs/heads/${{ github.event.inputs.branch }}"',
+  ].join('\n');
+  const flagged = extractRunScripts(vulnerable, 'synthetic-bad.yml').filter((s) =>
+    UNSAFE_CONTEXT.test(s.script),
+  );
+  assert.equal(flagged.length, 1, 'a interpolação vulnerável deveria ter sido detectada');
+});
+
+test('permite input não confiável passado via env var (padrão seguro)', () => {
+  const hardened = [
+    'jobs:',
+    '  x:',
+    '    steps:',
+    '    - name: push',
+    '      env:',
+    '        BRANCH: ${{ github.event.inputs.branch }}',
+    '      run: |',
+    '        git push origin "HEAD:refs/heads/${BRANCH}"',
+  ].join('\n');
+  const flagged = extractRunScripts(hardened, 'synthetic-good.yml').filter((s) =>
+    UNSAFE_CONTEXT.test(s.script),
+  );
+  assert.equal(flagged.length, 0, 'referência via ${BRANCH} no shell não deve ser sinalizada');
+});
+
+// O guard precisa ter o que varrer — senão passaria vazio por engano.
+test('há workflows e blocos run para o guard varrer', () => {
+  const files = listWorkflowFiles();
+  assert.ok(files.length > 0, 'nenhum workflow encontrado em .github/workflows');
+  const runCount = files.reduce(
+    (total, file) => total + extractRunScripts(fs.readFileSync(file, 'utf8'), file).length,
+    0,
+  );
+  assert.ok(runCount > 0, 'nenhum bloco run extraído dos workflows');
+});
+
+test('nenhum workflow interpola contexto não confiável em bloco run', () => {
+  const findings: string[] = [];
+  for (const file of listWorkflowFiles()) {
+    const text = fs.readFileSync(file, 'utf8');
+    for (const scriptBlock of extractRunScripts(text, path.basename(file))) {
+      if (UNSAFE_CONTEXT.test(scriptBlock.script)) {
+        findings.push(`${scriptBlock.file}:${scriptBlock.line}`);
+      }
+    }
+  }
+  assert.deepEqual(
+    findings,
+    [],
+    `blocos run com interpolação de contexto não confiável (use env var + $VAR): ${findings.join(', ')}`,
+  );
+});


### PR DESCRIPTION
## Contexto

Fixes #1016 — **[HIGH] Workflow branch input is interpolated directly into a shell command** (`other-ci-command-injection`).

O workflow `update-snapshots.yml` aceita uma branch livre via `workflow_dispatch` e a interpolava direto no refspec do `git push`, num passo com `GH_TOKEN` presente. Como expressões `${{ }}` são resolvidas **antes** do shell interpretar o bloco `run`, um nome de branch com command substitution (ex.: `main$(comando)`) — que é um nome git legalmente possível — executaria comandos arbitrários no runner com o token `contents: write`.

## Mudanças

### Fix do workflow (`update-snapshots.yml`)
- **Novo passo `Validate branch input`** (roda primeiro, antes de checkout/push):
  - Recebe a entrada por env var (`BRANCH`), nunca interpolada no corpo do script.
  - Allowlist estrita `^[A-Za-z0-9._/-]+$` → rejeita `$`, `` ` ``, `(`, `)`, `;`, `|`, espaço etc.
  - `git check-ref-format "refs/heads/$BRANCH"` como defesa em profundidade (barra `../evil`, `foo..bar`, sufixos inválidos).
  - Falha cedo (`::error::` + `exit 1`) se qualquer checagem reprovar.
- **`git push`** passa a usar a env var validada `${BRANCH}` em vez de `${{ github.event.inputs.branch }}`.
- **URL do repo** usa a built-in `${GITHUB_REPOSITORY}` em vez de `${{ github.repository }}`, removendo a última interpolação `${{ }}` do shell.

### Regression guard (`tests/workflow-command-injection-guard.test.ts`)
Cobre a **classe inteira**, não só este workflow. Varre `.github/workflows/*` e falha se algum bloco `run:` interpolar contexto controlável por terceiros (`${{ github.event.* }}`, `${{ github.head_ref }}`, `${{ inputs.* }}`) direto no shell.
- Extrator sem dependências isola apenas os corpos de `run:`, então **não** sinaliza o padrão seguro de mapear pra env var em `env:`/`with:` (usado corretamente em `discord-notify.yml`/`issue-triage.yml`).
- Casos sintéticos provam que o detector pega a forma exata do #1016 **e** que não marca o padrão env var + `${VAR}`.
- Sanity check garante que o guard tem workflows/run blocks a varrer (evita passar vazio por engano).

## Verificação

Validação da branch testada localmente:

| Entrada | Resultado |
|---|---|
| `main`, `feature/update-snaps`, `release/snapshots/v1.2.3` | ✅ ACEITA |
| `main$(touch /tmp/pwned)`, `` foo`whoami` ``, `foo;rm -rf /`, `foo\|bar`, `foo bar` | ❌ rejeitada (allowlist) |
| `../evil`, `foo..bar` | ❌ rejeitada (check-ref-format) |
| `` (vazia) | ❌ rejeitada |

- `pnpm test:regression` → **740 passando** (incluindo os 4 novos do guard)
- `pnpm typecheck` → sem erros
- Guard confirmado: só há interpolação de `github.event.*` em `env:`/`with:`/`concurrency` nos workflows atuais — nenhuma em `run:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)