### PR TITLE
fix(security): override js-yaml@3 para ^3.15.0 (Dependabot #45)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   esbuild: ^0.28.1
   ws: ^8.21.0
   undici: ^7.28.0
+  js-yaml@3: ^3.15.0
 
 importers:
 
@@ -3596,8 +3597,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -7670,7 +7671,7 @@ snapshots:
     dependencies:
       import-fresh: 2.0.0
       is-directory: 0.3.1
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       parse-json: 4.0.0
 
   cosmiconfig@9.0.2(typescript@6.0.3):
@@ -8418,7 +8419,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -8672,7 +8673,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,21 +24,15 @@ overrides:
   # injeção de header/cookie). Transitivo via wrangler > miniflare.
   # 7.28.0 corrige; pinado em ^7.28.0 (mesma major).
   undici: "^7.28.0"
-  # PENDENTE: GHSA-h67p-54hq-rp68 (moderate, DoS quadrático em merge keys do
-  # js-yaml via aliases repetidos). Transitivo build/dev-time via gray-matter
-  # (scripts/blog-manifest) e bundlesize2 > cosmiconfig — ambos na linha 3.x,
-  # que usa a API yaml.safeLoad. Resolvido instalado: js-yaml@3.14.2 (vulnerável).
-  #
-  # CORREÇÃO conhecida (atualiza nota anterior que dizia ser inviável): existe o
-  # backport js-yaml@3.15.0 (dist-tag v3-legacy, publicado 2026-06-26) que corrige
-  # NA PRÓPRIA linha 3.x e preserva safeLoad — logo NÃO quebra o gray-matter.
-  # O override correto é:  js-yaml: "^3.15.0"  (>=3.15.0 <4, mantém major 3.x).
-  #
-  # BLOQUEIO temporário: 3.15.0 ainda está dentro da janela `minimumReleaseAge`
-  # (10080 min / 7 dias) desta config — `pnpm install` rejeita com
-  # ERR_PNPM_NO_MATURE_MATCHING_VERSION até ~2026-07-03. Adotar o override acima
-  # quando a versão amadurecer (não burlar o cooldown via exclude para um release
-  # de poucos dias). Risco até lá: build/dev-time apenas, moderate, já na main.
+  # Dependabot #45 (moderate): GHSA-h67p-54hq-rp68 — DoS quadrático em merge
+  # keys do js-yaml via aliases repetidos. Transitivo build/dev-time via
+  # gray-matter (scripts/blog-manifest) e bundlesize2 > cosmiconfig@5 — ambos
+  # na linha 3.x, que usa a API yaml.safeLoad. O backport js-yaml@3.15.0
+  # (dist-tag v3-legacy, publicado 2026-06-26, cooldown de 7 dias vencido em
+  # 2026-07-03) corrige na própria linha 3.x e preserva safeLoad.
+  # Override escopado a "@3" de propósito: um override global rebaixaria a
+  # árvore js-yaml@4.2.0 (cosmiconfig@9), que já está corrigida e usa a API v4.
+  "js-yaml@3": "^3.15.0"
 
 legacyPeerDeps: true
 nodeLinker: hoisted


### PR DESCRIPTION
## Resumo

Resolve o [alerta Dependabot #45](https://github.com/felipewilliam2/AV-SITE/security/dependabot/45) ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) / CVE-2026-53550, moderate): DoS por complexidade quadrática no processamento de merge keys (`<<`) do `js-yaml` via aliases repetidos.

## Contexto

- Transitivo, escopo de desenvolvimento/build: `gray-matter` (geração do manifest do blog) e `bundlesize2 > cosmiconfig@5`, ambos na linha 3.x (`js-yaml@3.14.2`).
- O fix já estava documentado como PENDENTE no `pnpm-workspace.yaml`: o backport `js-yaml@3.15.0` (dist-tag `v3-legacy`, publicado 2026-06-26) corrige na própria linha 3.x e preserva a API `safeLoad`. Estava bloqueado pelo cooldown de 7 dias do `minimumReleaseAge`, que venceu em 2026-07-03.

## Mudanças

- Override **escopado** `"js-yaml@3": "^3.15.0"` — escopado de propósito: um override global rebaixaria a árvore `js-yaml@4.2.0` (`cosmiconfig@9`), que já está corrigida e usa a API v4.
- Comentário PENDENTE substituído pela nota de resolução, no mesmo padrão dos demais overrides.

## Verificação

- Lockfile: `js-yaml@3.14.2` removido, `js-yaml@3.15.0` resolvido, `js-yaml@4.2.0` intacto.
- Smoke test do `gray-matter` (parse de frontmatter) OK.
- `pnpm typecheck` (regenera manifest do blog + sitemap via gray-matter) ✅
- `pnpm test:regression`: 774/774 ✅

Sem mudança de comportamento em runtime de produção (dependência dev/build-time). Alerta deve ser fechado automaticamente pelo Dependabot após o merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)