### PR TITLE
fix(security): resolve MEDIUM hardening findings (logger, lead-logic, dev server, CI, HubSpot listener)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
-      - name: Install Puppeteer Browser
-        run: npx puppeteer browsers install chrome
-
       - name: Build
         run: pnpm run build
 

--- a/lib/error-tracking.ts
+++ b/lib/error-tracking.ts
@@ -13,7 +13,12 @@ const noopErrorTracker: ErrorTracker = () => undefined;
 let errorTracker: ErrorTracker = noopErrorTracker;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Error);
+    if (typeof value !== 'object' || value === null) return false;
+    // Only literal/plain objects. Native objects (Date, RegExp, Map, URL, …) are
+    // left untouched by the sanitizer so logs keep their meaningful values instead
+    // of being flattened into `{}`.
+    const proto = Object.getPrototypeOf(value);
+    return proto === null || proto === Object.prototype;
 }
 
 export function sanitizeForErrorTracking(value: unknown, depth = 0): unknown {

--- a/lib/error-tracking.ts
+++ b/lib/error-tracking.ts
@@ -16,7 +16,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Error);
 }
 
-function sanitizeForErrorTracking(value: unknown, depth = 0): unknown {
+export function sanitizeForErrorTracking(value: unknown, depth = 0): unknown {
     if (depth > 4) return TRUNCATED_VALUE;
 
     if (value instanceof Error) {

--- a/lib/lead-logic.ts
+++ b/lib/lead-logic.ts
@@ -122,26 +122,32 @@ function sanitizeTrackingKey(key: string): string {
     return key.trim().replace(/</g, '&lt;').replace(/>/g, '&gt;').substring(0, 64);
 }
 
+const MAX_TRACKING_EXTRAS = 15;
+
 function normalizeTrackingExtras(source: Record<string, unknown>): Record<string, string> | undefined {
     const extrasInput = toRecord(source.extras);
     const extras: Record<string, string> = {};
 
-    const appendExtra = (key: string, raw: unknown) => {
-        if (Object.keys(extras).length >= 15) return;
+    // Returns false once the cap is reached so callers can stop iterating over
+    // an attacker-supplied object with an unbounded number of keys.
+    const appendExtra = (key: string, raw: unknown): boolean => {
+        if (Object.keys(extras).length >= MAX_TRACKING_EXTRAS) return false;
 
         const normalized = normalizeNullable(raw);
-        if (!normalized) return;
+        if (normalized) {
+            extras[sanitizeTrackingKey(key)] = normalized;
+        }
 
-        extras[sanitizeTrackingKey(key)] = normalized;
+        return true;
     };
 
     for (const [key, raw] of Object.entries(extrasInput)) {
-        appendExtra(key, raw);
+        if (!appendExtra(key, raw)) break;
     }
 
     for (const [key, raw] of Object.entries(source)) {
         if (key === 'extras' || KNOWN_TRACKING_KEYS.has(key)) continue;
-        appendExtra(key, raw);
+        if (!appendExtra(key, raw)) break;
     }
 
     return Object.keys(extras).length > 0 ? extras : undefined;

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,4 +1,4 @@
-import { captureLoggerError } from './error-tracking';
+import { captureLoggerError, sanitizeForErrorTracking } from './error-tracking';
 
 type LoggerData = unknown;
 type ConsoleMethod = 'log' | 'info' | 'warn' | 'error';
@@ -15,7 +15,13 @@ function isDebugEnabled(): boolean {
 
 function writeLog(method: ConsoleMethod, prefix: string, message: string, data?: LoggerData): void {
     if (data !== undefined) {
-        console[method](prefix, message, data);
+        // Both the client Sentry setup and the Cloudflare middleware capture console
+        // output, so redact sensitive keys before writing — never rely on the
+        // error-tracker context alone (see captureLoggerError). Error instances are
+        // passed through so console keeps the stack trace (parity with the tracker,
+        // which also keeps the Error object rather than its data).
+        const safe = data instanceof Error ? data : sanitizeForErrorTracking(data);
+        console[method](prefix, message, safe);
         return;
     }
 

--- a/lib/schemas/submit-lead.ts
+++ b/lib/schemas/submit-lead.ts
@@ -12,7 +12,15 @@ const LeadUtmsSchema = z.looseObject({
 }).optional();
 
 // Validated as a plain object; individual fields are normalised by normalizeTracking.
-const LeadTrackingSchema = z.record(z.string(), z.unknown()).optional();
+// Cap the key count so an attacker cannot force expensive validation/normalization
+// with an unbounded tracking object (only ~15 extras are ever persisted).
+const MAX_TRACKING_KEYS = 50;
+const LeadTrackingSchema = z
+    .record(z.string(), z.unknown())
+    .refine((value) => Object.keys(value).length <= MAX_TRACKING_KEYS, {
+        message: `tracking accepts at most ${MAX_TRACKING_KEYS} keys`,
+    })
+    .optional();
 
 export const SubmitLeadBodySchema = z.object({
     firstName:   z.string().min(1).max(100),

--- a/lib/schemas/submit-lead.ts
+++ b/lib/schemas/submit-lead.ts
@@ -17,8 +17,17 @@ const LeadUtmsSchema = z.looseObject({
 const MAX_TRACKING_KEYS = 50;
 const LeadTrackingSchema = z
     .record(z.string(), z.unknown())
-    .refine((value) => Object.keys(value).length <= MAX_TRACKING_KEYS, {
-        message: `tracking accepts at most ${MAX_TRACKING_KEYS} keys`,
+    .refine((value) => {
+        if (Object.keys(value).length > MAX_TRACKING_KEYS) return false;
+        // extras is typed as z.unknown() (not recursed by Zod), so an attacker
+        // could otherwise nest a huge object here to bypass the top-level cap.
+        const extras = value.extras;
+        if (typeof extras === 'object' && extras !== null && !Array.isArray(extras)) {
+            return Object.keys(extras).length <= MAX_TRACKING_KEYS;
+        }
+        return true;
+    }, {
+        message: `tracking and its extras accept at most ${MAX_TRACKING_KEYS} keys`,
     })
     .optional();
 

--- a/public/utm-tracking.js
+++ b/public/utm-tracking.js
@@ -159,19 +159,6 @@
         trackSpecialistClick(target);
     }
 
-    function handleHubSpotMessage(event) {
-        if (event.data.type !== 'hsFormCallback' || event.data.eventName !== 'onFormSubmitted') {
-            return;
-        }
-
-        pushDataLayerEvent({
-            event: 'form_submission',
-            form_type: 'hubspot',
-            form_id: event.data.id,
-            page_location: window.location.href
-        });
-    }
-
     function initWhatsAppTracking() {
         const urlParams = new URLSearchParams(window.location.search);
         const tracking = readStoredTracking();
@@ -184,9 +171,6 @@
 
     // --- EVENT DELEGATION LOGIC ---
     document.body.addEventListener('click', handleBodyClick, { capture: true });
-
-    // 3. HubSpot Form Tracking
-    window.addEventListener("message", handleHubSpotMessage);
 
     // Inicialização: espera a página carregar + delay para GA4
     const init = () => setTimeout(initWhatsAppTracking, 1500);

--- a/tests/lib-lead-logic.test.ts
+++ b/tests/lib-lead-logic.test.ts
@@ -230,6 +230,32 @@ test('normalizeTracking sanitizes XSS in tracking keys and values', () => {
     );
 });
 
+test('normalizeTracking caps extras at 15 keys even for large unbounded objects', () => {
+    const utms = { utm_source: null, utm_medium: null, utm_campaign: null, utm_term: null, utm_content: null };
+
+    const extras: Record<string, string> = {};
+    for (let i = 0; i < 5000; i += 1) {
+        extras[`extra_${i}`] = `value_${i}`;
+    }
+
+    const result = normalizeTracking({ extras }, utms);
+
+    assert.equal(Object.keys(result.extras ?? {}).length, 15, 'extras must be capped at 15 entries');
+});
+
+test('normalizeTracking caps extras drawn from top-level unknown keys too', () => {
+    const utms = { utm_source: null, utm_medium: null, utm_campaign: null, utm_term: null, utm_content: null };
+
+    const source: Record<string, unknown> = {};
+    for (let i = 0; i < 5000; i += 1) {
+        source[`custom_${i}`] = `value_${i}`;
+    }
+
+    const result = normalizeTracking(source, utms);
+
+    assert.equal(Object.keys(result.extras ?? {}).length, 15, 'top-level extras must be capped at 15 entries');
+});
+
 test('normalizeTracking falls back to UTMs for missing tracking UTM fields', () => {
     const utms = {
         utm_source: 'google',

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -169,6 +169,23 @@ test('logger redige chaves sensíveis na saída de console em todos os níveis',
     }
 });
 
+test('logger preserva objetos nativos (Date) sem achatá-los em {}', () => {
+    const info = captureConsole('info');
+
+    try {
+        resetErrorTrackerForTests();
+        const when = new Date('2026-07-03T12:00:00.000Z');
+
+        logger.info('EVENTO', { when, count: 3 });
+
+        const logged = info.calls[0]?.[2] as { when: unknown; count: number };
+        assert.equal(logged.when, when, 'Date deve ser preservada como valor, não virar {}');
+        assert.equal(logged.count, 3);
+    } finally {
+        info.restore();
+    }
+});
+
 test('logger.error captura erros no error tracker registrado', () => {
     const error = captureConsole('error');
     const captured: Array<{ error: unknown; context?: ErrorCaptureContext }> = [];

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -130,6 +130,45 @@ test('logger.debug normaliza DEBUG antes de comparar', () => {
     }
 });
 
+test('logger redige chaves sensíveis na saída de console em todos os níveis', () => {
+    const info = captureConsole('info');
+    const warn = captureConsole('warn');
+    const error = captureConsole('error');
+
+    try {
+        resetErrorTrackerForTests();
+
+        const payload = {
+            requestId: 'req_123',
+            email: 'cliente@example.com',
+            token: 'super-secret-token',
+            nested: { phone: '+55 11 99999-9999' },
+        };
+        const expected = {
+            requestId: 'req_123',
+            email: '[redacted]',
+            token: '[redacted]',
+            nested: { phone: '[redacted]' },
+        };
+
+        logger.info('SUBMIT_LEAD info', payload);
+        logger.warn('SUBMIT_LEAD warn', payload);
+        logger.error('SUBMIT_LEAD error', payload);
+
+        assert.deepEqual(info.calls[0], ['[info]', 'SUBMIT_LEAD info', expected]);
+        assert.deepEqual(warn.calls[0], ['[warn]', 'SUBMIT_LEAD warn', expected]);
+        assert.deepEqual(error.calls[0], ['[error]', 'SUBMIT_LEAD error', expected]);
+
+        // O objeto original não deve ser mutado pela redação.
+        assert.equal(payload.email, 'cliente@example.com');
+        assert.equal(payload.token, 'super-secret-token');
+    } finally {
+        info.restore();
+        warn.restore();
+        error.restore();
+    }
+});
+
 test('logger.error captura erros no error tracker registrado', () => {
     const error = captureConsole('error');
     const captured: Array<{ error: unknown; context?: ErrorCaptureContext }> = [];

--- a/tests/submit-lead.test.ts
+++ b/tests/submit-lead.test.ts
@@ -101,6 +101,21 @@ test('validatePayload should reject tracking objects with an abusive number of k
     assert.equal(result.valid, false);
 });
 
+test('validatePayload should reject tracking whose nested extras has an abusive number of keys', () => {
+    const extras: Record<string, string> = {};
+    for (let i = 0; i < 200; i += 1) {
+        extras[`k_${i}`] = `v_${i}`;
+    }
+
+    const result = validatePayload({
+        firstName: 'Felipe', lastName: 'William', email: 'felipe@example.com', whatsapp: '+5511988314487',
+        bantSummary: 'Need: Praia', destination: 'Rio de Janeiro',
+        utms: {}, tracking: { extras },
+    });
+
+    assert.equal(result.valid, false);
+});
+
 test('validatePayload should require whatsapp and normalize it to E.164 digits', () => {
     const result = validatePayload({
         firstName: 'Felipe', lastName: 'William', email: 'felipe@example.com', whatsapp: ' (11) 98831-4487 ',

--- a/tests/submit-lead.test.ts
+++ b/tests/submit-lead.test.ts
@@ -86,6 +86,21 @@ test('validatePayload should preserve fbp and extras as tracking fields', () => 
     assert.deepEqual(result.data.tracking?.extras, { custom_source: 'chatbot' });
 });
 
+test('validatePayload should reject tracking objects with an abusive number of keys', () => {
+    const tracking: Record<string, string> = {};
+    for (let i = 0; i < 200; i += 1) {
+        tracking[`k_${i}`] = `v_${i}`;
+    }
+
+    const result = validatePayload({
+        firstName: 'Felipe', lastName: 'William', email: 'felipe@example.com', whatsapp: '+5511988314487',
+        bantSummary: 'Need: Praia', destination: 'Rio de Janeiro',
+        utms: {}, tracking,
+    });
+
+    assert.equal(result.valid, false);
+});
+
 test('validatePayload should require whatsapp and normalize it to E.164 digits', () => {
     const result = validatePayload({
         firstName: 'Felipe', lastName: 'William', email: 'felipe@example.com', whatsapp: ' (11) 98831-4487 ',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,10 +39,25 @@ async function readRequestBody(req: IncomingMessage): Promise<Buffer> {
   return Buffer.concat(chunks);
 }
 
+// Client-supplied forwarding headers must not reach the handlers in dev: the
+// shared getClientIP() trusts them when Cloudflare headers are absent, so a
+// network-adjacent attacker could spoof them to rotate rate-limit keys and abuse
+// the developer's local Gemini/Odoo credentials. Strip them at the boundary.
+const STRIPPED_FORWARDING_HEADERS = new Set([
+  'cf-connecting-ip',
+  'x-real-ip',
+  'x-vercel-forwarded-for',
+  'x-forwarded-for',
+]);
+
 async function toWebRequest(req: IncomingMessage, origin: string): Promise<Request> {
   const headers = new Headers();
 
   for (const [key, value] of Object.entries(req.headers)) {
+    if (STRIPPED_FORWARDING_HEADERS.has(key.toLowerCase())) {
+      continue;
+    }
+
     if (Array.isArray(value)) {
       for (const item of value) {
         headers.append(key, item);
@@ -54,6 +69,9 @@ async function toWebRequest(req: IncomingMessage, origin: string): Promise<Reque
       headers.set(key, value);
     }
   }
+
+  // Provide a fixed, trusted local client address for dev rate limiting.
+  headers.set('x-forwarded-for', '127.0.0.1');
 
   const method = req.method?.toUpperCase() || 'GET';
   const requestInit: RequestInit & { duplex?: 'half' } = {
@@ -191,7 +209,10 @@ export default defineConfig(({ mode, isSsrBuild }) => {
   // Base path: '/' para Netlify/Vercel, ou '/repo-name/' para GitHub Pages
   // Para GitHub Pages, defina a variável de ambiente VITE_BASE_PATH
   const base = env.VITE_BASE_PATH || process.env.VITE_BASE_PATH || '/';
-  const devHost = env.VITE_DEV_HOST || process.env.VITE_DEV_HOST || '0.0.0.0';
+  // Bind to loopback by default so the dev server (which proxies real
+  // provider-backed handlers with the developer's local credentials) is not
+  // reachable from the LAN. Set VITE_DEV_HOST=0.0.0.0 to opt into LAN exposure.
+  const devHost = env.VITE_DEV_HOST || process.env.VITE_DEV_HOST || '127.0.0.1';
   const devPort = Number(env.VITE_DEV_PORT || process.env.VITE_DEV_PORT || '3000');
   const devStrictPort = (env.VITE_DEV_STRICT_PORT || process.env.VITE_DEV_STRICT_PORT || 'false') === 'true';
   const shouldAnalyze = (env.ANALYZE || process.env.ANALYZE) === 'true';


### PR DESCRIPTION
Resolve os achados MEDIUM de segurança/hardening abertos que envolvem mudança de código. As issues de SHA-pinning de workflows (#1028, #1030 e as partes de pinning de #1029/#1031) já estavam resolvidas pelas PRs #1024/#1074/#1076/#1077 — todas as actions já estão pinadas em commit SHA.

## Mudanças

**#1034 — Logger redaction não protegia o console**
`writeLog()` agora passa `data` por `sanitizeForErrorTracking` (redação recursiva de chaves sensíveis) antes de qualquer `console.*`, em todos os níveis (`info`/`warn`/`error`). Instâncias de `Error` passam direto para preservar stack trace (paridade com o tracker). Teste novo em `tests/logger.test.ts`.

**#1027 — Tracking keys ilimitadas encareciam a validação**
`normalizeTrackingExtras` interrompe a iteração assim que o cap de 15 extras é atingido (antes iterava todo o objeto). O `LeadTrackingSchema` passa a rejeitar objetos com mais de 50 chaves. Testes novos em `tests/lib-lead-logic.test.ts` e `tests/submit-lead.test.ts`.

**#1032 — postMessage cross-origin forjava analytics de form HubSpot**
O listener `hsFormCallback`/`onFormSubmitted` era o único vestígio de HubSpot forms (nenhum form HubSpot é embarcado). Removido por completo em `public/utm-tracking.js`, eliminando o push de `form_submission` com `id` controlável e sem validação de origem.

**#1033 — Dev server exposto na LAN com IP spoofável**
`VITE_DEV_HOST` agora tem default `127.0.0.1` (exposição na LAN vira opt-in explícito). O adapter de API do dev remove headers de forwarding do cliente (`cf-connecting-ip`, `x-real-ip`, `x-vercel-forwarded-for`, `x-forwarded-for`) e fixa um IP local confiável antes de invocar os handlers. Apenas caminho de desenvolvimento; produção (Cloudflare) não é afetada.

**#1031 — CI executava código fora dos pins imutáveis**
Removido o passo vestigial `npx puppeteer browsers install chrome`: o build pré-renderiza via Vite SSR (`MemoryRouter`), sem browser, então nenhum código de registry roda fora do `pnpm install --frozen-lockfile`. Actions já estavam pinadas em SHA.

## Verificação
- `pnpm test:regression` — 772 testes passam
- `pnpm typecheck` — sem erros

Closes #1027
Closes #1031
Closes #1032
Closes #1033
Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)