### PR TITLE
fix(ci): harden refresh-reviews workflow against unpinned action refs (#1018)

### DIFF
--- a/.github/workflows/refresh-reviews.yml
+++ b/.github/workflows/refresh-reviews.yml
@@ -5,28 +5,33 @@ on:
     - cron: "0 6 * * 1" # toda segunda 06:00 UTC (~03:00 BRT)
   workflow_dispatch: {}
 
-permissions:
-  contents: write
-  pull-requests: write
+# Padrão sem escopo: cada job pede apenas a permissão que precisa (least privilege).
+permissions: {}
 
 jobs:
-  refresh-reviews:
-    name: Atualizar data/googleReviews.json
+  fetch-reviews:
+    name: Buscar reviews do Google
     runs-on: ubuntu-latest
+    # Só leitura. Este job roda os lifecycle scripts de terceiros (pnpm install) e
+    # recebe os segredos de terceiros (Outscraper/Cloudflare). Mantê-lo sem
+    # pull-requests:write e sem o GITHUB_TOKEN de escrita impede que código de
+    # dependência comprometido durante o install abuse do push/PR ou exfiltre o
+    # token privilegiado — os dois nunca coexistem no mesmo job.
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Não persistir o GITHUB_TOKEN como credencial git no runner: assim os
-          # scripts de lifecycle do pnpm install não conseguem lê-lo. O push
-          # reautentica explicitamente via token no passo de abertura do PR.
+          # scripts de lifecycle do pnpm install não conseguem lê-lo.
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Use Node.js 24
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"
@@ -44,6 +49,37 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: pnpm run reviews:fetch
 
+      - name: Upload reviews artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: google-reviews
+          path: data/googleReviews.json
+          retention-days: 1
+          if-no-files-found: error
+
+  open-pr:
+    name: Abrir PR com reviews atualizados
+    needs: fetch-reviews
+    runs-on: ubuntu-latest
+    # Escrita confinada aqui: este job NÃO instala dependências (nenhum lifecycle
+    # script de terceiros roda) e NÃO recebe segredos de terceiros. Só o
+    # GITHUB_TOKEN é exposto, e apenas para git/gh/jq (código de primeira parte).
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # O push reautentica explicitamente via token no passo de abertura do PR.
+          persist-credentials: false
+
+      - name: Download reviews artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: google-reviews
+          path: data
+
       - name: Open PR with updated reviews
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +92,6 @@ jobs:
           OLD_CONTENT="$(git show HEAD:data/googleReviews.json | jq -S 'del(.lastFetched)')"
           if [ "$NEW_CONTENT" = "$OLD_CONTENT" ]; then
             echo "Apenas lastFetched mudou — nenhum review novo. Pulando PR."
-            git checkout -- data/googleReviews.json
             exit 0
           fi
           git add data/googleReviews.json

--- a/tests/refresh-reviews-workflow-hardening.test.ts
+++ b/tests/refresh-reviews-workflow-hardening.test.ts
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+// Regression coverage for issue #1018: the scheduled/manual refresh-reviews
+// workflow runs with contents/pull-requests write scopes and exposes Outscraper,
+// Cloudflare, and GitHub tokens to job steps. A compromised mutable action ref or
+// dependency lifecycle script executed earlier could tamper with the workspace and
+// exfiltrate those secrets or abuse the write-scoped token. Guards:
+//   1. every GitHub Action pinned by full 40-char commit SHA;
+//   2. checkout keeps persist-credentials:false;
+//   3. least privilege — the secret-bearing fetch job (which runs pnpm install and
+//      third-party API secrets) never holds write scope, and the PR job (which holds
+//      the write token) never installs dependencies nor sees the third-party secrets.
+//      The two capabilities live in separate jobs.
+//
+// Parsed via plain text (no YAML dependency) to stay deterministic in CI.
+
+const SHA_PIN = /@[0-9a-f]{40}$/;
+
+async function readWorkflow(): Promise<string> {
+  return readFile(new URL('../.github/workflows/refresh-reviews.yml', import.meta.url), 'utf8');
+}
+
+// Split the `jobs:` mapping into per-job text blocks keyed by job id. Job ids are
+// the 2-space-indented keys under `jobs:`; a block runs until the next such key.
+function splitJobs(workflow: string): Map<string, string> {
+  const lines = workflow.split(/\r?\n/);
+  const jobsStart = lines.findIndex((line) => /^jobs:\s*$/.test(line));
+  assert.ok(jobsStart !== -1, 'workflow must declare a jobs: section');
+
+  const blocks = new Map<string, string>();
+  let currentId: string | null = null;
+  let buffer: string[] = [];
+  const flush = () => {
+    if (currentId) blocks.set(currentId, buffer.join('\n'));
+    buffer = [];
+  };
+
+  for (const line of lines.slice(jobsStart + 1)) {
+    const jobHeader = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+    if (jobHeader) {
+      flush();
+      currentId = jobHeader[1];
+      continue;
+    }
+    if (currentId) buffer.push(line);
+  }
+  flush();
+  return blocks;
+}
+
+test('refresh-reviews workflow pins every GitHub Action to a full commit SHA', async () => {
+  const workflow = await readWorkflow();
+
+  const usesLines = workflow.split(/\r?\n/).filter((line) => /^\s*(-\s*)?uses:/.test(line));
+  assert.ok(usesLines.length >= 3, 'expected at least the checkout/pnpm/node action steps');
+
+  for (const line of usesLines) {
+    // Strip inline `# tag` comments before validating so the SHA is anchored to
+    // the action ref itself, not to a version tag mentioned in the comment.
+    const ref = line.split('#')[0].replace(/^\s*(-\s*)?uses:\s*/, '').trim();
+    if (ref.startsWith('./')) continue; // local composite actions have no SHA to pin
+    assert.match(ref, SHA_PIN, `action must be pinned by SHA, not a mutable tag: ${ref}`);
+  }
+});
+
+test('refresh-reviews checkout does not persist git credentials', async () => {
+  const workflow = await readWorkflow();
+
+  assert.match(
+    workflow,
+    /persist-credentials:\s*false/,
+    'checkout must set persist-credentials:false so the write-scoped token is not left as a git credential',
+  );
+});
+
+test('refresh-reviews confines secrets and write scope to separate jobs', async () => {
+  const workflow = await readWorkflow();
+
+  // Workflow-level default grants no scope; each job opts in explicitly.
+  assert.match(workflow, /^permissions:\s*\{\}\s*$/m, 'workflow-level permissions must default to no scope');
+
+  const jobs = splitJobs(workflow);
+  const fetchEntry = [...jobs.entries()].find(([, block]) => block.includes('OUTSCRAPER_API_KEY'));
+  const prEntry = [...jobs.entries()].find(([, block]) => block.includes('GH_TOKEN'));
+
+  assert.ok(fetchEntry, 'expected a job that reads the third-party API secrets');
+  assert.ok(prEntry, 'expected a job that opens the PR with the GITHUB_TOKEN');
+  assert.notEqual(fetchEntry![0], prEntry![0], 'secret-bearing fetch and PR-opening work must be separate jobs');
+
+  // Strip comments so prose mentions (e.g. explaining why a scope is absent) do
+  // not trip the scope/install checks below.
+  const stripComments = (block: string) =>
+    block
+      .split(/\r?\n/)
+      .map((line) => line.split('#')[0])
+      .join('\n');
+
+  const fetchBlock = stripComments(fetchEntry![1]);
+  const prBlock = stripComments(prEntry![1]);
+
+  // The fetch job runs untrusted dependency lifecycle scripts, so it must not hold
+  // any write scope that a compromised install could abuse.
+  assert.doesNotMatch(fetchBlock, /pull-requests:\s*write/, 'fetch job must not have pull-requests:write');
+  assert.doesNotMatch(fetchBlock, /contents:\s*write/, 'fetch job must not have contents:write');
+
+  // The PR job holds the write token, so it must not install dependencies (no
+  // third-party lifecycle code) nor receive the third-party API secrets.
+  assert.doesNotMatch(prBlock, /pnpm\s+install/, 'PR job must not run pnpm install');
+  assert.doesNotMatch(prBlock, /OUTSCRAPER_API_KEY/, 'PR job must not receive third-party API secrets');
+});

--- a/tests/refresh-reviews-workflow-hardening.test.ts
+++ b/tests/refresh-reviews-workflow-hardening.test.ts
@@ -38,6 +38,10 @@ function splitJobs(workflow: string): Map<string, string> {
   };
 
   for (const line of lines.slice(jobsStart + 1)) {
+    // Stop at the next top-level key (e.g. a `concurrency:` block after `jobs:`)
+    // so unindented content never leaks into the last job's buffer. Comments and
+    // blank lines are ignored.
+    if (line.trim() !== '' && !line.trim().startsWith('#') && /^\S/.test(line)) break;
     const jobHeader = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
     if (jobHeader) {
       flush();
@@ -81,7 +85,18 @@ test('refresh-reviews confines secrets and write scope to separate jobs', async 
   // Workflow-level default grants no scope; each job opts in explicitly.
   assert.match(workflow, /^permissions:\s*\{\}\s*$/m, 'workflow-level permissions must default to no scope');
 
-  const jobs = splitJobs(workflow);
+  // Strip comments up front so prose mentions (e.g. explaining why a scope or
+  // secret is absent) never cause a false-positive job match or trip the
+  // scope/install checks below.
+  const stripComments = (block: string) =>
+    block
+      .split(/\r?\n/)
+      .map((line) => line.split('#')[0])
+      .join('\n');
+
+  const jobs = new Map(
+    [...splitJobs(workflow).entries()].map(([id, block]) => [id, stripComments(block)]),
+  );
   const fetchEntry = [...jobs.entries()].find(([, block]) => block.includes('OUTSCRAPER_API_KEY'));
   const prEntry = [...jobs.entries()].find(([, block]) => block.includes('GH_TOKEN'));
 
@@ -89,16 +104,8 @@ test('refresh-reviews confines secrets and write scope to separate jobs', async 
   assert.ok(prEntry, 'expected a job that opens the PR with the GITHUB_TOKEN');
   assert.notEqual(fetchEntry![0], prEntry![0], 'secret-bearing fetch and PR-opening work must be separate jobs');
 
-  // Strip comments so prose mentions (e.g. explaining why a scope is absent) do
-  // not trip the scope/install checks below.
-  const stripComments = (block: string) =>
-    block
-      .split(/\r?\n/)
-      .map((line) => line.split('#')[0])
-      .join('\n');
-
-  const fetchBlock = stripComments(fetchEntry![1]);
-  const prBlock = stripComments(prEntry![1]);
+  const fetchBlock = fetchEntry![1];
+  const prBlock = prEntry![1];
 
   // The fetch job runs untrusted dependency lifecycle scripts, so it must not hold
   // any write scope that a compromised install could abuse.


### PR DESCRIPTION
Fecha #1018.

## Problema

O workflow agendado/manual `refresh-reviews.yml` roda com `contents:write` + `pull-requests:write` e expõe segredos de terceiros (Outscraper, Cloudflare) e o `GITHUB_TOKEN` a passos do job. Usava refs **mutáveis** de actions (`@v7`, `@v6`, `@v6.0.9`). Uma action comprometida — ou um lifecycle script de dependência executado durante o `pnpm install` — antes dos passos com segredos poderia adulterar o workspace/toolchain e exfiltrar esses segredos ou abusar do token com escopo de escrita.

## Mudanças

- **Pinning por SHA de commit completo** em todas as actions (checkout, `pnpm/action-setup`, `setup-node`, `upload-artifact`, `download-artifact`), reusando os SHAs já verificados e mergeados em `release.yml` (#1017/#1052).
- **Divisão em dois jobs com least privilege:**
  - `fetch-reviews` — `contents:read`. Roda `pnpm install` (lifecycle scripts de terceiros) e recebe os segredos Outscraper/Cloudflare. Publica `data/googleReviews.json` via artifact. **Sem** escopo de escrita.
  - `open-pr` — `contents:write` + `pull-requests:write`. Baixa o artifact e abre o PR com o `GITHUB_TOKEN`. **Não** instala dependências e **não** vê os segredos de terceiros.
  - O token de escrita e os segredos de terceiros **nunca coexistem no mesmo job**.
- `permissions: {}` como default no nível do workflow; cada job opta explicitamente.
- Mantido `persist-credentials: false` no checkout.

## Teste

Novo `tests/refresh-reviews-workflow-hardening.test.ts` (espelha `release-workflow-hardening.test.ts`): valida SHA pinning de 40 chars, `persist-credentials:false` e a separação de segredos/escrita entre jobs. Parsing textual, sem dependência de YAML.

`pnpm test:regression` — 755/755 passam (inclui o guard que varre todos os workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)