### PR TITLE
fix(odoo): upsert não-destrutivo de partner para impedir overwrite público (#1021)

### DIFF
--- a/services/odoo.ts
+++ b/services/odoo.ts
@@ -130,6 +130,30 @@ function executeKw<T>(
 export type OdooPartnerFields = Record<string, unknown>;
 
 /**
+ * Scalar `res.partner` fields a public form must never overwrite on an existing
+ * match — they are only filled when the record's value is blank. The 5 forms are
+ * public and dedup by caller-supplied e-mail/phone, so overwriting would let
+ * anyone who knows a customer's contact corrupt their record (issue #1021).
+ * `comment` (append-only) and `category_id` (additive `(4, id)` link commands)
+ * are non-destructive and handled separately.
+ */
+const PROTECTED_SCALAR_FIELDS = [
+    'name',
+    'email',
+    'phone',
+    'x_lgpd_consent',
+    'x_perfil_do_viajante',
+    'x_nps_score',
+] as const;
+
+type ExistingPartner = { id: number } & Record<string, unknown>;
+
+/** Odoo returns `false` (not '' or 0-as-empty) for unset text/number fields over JSON-RPC. */
+function isBlankOdooValue(value: unknown): boolean {
+    return value === false || value === null || value === undefined || value === '';
+}
+
+/**
  * Per-submit session: authenticates once, then exposes ORM helpers that share a
  * single time budget. Create one with `openOdooSession()` at the start of a submit.
  */
@@ -147,8 +171,9 @@ export async function openOdooSession(config: OdooConfig): Promise<OdooSession> 
     const deadline = Date.now() + TOTAL_DEADLINE_MS;
     const uid = await authenticate(config, deadline);
 
-    // Odoo returns `false` (not '') for empty text fields over JSON-RPC.
-    async function findPartner(fields: OdooPartnerFields): Promise<{ id: number; comment: string | false } | null> {
+    // Odoo returns `false` (not '') for empty text fields over JSON-RPC. Reads the
+    // protected scalars so upsertPartner can fill-if-blank without overwriting.
+    async function findPartner(fields: OdooPartnerFields): Promise<ExistingPartner | null> {
         const email = typeof fields.email === 'string' && fields.email.trim() !== '' ? fields.email.trim() : null;
         const phone = typeof fields.phone === 'string' && fields.phone.trim() !== '' ? fields.phone.trim() : null;
         const domain = email
@@ -158,12 +183,12 @@ export async function openOdooSession(config: OdooConfig): Promise<OdooSession> 
                 : null;
         if (!domain) return null;
 
-        const rows = await executeKw<Array<{ id: number; comment: string | false }>>(
+        const rows = await executeKw<ExistingPartner[]>(
             config,
             uid,
             'res.partner',
             'search_read',
-            [domain, ['id', 'comment']],
+            [domain, ['id', 'comment', ...PROTECTED_SCALAR_FIELDS]],
             deadline,
             { limit: 1 },
         );
@@ -181,9 +206,20 @@ export async function openOdooSession(config: OdooConfig): Promise<OdooSession> 
                     const previous = typeof existing.comment === 'string' ? existing.comment.trim() : '';
                     updateFields.comment = previous ? `${previous}\n\n${fields.comment}` : fields.comment;
                 }
+                // Non-destructive upsert: never overwrite a protected scalar that
+                // already holds a value — a public form can't prove it owns the
+                // matched record (issue #1021). Blank fields are still enriched.
+                for (const key of PROTECTED_SCALAR_FIELDS) {
+                    if (key in updateFields && !isBlankOdooValue(existing[key])) {
+                        delete updateFields[key];
+                    }
+                }
                 // Forms that only capture a partial name (e.g. NPS asks for firstname
                 // only) must not clobber a fuller name already on file.
                 if (options?.preserveName) delete updateFields.name;
+                // The filter above may leave only additive updates (comment/tags) or
+                // nothing at all; skip the write when there's nothing left to persist.
+                if (Object.keys(updateFields).length === 0) return existing.id;
                 await executeKw<boolean>(config, uid, 'res.partner', 'write', [[existing.id], updateFields], deadline);
                 return existing.id;
             }

--- a/tests/odoo-mock.ts
+++ b/tests/odoo-mock.ts
@@ -32,6 +32,12 @@ export interface OdooMockOptions {
     existingPartnerId?: number | null;
     /** `comment` returned for the existing partner (Odoo returns false when empty). */
     existingComment?: string | false;
+    /**
+     * Extra scalar fields the search_read row reports for the existing partner
+     * (e.g. `{ name: 'Ana Silva', x_nps_score: 8 }`). Lets tests exercise the
+     * non-destructive fill-if-blank guard. Odoo returns `false` for unset fields.
+     */
+    existingFields?: Record<string, unknown>;
     newPartnerId?: number;
     leadId?: number;
     /** Force every RPC to fail with this HTTP status. */
@@ -72,6 +78,7 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
         uid = 7,
         existingPartnerId = null,
         existingComment = false,
+        existingFields = {},
         newPartnerId = 101,
         leadId = 555,
         failStatus,
@@ -102,7 +109,9 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
             calls.push({ model, method: ormMethod, args: ormArgs, kwargs });
 
             if (ormMethod === 'search_read') {
-                result = existingPartnerId ? [{ id: existingPartnerId, comment: existingComment }] : [];
+                result = existingPartnerId
+                    ? [{ id: existingPartnerId, comment: existingComment, ...existingFields }]
+                    : [];
             } else if (ormMethod === 'create') {
                 result = model === 'crm.lead' ? leadId : newPartnerId;
             } else if (ormMethod === 'write') {

--- a/tests/odoo-service.test.ts
+++ b/tests/odoo-service.test.ts
@@ -81,6 +81,79 @@ test('upsertPartner — uses the new comment when the partner has none', async (
     assert.equal((write.args[1] as Record<string, unknown>).comment, 'Primeira nota');
 });
 
+// Non-destructive upsert — a public form must not overwrite populated scalar
+// fields of a partner it matched by e-mail/phone (issue #1021).
+
+test('upsertPartner — does not overwrite populated name/phone/email on an existing match', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+    const mock = createOdooMock({
+        existingPartnerId: 60,
+        existingFields: { name: 'Ana Carolina Silva', email: 'ana@example.com', phone: '+5511999998888' },
+    });
+    global.fetch = mock.fetch;
+
+    const session = await openOdooSession(config());
+    await session.upsertPartner({
+        name: 'Hacker',
+        email: 'ana@example.com',
+        phone: '+5511000000000',
+        comment: 'nota',
+    });
+
+    const fields = mock.calls.find((c) => c.method === 'write')!.args[1] as Record<string, unknown>;
+    assert.equal('name' in fields, false, 'populated name must not be overwritten');
+    assert.equal('phone' in fields, false, 'populated phone must not be overwritten');
+    assert.equal('email' in fields, false, 'populated email must not be overwritten');
+    assert.equal(fields.comment, 'nota', 'additive comment still applies');
+});
+
+test('upsertPartner — fills a blank protected field on an existing match (enrichment)', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+    // Matched by e-mail; phone is unset (Odoo reports `false`), so it may be filled.
+    const mock = createOdooMock({
+        existingPartnerId: 61,
+        existingFields: { name: 'Ana', email: 'ana@example.com', phone: false },
+    });
+    global.fetch = mock.fetch;
+
+    const session = await openOdooSession(config());
+    await session.upsertPartner({ name: 'Ana', email: 'ana@example.com', phone: '+5511999998888' });
+
+    const fields = mock.calls.find((c) => c.method === 'write')!.args[1] as Record<string, unknown>;
+    assert.equal(fields.phone, '+5511999998888', 'a blank field is enriched, not blocked');
+    assert.equal('name' in fields, false, 'populated name stays untouched');
+});
+
+test('upsertPartner — does not overwrite an existing NPS score (0 counts as populated)', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+    const mock = createOdooMock({
+        existingPartnerId: 62,
+        existingFields: { email: 'ana@example.com', x_nps_score: 0 },
+    });
+    global.fetch = mock.fetch;
+
+    const session = await openOdooSession(config());
+    await session.upsertPartner({ email: 'ana@example.com', x_nps_score: 10, comment: 'nps' });
+
+    const fields = mock.calls.find((c) => c.method === 'write')!.args[1] as Record<string, unknown>;
+    assert.equal('x_nps_score' in fields, false, 'an existing score (even 0) must not be overwritten');
+});
+
+test('upsertPartner — skips the write when the guard leaves nothing to persist', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+    const mock = createOdooMock({
+        existingPartnerId: 63,
+        existingFields: { name: 'Ana', email: 'ana@example.com', x_lgpd_consent: true },
+    });
+    global.fetch = mock.fetch;
+
+    const session = await openOdooSession(config());
+    const id = await session.upsertPartner({ name: 'Ana', email: 'ana@example.com', x_lgpd_consent: true });
+
+    assert.equal(id, 63);
+    assert.equal(mock.calls.some((c) => c.method === 'write'), false, 'no write when only no-op overwrites remain');
+});
+
 test('createLead — issues a crm.lead.create and returns the id', async (t) => {
     t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
     const mock = createOdooMock({ leadId: 777 });


### PR DESCRIPTION
## Resumo

- **O que muda:** Em `services/odoo.ts`, ao encontrar um `res.partner` existente (dedup por e-mail/telefone), os campos escalares mutáveis (`name`, `email`, `phone`, `x_lgpd_consent`, `x_perfil_do_viajante`, `x_nps_score`) só são escritos quando o valor atual está em branco (fill-if-blank) — nunca sobrescrevem valor já preenchido. `comment` (append-only) e `category_id` (comandos aditivos `(4, id)`) continuam como antes; o `write` é pulado quando o filtro não deixa nada a persistir.
- **Por quê:** Os 5 formulários são públicos e deduplicam por e-mail/telefone fornecidos pelo cliente. Antes, o handler fazia `write` do objeto inteiro por cima do registro casado, permitindo que qualquer pessoa que soubesse o e-mail de um cliente corrompesse nome, contato, consentimento de marketing, perfil de viajante ou a nota de NPS (o NPS era o caso mais claro — `pages/NpsPage.tsx` só pré-preenche o e-mail pela URL, sem convite assinado nem prova de posse).
- **Impacto para o usuário:** Nenhum impacto visível nos fluxos legítimos — parceiros novos são criados com todos os campos, e campos em branco de parceiros existentes continuam sendo enriquecidos. Dados já preenchidos de clientes reais ficam protegidos contra sobrescrita.
- **Nível de risco:** baixo

## Issue relacionada

Closes #1021

## Tipo de mudança

- [x] 🐛 Bug fix

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only)
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível)

Adicionadas 4 regressões em `tests/odoo-service.test.ts` (bloqueio de overwrite de name/email/phone, enriquecimento de campo em branco, proteção de `x_nps_score` existente incluindo `0`, e skip do write quando só restam no-ops). `tests/odoo-mock.ts` ganhou a opção `existingFields` para simular campos já preenchidos no parceiro.

Comandos executados:

```text
pnpm typecheck
pnpm test:regression   # 763 passing
```

## API & Segurança

- [ ] Não se aplica
- [x] Inputs validados/sanitizados na borda, antes de side effects ou chamadas a providers
- [x] Respostas e códigos de erro permanecem estruturados; helpers compartilhados reutilizados
- [x] Sem secrets ou PII bruta em logs
- [x] `dangerouslySetInnerHTML` não foi introduzido sem fonte controlada e justificativa

A correção vive na camada de transporte (`services/odoo.ts`), onde o registro existente é lido; o mapeamento puro (`lib/odoo-lead-mapping.ts`) fica intacto, preservando a separação de responsabilidades.

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`fix:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

**Risco residual (decisão de escopo):** campos ainda em branco de um parceiro existente podem ser preenchidos por quem souber o e-mail. A autenticação de posse do registro (token de convite assinado/expirável no NPS) foi deixada fora deste PR — exige coordenação com quem envia o convite (n8n/e-mail) para gerar o token. Follow-up recomendado se a proteção total do NPS for necessária.

🤖 Generated with [Claude Code](https://claude.com/claude-code)