### PR TITLE
fix(ci): claude-review posta comentário de review na PR

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -92,6 +92,12 @@ jobs:
           additional_permissions: |
             actions: read
 
+          # Força modo "tag" com comment tracking. Sem isso, o `prompt` abaixo
+          # ativa o modo "agent", que não instala nenhuma ferramenta de escrita
+          # no GitHub por padrão — a review rodava com sucesso mas não postava
+          # nada visível na PR (issue #1087).
+          track_progress: true
+
           # Uma review consolidada por push, não um comentário novo a cada commit
           use_sticky_comment: true
           # Filtra comentários de teste/sonda antes de postar inline
@@ -114,3 +120,4 @@ jobs:
 
           claude_args: |
             --max-turns 15
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## Resumo

Corrige o bug descrito na #1087: o job `claude-review` rodava com sucesso (`num_turns > 0`, custo cobrado) mas nunca postava nenhum comentário/review visível na PR, com `permission_denials_count: 1` no resultado.

## Causa raiz

O `prompt` custom passado ao `claude-code-action` no job `claude-review` ativa o modo **"agent"** da action (em vez do modo "tag"). Modo agent:
- **não** instala o servidor MCP `github_comment` (usado por `update_claude_comment`) a menos que a tool esteja explicitamente em `--allowedTools`
- **não** instala o servidor MCP `github_inline_comment` pelo mesmo motivo
- não tem nenhum mecanismo de "sticky comment"/tracking comment (isso só existe no modo tag)

Ou seja: mesmo com `use_sticky_comment: true` e `classify_inline_comments: true` configurados, nenhum dos dois fazia efeito, porque o modo agent não usa esse mecanismo. Claude ficava sem nenhuma ferramenta de escrita no GitHub — a única tentativa de escrita (provavelmente via `Bash(gh pr comment ...)`) foi negada pelo permission system headless (sem prompt interativo = deny), o que bate com `permission_denials_count: 1`.

Confirmado lendo o código-fonte do `anthropics/claude-code-action` (`src/modes/detector.ts`, `src/modes/agent/index.ts`, `src/mcp/install-mcp-server.ts`, `src/modes/tag/index.ts`) e comparando com o exemplo oficial `examples/pr-review-comprehensive.yml`, que usa exatamente `track_progress: true` para este cenário.

## Fix

- `track_progress: true` — força modo "tag", que inclui `mcp__github_comment__update_claude_comment` incondicionalmente (usado internamente pelo `use_sticky_comment`).
- `--allowedTools "mcp__github_inline_comment__create_inline_comment"` em `claude_args` — no modo tag, tools `mcp__github_*` do `claude_args` do usuário são mescladas na lista interna da action (`tagModeTools`), então isso habilita tanto a permissão quanto a instalação do servidor MCP de comentário inline.

Não foi necessário adicionar `Bash(gh pr diff/view/comment)` como no exemplo oficial: o modo tag já busca o diff/arquivos alterados da PR via GraphQL e injeta no contexto do prompt automaticamente, e a postagem do resumo é feita via `update_claude_comment`, não via `gh` CLI.

## Test plan

- [ ] Confirmar que o job `claude-review` roda nesta própria PR (evento `pull_request: opened`)
- [ ] Confirmar que um comentário sticky (resumo) aparece na PR, criado pelo bot `claude`
- [ ] Se houver achados, confirmar que comentários inline aparecem no diff
- [ ] Confirmar que o job `claude` (modo `@claude` mention) continua funcionando normalmente (não foi tocado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)