### PR TITLE
feat(sobre): autoridade de entidade GEO na /sobre

### DIFF
--- a/components/about/ConsultoresSection.tsx
+++ b/components/about/ConsultoresSection.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { m } from 'framer-motion';
+import { InstagramLogo, LinkedinLogo } from '@phosphor-icons/react';
+import { LazyImage } from '../ui/LazyImage';
+import type { Author } from '../../data/blogData';
+import { fadeUp } from './aboutMotion';
+
+interface ConsultoresSectionProps {
+  team: Author[];
+}
+
+// Seção "Quem planeja a sua viagem": consultores como entidades E-E-A-T.
+// O JSON-LD Person correspondente é emitido em pages/About.tsx.
+export const ConsultoresSection: React.FC<ConsultoresSectionProps> = ({ team }) => (
+  <section id="consultores" className="mt-32">
+    <m.div
+      className="text-center mb-16"
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+      variants={fadeUp}
+      custom={0}
+    >
+      <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4">Quem planeja a sua viagem</h2>
+      <p className="text-zinc-500 font-medium max-w-2xl mx-auto">
+        Atendimento consultivo é feito por gente de verdade. Conheça os consultores que desenham cada roteiro sob medida.
+      </p>
+    </m.div>
+
+    <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      {team.map((member, i) => (
+        <m.div
+          key={member.id}
+          className="bg-white p-8 rounded-[2.5rem] border-2 border-zinc-100 shadow-sm hover:shadow-xl transition duration-300 flex flex-col sm:flex-row items-center sm:items-start gap-6 text-center sm:text-left"
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          variants={fadeUp}
+          custom={i + 1}
+        >
+          {member.image && (
+            <LazyImage
+              src={member.image}
+              alt={`${member.name}, ${member.role} na Anhangá Viagens`}
+              width={96}
+              height={96}
+              className="size-24 rounded-2xl object-cover shrink-0 border-4 border-white shadow-md"
+            />
+          )}
+          <div>
+            <h3 className="text-xl font-black text-anhanga-dark leading-tight">{member.name}</h3>
+            <p className="text-sm font-bold text-anhanga-action uppercase tracking-wide mb-3">{member.role}</p>
+            <p className="text-zinc-500 font-medium leading-relaxed mb-4">{member.bio}</p>
+            {member.social && (member.social.instagram || member.social.linkedin) && (
+              <div className="flex items-center justify-center sm:justify-start gap-3">
+                {member.social.instagram && (
+                  <a
+                    href={member.social.instagram}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`Instagram de ${member.name}`}
+                    className="size-9 rounded-full bg-anhanga-action/10 text-anhanga-action flex items-center justify-center hover:bg-anhanga-action hover:text-white transition-colors"
+                  >
+                    <InstagramLogo className="size-4" weight="fill" />
+                  </a>
+                )}
+                {member.social.linkedin && (
+                  <a
+                    href={member.social.linkedin}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`LinkedIn de ${member.name}`}
+                    className="size-9 rounded-full bg-anhanga-action/10 text-anhanga-action flex items-center justify-center hover:bg-anhanga-action hover:text-white transition-colors"
+                  >
+                    <LinkedinLogo className="size-4" weight="fill" />
+                  </a>
+                )}
+              </div>
+            )}
+          </div>
+        </m.div>
+      ))}
+    </div>
+  </section>
+);

--- a/components/about/CtaSection.tsx
+++ b/components/about/CtaSection.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { m } from 'framer-motion';
+import { Sparkles } from 'lucide-react';
+import { openContactModal } from '../../utils/contactForm';
+import { fadeUp } from './aboutMotion';
+
+// CTA final da página /sobre.
+export const CtaSection: React.FC = () => (
+  <m.section
+    className="mt-32 text-center"
+    initial="hidden"
+    whileInView="visible"
+    viewport={{ once: true }}
+    variants={fadeUp}
+  >
+    <div className="bg-brand-cyan/5 rounded-[3rem] p-12 md:p-20 border-2 border-dashed border-brand-cyan/20">
+      <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-6">Pronto para sua próxima história?</h2>
+      <p className="text-zinc-600 text-lg font-medium mb-10 max-w-xl mx-auto">
+        Seja para um festival épico ou um refúgio relaxante, nós desenhamos a viagem perfeita para você.
+      </p>
+      <button
+        type="button"
+        onClick={() => openContactModal({ source: 'about' })}
+        className="btn-whatsapp btn-specialist bg-brand-vibrant text-white px-10 py-5 rounded-2xl font-black text-lg shadow-xl shadow-brand-vibrant/20 hover:scale-105 transition-transform active:scale-95 flex items-center gap-3 mx-auto"
+        data-tracking="footer-about"
+      >
+        Começar Planejamento
+        <Sparkles className="size-5" />
+      </button>
+    </div>
+  </m.section>
+);

--- a/components/about/ExpertiseSection.tsx
+++ b/components/about/ExpertiseSection.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { m } from 'framer-motion';
+import { ShieldCheck, Users, Sparkles } from 'lucide-react';
+import { fadeUp } from './aboutMotion';
+
+const EXPERTISE_ITEMS = [
+  {
+    icon: Users,
+    title: 'Atendimento Humano',
+    desc: 'Nada de bots ou respostas automáticas. Você fala com especialistas que conhecem os destinos de verdade.',
+    color: 'bg-orange-100 text-orange-600',
+  },
+  {
+    icon: Sparkles,
+    title: 'Curadoria Premium',
+    desc: 'Selecionamos hotéis e experiências que fogem do óbvio, garantindo que sua viagem seja única.',
+    color: 'bg-brand-cyan/10 text-brand-cyan',
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Suporte 24/7',
+    desc: 'Durante sua viagem, nossa equipe está a um WhatsApp de distância para resolver qualquer imprevisto.',
+    color: 'bg-emerald-100 text-emerald-600',
+  },
+];
+
+// Seção "Por que viajar com a Anhangá?": diferenciais em cards.
+export const ExpertiseSection: React.FC = () => (
+  <section className="mb-32">
+    <m.div
+      className="text-center mb-16"
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+      variants={fadeUp}
+      custom={0}
+    >
+      <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Por que viajar com a Anhangá?</h2>
+      <p className="text-zinc-500 font-medium">O que nos torna diferentes no mercado de turismo.</p>
+    </m.div>
+
+    <div className="grid md:grid-cols-3 gap-8">
+      {EXPERTISE_ITEMS.map((item, i) => (
+        <m.div
+          key={item.title}
+          className="bg-white p-10 rounded-[2.5rem] border-2 border-zinc-100 shadow-sm hover:shadow-xl transition duration-300"
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          variants={fadeUp}
+          custom={i + 1}
+        >
+          <div className={`size-14 rounded-2xl ${item.color} flex items-center justify-center mb-6`}>
+            <item.icon className="size-8" />
+          </div>
+          <h3 className="text-xl font-black text-brand-dark mb-4">{item.title}</h3>
+          <p className="text-zinc-500 font-medium leading-relaxed">{item.desc}</p>
+        </m.div>
+      ))}
+    </div>
+  </section>
+);

--- a/components/about/HeroSection.tsx
+++ b/components/about/HeroSection.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { m } from 'framer-motion';
+import { Sparkles } from 'lucide-react';
+import { openContactModal } from '../../utils/contactForm';
+import { fadeUp } from './aboutMotion';
+
+// Hero da página /sobre: proposta de valor + CTA de orçamento.
+export const HeroSection: React.FC = () => (
+  <m.section
+    className="text-center mb-24"
+    initial="hidden"
+    animate="visible"
+    variants={fadeUp}
+    custom={0}
+  >
+    <div className="inline-block relative mb-6">
+      <span className="absolute inset-0 bg-brand-cyan/20 transform -skew-x-12 rounded-lg"></span>
+      <span className="relative px-4 py-1 text-brand-dark font-black uppercase tracking-widest text-sm flex items-center gap-2">
+        <Sparkles className="size-4 text-brand-cyan" /> Nossa Essência
+      </span>
+    </div>
+    <h1 className="text-5xl md:text-6xl font-black text-brand-dark mb-6 leading-tight">
+      Viagens com alma, <br />
+      <span className="text-brand-cyan">
+        design e zero estresse.
+      </span>
+    </h1>
+    <p className="max-w-2xl mx-auto text-zinc-600 text-lg md:text-xl font-medium leading-relaxed mb-8">
+      Na Anhangá Viagens, acreditamos que viajar é mais do que carimbar um passaporte: é sobre colecionar histórias que valem a pena ser contadas.
+    </p>
+    <div className="flex justify-center">
+      <button
+        type="button"
+        onClick={() => openContactModal({ source: 'about' })}
+        className="btn-whatsapp btn-specialist bg-brand-vibrant text-white px-8 py-4 rounded-2xl font-black text-lg shadow-xl shadow-brand-vibrant/20 hover:scale-105 transition-transform active:scale-95 flex items-center gap-3"
+        data-tracking="hero-about"
+      >
+        Solicitar Orçamento
+        <Sparkles className="size-5" />
+      </button>
+    </div>
+  </m.section>
+);

--- a/components/about/HistoriaSection.tsx
+++ b/components/about/HistoriaSection.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { m } from 'framer-motion';
+import { Heart } from 'lucide-react';
+import { LazyImage } from '../ui/LazyImage';
+import { fadeUp } from './aboutMotion';
+
+// Seção "Nossa História": narrativa da marca + imagem da equipe.
+export const HistoriaSection: React.FC = () => (
+  <section id="nossa-historia" className="mb-32">
+    <div className="flex flex-col lg:flex-row gap-16 items-center">
+      <m.div
+        className="w-full lg:w-1/2"
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        variants={fadeUp}
+        custom={1}
+      >
+        <div className="relative">
+          <div className="absolute -top-4 -left-4 size-24 bg-brand-yellow/30 rounded-full blur-2xl z-0"></div>
+          <div className="relative rounded-3xl overflow-hidden border-8 border-white shadow-2xl rotate-2 hover:rotate-0 transition-transform duration-500">
+            <LazyImage
+              src="images/about/equipe-anhanga.jpg"
+              alt="Equipe da Anhangá Viagens planejando um roteiro personalizado"
+              width={800}
+              height={600}
+              className="w-full h-auto object-cover aspect-[4/3]"
+            />
+          </div>
+          <div className="absolute -bottom-6 -right-6 bg-white p-6 rounded-2xl shadow-xl border border-zinc-100 hidden md:block">
+            <div className="flex items-center gap-4">
+              <div className="size-12 bg-brand-cyan/10 rounded-full flex items-center justify-center text-brand-cyan">
+                <Heart className="size-6 fill-current" />
+              </div>
+              <div>
+                <p className="text-xs font-bold text-zinc-400 uppercase tracking-wider">Paixão por</p>
+                <p className="text-lg font-black text-brand-dark leading-none">Pessoas</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </m.div>
+
+      <m.div
+        className="w-full lg:w-1/2"
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        variants={fadeUp}
+        custom={2}
+      >
+        <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-6">Nossa História</h2>
+        <div className="space-y-4 text-zinc-600 font-medium leading-relaxed text-lg">
+          <p>
+            A Anhangá Viagens nasceu em São Paulo com um propósito claro: resgatar o prazer de planejar uma viagem sem as dores de cabeça da burocracia digital e dos roteiros engessados.
+          </p>
+          <p>
+            Fundada por especialistas apaixonados pelo setor, nossa agência foca no <strong>atendimento consultivo</strong>. Não somos apenas um motor de busca; somos curadores de experiências.
+          </p>
+          <p>
+            Do primeiro café (virtual ou presencial) até o seu retorno para casa, cuidamos de cada detalhe como se a viagem fosse nossa. É esse cuidado artesanal que nos define.
+          </p>
+        </div>
+      </m.div>
+    </div>
+  </section>
+);

--- a/components/about/TrustFaqSection.tsx
+++ b/components/about/TrustFaqSection.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { m } from 'framer-motion';
+import { fadeUp } from './aboutMotion';
+
+interface TrustFaqItem {
+  question: string;
+  answer: string;
+}
+
+interface TrustFaqSectionProps {
+  items: TrustFaqItem[];
+}
+
+// FAQ de confiança answer-first. Mesma fonte (items) alimenta o FAQPage
+// JSON-LD emitido em pages/About.tsx — sem drift entre schema e texto.
+export const TrustFaqSection: React.FC<TrustFaqSectionProps> = ({ items }) => (
+  <section id="perguntas-frequentes" className="mt-32">
+    <m.div
+      className="text-center mb-16"
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+      variants={fadeUp}
+      custom={0}
+    >
+      <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4">Perguntas frequentes sobre a Anhangá</h2>
+      <p className="text-zinc-500 font-medium max-w-2xl mx-auto">
+        Confiança, credenciamentos e como funciona o atendimento — em respostas diretas.
+      </p>
+    </m.div>
+
+    <div className="max-w-3xl mx-auto space-y-5">
+      {items.map((item, i) => (
+        <m.div
+          key={item.question}
+          className="bg-white p-8 rounded-3xl border-2 border-zinc-100 shadow-sm"
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          variants={fadeUp}
+          custom={i + 1}
+        >
+          <h3 className="text-lg md:text-xl font-black text-anhanga-dark mb-3">{item.question}</h3>
+          <p className="text-zinc-600 font-medium leading-relaxed">{item.answer}</p>
+        </m.div>
+      ))}
+    </div>
+  </section>
+);

--- a/components/about/TrustSection.tsx
+++ b/components/about/TrustSection.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { Award, Anchor, Ship, Coffee } from 'lucide-react';
+
+// Seção "Agência Certificada": credenciamentos como fatos verificáveis em texto
+// (Cadastur, Beto Carrero, Hopi Hari, NCL) — os mesmos sinais que o JSON-LD de
+// entidade em pages/About.tsx expõe para motores de resposta.
+export const TrustSection: React.FC = () => (
+  <section id="certificacoes" className="bg-brand-dark rounded-[3rem] p-12 md:p-20 text-white overflow-hidden relative">
+    <div className="absolute top-0 right-0 size-64 bg-brand-vibrant/20 blur-[100px] rounded-full"></div>
+    <div className="absolute bottom-0 left-0 size-64 bg-brand-cyan/10 blur-[100px] rounded-full"></div>
+
+    <div className="relative z-10 flex flex-col lg:flex-row gap-16 items-center">
+      <div className="w-full lg:w-1/2">
+        <div className="inline-flex items-center gap-2 px-4 py-1 bg-white/10 rounded-full text-brand-cyan text-sm font-bold mb-6">
+          <Award className="size-4" /> Credibilidade & Confiança
+        </div>
+        <h2 className="text-3xl md:text-4xl font-black mb-6">Agência Certificada</h2>
+        <p className="text-zinc-300 text-lg font-medium leading-relaxed mb-8">
+          Sua segurança é nossa prioridade. A Anhangá Viagens é uma empresa devidamente registrada nos órgãos competentes, garantindo total conformidade legal para suas férias.
+        </p>
+
+        <ul className="space-y-6">
+          <li className="flex items-start gap-4">
+            <div className="size-6 rounded-full bg-brand-cyan/20 flex items-center justify-center shrink-0 mt-1">
+              <div className="size-2 rounded-full bg-brand-cyan"></div>
+            </div>
+            <div>
+              <p className="font-bold text-lg leading-none mb-1">Cadastur Oficial</p>
+              <p className="text-zinc-400">Registro MTUR: 37.036.732/0001-41</p>
+            </div>
+          </li>
+          <li className="flex items-start gap-4">
+            <div className="size-6 rounded-full bg-brand-cyan/20 flex items-center justify-center shrink-0 mt-1">
+              <div className="size-2 rounded-full bg-brand-cyan"></div>
+            </div>
+            <div>
+              <p className="font-bold text-lg leading-none mb-1">Sede Própria em São Paulo</p>
+              <p className="text-zinc-400">Av. Dom Pedro I, 773 - Vila Monumento, CEP 01552-001</p>
+            </div>
+          </li>
+          <li className="flex items-start gap-4">
+            <div className="size-6 rounded-full bg-anhanga-action/20 flex items-center justify-center shrink-0 mt-1">
+              <div className="size-2 rounded-full bg-anhanga-action"></div>
+            </div>
+            <div>
+              <p className="font-bold text-lg leading-none mb-1">Agente Credenciado</p>
+              <p className="text-zinc-400">Beto Carrero World e Hopi Hari</p>
+            </div>
+          </li>
+          <li className="flex items-start gap-4">
+            <div className="size-6 rounded-full bg-anhanga-action/20 flex items-center justify-center shrink-0 mt-1">
+              <div className="size-2 rounded-full bg-anhanga-action"></div>
+            </div>
+            <div>
+              <p className="font-bold text-lg leading-none mb-1">Parceira Norwegian Cruise Line</p>
+              <p className="text-zinc-400">Cruzeiros nacionais e internacionais (NCL)</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div className="w-full lg:w-1/2 grid grid-cols-2 gap-4">
+        <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
+          <Award className="size-12 text-brand-cyan mb-4" />
+          <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Membro Oficial</p>
+          <p className="font-black text-xl">Beto Carrero World</p>
+          <p className="text-xs text-brand-cyan mt-1">Agente Credenciado</p>
+        </div>
+        <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
+          <Anchor className="size-12 text-anhanga-action mb-4" />
+          <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Membro Oficial</p>
+          <p className="font-black text-xl">Hopi Hari</p>
+          <p className="text-xs text-anhanga-action mt-1">Agente Credenciado</p>
+        </div>
+        <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
+          <Ship className="size-12 text-anhanga-action mb-4" />
+          <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Parceira</p>
+          <p className="font-black text-xl">Norwegian Cruise Line</p>
+          <p className="text-xs text-anhanga-action mt-1">Cruzeiros NCL</p>
+        </div>
+        <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
+          <Coffee className="size-12 text-brand-yellow mb-4" />
+          <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Localizada em</p>
+          <p className="font-black text-xl">São Paulo - SP</p>
+          <p className="text-xs text-brand-yellow mt-1">Atendimento Presencial</p>
+        </div>
+        <div className="col-span-2 bg-white/5 backdrop-blur-sm p-6 rounded-3xl border border-white/10 flex items-center justify-center gap-6">
+          <div className="text-center">
+            <p className="text-3xl font-black text-brand-vibrant">4.9/5</p>
+            <p className="text-[10px] font-bold uppercase tracking-widest opacity-50">Avaliação Média</p>
+          </div>
+          <div className="h-10 w-px bg-white/10"></div>
+          <div className="text-center">
+            <p className="text-3xl font-black text-brand-cyan">100%</p>
+            <p className="text-[10px] font-bold uppercase tracking-widest opacity-50">Roteiros sob medida</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+);

--- a/components/about/aboutMotion.ts
+++ b/components/about/aboutMotion.ts
@@ -1,0 +1,15 @@
+import type { Variants } from 'framer-motion';
+
+// Variante de entrada compartilhada pelas seções da página /sobre.
+export const fadeUp: Variants = {
+  hidden: { opacity: 0, y: 30 },
+  visible: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: {
+      delay: i * 0.1,
+      duration: 0.6,
+      ease: 'easeOut',
+    },
+  }),
+};

--- a/components/schemas/PersonSchema.tsx
+++ b/components/schemas/PersonSchema.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { StructuredData } from './StructuredData';
 
+export interface PersonWorksFor {
+    name: string;
+    url?: string;
+}
+
 export interface PersonSchemaProps {
     name: string;
     image?: string;
@@ -8,6 +13,10 @@ export interface PersonSchemaProps {
     jobTitle?: string;
     url?: string;
     sameAs?: string[];
+    worksFor?: PersonWorksFor;
+    // Unique head-tag id — required when a page renders more than one Person
+    // (StructuredData keys tags by id, so duplicates would collide/dedupe).
+    id?: string;
 }
 
 export const PersonSchema: React.FC<PersonSchemaProps> = ({
@@ -16,7 +25,9 @@ export const PersonSchema: React.FC<PersonSchemaProps> = ({
     description,
     jobTitle,
     url,
-    sameAs
+    sameAs,
+    worksFor,
+    id = "person"
 }) => {
     const schema = {
         "@context": "https://schema.org",
@@ -26,8 +37,15 @@ export const PersonSchema: React.FC<PersonSchemaProps> = ({
         ...(description && { "description": description }),
         ...(jobTitle && { "jobTitle": jobTitle }),
         ...(url && { "url": url }),
-        ...(sameAs && sameAs.length > 0 && { "sameAs": sameAs })
+        ...(sameAs && sameAs.length > 0 && { "sameAs": sameAs }),
+        ...(worksFor && {
+            "worksFor": {
+                "@type": "TravelAgency",
+                "name": worksFor.name,
+                ...(worksFor.url && { "url": worksFor.url })
+            }
+        })
     };
 
-    return <StructuredData id="person" data={schema} />;
+    return <StructuredData id={id} data={schema} />;
 };

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -4,9 +4,56 @@ import { m, Variants } from 'framer-motion';
 import { Seo } from '../components/Seo';
 import { OrganizationSchema } from '../components/schemas/OrganizationSchema';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
+import { FAQPageSchema } from '../components/schemas/FAQPageSchema';
+import { PersonSchema } from '../components/schemas/PersonSchema';
 import { LazyImage } from '../components/ui/LazyImage';
 import { openContactModal } from '../utils/contactForm';
-import { ShieldCheck, Award, Users, Sparkles, Heart, Coffee } from 'lucide-react';
+import { getReviewSummary } from '../data/reviewsAdapter';
+import { AUTHORS } from '../data/blogData';
+import googleReviewsRaw from '../data/googleReviews.json';
+import type { GoogleReviewsData } from '../types/reviews';
+import { ShieldCheck, Award, Users, Sparkles, Heart, Coffee, Ship, Anchor } from 'lucide-react';
+import { InstagramLogo, LinkedinLogo } from '@phosphor-icons/react';
+
+const ORG_NAME = 'Anhangá Viagens';
+const ORG_URL = 'https://www.anhanga.tur.br/';
+
+const reviewSummary = getReviewSummary(googleReviewsRaw as GoogleReviewsData);
+
+// FAQ de entidade/confiança — respostas answer-first e verificáveis, o padrão
+// que motores de resposta (ChatGPT, Gemini, Perplexity) extraem para
+// *recomendar* a marca, não só citar fatos. Mantido em sincronia com a seção
+// visível renderizada abaixo e com o FAQPage JSON-LD.
+const TRUST_FAQ_ITEMS = [
+  {
+    question: 'A Anhangá Viagens é confiável?',
+    answer:
+      'Sim. A Anhangá Viagens é uma agência de turismo registrada no Cadastur (Ministério do Turismo) sob o CNPJ 37.036.732/0001-41, com sede física em São Paulo, na Av. Dom Pedro I, 773 — Vila Monumento. É agente credenciado do Beto Carrero World e do Hopi Hari e parceira da Norwegian Cruise Line (NCL). O atendimento é consultivo e humano, com suporte 24h por WhatsApp durante toda a viagem.',
+  },
+  {
+    question: 'A Anhangá é registrada no Cadastur?',
+    answer:
+      'Sim. O registro no Cadastur, cadastro oficial do Ministério do Turismo do Brasil, é 37.036.732/0001-41 — o mesmo número do CNPJ. O Cadastur é a autorização que habilita uma empresa a operar legalmente como agência de turismo no país.',
+  },
+  {
+    question: 'Quais credenciamentos e parcerias a Anhangá possui?',
+    answer:
+      'A Anhangá é agente credenciado do Beto Carrero World e do Hopi Hari, parceira da Norwegian Cruise Line (NCL) para cruzeiros e registrada no Cadastur do Ministério do Turismo. Esses credenciamentos permitem emitir ingressos, pacotes e reservas oficiais desses parceiros com condições e suporte diretos.',
+  },
+  {
+    question: 'Como funciona o atendimento da Anhangá?',
+    answer:
+      'O atendimento é consultivo, não de balcão. Um consultor humano desenha o roteiro dia a dia conforme seu perfil e orçamento — sem pacotes prontos de prateleira. Você aprova a proposta com todos os custos listados antes de qualquer emissão e conta com suporte 24h por WhatsApp durante a viagem. O primeiro contato pode ser pelo chat com IA no site, por WhatsApp ou presencialmente em São Paulo.',
+  },
+  {
+    question: 'A Anhangá tem sede física e atendimento presencial?',
+    answer:
+      'Sim. A sede fica na Av. Dom Pedro I, 773 — Vila Monumento, São Paulo (SP), CEP 01552-001. O atendimento pode ser presencial, por WhatsApp no (11) 5283-3309 ou pelo chat com IA disponível no site.',
+  },
+];
+
+// Consultores expostos como entidades Person (E-E-A-T) ligados à organização.
+const TEAM = [AUTHORS['felipe-william'], AUTHORS['queila-oliveira']].filter(Boolean);
 
 const fadeUp: Variants = {
   hidden: { opacity: 0, y: 30 },
@@ -43,10 +90,28 @@ const About: React.FC = () => {
     <div className="bg-brand-surface pt-32 pb-20">
       <Seo
         title="Sobre a Anhangá Viagens | Agência de Viagens em São Paulo"
-        description="Conheça a história da Anhangá Viagens. Agência de turismo credenciada no Cadastur em São Paulo, especializada em roteiros personalizados."
+        description="Anhangá Viagens: agência registrada no Cadastur (CNPJ 37.036.732/0001-41), com sede em São Paulo, agente credenciado Beto Carrero World e Hopi Hari e parceira Norwegian Cruise Line. Atendimento consultivo e roteiros personalizados."
         canonical="https://www.anhanga.tur.br/sobre/"
       />
-      <OrganizationSchema />
+      <OrganizationSchema
+        aggregateRating={reviewSummary ? {
+          ratingValue: reviewSummary.averageRating,
+          reviewCount: reviewSummary.totalReviews,
+        } : undefined}
+      />
+      <FAQPageSchema items={TRUST_FAQ_ITEMS} />
+      {TEAM.map((member) => (
+        <PersonSchema
+          key={member.id}
+          id={`person-${member.id}`}
+          name={member.name}
+          image={member.image}
+          description={member.bio}
+          jobTitle={member.role}
+          sameAs={member.social ? (Object.values(member.social).filter(Boolean) as string[]) : undefined}
+          worksFor={{ name: ORG_NAME, url: ORG_URL }}
+        />
+      ))}
       <BreadcrumbSchema
         items={[
           { name: 'Home', item: 'https://www.anhanga.tur.br/' },
@@ -236,7 +301,25 @@ const About: React.FC = () => {
                   </div>
                   <div>
                     <p className="font-bold text-lg leading-none mb-1">Sede Própria em São Paulo</p>
-                    <p className="text-zinc-400">Av. Dom Pedro I, 773 - Vila Monumento</p>
+                    <p className="text-zinc-400">Av. Dom Pedro I, 773 - Vila Monumento, CEP 01552-001</p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-4">
+                  <div className="size-6 rounded-full bg-anhanga-action/20 flex items-center justify-center shrink-0 mt-1">
+                    <div className="size-2 rounded-full bg-anhanga-action"></div>
+                  </div>
+                  <div>
+                    <p className="font-bold text-lg leading-none mb-1">Agente Credenciado</p>
+                    <p className="text-zinc-400">Beto Carrero World e Hopi Hari</p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-4">
+                  <div className="size-6 rounded-full bg-anhanga-action/20 flex items-center justify-center shrink-0 mt-1">
+                    <div className="size-2 rounded-full bg-anhanga-action"></div>
+                  </div>
+                  <div>
+                    <p className="font-bold text-lg leading-none mb-1">Parceira Norwegian Cruise Line</p>
+                    <p className="text-zinc-400">Cruzeiros nacionais e internacionais (NCL)</p>
                   </div>
                 </li>
               </ul>
@@ -248,6 +331,18 @@ const About: React.FC = () => {
                 <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Membro Oficial</p>
                 <p className="font-black text-xl">Beto Carrero World</p>
                 <p className="text-xs text-brand-cyan mt-1">Agente Credenciado</p>
+              </div>
+              <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
+                <Anchor className="size-12 text-anhanga-action mb-4" />
+                <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Membro Oficial</p>
+                <p className="font-black text-xl">Hopi Hari</p>
+                <p className="text-xs text-anhanga-action mt-1">Agente Credenciado</p>
+              </div>
+              <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
+                <Ship className="size-12 text-anhanga-action mb-4" />
+                <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Parceira</p>
+                <p className="font-black text-xl">Norwegian Cruise Line</p>
+                <p className="text-xs text-anhanga-action mt-1">Cruzeiros NCL</p>
               </div>
               <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
                 <Coffee className="size-12 text-brand-yellow mb-4" />
@@ -267,6 +362,114 @@ const About: React.FC = () => {
                 </div>
               </div>
             </div>
+          </div>
+        </section>
+
+        {/* TEAM / CONSULTORES SECTION */}
+        <section id="consultores" className="mt-32">
+          <m.div
+            className="text-center mb-16"
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={fadeUp}
+            custom={0}
+          >
+            <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4">Quem planeja a sua viagem</h2>
+            <p className="text-zinc-500 font-medium max-w-2xl mx-auto">
+              Atendimento consultivo é feito por gente de verdade. Conheça os consultores que desenham cada roteiro sob medida.
+            </p>
+          </m.div>
+
+          <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+            {TEAM.map((member, i) => (
+              <m.div
+                key={member.id}
+                className="bg-white p-8 rounded-[2.5rem] border-2 border-zinc-100 shadow-sm hover:shadow-xl transition duration-300 flex flex-col sm:flex-row items-center sm:items-start gap-6 text-center sm:text-left"
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true }}
+                variants={fadeUp}
+                custom={i + 1}
+              >
+                {member.image && (
+                  <img
+                    src={member.image}
+                    alt={`${member.name}, ${member.role} na Anhangá Viagens`}
+                    width={96}
+                    height={96}
+                    loading="lazy"
+                    decoding="async"
+                    className="size-24 rounded-2xl object-cover shrink-0 border-4 border-white shadow-md"
+                  />
+                )}
+                <div>
+                  <h3 className="text-xl font-black text-anhanga-dark leading-tight">{member.name}</h3>
+                  <p className="text-sm font-bold text-anhanga-action uppercase tracking-wide mb-3">{member.role}</p>
+                  <p className="text-zinc-500 font-medium leading-relaxed mb-4">{member.bio}</p>
+                  {member.social && (
+                    <div className="flex items-center justify-center sm:justify-start gap-3">
+                      {member.social.instagram && (
+                        <a
+                          href={member.social.instagram}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label={`Instagram de ${member.name}`}
+                          className="size-9 rounded-full bg-anhanga-action/10 text-anhanga-action flex items-center justify-center hover:bg-anhanga-action hover:text-white transition-colors"
+                        >
+                          <InstagramLogo className="size-4" weight="fill" />
+                        </a>
+                      )}
+                      {member.social.linkedin && (
+                        <a
+                          href={member.social.linkedin}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label={`LinkedIn de ${member.name}`}
+                          className="size-9 rounded-full bg-anhanga-action/10 text-anhanga-action flex items-center justify-center hover:bg-anhanga-action hover:text-white transition-colors"
+                        >
+                          <LinkedinLogo className="size-4" weight="fill" />
+                        </a>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </m.div>
+            ))}
+          </div>
+        </section>
+
+        {/* FAQ / CONFIANÇA SECTION */}
+        <section id="perguntas-frequentes" className="mt-32">
+          <m.div
+            className="text-center mb-16"
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={fadeUp}
+            custom={0}
+          >
+            <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4">Perguntas frequentes sobre a Anhangá</h2>
+            <p className="text-zinc-500 font-medium max-w-2xl mx-auto">
+              Confiança, credenciamentos e como funciona o atendimento — em respostas diretas.
+            </p>
+          </m.div>
+
+          <div className="max-w-3xl mx-auto space-y-5">
+            {TRUST_FAQ_ITEMS.map((item, i) => (
+              <m.div
+                key={item.question}
+                className="bg-white p-8 rounded-3xl border-2 border-zinc-100 shadow-sm"
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true }}
+                variants={fadeUp}
+                custom={i + 1}
+              >
+                <h3 className="text-lg md:text-xl font-black text-anhanga-dark mb-3">{item.question}</h3>
+                <p className="text-zinc-600 font-medium leading-relaxed">{item.answer}</p>
+              </m.div>
+            ))}
           </div>
         </section>
 

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -393,13 +393,11 @@ const About: React.FC = () => {
                 custom={i + 1}
               >
                 {member.image && (
-                  <img
+                  <LazyImage
                     src={member.image}
                     alt={`${member.name}, ${member.role} na Anhangá Viagens`}
                     width={96}
                     height={96}
-                    loading="lazy"
-                    decoding="async"
                     className="size-24 rounded-2xl object-cover shrink-0 border-4 border-white shadow-md"
                   />
                 )}
@@ -407,7 +405,7 @@ const About: React.FC = () => {
                   <h3 className="text-xl font-black text-anhanga-dark leading-tight">{member.name}</h3>
                   <p className="text-sm font-bold text-anhanga-action uppercase tracking-wide mb-3">{member.role}</p>
                   <p className="text-zinc-500 font-medium leading-relaxed mb-4">{member.bio}</p>
-                  {member.social && (
+                  {member.social && (member.social.instagram || member.social.linkedin) && (
                     <div className="flex items-center justify-center sm:justify-start gap-3">
                       {member.social.instagram && (
                         <a

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -1,19 +1,21 @@
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { m, Variants } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Seo } from '../components/Seo';
 import { OrganizationSchema } from '../components/schemas/OrganizationSchema';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '../components/schemas/FAQPageSchema';
 import { PersonSchema } from '../components/schemas/PersonSchema';
 import { LazyImage } from '../components/ui/LazyImage';
+import { ConsultoresSection } from '../components/about/ConsultoresSection';
+import { TrustFaqSection } from '../components/about/TrustFaqSection';
+import { fadeUp } from '../components/about/aboutMotion';
 import { openContactModal } from '../utils/contactForm';
 import { getReviewSummary } from '../data/reviewsAdapter';
 import { AUTHORS } from '../data/blogData';
 import googleReviewsRaw from '../data/googleReviews.json';
 import type { GoogleReviewsData } from '../types/reviews';
 import { ShieldCheck, Award, Users, Sparkles, Heart, Coffee, Ship, Anchor } from 'lucide-react';
-import { InstagramLogo, LinkedinLogo } from '@phosphor-icons/react';
 
 const ORG_NAME = 'Anhangá Viagens';
 const ORG_URL = 'https://www.anhanga.tur.br/';
@@ -54,19 +56,6 @@ const TRUST_FAQ_ITEMS = [
 
 // Consultores expostos como entidades Person (E-E-A-T) ligados à organização.
 const TEAM = [AUTHORS['felipe-william'], AUTHORS['queila-oliveira']].filter(Boolean);
-
-const fadeUp: Variants = {
-  hidden: { opacity: 0, y: 30 },
-  visible: (i: number) => ({
-    opacity: 1,
-    y: 0,
-    transition: {
-      delay: i * 0.1,
-      duration: 0.6,
-      ease: 'easeOut',
-    },
-  }),
-};
 
 const About: React.FC = () => {
   const { hash } = useLocation();
@@ -366,110 +355,10 @@ const About: React.FC = () => {
         </section>
 
         {/* TEAM / CONSULTORES SECTION */}
-        <section id="consultores" className="mt-32">
-          <m.div
-            className="text-center mb-16"
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true }}
-            variants={fadeUp}
-            custom={0}
-          >
-            <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4">Quem planeja a sua viagem</h2>
-            <p className="text-zinc-500 font-medium max-w-2xl mx-auto">
-              Atendimento consultivo é feito por gente de verdade. Conheça os consultores que desenham cada roteiro sob medida.
-            </p>
-          </m.div>
-
-          <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
-            {TEAM.map((member, i) => (
-              <m.div
-                key={member.id}
-                className="bg-white p-8 rounded-[2.5rem] border-2 border-zinc-100 shadow-sm hover:shadow-xl transition duration-300 flex flex-col sm:flex-row items-center sm:items-start gap-6 text-center sm:text-left"
-                initial="hidden"
-                whileInView="visible"
-                viewport={{ once: true }}
-                variants={fadeUp}
-                custom={i + 1}
-              >
-                {member.image && (
-                  <LazyImage
-                    src={member.image}
-                    alt={`${member.name}, ${member.role} na Anhangá Viagens`}
-                    width={96}
-                    height={96}
-                    className="size-24 rounded-2xl object-cover shrink-0 border-4 border-white shadow-md"
-                  />
-                )}
-                <div>
-                  <h3 className="text-xl font-black text-anhanga-dark leading-tight">{member.name}</h3>
-                  <p className="text-sm font-bold text-anhanga-action uppercase tracking-wide mb-3">{member.role}</p>
-                  <p className="text-zinc-500 font-medium leading-relaxed mb-4">{member.bio}</p>
-                  {member.social && (member.social.instagram || member.social.linkedin) && (
-                    <div className="flex items-center justify-center sm:justify-start gap-3">
-                      {member.social.instagram && (
-                        <a
-                          href={member.social.instagram}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label={`Instagram de ${member.name}`}
-                          className="size-9 rounded-full bg-anhanga-action/10 text-anhanga-action flex items-center justify-center hover:bg-anhanga-action hover:text-white transition-colors"
-                        >
-                          <InstagramLogo className="size-4" weight="fill" />
-                        </a>
-                      )}
-                      {member.social.linkedin && (
-                        <a
-                          href={member.social.linkedin}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label={`LinkedIn de ${member.name}`}
-                          className="size-9 rounded-full bg-anhanga-action/10 text-anhanga-action flex items-center justify-center hover:bg-anhanga-action hover:text-white transition-colors"
-                        >
-                          <LinkedinLogo className="size-4" weight="fill" />
-                        </a>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </m.div>
-            ))}
-          </div>
-        </section>
+        <ConsultoresSection team={TEAM} />
 
         {/* FAQ / CONFIANÇA SECTION */}
-        <section id="perguntas-frequentes" className="mt-32">
-          <m.div
-            className="text-center mb-16"
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true }}
-            variants={fadeUp}
-            custom={0}
-          >
-            <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4">Perguntas frequentes sobre a Anhangá</h2>
-            <p className="text-zinc-500 font-medium max-w-2xl mx-auto">
-              Confiança, credenciamentos e como funciona o atendimento — em respostas diretas.
-            </p>
-          </m.div>
-
-          <div className="max-w-3xl mx-auto space-y-5">
-            {TRUST_FAQ_ITEMS.map((item, i) => (
-              <m.div
-                key={item.question}
-                className="bg-white p-8 rounded-3xl border-2 border-zinc-100 shadow-sm"
-                initial="hidden"
-                whileInView="visible"
-                viewport={{ once: true }}
-                variants={fadeUp}
-                custom={i + 1}
-              >
-                <h3 className="text-lg md:text-xl font-black text-anhanga-dark mb-3">{item.question}</h3>
-                <p className="text-zinc-600 font-medium leading-relaxed">{item.answer}</p>
-              </m.div>
-            ))}
-          </div>
-        </section>
+        <TrustFaqSection items={TRUST_FAQ_ITEMS} />
 
         {/* CTA */}
         <m.section

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -1,21 +1,21 @@
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { m } from 'framer-motion';
 import { Seo } from '../components/Seo';
 import { OrganizationSchema } from '../components/schemas/OrganizationSchema';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '../components/schemas/FAQPageSchema';
 import { PersonSchema } from '../components/schemas/PersonSchema';
-import { LazyImage } from '../components/ui/LazyImage';
+import { HeroSection } from '../components/about/HeroSection';
+import { HistoriaSection } from '../components/about/HistoriaSection';
+import { ExpertiseSection } from '../components/about/ExpertiseSection';
+import { TrustSection } from '../components/about/TrustSection';
 import { ConsultoresSection } from '../components/about/ConsultoresSection';
 import { TrustFaqSection } from '../components/about/TrustFaqSection';
-import { fadeUp } from '../components/about/aboutMotion';
-import { openContactModal } from '../utils/contactForm';
+import { CtaSection } from '../components/about/CtaSection';
 import { getReviewSummary } from '../data/reviewsAdapter';
 import { AUTHORS } from '../data/blogData';
 import googleReviewsRaw from '../data/googleReviews.json';
 import type { GoogleReviewsData } from '../types/reviews';
-import { ShieldCheck, Award, Users, Sparkles, Heart, Coffee, Ship, Anchor } from 'lucide-react';
 
 const ORG_NAME = 'Anhangá Viagens';
 const ORG_URL = 'https://www.anhanga.tur.br/';
@@ -24,8 +24,8 @@ const reviewSummary = getReviewSummary(googleReviewsRaw as GoogleReviewsData);
 
 // FAQ de entidade/confiança — respostas answer-first e verificáveis, o padrão
 // que motores de resposta (ChatGPT, Gemini, Perplexity) extraem para
-// *recomendar* a marca, não só citar fatos. Mantido em sincronia com a seção
-// visível renderizada abaixo e com o FAQPage JSON-LD.
+// *recomendar* a marca, não só citar fatos. A mesma fonte alimenta o FAQPage
+// JSON-LD e a seção visível (TrustFaqSection) — sem drift.
 const TRUST_FAQ_ITEMS = [
   {
     question: 'A Anhangá Viagens é confiável?',
@@ -109,281 +109,13 @@ const About: React.FC = () => {
       />
 
       <div className="container mx-auto px-6">
-        {/* HERO SECTION */}
-        <m.section
-          className="text-center mb-24"
-          initial="hidden"
-          animate="visible"
-          variants={fadeUp}
-          custom={0}
-        >
-          <div className="inline-block relative mb-6">
-            <span className="absolute inset-0 bg-brand-cyan/20 transform -skew-x-12 rounded-lg"></span>
-            <span className="relative px-4 py-1 text-brand-dark font-black uppercase tracking-widest text-sm flex items-center gap-2">
-              <Sparkles className="size-4 text-brand-cyan" /> Nossa Essência
-            </span>
-          </div>
-          <h1 className="text-5xl md:text-6xl font-black text-brand-dark mb-6 leading-tight">
-            Viagens com alma, <br />
-            <span className="text-brand-cyan">
-              design e zero estresse.
-            </span>
-          </h1>
-          <p className="max-w-2xl mx-auto text-zinc-600 text-lg md:text-xl font-medium leading-relaxed mb-8">
-            Na Anhangá Viagens, acreditamos que viajar é mais do que carimbar um passaporte: é sobre colecionar histórias que valem a pena ser contadas.
-          </p>
-          <div className="flex justify-center">
-            <button
-              type="button"
-              onClick={() => openContactModal({ source: 'about' })}
-              className="btn-whatsapp btn-specialist bg-brand-vibrant text-white px-8 py-4 rounded-2xl font-black text-lg shadow-xl shadow-brand-vibrant/20 hover:scale-105 transition-transform active:scale-95 flex items-center gap-3"
-              data-tracking="hero-about"
-            >
-              Solicitar Orçamento
-              <Sparkles className="size-5" />
-            </button>
-          </div>
-        </m.section>
-
-        {/* HISTORIA SECTION */}
-        <section id="nossa-historia" className="mb-32">
-          <div className="flex flex-col lg:flex-row gap-16 items-center">
-            <m.div
-              className="w-full lg:w-1/2"
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true }}
-              variants={fadeUp}
-              custom={1}
-            >
-              <div className="relative">
-                <div className="absolute -top-4 -left-4 size-24 bg-brand-yellow/30 rounded-full blur-2xl z-0"></div>
-                <div className="relative rounded-3xl overflow-hidden border-8 border-white shadow-2xl rotate-2 hover:rotate-0 transition-transform duration-500">
-                  <LazyImage
-                    src="images/about/equipe-anhanga.jpg"
-                    alt="Equipe da Anhangá Viagens planejando um roteiro personalizado"
-                    width={800}
-                    height={600}
-                    className="w-full h-auto object-cover aspect-[4/3]"
-                  />
-                </div>
-                <div className="absolute -bottom-6 -right-6 bg-white p-6 rounded-2xl shadow-xl border border-zinc-100 hidden md:block">
-                  <div className="flex items-center gap-4">
-                    <div className="size-12 bg-brand-cyan/10 rounded-full flex items-center justify-center text-brand-cyan">
-                      <Heart className="size-6 fill-current" />
-                    </div>
-                    <div>
-                      <p className="text-xs font-bold text-zinc-400 uppercase tracking-wider">Paixão por</p>
-                      <p className="text-lg font-black text-brand-dark leading-none">Pessoas</p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </m.div>
-
-            <m.div
-              className="w-full lg:w-1/2"
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true }}
-              variants={fadeUp}
-              custom={2}
-            >
-              <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-6">Nossa História</h2>
-              <div className="space-y-4 text-zinc-600 font-medium leading-relaxed text-lg">
-                <p>
-                  A Anhangá Viagens nasceu em São Paulo com um propósito claro: resgatar o prazer de planejar uma viagem sem as dores de cabeça da burocracia digital e dos roteiros engessados.
-                </p>
-                <p>
-                  Fundada por especialistas apaixonados pelo setor, nossa agência foca no <strong>atendimento consultivo</strong>. Não somos apenas um motor de busca; somos curadores de experiências.
-                </p>
-                <p>
-                  Do primeiro café (virtual ou presencial) até o seu retorno para casa, cuidamos de cada detalhe como se a viagem fosse nossa. É esse cuidado artesanal que nos define.
-                </p>
-              </div>
-            </m.div>
-          </div>
-        </section>
-
-        {/* EXPERTISE SECTION */}
-        <section className="mb-32">
-          <m.div
-            className="text-center mb-16"
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true }}
-            variants={fadeUp}
-            custom={0}
-          >
-            <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Por que viajar com a Anhangá?</h2>
-            <p className="text-zinc-500 font-medium">O que nos torna diferentes no mercado de turismo.</p>
-          </m.div>
-
-          <div className="grid md:grid-cols-3 gap-8">
-            {[
-              {
-                icon: Users,
-                title: "Atendimento Humano",
-                desc: "Nada de bots ou respostas automáticas. Você fala com especialistas que conhecem os destinos de verdade.",
-                color: "bg-orange-100 text-orange-600"
-              },
-              {
-                icon: Sparkles,
-                title: "Curadoria Premium",
-                desc: "Selecionamos hotéis e experiências que fogem do óbvio, garantindo que sua viagem seja única.",
-                color: "bg-brand-cyan/10 text-brand-cyan"
-              },
-              {
-                icon: ShieldCheck,
-                title: "Suporte 24/7",
-                desc: "Durante sua viagem, nossa equipe está a um WhatsApp de distância para resolver qualquer imprevisto.",
-                color: "bg-emerald-100 text-emerald-600"
-              }
-            ].map((item, i) => (
-              <m.div
-                key={item.title}
-                className="bg-white p-10 rounded-[2.5rem] border-2 border-zinc-100 shadow-sm hover:shadow-xl transition duration-300"
-                initial="hidden"
-                whileInView="visible"
-                viewport={{ once: true }}
-                variants={fadeUp}
-                custom={i + 1}
-              >
-                <div className={`size-14 rounded-2xl ${item.color} flex items-center justify-center mb-6`}>
-                  <item.icon className="size-8" />
-                </div>
-                <h3 className="text-xl font-black text-brand-dark mb-4">{item.title}</h3>
-                <p className="text-zinc-500 font-medium leading-relaxed">{item.desc}</p>
-              </m.div>
-            ))}
-          </div>
-        </section>
-
-        {/* TRUST & COMPLIANCE SECTION */}
-        <section id="certificacoes" className="bg-brand-dark rounded-[3rem] p-12 md:p-20 text-white overflow-hidden relative">
-          <div className="absolute top-0 right-0 size-64 bg-brand-vibrant/20 blur-[100px] rounded-full"></div>
-          <div className="absolute bottom-0 left-0 size-64 bg-brand-cyan/10 blur-[100px] rounded-full"></div>
-
-          <div className="relative z-10 flex flex-col lg:flex-row gap-16 items-center">
-            <div className="w-full lg:w-1/2">
-              <div className="inline-flex items-center gap-2 px-4 py-1 bg-white/10 rounded-full text-brand-cyan text-sm font-bold mb-6">
-                <Award className="size-4" /> Credibilidade & Confiança
-              </div>
-              <h2 className="text-3xl md:text-4xl font-black mb-6">Agência Certificada</h2>
-              <p className="text-zinc-300 text-lg font-medium leading-relaxed mb-8">
-                Sua segurança é nossa prioridade. A Anhangá Viagens é uma empresa devidamente registrada nos órgãos competentes, garantindo total conformidade legal para suas férias.
-              </p>
-
-              <ul className="space-y-6">
-                <li className="flex items-start gap-4">
-                  <div className="size-6 rounded-full bg-brand-cyan/20 flex items-center justify-center shrink-0 mt-1">
-                    <div className="size-2 rounded-full bg-brand-cyan"></div>
-                  </div>
-                  <div>
-                    <p className="font-bold text-lg leading-none mb-1">Cadastur Oficial</p>
-                    <p className="text-zinc-400">Registro MTUR: 37.036.732/0001-41</p>
-                  </div>
-                </li>
-                <li className="flex items-start gap-4">
-                  <div className="size-6 rounded-full bg-brand-cyan/20 flex items-center justify-center shrink-0 mt-1">
-                    <div className="size-2 rounded-full bg-brand-cyan"></div>
-                  </div>
-                  <div>
-                    <p className="font-bold text-lg leading-none mb-1">Sede Própria em São Paulo</p>
-                    <p className="text-zinc-400">Av. Dom Pedro I, 773 - Vila Monumento, CEP 01552-001</p>
-                  </div>
-                </li>
-                <li className="flex items-start gap-4">
-                  <div className="size-6 rounded-full bg-anhanga-action/20 flex items-center justify-center shrink-0 mt-1">
-                    <div className="size-2 rounded-full bg-anhanga-action"></div>
-                  </div>
-                  <div>
-                    <p className="font-bold text-lg leading-none mb-1">Agente Credenciado</p>
-                    <p className="text-zinc-400">Beto Carrero World e Hopi Hari</p>
-                  </div>
-                </li>
-                <li className="flex items-start gap-4">
-                  <div className="size-6 rounded-full bg-anhanga-action/20 flex items-center justify-center shrink-0 mt-1">
-                    <div className="size-2 rounded-full bg-anhanga-action"></div>
-                  </div>
-                  <div>
-                    <p className="font-bold text-lg leading-none mb-1">Parceira Norwegian Cruise Line</p>
-                    <p className="text-zinc-400">Cruzeiros nacionais e internacionais (NCL)</p>
-                  </div>
-                </li>
-              </ul>
-            </div>
-
-            <div className="w-full lg:w-1/2 grid grid-cols-2 gap-4">
-              <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
-                <Award className="size-12 text-brand-cyan mb-4" />
-                <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Membro Oficial</p>
-                <p className="font-black text-xl">Beto Carrero World</p>
-                <p className="text-xs text-brand-cyan mt-1">Agente Credenciado</p>
-              </div>
-              <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
-                <Anchor className="size-12 text-anhanga-action mb-4" />
-                <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Membro Oficial</p>
-                <p className="font-black text-xl">Hopi Hari</p>
-                <p className="text-xs text-anhanga-action mt-1">Agente Credenciado</p>
-              </div>
-              <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
-                <Ship className="size-12 text-anhanga-action mb-4" />
-                <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Parceira</p>
-                <p className="font-black text-xl">Norwegian Cruise Line</p>
-                <p className="text-xs text-anhanga-action mt-1">Cruzeiros NCL</p>
-              </div>
-              <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
-                <Coffee className="size-12 text-brand-yellow mb-4" />
-                <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Localizada em</p>
-                <p className="font-black text-xl">São Paulo - SP</p>
-                <p className="text-xs text-brand-yellow mt-1">Atendimento Presencial</p>
-              </div>
-              <div className="col-span-2 bg-white/5 backdrop-blur-sm p-6 rounded-3xl border border-white/10 flex items-center justify-center gap-6">
-                <div className="text-center">
-                  <p className="text-3xl font-black text-brand-vibrant">4.9/5</p>
-                  <p className="text-[10px] font-bold uppercase tracking-widest opacity-50">Avaliação Média</p>
-                </div>
-                <div className="h-10 w-px bg-white/10"></div>
-                <div className="text-center">
-                  <p className="text-3xl font-black text-brand-cyan">100%</p>
-                  <p className="text-[10px] font-bold uppercase tracking-widest opacity-50">Roteiros sob medida</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* TEAM / CONSULTORES SECTION */}
+        <HeroSection />
+        <HistoriaSection />
+        <ExpertiseSection />
+        <TrustSection />
         <ConsultoresSection team={TEAM} />
-
-        {/* FAQ / CONFIANÇA SECTION */}
         <TrustFaqSection items={TRUST_FAQ_ITEMS} />
-
-        {/* CTA */}
-        <m.section
-          className="mt-32 text-center"
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true }}
-          variants={fadeUp}
-        >
-          <div className="bg-brand-cyan/5 rounded-[3rem] p-12 md:p-20 border-2 border-dashed border-brand-cyan/20">
-            <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-6">Pronto para sua próxima história?</h2>
-            <p className="text-zinc-600 text-lg font-medium mb-10 max-w-xl mx-auto">
-              Seja para um festival épico ou um refúgio relaxante, nós desenhamos a viagem perfeita para você.
-            </p>
-            <button
-              type="button"
-              onClick={() => openContactModal({ source: 'about' })}
-              className="btn-whatsapp btn-specialist bg-brand-vibrant text-white px-10 py-5 rounded-2xl font-black text-lg shadow-xl shadow-brand-vibrant/20 hover:scale-105 transition-transform active:scale-95 flex items-center gap-3 mx-auto"
-              data-tracking="footer-about"
-            >
-              Começar Planejamento
-              <Sparkles className="size-5" />
-            </button>
-          </div>
-        </m.section>
+        <CtaSection />
       </div>
     </div>
   );

--- a/tests/about-entity-authority.test.ts
+++ b/tests/about-entity-authority.test.ts
@@ -36,9 +36,21 @@ test('About FAQ de confiança cobre as queries de entidade', async () => {
   const source = await readRepoFile('pages/About.tsx');
   assert.match(source, /é confiável\?/, 'Falta a pergunta "é confiável?"');
   assert.match(source, /registrada no Cadastur\?/, 'Falta a pergunta sobre Cadastur');
-  // O mesmo array alimenta o JSON-LD e a seção visível — sem drift possível.
+  // O mesmo array (TRUST_FAQ_ITEMS) alimenta o JSON-LD e a seção visível — sem
+  // drift possível. O render visível vive em TrustFaqSection (ver teste abaixo).
   assert.match(source, /<FAQPageSchema items=\{TRUST_FAQ_ITEMS\}/);
-  assert.match(source, /TRUST_FAQ_ITEMS\.map/, 'FAQ não é renderizado visivelmente');
+  assert.match(source, /<TrustFaqSection items=\{TRUST_FAQ_ITEMS\}/, 'FAQ visível não recebe a mesma fonte do schema');
+});
+
+test('seções visíveis extraídas renderizam a partir da fonte compartilhada', async () => {
+  const faqSection = await readRepoFile('components/about/TrustFaqSection.tsx');
+  assert.match(faqSection, /items\.map/, 'TrustFaqSection não renderiza os itens');
+  assert.match(faqSection, /item\.question/, 'TrustFaqSection não exibe a pergunta');
+  assert.match(faqSection, /item\.answer/, 'TrustFaqSection não exibe a resposta');
+
+  const consultores = await readRepoFile('components/about/ConsultoresSection.tsx');
+  assert.match(consultores, /team\.map/, 'ConsultoresSection não renderiza os consultores');
+  assert.match(consultores, /member\.social\.instagram \|\| member\.social\.linkedin/, 'guard de social vazio ausente');
 });
 
 test('PersonSchema emite worksFor e id configurável', async () => {

--- a/tests/about-entity-authority.test.ts
+++ b/tests/about-entity-authority.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+// Regressão da estratégia GEO/AEO (docs/seo/geo-content-strategy-2026-07.md):
+// a /sobre é a página-âncora de entidade. Estes testes travam os sinais de
+// confiança que motores de resposta (ChatGPT/Gemini/Perplexity) extraem para
+// *recomendar* a marca: schema de organização com AggregateRating, FAQPage de
+// confiança, Person dos consultores ligados à organização e credenciamentos
+// como fatos verificáveis em texto renderizado (não só imagem).
+
+const readRepoFile = (path: string) => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('About renders the entity/trust JSON-LD schemas', async () => {
+  const source = await readRepoFile('pages/About.tsx');
+  assert.match(source, /<FAQPageSchema\b/, 'FAQPage schema ausente');
+  assert.match(source, /<PersonSchema\b/, 'Person schema ausente');
+  assert.match(source, /<OrganizationSchema[\s\S]*aggregateRating=/, 'AggregateRating não passado ao OrganizationSchema');
+});
+
+test('About Person schemas link consultores à organização (worksFor + id único)', async () => {
+  const source = await readRepoFile('pages/About.tsx');
+  assert.match(source, /worksFor=\{\{\s*name:\s*ORG_NAME/, 'Person schema não define worksFor da organização');
+  assert.match(source, /id=\{`person-\$\{member\.id\}`\}/, 'Person schema precisa de id único por consultor');
+});
+
+test('About expõe credenciamentos como fatos verificáveis em texto', async () => {
+  const source = await readRepoFile('pages/About.tsx');
+  // CNPJ/Cadastur, Hopi Hari e NCL precisam aparecer no conteúdo renderizado.
+  assert.match(source, /37\.036\.732\/0001-41/, 'CNPJ/Cadastur ausente do texto');
+  assert.match(source, /Hopi Hari/, 'Credenciamento Hopi Hari ausente do texto');
+  assert.match(source, /Norwegian Cruise Line/, 'Parceria NCL ausente do texto');
+});
+
+test('About FAQ de confiança cobre as queries de entidade', async () => {
+  const source = await readRepoFile('pages/About.tsx');
+  assert.match(source, /é confiável\?/, 'Falta a pergunta "é confiável?"');
+  assert.match(source, /registrada no Cadastur\?/, 'Falta a pergunta sobre Cadastur');
+  // O mesmo array alimenta o JSON-LD e a seção visível — sem drift possível.
+  assert.match(source, /<FAQPageSchema items=\{TRUST_FAQ_ITEMS\}/);
+  assert.match(source, /TRUST_FAQ_ITEMS\.map/, 'FAQ não é renderizado visivelmente');
+});
+
+test('PersonSchema emite worksFor e id configurável', async () => {
+  const source = await readRepoFile('components/schemas/PersonSchema.tsx');
+  assert.match(source, /worksFor\?:/, 'prop worksFor ausente');
+  assert.match(source, /"worksFor":/, 'worksFor não é emitido no JSON-LD');
+  assert.match(source, /id\s*=\s*"person"/, 'id deve ter default retrocompatível');
+  assert.match(source, /StructuredData id=\{id\}/, 'id não é repassado ao StructuredData');
+});

--- a/tests/static-media-assets.test.ts
+++ b/tests/static-media-assets.test.ts
@@ -16,10 +16,11 @@ function assertMissingHosts(content: string, hosts: string[], label: string): vo
 }
 
 test('core static image sources should not rely on external image CDNs', async () => {
-  const [mediaConfig, mapDestinations, aboutPage, highlights, sitemap] = await Promise.all([
+  const [mediaConfig, mapDestinations, aboutPage, aboutHistoria, highlights, sitemap] = await Promise.all([
     readRepoFile('data/mediaConfig.ts'),
     readRepoFile('data/mapDestinations.ts'),
     readRepoFile('pages/About.tsx'),
+    readRepoFile('components/about/HistoriaSection.tsx'),
     readRepoFile('components/Highlights.tsx'),
     readRepoFile('public/sitemap.xml'),
   ]);
@@ -43,7 +44,14 @@ test('core static image sources should not rely on external image CDNs', async (
     ['images.pexels.com'],
     'pages/About.tsx',
   );
-  assert.match(aboutPage, /images\/about\/.+\.(jpg|jpeg|webp)/);
+  // A imagem local da /sobre vive na HistoriaSection (extraída de About.tsx
+  // na composição enxuta — ver components/about/).
+  assertMissingHosts(
+    aboutHistoria,
+    ['images.pexels.com'],
+    'components/about/HistoriaSection.tsx',
+  );
+  assert.match(aboutHistoria, /images\/about\/.+\.(jpg|jpeg|webp)/);
 
   assertMissingHosts(
     highlights,


### PR DESCRIPTION
## Contexto

Implementa o **apêndice de entidade** do `docs/seo/geo-content-strategy-2026-07.md` na `pages/About.tsx`. A `/sobre` é a página-âncora que LLMs (ChatGPT/Gemini/Perplexity) consultam para entender e **recomendar** a marca — não só citar fatos. O objetivo é expor os sinais de confiança estruturados e em texto.

## Mudanças

- **`OrganizationSchema` com `aggregateRating`** — via `getReviewSummary` + `googleReviews.json` (mesmo padrão da Home).
- **`FAQPageSchema` de confiança** — 5 perguntas answer-first ("é confiável?", "registrada no Cadastur?", "credenciamentos?", "como funciona o atendimento?", "sede física?") **+ seção visível** `#perguntas-frequentes`. Ambas alimentadas pelo mesmo `TRUST_FAQ_ITEMS` (sem drift entre JSON-LD e texto).
- **2 `PersonSchema`** (Felipe William, Queila) com `worksFor`→Anhangá + `sameAs` social + seção visível `#consultores` (E-E-A-T).
- **Credenciamentos como texto verificável** — Hopi Hari + Norwegian Cruise Line adicionados à seção de confiança e ao FAQ (antes só Beto Carrero + Cadastur eram visíveis).
- **`PersonSchema`** ganha props opcionais `id` (chave única do head tag, evita colisão entre 2 Person) e `worksFor` — retrocompatível com o uso no blog.
- Ícones sociais via `@phosphor-icons/react` (`InstagramLogo`/`LinkedinLogo`) — lucide-react desta versão não exporta os brand icons.

## Testes

- `pnpm typecheck` limpo
- `pnpm test:regression` — 793 testes passam (incl. novo `tests/about-entity-authority.test.ts` e o ratchet `brand-*`: markup novo usa `anhanga-*`)
- `pnpm build` prerenderiza `/sobre` sem erro; JSON-LD confirmado no HTML estático (TravelAgency+AggregateRating, FAQPage 5x, 2 Person com worksFor/sameAs) + fatos Hopi Hari/NCL/Cadastur em texto

## Notas / fora de escopo (do próprio doc)

- **AggregateRating thin** hoje (2 reviews / 5.0) — consistente com a Home; ganha peso com mais reviews.
- **NCL não entrou no `memberOf` do schema** (só Beto Carrero + Hopi Hari) — decisão semântica: parceria ≠ membership. Fica no texto/FAQ.
- **Off-site/futuro**: knowledge graph (Wikidata/Crunchbase) e baseline de citação multiplataforma ("Ação zero" do doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)