### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Use Node.js 24
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"
@@ -49,7 +49,7 @@ jobs:
         run: pnpm run test:size
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v5.0.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           # Falha o PR a partir de severidade "high" (ajustar para "moderate" se
           # quiser um gate mais rígido).

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,9 +14,9 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: pnpm/action-setup@v6.0.9
-    - uses: actions/setup-node@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
         cache: 'pnpm'
@@ -35,7 +35,7 @@ jobs:
     # workflow manual update-snapshots.yml (workflow_dispatch).
     - name: Run Playwright tests
       run: pnpm exec playwright test
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: playwright-report

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: "actions/checkout@v7"
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
         with:
           # A action compara o diff entre commits para detectar TODOs adicionados
           # e removidos. fetch-depth: 0 garante histórico suficiente para isso e


### PR DESCRIPTION
## Contexto

Resolve #1025 (MEDIUM — `other-ci-supply-chain`). O `playwright.yml` executava actions por tags mutáveis (`actions/checkout@v7`, `actions/setup-node@v6`, `actions/upload-artifact@v7`). Se uma tag for movida ou a action upstream for comprometida, código controlado por atacante roda no CI e pode adulterar resultados de teste e artefatos.

## Mudança

Pinei os refs mutáveis para SHAs imutáveis, mantendo o comentário `# vX.Y.Z` (padrão já usado no repo para o Dependabot continuar bumpando). Além do `playwright.yml` citado na issue, estendi para os outros stragglers com a mesma vuln, alinhando à convenção já adotada nos demais workflows:

| Workflow | Actions pinadas |
|---|---|
| `playwright.yml` | checkout, pnpm/action-setup, setup-node, upload-artifact |
| `ci.yml` | checkout, pnpm/action-setup, setup-node, upload-artifact |
| `dependency-review.yml` | checkout, dependency-review-action |
| `todo.yml` | checkout |

Após esta PR, **nenhum** workflow em `.github/workflows/` usa ref mutável.

## SHAs

- `actions/checkout` `9c091bb` (v7.0.0), `pnpm/action-setup` `0ebf471` (v6.0.9), `actions/setup-node` `48b55a0` (v6.4.0), `actions/upload-artifact` `043fb46` (v7.0.1) — idênticos aos já pinados em `release.yml`/`update-snapshots.yml`.
- `actions/dependency-review-action` `a1d282b` (v5.0.0) — resolvido via GitHub API.

## Verificação

- `grep -rn "uses:.*@v[0-9]" .github/workflows/` → sem resultados.
- Edições restritas às linhas `uses:`; estrutura dos workflows inalterada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)