### PR TITLE
fix: block city-only blocked destinations in AI safety check

### DIFF
--- a/lib/ai/constants.ts
+++ b/lib/ai/constants.ts
@@ -57,17 +57,18 @@ export const BLOCKED_DESTINATIONS: Array<{ category: SafetyCategory; country: st
         country: c.country,
         aliases: c.aliases
     })),
-    // Other blocked regions
-    { category: 'war', country: 'Ucrânia', aliases: ['ucrania', 'ukraine'] },
-    { category: 'war', country: 'Sudão', aliases: ['sudao', 'sudan'] },
-    { category: 'war', country: 'Afeganistão', aliases: ['afeganistao', 'afghanistan'] },
-    { category: 'sanctions', country: 'Rússia', aliases: ['russia'] },
-    { category: 'sanctions', country: 'Bielorrússia', aliases: ['bielorrussia', 'belarus'] },
-    { category: 'sanctions', country: 'Coreia do Norte', aliases: ['coreia do norte', 'north korea'] },
-    { category: 'sanctions', country: 'Venezuela', aliases: ['venezuela'] },
-    { category: 'sanctions', country: 'Cuba', aliases: ['cuba'] },
-    { category: 'instability', country: 'Haiti', aliases: ['haiti'] },
-    { category: 'instability', country: 'Mianmar', aliases: ['mianmar', 'myanmar'] },
-    { category: 'instability', country: 'Líbia', aliases: ['libia', 'libya'] },
-    { category: 'instability', country: 'Somália', aliases: ['somalia'] },
+    // Other blocked regions — aliases include major cities/endonyms so a city-only
+    // destination (ex: "Moscou") still triggers the block (issue #1022)
+    { category: 'war', country: 'Ucrânia', aliases: ['ucrania', 'ukraine', 'kiev', 'kyiv', 'odessa', 'lviv'] },
+    { category: 'war', country: 'Sudão', aliases: ['sudao', 'sudan', 'cartum', 'khartoum'] },
+    { category: 'war', country: 'Afeganistão', aliases: ['afeganistao', 'afghanistan', 'cabul', 'kabul'] },
+    { category: 'sanctions', country: 'Rússia', aliases: ['russia', 'moscou', 'moscow', 'moscovo', 'sao petersburgo', 'saint petersburg', 'st petersburg', 'san petersburgo'] },
+    { category: 'sanctions', country: 'Bielorrússia', aliases: ['bielorrussia', 'belarus', 'minsk'] },
+    { category: 'sanctions', country: 'Coreia do Norte', aliases: ['coreia do norte', 'north korea', 'pyongyang', 'pionguiangue'] },
+    { category: 'sanctions', country: 'Venezuela', aliases: ['venezuela', 'caracas', 'maracaibo'] },
+    { category: 'sanctions', country: 'Cuba', aliases: ['cuba', 'havana', 'habana', 'varadero'] },
+    { category: 'instability', country: 'Haiti', aliases: ['haiti', 'porto principe', 'port-au-prince', 'port au prince'] },
+    { category: 'instability', country: 'Mianmar', aliases: ['mianmar', 'myanmar', 'birmania', 'burma', 'yangon', 'rangum', 'rangoon', 'naypyidaw'] },
+    { category: 'instability', country: 'Líbia', aliases: ['libia', 'libya', 'tripoli'] },
+    { category: 'instability', country: 'Somália', aliases: ['somalia', 'mogadiscio', 'mogadishu'] },
 ];

--- a/lib/ai/constants.ts
+++ b/lib/ai/constants.ts
@@ -59,16 +59,16 @@ export const BLOCKED_DESTINATIONS: Array<{ category: SafetyCategory; country: st
     })),
     // Other blocked regions — aliases include major cities/endonyms so a city-only
     // destination (ex: "Moscou") still triggers the block (issue #1022)
-    { category: 'war', country: 'Ucrânia', aliases: ['ucrania', 'ukraine', 'kiev', 'kyiv', 'odessa', 'lviv'] },
+    { category: 'war', country: 'Ucrânia', aliases: ['ucrania', 'ukraine', 'kiev', 'kyiv', 'odessa', 'odesa', 'lviv', 'kharkiv', 'kharkov', 'dnipro'] },
     { category: 'war', country: 'Sudão', aliases: ['sudao', 'sudan', 'cartum', 'khartoum'] },
     { category: 'war', country: 'Afeganistão', aliases: ['afeganistao', 'afghanistan', 'cabul', 'kabul'] },
-    { category: 'sanctions', country: 'Rússia', aliases: ['russia', 'moscou', 'moscow', 'moscovo', 'sao petersburgo', 'saint petersburg', 'st petersburg', 'san petersburgo'] },
+    { category: 'sanctions', country: 'Rússia', aliases: ['russia', 'moscou', 'moscow', 'moscovo', 'sao petersburgo', 'saint petersburg', 'st petersburg', 'st. petersburg', 'san petersburgo', 'sochi'] },
     { category: 'sanctions', country: 'Bielorrússia', aliases: ['bielorrussia', 'belarus', 'minsk'] },
     { category: 'sanctions', country: 'Coreia do Norte', aliases: ['coreia do norte', 'north korea', 'pyongyang', 'pionguiangue'] },
-    { category: 'sanctions', country: 'Venezuela', aliases: ['venezuela', 'caracas', 'maracaibo'] },
+    { category: 'sanctions', country: 'Venezuela', aliases: ['venezuela', 'caracas', 'maracaibo', 'margarita', 'isla margarita'] },
     { category: 'sanctions', country: 'Cuba', aliases: ['cuba', 'havana', 'habana', 'varadero'] },
     { category: 'instability', country: 'Haiti', aliases: ['haiti', 'porto principe', 'port-au-prince', 'port au prince'] },
     { category: 'instability', country: 'Mianmar', aliases: ['mianmar', 'myanmar', 'birmania', 'burma', 'yangon', 'rangum', 'rangoon', 'naypyidaw'] },
     { category: 'instability', country: 'Líbia', aliases: ['libia', 'libya', 'tripoli'] },
-    { category: 'instability', country: 'Somália', aliases: ['somalia', 'mogadiscio', 'mogadishu'] },
+    { category: 'instability', country: 'Somália', aliases: ['somalia', 'mogadiscio', 'mogadishu', 'somaliland', 'somalilandia'] },
 ];

--- a/tests/chatbot-regressions.test.ts
+++ b/tests/chatbot-regressions.test.ts
@@ -83,6 +83,36 @@ test('safety check should block remaining Middle Eastern countries', () => {
     }
 });
 
+// Issue #1022: destinos bloqueados devem ser detectados mesmo quando o modelo
+// emite só a cidade, sem o nome do país.
+test('safety check should block city-only blocked destinations', () => {
+    const testCases = [
+        { destination: 'Moscou', expected: 'Rússia', category: 'sanctions' },
+        { destination: 'São Petersburgo', expected: 'Rússia', category: 'sanctions' },
+        { destination: 'Havana', expected: 'Cuba', category: 'sanctions' },
+        { destination: 'Varadero', expected: 'Cuba', category: 'sanctions' },
+        { destination: 'Caracas', expected: 'Venezuela', category: 'sanctions' },
+        { destination: 'Pyongyang', expected: 'Coreia do Norte', category: 'sanctions' },
+        { destination: 'Minsk', expected: 'Bielorrússia', category: 'sanctions' },
+        { destination: 'Kiev', expected: 'Ucrânia', category: 'war' },
+        { destination: 'Kyiv', expected: 'Ucrânia', category: 'war' },
+        { destination: 'Cabul', expected: 'Afeganistão', category: 'war' },
+        { destination: 'Cartum', expected: 'Sudão', category: 'war' },
+        { destination: 'Porto Príncipe', expected: 'Haiti', category: 'instability' },
+        { destination: 'Port-au-Prince', expected: 'Haiti', category: 'instability' },
+        { destination: 'Yangon', expected: 'Mianmar', category: 'instability' },
+        { destination: 'Trípoli', expected: 'Líbia', category: 'instability' },
+        { destination: 'Mogadíscio', expected: 'Somália', category: 'instability' },
+    ];
+
+    for (const { destination, expected, category } of testCases) {
+        const result = detectBlockedDestination(destination);
+        assert.ok(result, `${destination} must be blocked`);
+        assert.equal(result?.country, expected);
+        assert.equal(result?.category, category);
+    }
+});
+
 // Liberados em jun/2026 após estabilização do conflito regional. Antes bloqueados pela Policy #186.
 test('safety check should allow destinations released in jun/2026', () => {
     const releasedDestinations = [

--- a/tests/chatbot-regressions.test.ts
+++ b/tests/chatbot-regressions.test.ts
@@ -103,6 +103,12 @@ test('safety check should block city-only blocked destinations', () => {
         { destination: 'Yangon', expected: 'Mianmar', category: 'instability' },
         { destination: 'Trípoli', expected: 'Líbia', category: 'instability' },
         { destination: 'Mogadíscio', expected: 'Somália', category: 'instability' },
+        { destination: 'Sochi', expected: 'Rússia', category: 'sanctions' },
+        { destination: 'St. Petersburg', expected: 'Rússia', category: 'sanctions' },
+        { destination: 'Odesa', expected: 'Ucrânia', category: 'war' },
+        { destination: 'Kharkiv', expected: 'Ucrânia', category: 'war' },
+        { destination: 'Isla Margarita', expected: 'Venezuela', category: 'sanctions' },
+        { destination: 'Somaliland', expected: 'Somália', category: 'instability' },
     ];
 
     for (const { destination, expected, category } of testCases) {


### PR DESCRIPTION
## Resumo

Fecha #1022. As entradas de `BLOCKED_DESTINATIONS` fora do Oriente Médio só tinham aliases de nome de país, então um tool call `generate_budget_link` com destino só-cidade (Moscou, Havana, Caracas, Pyongyang, Kiev, Cabul...) passava pelo `detectBlockedDestination()` e permitia o handoff de WhatsApp/lead.

## Mudanças

- `lib/ai/constants.ts`: aliases de capitais/cidades principais e endônimos adicionados a cada entrada bloqueada (Ucrânia, Sudão, Afeganistão, Rússia, Bielorrússia, Coreia do Norte, Venezuela, Cuba, Haiti, Mianmar, Líbia, Somália), espelhando o padrão já usado em `MIDDLE_EAST_COUNTRIES`.
- `tests/chatbot-regressions.test.ts`: novo teste cobrindo 16 destinos só-cidade bloqueados (incl. variantes PT/EN e hifenização de Port-au-Prince).

O `hasAliasMatch` já casa aliases como termos independentes (word-boundary), então não há risco de falso positivo tipo "ira" dentro de "emirados".

## Verificação

- `pnpm test:regression`: 764 pass, 0 fail
- `pnpm typecheck`: ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)