### PR TITLE
fix(nps): sanitize free text at the provider boundary

### DIFF
--- a/lib/schemas/submit-nps.ts
+++ b/lib/schemas/submit-nps.ts
@@ -7,8 +7,15 @@ import { cleanString } from '../lead-logic';
 // cleanString/normalizeNullable. Escaping angle brackets here keeps NPS on that
 // boundary so raw markup never reaches CRM notes. `.max()` bounds the raw input
 // before cleanString escapes, matching the other paths' order.
+//
+// `firstname` also re-checks the bound AFTER escaping: cleanString turns each
+// `<`/`>` into a 4-char entity, so a name full of angle brackets could quadruple
+// past the 100-char limit of the res.partner.name Char field. The contact path
+// applies the same post-sanitization guard (`if (firstName.length > 100)`).
+// reason/highlight target the unbounded `comment` Text field (and cleanString
+// self-caps at 10k), so they don't need the extra guard.
 export const SubmitNpsBodySchema = z.object({
-    firstname: z.string().trim().min(1).max(100).transform(cleanString),
+    firstname: z.string().trim().min(1).max(100).transform(cleanString).refine((v) => v.length <= 100, { message: 'Nome inválido.' }),
     email:     z.email().max(254),
     score:     z.number().int().min(0).max(10),
     reason:    z.string().trim().min(1).max(2000).transform(cleanString),

--- a/lib/schemas/submit-nps.ts
+++ b/lib/schemas/submit-nps.ts
@@ -1,11 +1,18 @@
 import { z } from 'zod';
+import { cleanString } from '../lead-logic';
 
+// Free-text NPS fields feed res.partner.name/comment via the Odoo mapper, which
+// (unlike buildDescriptionHtml) assumes its inputs were already escaped at the
+// provider boundary — the same contract lead/contact/quiz/waitlist honor through
+// cleanString/normalizeNullable. Escaping angle brackets here keeps NPS on that
+// boundary so raw markup never reaches CRM notes. `.max()` bounds the raw input
+// before cleanString escapes, matching the other paths' order.
 export const SubmitNpsBodySchema = z.object({
-    firstname: z.string().trim().min(1).max(100),
+    firstname: z.string().trim().min(1).max(100).transform(cleanString),
     email:     z.email().max(254),
     score:     z.number().int().min(0).max(10),
-    reason:    z.string().trim().min(1).max(2000),
-    highlight: z.string().trim().max(2000).default(''),
+    reason:    z.string().trim().min(1).max(2000).transform(cleanString),
+    highlight: z.string().trim().max(2000).default('').transform(cleanString),
 });
 
 export type SubmitNpsRequest = z.infer<typeof SubmitNpsBodySchema>;

--- a/tests/submit-nps-schema.test.ts
+++ b/tests/submit-nps-schema.test.ts
@@ -108,3 +108,30 @@ test('rejeita whitespace-only reason', () => {
     const result = SubmitNpsBodySchema.safeParse({ ...VALID, reason: '   ' });
     assert.equal(result.success, false);
 });
+
+test('escapa angle brackets em reason (sanitização de fronteira)', () => {
+    const result = SubmitNpsBodySchema.safeParse({
+        ...VALID,
+        reason: '<script>alert(1)</script>',
+    });
+    assert.equal(result.success, true);
+    if (result.success) {
+        assert.equal(result.data.reason, '&lt;script&gt;alert(1)&lt;/script&gt;');
+        assert.equal(result.data.reason.includes('<'), false);
+        assert.equal(result.data.reason.includes('>'), false);
+    }
+});
+
+test('escapa angle brackets em highlight e firstname', () => {
+    const result = SubmitNpsBodySchema.safeParse({
+        ...VALID,
+        firstname: 'João <b>',
+        highlight: 'Japão <img src=x onerror=alert(1)>',
+    });
+    assert.equal(result.success, true);
+    if (result.success) {
+        assert.equal(result.data.firstname, 'João &lt;b&gt;');
+        assert.equal(result.data.highlight.includes('<'), false);
+        assert.equal(result.data.highlight.includes('>'), false);
+    }
+});

--- a/tests/submit-nps-schema.test.ts
+++ b/tests/submit-nps-schema.test.ts
@@ -122,6 +122,15 @@ test('escapa angle brackets em reason (sanitização de fronteira)', () => {
     }
 });
 
+test('rejeita firstname que excede 100 chars APÓS o escape', () => {
+    // 40 caracteres "<" → 160 chars após cleanString (cada "<" vira "&lt;").
+    const result = SubmitNpsBodySchema.safeParse({ ...VALID, firstname: '<'.repeat(40) });
+    assert.equal(result.success, false);
+    if (!result.success) {
+        assert.equal(result.error.issues[0]?.path[0], 'firstname');
+    }
+});
+
 test('escapa angle brackets em highlight e firstname', () => {
     const result = SubmitNpsBodySchema.safeParse({
         ...VALID,

--- a/tests/submit-nps.test.ts
+++ b/tests/submit-nps.test.ts
@@ -280,6 +280,28 @@ test('submit-nps writes x_nps_score and a comment with reason/highlight on the p
     assert.match(String(partner.comment), /Momento marcante: A visita às Cataratas do Iguaçu\./);
 });
 
+test('submit-nps escapes angle brackets from free text before writing the partner comment', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    const mock = createOdooMock();
+    global.fetch = mock.fetch;
+
+    const response = await handler(buildRequest(validBody({
+        firstname: 'Ana <b>',
+        reason: '<script>alert(1)</script>',
+        highlight: '<img src=x onerror=alert(2)>',
+    })));
+    assert.equal(response.status, 201);
+
+    const partner = mock.partnerFields()!;
+    const comment = String(partner.comment);
+    assert.equal(comment.includes('<'), false, 'comment must not contain raw angle brackets');
+    assert.equal(comment.includes('>'), false, 'comment must not contain raw angle brackets');
+    assert.match(comment, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+    assert.match(comment, /&lt;img src=x onerror=alert\(2\)&gt;/);
+    assert.equal(String(partner.name).includes('<'), false, 'partner name must be escaped too');
+});
+
 test('submit-nps does NOT overwrite the full name of an existing partner (firstname-only form)', async (t) => {
     t.after(restore);
     setOdooEnv();


### PR DESCRIPTION
## Contexto

Resolve #1026 (MEDIUM — `other-crm-content-injection`). O caminho de NPS era o único form que ia do Zod (`SubmitNpsBodySchema`, só `trim`+`max`) **direto** para o mapper Odoo. `leadInputFromSubmitNps` interpola `reason`/`highlight`/`firstname` cru em `res.partner.comment` e `res.partner.name`.

O `buildDescriptionHtml` documenta que os valores chegam **já escapados na fronteira** — contrato que lead/contact/quiz/waitlist honram via `cleanString`/`normalizeNullable`. O NPS não honrava, permitindo persistir markup/HTML cru em notas do CRM (stored HTML/XSS se o widget de nota, e-mail ou relatório do Odoo renderizar como rich text).

## Mudança

Aplico `cleanString` (escapa `<`→`&lt;`, `>`→`&gt;`) em `firstname`/`reason`/`highlight` via `.transform()` do Zod, **no momento da validação** (como recomenda a issue e alinhado aos outros forms). `.max()` limita o input cru antes do escape, mesma ordem dos demais caminhos.

```diff
-    firstname: z.string().trim().min(1).max(100),
+    firstname: z.string().trim().min(1).max(100).transform(cleanString),
-    reason:    z.string().trim().min(1).max(2000),
-    highlight: z.string().trim().max(2000).default(''),
+    reason:    z.string().trim().min(1).max(2000).transform(cleanString),
+    highlight: z.string().trim().max(2000).default('').transform(cleanString),
```

Sem impacto no bundle do browser: o cliente usa apenas o **tipo** `SubmitNpsRequest` (type-only); só o handler de API importa o valor do schema.

## Testes (regressão)

- `tests/submit-nps-schema.test.ts`: escape de angle brackets em `reason`, `highlight` e `firstname`; validações existentes (empty/over-max) seguem valendo.
- `tests/submit-nps.test.ts`: teste **end-to-end** com payload malicioso (`<script>`, `<img onerror>`) provando que o `comment` do partner não contém `<`/`>` crus e que o `name` também é escapado.

## Verificação

- `pnpm test:regression` → 767/767 (inclui os 47 testes de NPS).
- `pnpm typecheck` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)