### PR TITLE
test(e2e): mock globe.gl no /corporativo p/ estabilizar visual e2e (#1065)

### DIFF
--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -2,7 +2,44 @@ import { test, expect } from '@playwright/test';
 import type { SubmitLeadRequest } from '../../types/leadCapture';
 import { CorporativoPage } from './pages/CorporativoPage';
 
+// CorpGlobe faz `import('globe.gl')` em runtime e busca uma textura em
+// media.anhanga.tur.br — dependência externa + contexto WebGL que só existe
+// para enfeitar o hero (aria-hidden). Em e2e isso é fonte de ruído (console
+// errors) e de flakiness (WebGL headless, re-otimização de deps do Vite, fetch
+// externo). Trocamos o módulo pré-bundlado do Vite (`globe__gl.js`) por um stub
+// no-op encadeável, então o `import()` resolve, nada renderiza no canvas e
+// nenhuma rede externa é tocada. O teste de fallback sobrescreve isto abortando
+// a rota (registro posterior tem precedência no Playwright).
+const GLOBE_STUB_MODULE = `
+  export default function Globe() {
+    const api = new Proxy(function () {}, {
+      get(_target, prop) {
+        if (prop === 'renderer') return () => null;
+        if (prop === 'controls') return () => ({});
+        return () => api;
+      },
+      apply() { return api; },
+      construct() { return api; },
+    });
+    return api;
+  }
+`;
+
+async function stubCorpGlobe(page: import('@playwright/test').Page) {
+  await page.route('**/globe__gl.js*', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: GLOBE_STUB_MODULE,
+    })
+  );
+}
+
 test.describe('Corporativo Landing Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubCorpGlobe(page);
+  });
+
   test('should push correct dataLayer event on landing view', async ({ page }) => {
     const landing = new CorporativoPage(page);
     await landing.goto();
@@ -155,6 +192,8 @@ test.describe('Corporativo Landing Page', () => {
     // por design, então a asserção de visibilidade só vale no desktop.
     test.skip(isMobile, 'Globo é decorativo desktop-only (hidden lg:block)');
 
+    // Sobrescreve o stub no-op do beforeEach: registrado depois, tem precedência
+    // no Playwright, então aqui o módulo falha de fato e exercita o catch → fallback.
     await page.route(/globe(\.|__)gl|three-globe/, route => route.abort());
 
     const landing = new CorporativoPage(page);

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -6,10 +6,12 @@ import { CorporativoPage } from './pages/CorporativoPage';
 // media.anhanga.tur.br — dependência externa + contexto WebGL que só existe
 // para enfeitar o hero (aria-hidden). Em e2e isso é fonte de ruído (console
 // errors) e de flakiness (WebGL headless, re-otimização de deps do Vite, fetch
-// externo). Trocamos o módulo pré-bundlado do Vite (`globe__gl.js`) por um stub
-// no-op encadeável, então o `import()` resolve, nada renderiza no canvas e
-// nenhuma rede externa é tocada. O teste de fallback sobrescreve isto abortando
-// a rota (registro posterior tem precedência no Playwright).
+// externo). Trocamos o módulo do globe.gl por um stub no-op encadeável, então o
+// `import()` resolve, nada renderiza no canvas e nenhuma rede externa é tocada.
+// A rota casa tanto o pré-bundle do Vite dev (`.vite/deps/globe__gl.js`) quanto
+// um chunk de build (`globe.gl-HASH.js`) — mesma regex do teste de fallback,
+// que sobrescreve isto abortando a rota (registro posterior tem precedência).
+const GLOBE_MODULE_ROUTE = /globe(\.|__)gl/;
 const GLOBE_STUB_MODULE = `
   export default function Globe() {
     const api = new Proxy(function () {}, {
@@ -26,7 +28,7 @@ const GLOBE_STUB_MODULE = `
 `;
 
 async function stubCorpGlobe(page: import('@playwright/test').Page) {
-  await page.route('**/globe__gl.js*', route =>
+  await page.route(GLOBE_MODULE_ROUTE, route =>
     route.fulfill({
       status: 200,
       contentType: 'application/javascript',


### PR DESCRIPTION
## Contexto

Fecha #1065 — estabilizar o e2e visual: mock do `globe.gl`, revisão do seletor webkit no `/corporativo` e verificação das baselines visuais.

## O que foi feito

### 1. Mock do `globe.gl` (`tests/e2e/corporativo.spec.ts`)
O `CorpGlobe` faz `import('globe.gl')` em runtime e busca uma textura em `media.anhanga.tur.br` — dependência externa + contexto WebGL puramente decorativo (`aria-hidden`). Em e2e isso era fonte de ruído de console e de flakiness (WebGL headless, re-otimização de deps do Vite, fetch externo).

- Adicionado `stubCorpGlobe()` num `beforeEach`: substitui o módulo pré-bundlado do Vite (`globe__gl.js`) por um stub no-op encadeável via `page.route`. O `import()` resolve, nada renderiza no canvas e **nenhuma rede externa é tocada**.
- O teste de fallback continua abortando a rota (registro posterior tem precedência no Playwright), preservando a cobertura do caminho de erro real.
- Verificado com sonda temporária: `STUB_HIT=1`, `TEXTURE_HIT=0`.

> O root cause do "Failed to fetch dynamically imported module" já tinha sido tratado em #987 (pré-bundle em `optimizeDeps`). Este mock isola o restante (WebGL + textura externa) e silencia o ruído nos testes que não exercitam o fallback.

### 2. Seletor webkit `/corporativo`
Não reproduziu o `element(s) not found`: `corporativo.spec.ts` rodou **3× seguidas verde no webkit** (8/8) e verde em chromium (8/8) e Mobile Chrome (7/7, fallback é desktop-only). Considerado resolvido pelas mudanças anteriores; sem alteração de seletor necessária.

### 3. Baselines visuais
Investigado: as baselines **`-linux`** (as autoritativas — o gate `playwright.yml` roda em ubuntu, chromium + Mobile Chrome) **já estão atualizadas**. Disparei o workflow sancionado `update-snapshots.yml` nesta branch e o resultado foi **"No snapshot changes to commit"** — o render atual bate com `home-page-chromium-linux.png` (1280×6640). O gate visual do CI já passa.

A divergência que aparece **localmente** (`home-page-*-darwin`, ~6664px vs baseline 6421px) é diferença de font metrics por plataforma — exatamente o caso que o comentário no topo do `visual.spec.ts` descreve ("rodar localmente acusa diff sempre — sem ser regressão de produto"). Não-autoritativa, não commitada.

## Verificação
- `corporativo.spec.ts`: 3× webkit + chromium + Mobile Chrome → verde, determinístico.
- Suíte não-visual completa (`--grep-invert @visual`, chromium): **145 passed**.
- `update-snapshots.yml` (ubuntu) → "No snapshot changes to commit": baselines de CI já corretas.

## Notas
- Snapshots tratados como mudança intencional de produto (`docs/standards/testing.md`).
- Merge é humano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
