### PR TITLE
fix(ci): pin write-scoped workflow actions to commit SHAs (#1024)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,13 +36,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.159
+        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/generate-blog-manifest.yml
+++ b/.github/workflows/generate-blog-manifest.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Não persistir o GITHUB_TOKEN como credencial git no runner: assim um
           # script de lifecycle de dependência (pnpm install abaixo) não consegue
@@ -24,10 +24,10 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Use Node.js 24
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"


### PR DESCRIPTION
Fecha #1024.

## Contexto

O finding original de #1024 era sobre `update-snapshots.yml` usar tags mutáveis de actions num job com `contents: write`. Esse arquivo **já foi corrigido** na `main` (PR #1054 + bumps do dependabot já vêm pinados em SHA).

Ao auditar todos os workflows write-scoped, encontrei **os outros dois com exatamente o mesmo problema**:
- `claude.yml` (`contents/pull-requests/issues: write`)
- `generate-blog-manifest.yml` (`contents/pull-requests: write`)

## Mudança

Pina todas as actions desses dois workflows em commit SHA imutável, mantendo o comentário `# vX.Y.Z` para o dependabot seguir atualizando por um processo revisado:

| Action | Tag | SHA |
|---|---|---|
| actions/checkout | v7.0.0 | `9c091bb` |
| anthropics/claude-code-action | v1.0.159 | `a92e7c7` |
| pnpm/action-setup | v6.0.9 | `0ebf471` |
| actions/setup-node | v6.4.0 | `48b55a0` |

Todos os SHAs foram resolvidos via API do GitHub (tags anotadas dereferenciadas para o commit real). Após a mudança, nenhum workflow write-scoped do repo referencia actions por tag mutável.

🤖 Generated with [Claude Code](https://claude.com/claude-code)