### PR TITLE
fix(logger): guard process access so browser chat path doesn't crash

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -4,6 +4,11 @@ type LoggerData = unknown;
 type ConsoleMethod = 'log' | 'info' | 'warn' | 'error';
 
 function isDebugEnabled(): boolean {
+    // This logger is shared between server handlers and browser code. In the
+    // browser bundle `process` is not defined (Vite only replaces the
+    // `process.env.GEMINI_MODEL` token), so reading it unguarded throws a
+    // ReferenceError and breaks the caller (e.g. the chat request path).
+    if (typeof process === 'undefined' || !process.env) return false;
     const debug = process.env.DEBUG;
     return typeof debug === 'string' && debug.toLowerCase() === 'true';
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -8,7 +8,7 @@ function isDebugEnabled(): boolean {
     // browser bundle `process` is not defined (Vite only replaces the
     // `process.env.GEMINI_MODEL` token), so reading it unguarded throws a
     // ReferenceError and breaks the caller (e.g. the chat request path).
-    if (typeof process === 'undefined' || !process.env) return false;
+    if (typeof process === 'undefined' || !process?.env) return false;
     const debug = process.env.DEBUG;
     return typeof debug === 'string' && debug.toLowerCase() === 'true';
 }

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -48,6 +48,24 @@ test('logger.debug escreve apenas quando DEBUG=true', () => {
     }
 });
 
+test('logger.debug não quebra quando process é indefinido (bundle do browser)', () => {
+    const globalWithProcess = globalThis as { process?: NodeJS.Process };
+    const originalProcess = globalWithProcess.process;
+    const log = captureConsole('log');
+
+    try {
+        // Simula o bundle do browser, onde `process` não existe: a leitura
+        // desprotegida de process.env.DEBUG lançava ReferenceError.
+        delete globalWithProcess.process;
+
+        assert.doesNotThrow(() => logger.debug('debug no browser', { source: 'test' }));
+        assert.deepEqual(log.calls, []);
+    } finally {
+        globalWithProcess.process = originalProcess;
+        log.restore();
+    }
+});
+
 test('logger escreve os níveis públicos com prefixos estáveis', () => {
     const info = captureConsole('info');
     const warn = captureConsole('warn');

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -57,8 +57,13 @@ test('logger.debug não quebra quando process é indefinido (bundle do browser)'
         // Simula o bundle do browser, onde `process` não existe: a leitura
         // desprotegida de process.env.DEBUG lançava ReferenceError.
         delete globalWithProcess.process;
+        assert.doesNotThrow(() => logger.debug('debug sem process', { source: 'test' }));
 
-        assert.doesNotThrow(() => logger.debug('debug no browser', { source: 'test' }));
+        // Alguns ambientes/mocks definem `process` como null: `!process.env`
+        // sem optional chaining lançaria TypeError.
+        globalWithProcess.process = null as unknown as NodeJS.Process;
+        assert.doesNotThrow(() => logger.debug('debug com process null', { source: 'test' }));
+
         assert.deepEqual(log.calls, []);
     } finally {
         globalWithProcess.process = originalProcess;


### PR DESCRIPTION
## Resumo

- **O que muda:** `isDebugEnabled()` em `lib/logger.ts` agora guarda o acesso a `process` com `typeof process === 'undefined' || !process.env` antes de ler `process.env.DEBUG`.
- **Por quê:** o logger é compartilhado entre handlers de servidor e código de browser. No bundle do browser o Vite só substitui o token `process.env.GEMINI_MODEL` (`vite.config.ts`), então `process` fica indefinido e a leitura desprotegida lançava `ReferenceError: process is not defined`. Isso quebrava `logger.debug` em `services/geminiService.ts:213`, chamado antes do `fetch('/api/generate')`, derrubando o request do chat no fallback de erro em vez de contatar a API.
- **Impacto para o usuário:** o caminho do chatbot deixa de correr o risco de crashar antes de chamar a API por causa de logging de debug.
- **Nível de risco:** baixo

## Issue relacionada

Closes #1020

## Tipo de mudança

- [x] 🐛 Bug fix

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only)
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível)

Novo teste de regressão em `tests/logger.test.ts` simula o bundle do browser (`delete globalThis.process`) e verifica que `logger.debug` não lança e permanece silencioso.

Comandos executados:

```text
tsx --test tests/logger.test.ts   # 7 passam (incl. o novo)
pnpm typecheck                    # sem erros
```

## API & Segurança

- [x] Não se aplica
- [x] Sem secrets ou PII bruta em logs

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`fix:`)

## Exceções / observações para o revisor

Guardei com `typeof process` (em vez de `import.meta.env`) para manter um único comportamento em servidor e browser sem introduzir uma nova var `VITE_DEBUG`. Debug no browser segue desabilitado por padrão, que era o comportamento efetivo esperado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)