### PR TITLE
feat(ci): Claude Code como reviewer automático de PR

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,6 +9,8 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
 
 jobs:
   claude:
@@ -42,7 +44,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
+        uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1.0.165
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -57,3 +59,56 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
+
+  claude-review:
+    # Substitui o Gemini Code Assist (descontinuado) como reviewer automático de PR.
+    # Restrito a autores confiáveis e a PRs não-draft para não gastar créditos à toa.
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      (
+        github.event.pull_request.user.login == github.repository_owner ||
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1.0.165
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          additional_permissions: |
+            actions: read
+
+          # Uma review consolidada por push, não um comentário novo a cada commit
+          use_sticky_comment: true
+          # Filtra comentários de teste/sonda antes de postar inline
+          classify_inline_comments: true
+
+          prompt: |
+            Revise este pull request como reviewer automático deste repositório.
+
+            Leia primeiro os padrões do projeto antes de avaliar o diff:
+            - docs/standards/code-style.md, testing.md, api-conventions.md, security.md
+            - .claude/rules/ (mesmas regras, aplicadas via CLAUDE.md)
+
+            Foque em, nesta ordem de prioridade:
+            1. Bugs de correção, regressões e edge cases não tratados
+            2. Riscos de segurança: validação/sanitização de input, secrets, verificação de webhooks, rate limiting
+            3. Violação de convenções documentadas (ex.: lógica de handler fora de api/, helpers duplicados em vez de reuso de lib/ e services/, resposta fora do formato { ok, code?, error?, data? })
+            4. Mudança de comportamento sem teste automatizado correspondente (docs/standards/testing.md)
+
+            Não repita o que já é coberto por lint, typecheck ou CI. Não comente sobre estilo já garantido por ferramentas automatizadas. Poste um resumo curto e comentários inline apenas onde houver um problema real e acionável — prefira silêncio a ruído.
+
+          claude_args: |
+            --max-turns 15

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,7 @@ jobs:
       pull-requests: write
       issues: write
       actions: read # Required for Claude to read CI results on PRs
+      id-token: write # Required to exchange an OIDC token for the claude[bot] GitHub App token
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -76,6 +77,7 @@ jobs:
       pull-requests: write
       issues: read
       actions: read
+      id-token: write # Required to exchange an OIDC token for the claude[bot] GitHub App token
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Resumo
- Adiciona job `claude-review` em `.github/workflows/claude.yml`, disparado em `pull_request: [opened, synchronize, ready_for_review]`, para substituir o Gemini Code Assist (descontinuado em ~2 semanas) como reviewer automático.
- Restrito a autores confiáveis (`OWNER`/`MEMBER`/`COLLABORATOR`) e PRs não-draft, para evitar gasto de créditos em PRs externos.
- Usa `use_sticky_comment: true` (uma review consolidada por push) e `classify_inline_comments` (filtra comentários de teste/sonda).
- Prompt de review referencia `docs/standards/` e `.claude/rules/` como fonte de verdade do projeto.
- Bump do `claude-code-action` pinado de `v1.0.159` → `v1.0.165` em ambos os jobs (SHA de commit verificado via API do GitHub, não apenas a tag).

## Não incluído (follow-up necessário)
`pr-babysit/SKILL.md` e o CLAUDE.md (seção "Fluxo de PR") hoje esperam explicitamente por reviews do `gemini-code-assist` para considerar uma PR pronta. O novo reviewer comenta sob outra identidade (GitHub App do Claude / `github-actions[bot]`), então depois que o Gemini for desligado essas referências precisam ser atualizadas — fora do escopo desta mudança pontual.

## Test plan
- [ ] YAML validado localmente (js-yaml) — OK
- [ ] Inputs do action (`use_sticky_comment`, `classify_inline_comments`, `additional_permissions`, `prompt`, `claude_args`) conferidos contra o `action.yml` real da tag `v1.0.165` — OK
- [ ] Confirmar em um PR real que o job `claude-review` dispara e posta a review (só validável após merge, já que o workflow roda a partir do estado do branch alvo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)