### PR TITLE
fix(ci): isolate write token from branch code in update-snapshots (#1019)

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -6,12 +6,18 @@ on:
         description: 'Branch to update snapshots on'
         required: true
         default: 'main'
-permissions:
-  contents: write
+# Padrão sem escopo: cada job pede apenas a permissão que precisa (least privilege).
+# O job que roda código controlado pela branch escolhida (pnpm install, Playwright)
+# fica com contents: read e SEM o GITHUB_TOKEN de escrita; o push privilegiado vive
+# num job separado que não instala dependências. As duas capacidades nunca coexistem
+# no mesmo runner, então código da branch não persiste estado (hooks git, processos)
+# capaz de abusar do token de escrita.
+permissions: {}
 jobs:
-  update-snapshots:
-    timeout-minutes: 60
+  validate-branch:
+    name: Validar branch de entrada
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
     - name: Validate branch input
       env:
@@ -31,14 +37,29 @@ jobs:
           echo "::error::Branch inválida: falhou em git check-ref-format."
           exit 1
         fi
-    - uses: actions/checkout@v7
+  generate-snapshots:
+    name: Gerar snapshots atualizados
+    needs: validate-branch
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    # Só leitura. Este job faz checkout da branch escolhida pelo chamador e roda os
+    # lifecycle scripts de terceiros (pnpm install) + Playwright. Sem contents: write
+    # e sem o GITHUB_TOKEN de escrita, código da branch não tem como abusar do push
+    # nem exfiltrar o token privilegiado — ele nunca está presente neste runner.
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         ref: ${{ github.event.inputs.branch }}
         # Não persistir o GITHUB_TOKEN como credencial git: evita que scripts de
-        # lifecycle do pnpm install leiam o token. O push reautentica via token URL.
+        # lifecycle do pnpm install o leiam.
         persist-credentials: false
-    - uses: pnpm/action-setup@v6.0.9
-    - uses: actions/setup-node@v6
+    - name: Install pnpm
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+    - name: Use Node.js 24
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
         cache: 'pnpm'
@@ -48,11 +69,39 @@ jobs:
       run: pnpm exec playwright install --with-deps chromium
     - name: Update visual snapshots
       run: pnpm exec playwright test tests/e2e/visual.spec.ts --update-snapshots
+    - name: Upload updated snapshots
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: updated-snapshots
+        path: tests/e2e/visual.spec.ts-snapshots/
+        retention-days: 1
+        if-no-files-found: error
+  commit-snapshots:
+    name: Commitar snapshots atualizados
+    needs: generate-snapshots
+    runs-on: ubuntu-latest
+    # Escrita confinada aqui: este job NÃO instala dependências (nenhum lifecycle
+    # script de terceiros roda) e faz um checkout limpo da branch. Só o GITHUB_TOKEN
+    # de escrita é exposto, e apenas para git — código de primeira parte.
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ github.event.inputs.branch }}
+        # O push reautentica explicitamente via token URL no passo de commit.
+        persist-credentials: false
+    - name: Download updated snapshots
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      with:
+        name: updated-snapshots
+        path: tests/e2e/visual.spec.ts-snapshots/
     - name: Commit updated snapshots
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Branch validada no passo "Validate branch input"; usada como env var
-        # (nunca interpolada direto no corpo do script) para evitar injeção.
+        # Branch já validada no job "validate-branch"; usada como env var (nunca
+        # interpolada direto no corpo do script) para evitar injeção.
         BRANCH: ${{ github.event.inputs.branch }}
       run: |
         git config user.name "github-actions[bot]"
@@ -61,6 +110,9 @@ jobs:
         if git diff --staged --quiet; then
           echo "No snapshot changes to commit."
         else
-          git commit -m "test: update visual regression baselines [skip ci]"
+          # --no-verify: checkout limpo, mas como este é o único job com o token de
+          # escrita, desabilitamos hooks no commit por defesa em profundidade
+          # (nenhum install ativou core.hooksPath aqui).
+          git commit --no-verify -m "test: update visual regression baselines [skip ci]"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" "HEAD:refs/heads/${BRANCH}"
         fi

--- a/tests/update-snapshots-workflow-hardening.test.ts
+++ b/tests/update-snapshots-workflow-hardening.test.ts
@@ -17,6 +17,12 @@ import { readFile } from 'node:fs/promises';
 
 const SHA_PIN = /@[0-9a-f]{40}$/;
 
+// Matches any spelling of the write-scoped token so the guard stays correct if the
+// workflow is refactored from `GH_TOKEN`/`secrets.GITHUB_TOKEN` to the
+// `${{ github.token }}` form. Word boundaries keep `GH_TOKEN` from being conflated
+// with unrelated identifiers.
+const WRITE_TOKEN = /\bGH_TOKEN\b|\bGITHUB_TOKEN\b|github\.token/;
+
 async function readWorkflow(): Promise<string> {
   return readFile(new URL('../.github/workflows/update-snapshots.yml', import.meta.url), 'utf8');
 }
@@ -95,7 +101,7 @@ test('update-snapshots confines branch code and write scope to separate jobs', a
     [...splitJobs(workflow).entries()].map(([id, block]) => [id, stripComments(block)]),
   );
   const generateEntry = [...jobs.entries()].find(([, block]) => block.includes('pnpm install'));
-  const commitEntry = [...jobs.entries()].find(([, block]) => block.includes('GH_TOKEN'));
+  const commitEntry = [...jobs.entries()].find(([, block]) => WRITE_TOKEN.test(block));
 
   assert.ok(generateEntry, 'expected a job that installs dependencies and runs branch code');
   assert.ok(commitEntry, 'expected a job that pushes with the GITHUB_TOKEN');
@@ -111,7 +117,7 @@ test('update-snapshots confines branch code and write scope to separate jobs', a
   // The generation job runs untrusted branch code (pnpm lifecycle scripts,
   // Playwright), so it must not hold any write scope that code could abuse.
   assert.doesNotMatch(generateBlock, /contents:\s*write/, 'generation job must not have contents:write');
-  assert.doesNotMatch(generateBlock, /GH_TOKEN/, 'generation job must not receive the write-scoped token');
+  assert.doesNotMatch(generateBlock, WRITE_TOKEN, 'generation job must not receive the write-scoped token');
 
   // The commit job holds the write token, so it must not install dependencies
   // (no third-party lifecycle code runs in the same runner as the token).

--- a/tests/update-snapshots-workflow-hardening.test.ts
+++ b/tests/update-snapshots-workflow-hardening.test.ts
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+// Regression coverage for issue #1019: the manual update-snapshots workflow checks
+// out a caller-selected branch and runs pnpm install + Playwright before a
+// write-scoped git push. If snapshot generation and the token-bearing push share
+// one job, branch code can persist state (git hooks, background processes) in the
+// runner workspace before the token step and abuse the later push. Guards:
+//   1. every GitHub Action pinned by full 40-char commit SHA;
+//   2. checkout keeps persist-credentials:false;
+//   3. least privilege — the job that runs branch code (pnpm install / Playwright)
+//      never holds write scope, and the job that holds the GITHUB_TOKEN never
+//      installs dependencies. The two capabilities live in separate jobs.
+//
+// Parsed via plain text (no YAML dependency) to stay deterministic in CI.
+
+const SHA_PIN = /@[0-9a-f]{40}$/;
+
+async function readWorkflow(): Promise<string> {
+  return readFile(new URL('../.github/workflows/update-snapshots.yml', import.meta.url), 'utf8');
+}
+
+// Split the `jobs:` mapping into per-job text blocks keyed by job id. Job ids are
+// the 2-space-indented keys under `jobs:`; a block runs until the next such key.
+function splitJobs(workflow: string): Map<string, string> {
+  const lines = workflow.split(/\r?\n/);
+  const jobsStart = lines.findIndex((line) => /^jobs:\s*$/.test(line));
+  assert.ok(jobsStart !== -1, 'workflow must declare a jobs: section');
+
+  const blocks = new Map<string, string>();
+  let currentId: string | null = null;
+  let buffer: string[] = [];
+  const flush = () => {
+    if (currentId) blocks.set(currentId, buffer.join('\n'));
+    buffer = [];
+  };
+
+  for (const line of lines.slice(jobsStart + 1)) {
+    // Stop at the next top-level key so unindented content never leaks into the
+    // last job's buffer. Comments and blank lines are ignored.
+    if (line.trim() !== '' && !line.trim().startsWith('#') && /^\S/.test(line)) break;
+    const jobHeader = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+    if (jobHeader) {
+      flush();
+      currentId = jobHeader[1];
+      continue;
+    }
+    if (currentId) buffer.push(line);
+  }
+  flush();
+  return blocks;
+}
+
+test('update-snapshots workflow pins every GitHub Action to a full commit SHA', async () => {
+  const workflow = await readWorkflow();
+
+  const usesLines = workflow.split(/\r?\n/).filter((line) => /^\s*(-\s*)?uses:/.test(line));
+  assert.ok(usesLines.length >= 3, 'expected at least the checkout/pnpm/node action steps');
+
+  for (const line of usesLines) {
+    // Strip inline `# tag` comments before validating so the SHA is anchored to
+    // the action ref itself, not to a version tag mentioned in the comment.
+    const ref = line.split('#')[0].replace(/^\s*(-\s*)?uses:\s*/, '').trim();
+    if (ref.startsWith('./')) continue; // local composite actions have no SHA to pin
+    assert.match(ref, SHA_PIN, `action must be pinned by SHA, not a mutable tag: ${ref}`);
+  }
+});
+
+test('update-snapshots checkout does not persist git credentials', async () => {
+  const workflow = await readWorkflow();
+
+  assert.match(
+    workflow,
+    /persist-credentials:\s*false/,
+    'checkout must set persist-credentials:false so the write-scoped token is not left as a git credential',
+  );
+});
+
+test('update-snapshots confines branch code and write scope to separate jobs', async () => {
+  const workflow = await readWorkflow();
+
+  // Workflow-level default grants no scope; each job opts in explicitly.
+  assert.match(workflow, /^permissions:\s*\{\}\s*$/m, 'workflow-level permissions must default to no scope');
+
+  // Strip comments up front so prose mentions (e.g. explaining why a scope or
+  // install is absent) never cause a false-positive job match or trip the checks.
+  const stripComments = (block: string) =>
+    block
+      .split(/\r?\n/)
+      .map((line) => line.split('#')[0])
+      .join('\n');
+
+  const jobs = new Map(
+    [...splitJobs(workflow).entries()].map(([id, block]) => [id, stripComments(block)]),
+  );
+  const generateEntry = [...jobs.entries()].find(([, block]) => block.includes('pnpm install'));
+  const commitEntry = [...jobs.entries()].find(([, block]) => block.includes('GH_TOKEN'));
+
+  assert.ok(generateEntry, 'expected a job that installs dependencies and runs branch code');
+  assert.ok(commitEntry, 'expected a job that pushes with the GITHUB_TOKEN');
+  assert.notEqual(
+    generateEntry![0],
+    commitEntry![0],
+    'branch-code generation and token-bearing push must be separate jobs',
+  );
+
+  const generateBlock = generateEntry![1];
+  const commitBlock = commitEntry![1];
+
+  // The generation job runs untrusted branch code (pnpm lifecycle scripts,
+  // Playwright), so it must not hold any write scope that code could abuse.
+  assert.doesNotMatch(generateBlock, /contents:\s*write/, 'generation job must not have contents:write');
+  assert.doesNotMatch(generateBlock, /GH_TOKEN/, 'generation job must not receive the write-scoped token');
+
+  // The commit job holds the write token, so it must not install dependencies
+  // (no third-party lifecycle code runs in the same runner as the token).
+  assert.doesNotMatch(commitBlock, /pnpm\s+install/, 'commit job must not run pnpm install');
+});


### PR DESCRIPTION
## Resumo

- **O que muda:** `update-snapshots.yml` deixa de rodar tudo num único job. Agora são três jobs com escopos isolados: `validate-branch` (`permissions: {}`, allowlist + `git check-ref-format` no input), `generate-snapshots` (`contents: read`, roda `pnpm install` + Playwright e sobe os snapshots como artifact, sem token) e `commit-snapshots` (`contents: write`, checkout limpo sem install, baixa o artifact e faz push com o `GITHUB_TOKEN`).
- **Por quê:** no fluxo antigo, código controlado pela branch escolhida (`pnpm install`, Playwright) rodava **antes** do passo de commit que expõe o token de escrita. Código da branch podia persistir estado no mesmo runner (git hooks, processos em background) e abusar do `git push` posterior. `persist-credentials: false` só impede o checkout de gravar o token no git config — não isola o passo com token do código que já rodou. Separar as capacidades garante que o token de escrita e o código de terceiros nunca coexistem no mesmo runner.
- **Impacto para o usuário:** nenhum impacto funcional — o workflow continua atualizando os snapshots visuais na branch escolhida via `workflow_dispatch`. Mudança puramente de postura de segurança/CI.
- **Nível de risco:** baixo

## Issue relacionada

Closes #1019

## Tipo de mudança

- [x] ⚙️ Infra / CI

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only)
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível)

Novo `tests/update-snapshots-workflow-hardening.test.ts` (espelha o guard de `refresh-reviews`): valida SHA-pin em todas as actions, `persist-credentials: false`, e a separação entre o job que roda código da branch (sem write scope, sem token) e o job que detém o `GITHUB_TOKEN` (sem `pnpm install`).

Comandos executados:

\`\`\`text
npx tsx --test tests/update-snapshots-workflow-hardening.test.ts tests/workflow-command-injection-guard.test.ts  # 7 pass / 0 fail
\`\`\`

## API & Segurança

- [x] Não se aplica
- [x] Sem secrets ou PII bruta em logs

Endurecimento de workflow de CI; não toca handlers de `api/`. A branch do dispatch continua validada por allowlist + `git check-ref-format` e sempre passada via env var (`${BRANCH}`), nunca interpolada como `${{ }}` no shell.

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`fix:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

- Actions pinadas por SHA reutilizando os mesmos SHAs já presentes em `refresh-reviews.yml` (checkout v7.0.0, pnpm/action-setup v6.0.9, setup-node v6.4.0, upload/download-artifact v7).
- `git commit --no-verify` no job de commit é defesa em profundidade: o checkout é limpo e nenhum `pnpm install` roda ali (logo `core.hooksPath` não é ativado), mas como é o único job com o token de escrita, desabilitamos hooks explicitamente.
- Segue o padrão de dois jobs já consolidado em `refresh-reviews.yml` (#1018).