### PR TITLE
fix(ci): pin react-doctor workflow actions to SHAs and drop issues:write

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -14,10 +14,11 @@ on:
   push:
     branches: ["main"]
 
+# Least privilege: the action only comments/reviews on PRs (pull-requests: write
+# covers issue-style comments on PRs) and publishes a commit status.
 permissions:
   contents: read
   pull-requests: write
-  issues: write
   statuses: write
 
 # Cancels any in-flight scan for the same PR (or branch, on push) the moment a new commit arrives, so reviewers only ever see the latest run.
@@ -29,9 +30,9 @@ jobs:
   react-doctor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: millionco/react-doctor@v2.2.2
+      - uses: millionco/react-doctor@0b4f4f4bd248a154e64eb508a48347f71154b3f3 # v2.2.2
         # Advisory by default: React Doctor reports findings on every PR — a
         # sticky summary comment, inline review comments, and a commit status
         # with the health score — but never fails the check, so it won't red-X


### PR DESCRIPTION
## Resumo

Resolve #1023 — o workflow `react-doctor.yml` rodava actions com refs mutáveis (`@v7`, `@v2.2.2`) e permissões de escrita além do necessário.

## Mudanças

- **Pin por SHA completo**: `actions/checkout@9c091bb…` (v7.0.0) e `millionco/react-doctor@0b4f4f4…` (v2.2.2). SHAs verificados via API do GitHub (tag anotada do react-doctor dereferenciada para o commit). Dependabot continua atualizando pins por SHA quando há comentário de versão.
- **Menor privilégio**: removido `issues: write`. Inspecionei o `action.yml` do react-doctor — ele usa `issues.createComment/updateComment` apenas em PRs (coberto por `pull-requests: write` no mapeamento do `GITHUB_TOKEN`), `pulls.createReview` e `repos.createCommitStatus`. `pull-requests: write` e `statuses: write` mantidos porque comment/review-comments/commit-status estão ativos (defaults).

## Testes

Sem testes de runtime — mudança só de workflow CI (docs/CI exempt). Nenhum teste referencia o arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)