### PR TITLE
fix(sobre): TrustSection sem padrões banidos, presença do público corporativo e drift de consistência

### DIFF
--- a/.impeccable/critique/2026-07-05T03-10-56Z__pages-about-tsx.md
+++ b/.impeccable/critique/2026-07-05T03-10-56Z__pages-about-tsx.md
@@ -1,0 +1,103 @@
+---
+target: "página sobre (pages/About.tsx) — foco P2 pós PR #1086"
+total_score: 26
+p0_count: 0
+p1_count: 2
+timestamp: 2026-07-05T03-10-56Z
+slug: pages-about-tsx
+---
+Method: dual-agent (A: a1a9d4b6eea9ee411 · B: a9f8c45b07ebe5af6)
+⚠️ Browser evidence unavailable this session (no Chrome/Playwright/computer-use tool exposed to either assessment) — both assessments ran as genuinely isolated sub-agents from source code + a clean deterministic scan. Findings below were cross-verified with exact file:line citations from both sides.
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 2 | Button press-down exists, but no visible feedback for `openContactModal()` beyond the click itself |
+| 2 | Match System / Real World | 3 | Concrete real facts (CNPJ, endereço, sócios) match trust criteria; undercut by templated phrasing ("não somos apenas X, somos Y") |
+| 3 | User Control and Freedom | 3 | Hash deep-links to 4 sections with smooth scroll; no traps |
+| 4 | Consistency and Standards | 2 | 2 icon libraries, `brand-*`/`anhanga-*` mixed in the *same file* (`TrustSection.tsx`), 2 badge shapes |
+| 5 | Error Prevention | 3 | No forms on this page; little surface to break |
+| 6 | Recognition Rather Than Recall | 3 | Section headers + badges aid scanning |
+| 7 | Flexibility and Efficiency | 2 | Reduced-motion now respected (fixed); no other efficiency features expected for this page type |
+| 8 | Aesthetic and Minimalist Design | 1 | Blur blobs, glass cards on dark bg, stat tile, rainbow icon cards, borders on every card — the system's own "peso físico só onde se age" principle broken repeatedly |
+| 9 | Error Recovery | 3 | N/A — no error states on this static page |
+| 10 | Help and Documentation | 4 | FAQ is genuine embedded trust documentation, answer-first, verifiable, feeds JSON-LD |
+| **Total** | | **26/40** | **Acceptable — same total as the previous run, despite the 3 P1 fixes** |
+
+**Why the score didn't move**: the last commit (`a81ccf0`) fixed 3 real P1s (bot contradiction, non-signature CTA, motion/no-JS gating) — confirmed still fixed. But this deeper pass surfaced that `TrustSection.tsx` alone concentrates nearly every pattern DESIGN.md explicitly bans, which the prior critique undercounted. Heuristic #8 (Aesthetic/Minimalist) dropping to 1/4 offset the gains elsewhere.
+
+## Anti-Patterns Verdict
+
+**LLM assessment**: Meaningfully de-slopped from before (verified: `ExpertiseSection.tsx:10` no longer contradicts the FAQ; both real CTAs now use the signature `variant="cta"` amber/shadow-hard button; `MotionConfig reducedMotion="user"` + `<noscript>` fallback are in place). But `TrustSection.tsx` — the page's single highest-stakes "prove we're trustworthy" section — still reads as a generic SaaS credentials panel: two decorative `blur-[100px]` blobs, five `bg-white/5 backdrop-blur-sm border border-white/10` glass tiles used as isolated cards on a dark background (DESIGN.md forbids this explicitly: *"Em contexto dark, não usar cards isolados"*), and a `4.9/5 + 100%` stat tile that is structurally identical to the banned hero-metric template even though it isn't on a literal gradient.
+
+**Deterministic scan**: `detect.mjs --json pages/About.tsx components/about/` → exit 0, zero findings. As before, the generic ruleset (gradient text, side-stripe borders, eyebrows, numbered scaffolding) doesn't check this project's own DESIGN.md rules. Manual review (Assessment B) found, with exact file:line evidence:
+- **Card borders on every card-like container** — `ExpertiseSection.tsx:46`, `ConsultoresSection.tsx:34`, `TrustFaqSection.tsx:36`, `HistoriaSection.tsx:30`, `TrustSection.tsx:63/69/75/81/87` (×5, border-only, no shadow at all), `CtaSection.tsx:17` — directly against *"Border: Nenhuma... nunca border."*
+- **Four different corner radii** in the same page composition: `rounded-2xl`, `rounded-3xl`, `rounded-[2.5rem]`, `rounded-[3rem]` — none of the card containers actually use the documented `rounded-2xl` standard.
+- **Legacy `brand-*` tokens** (explicitly commented `LEGADO — não usar em código novo` in `tailwind.config.mjs`) still used 14+ times, concentrated in `TrustSection.tsx`, which mixes `brand-*` and `anhanga-*` *in the same file* for the same visual role — a half-migrated component, not a stale leftover.
+- **Off-palette colors**: `bg-orange-100`/`text-orange-600`, `bg-emerald-100`/`text-emerald-600` in `ExpertiseSection.tsx:11,23` — neither color exists anywhere in the documented palette.
+- **`tracking-tighter` on 4 uppercase labels** in `TrustSection.tsx:65,71,77,83`, directly contradicting the Label token's `0.1em` spec — and inconsistent within the same file, since lines 90/95 correctly use `tracking-widest`.
+
+**Visual overlays**: Not available — no browser/screenshot/JS-execution tool was exposed to either assessment this session. Nothing here is a live-render claim.
+
+## Overall Impression
+
+The three P1s from the last run are genuinely fixed — that work held up under a fresh, independent re-check. But this pass went one section deeper and found that `TrustSection.tsx` — precisely the section whose job is proving the agency is trustworthy and not a cold, templated operation — is the most template-coded part of the entire page. It also surfaced something the prior run missed entirely: the "Corporativo/eventos" segment that PRODUCT.md names as one of exactly two user segments has zero presence anywhere on `/sobre`. The P2 cluster (borders, radii, token drift, off-palette color, touch targets, dual icon libraries) is real and adds up, but it's `TrustSection.tsx`'s concentration of banned patterns that should be fixed first — it's the one place where "looks AI-generated" and "undermines the page's actual job" are the same finding.
+
+## What's Working
+
+1. **`TrustFaqSection` + shared `TRUST_FAQ_ITEMS`** (`About.tsx:30-56`) — answer-first, single source of truth feeding both the visible FAQ and `FAQPageSchema` JSON-LD. Concrete, checkable claims (CNPJ, endereço, sócios nomeados) instead of generic trust badges — genuinely strong GEO + human-trust writing at once.
+2. **Named `Person` entities in `ConsultoresSection`** — real consultants, bios, socials, directly operationalizing "acolhedora e pessoal" and countering the "luxo frio impessoal" anti-reference.
+3. **Real edge-case care**: hash deep-linking with a settle timer before `scrollIntoView` (`About.tsx:64-77`), and a deliberate `<noscript>` CSS override for no-JS (`About.tsx:81-90`) — the kind of correctness work a templated page usually skips.
+
+## Priority Issues
+
+**[P1] `TrustSection.tsx` concentrates nearly every pattern DESIGN.md explicitly bans, in the page's highest-stakes section.**
+Why it matters: this is the section whose entire job is proving the agency isn't a cold, generic operation — and it's currently the most SaaS-template-coded part of the page (2 decorative blur blobs, 5 isolated glass cards on a dark background, a hero-metric stat tile, mixed legacy/current color tokens in the same file, `tracking-tighter` labels against spec, and pure white text where the "Regra do Branco Rebaixado" requires `white/90`).
+Fix: remove the two blur blobs (lines 9-10); replace the 5 glass-panel tiles with the documented "seção com fundo próprio" pattern instead of isolated dark-context cards; fold the 4.9/5 + 100% stat pair into running text or the bulleted list rather than a boxed tile; migrate every `brand-*` class in this file to `anhanga-*`; fix the 4 `tracking-tighter` labels to `tracking-[0.1em]`; change `text-white` to `text-white/90`.
+Suggested command: `/impeccable distill` then `/impeccable colorize`
+
+**[P1] The "Corporativo/eventos" segment — one of PRODUCT.md's exactly two named user segments — has zero presence on `/sobre`.**
+Why it matters: every section (Historia, Expertise, Trust's credentials, Consultores, FAQ) speaks only to the leisure segment (Beto Carrero, Hopi Hari, NCL). A corporate/events decision-maker vetting the agency before a group trip or incentive event finds no relevant credential, no case study, and no signposted path to `/corporativo` — the page silently fails half its own named audience.
+Fix: add one FAQ item or Trust bullet addressing group/corporate capability, or route that persona toward `/corporativo` from the CTA copy.
+Suggested command: `/impeccable clarify`
+
+**[P2] Card border rule and corner-radius inconsistency, stacked across every section.**
+Every card-like container on the page has a border (`ExpertiseSection.tsx:46`, `ConsultoresSection.tsx:34`, `TrustFaqSection.tsx:36`, `HistoriaSection.tsx:30`, `TrustSection.tsx` ×5, `CtaSection.tsx:17`) despite DESIGN.md's explicit "Border: Nenhuma." Radii fragment into four different values (`rounded-2xl`/`rounded-3xl`/`rounded-[2.5rem]`/`rounded-[3rem]`) with none using the documented 16px standard.
+Why it matters: individually small, but stacked across 6 components it's the clearest "assembled in separate passes, never swept for consistency" tell — and it directly contradicts the system's own flagship card rule.
+Fix: drop borders everywhere, rely on `shadow-float` + tonalized backgrounds per spec; standardize all card radii to `rounded-2xl`.
+Suggested command: `/impeccable polish`
+
+**[P2] Token and palette drift: legacy `brand-*` classes, off-palette colors, dual icon libraries.**
+14+ legacy `brand-*` occurrences remain (explicitly marked "LEGADO — não usar em código novo" in `tailwind.config.mjs`), concentrated in a half-migrated `TrustSection.tsx` that mixes `brand-*` and `anhanga-*` for the identical bullet-dot role in the same list. `ExpertiseSection.tsx` uses off-palette `orange-100`/`emerald-100` tints that exist nowhere in the documented palette. Two icon libraries (`lucide-react` + `@phosphor-icons/react`) load simultaneously for one page.
+Why it matters: this is the exact kind of unmanaged sprawl `tests/tailwind-brand-namespace-guard.test.ts` exists to prevent elsewhere in the codebase — `/sobre` appears to have been built or edited before/outside that migration.
+Fix: migrate all `brand-*` → `anhanga-*` tokens in `components/about/`; replace `orange-100`/`emerald-100` with palette-consistent tints; standardize on one icon library (likely `lucide-react`, used in 5 of 7 files).
+Suggested command: `/impeccable polish`
+
+**[P2] Accessibility and motion details: sub-44px touch targets, no FAQ progressive disclosure, a stagger-delay bug.**
+`ConsultoresSection.tsx:62,73`'s Instagram/LinkedIn links are `size-9` (36px), under the 44×44px minimum for real interactive elements. `TrustFaqSection.tsx:32-47` renders all 5 FAQ answers fully expanded with no accordion — directly against PRODUCT.md's own "baixa carga cognitiva" note for the mobile-at-night persona. Separately: `CtaSection.tsx` is the only animated section missing the `custom={i}` prop every sibling section passes to `fadeUp`'s variants (`aboutMotion.ts:10` computes `delay: i * 0.1`), meaning `i` is `undefined` there and the delay resolves to `NaN` — a real, if minor, motion bug.
+Why it matters: the touch targets and FAQ density work directly against the stated mobile-first, low-cognitive-load design principle; the NaN delay is a small correctness bug in an otherwise-consistent animation API.
+Fix: bump social icons to `size-11`; convert the FAQ to an accordion; pass `custom={i}` to `CtaSection`'s motion wrapper.
+Suggested command: `/impeccable harden`
+
+## Persona Red Flags
+
+**Jordan (confused first-timer, leisure family, mobile, at night, deciding "em quem confiar?")**: The Hero's opening line breaks the brand's mandated second-person voice ("Na Anhangá Viagens, acreditamos que..." instead of addressing "você" directly) at the exact moment Jordan most needs to feel personally addressed. Scrolling further, she hits `TrustSection`'s dark glass-panel "dashboard" with a 4.9/5 stat tile — visually closer to a SaaS pricing page than "conversa, não transação." If she wants one specific FAQ answer, she must scroll past 4 other fully-expanded paragraphs first.
+
+**Corporativo buyer (PRODUCT.md's own named second segment — empresas/grupos, eventos, incentivo)**: Finds only leisure-tourism credentials (Cadastur, Beto Carrero, Hopi Hari, NCL) in Trust; the FAQ's "how service works" answer is framed entirely around one traveler's personal itinerary; both CTAs ("Solicitar Orçamento," "Começar Planejamento") read as individual-traveler asks with no link toward `/corporativo`. This segment is invisible on its own agency's About page.
+
+**Riley (stress-tester, screen reader/keyboard, inspects edge cases)**: 36px social-link touch targets fail the 44px floor immediately. Decorative icons (Sparkles, ShieldCheck, Heart, Award, Anchor, Ship, Coffee) carry no `aria-hidden="true"` across any file, so a screen reader announces redundant icon noise around every heading. `CtaSection`'s missing `custom={i}` prop produces a `NaN` animation delay — the one broken instance in an otherwise-consistent motion contract.
+
+## Minor Observations
+
+- H1 (`HeroSection.tsx:23`) uses `leading-tight` (1.25) with no tracking utility — DESIGN.md's Display token specifies `line-height 0.9`, `letter-spacing -0.02em`; neither is hit.
+- All `<h2>` section headings use `font-black` (900) at fixed Tailwind sizes, not the documented Headline token (weight 800, fluid `clamp(1.5rem,3vw,2.5rem)`).
+- `TrustSection.tsx` is the only section with no scroll-reveal wrapper at all (every sibling uses `initial="hidden" whileInView="visible"`) — breaks the page's otherwise-consistent animation rhythm right at its highest-stakes section.
+- `opacity-50` on small labels sitting on `bg-white/5 backdrop-blur-sm` panels in `TrustSection.tsx` is worth a real contrast check once browser tooling is available — at 14px bold this sits right at the WCAG large-text threshold.
+- The same four credential facts (Cadastur, Beto Carrero, Hopi Hari, NCL) are repeated near-verbatim in three places (bullets → card grid → FAQ) — good for GEO extraction, redundant for a human reading start to finish.
+
+## Questions to Consider
+
+1. If "Border: Nenhuma" is the design system's single loudest card rule, and every card on this page has one, was that rule ever actually enforced anywhere — or is `/sobre` the first place someone looked closely enough to notice?
+2. `TrustSection` is the only section not wrapped in scroll-reveal, and the only file mixing `brand-*` and `anhanga-*` tokens for the same role — was it built in a different pass than the rest of the page?
+3. PRODUCT.md names two user segments with equal weight. If a corporate/events prospect can read the entire About page and find zero evidence the agency serves that segment, is `/sobre` actually the company's About page, or quietly just the leisure family's About page?

--- a/components/about/ConsultoresSection.tsx
+++ b/components/about/ConsultoresSection.tsx
@@ -31,7 +31,7 @@ export const ConsultoresSection: React.FC<ConsultoresSectionProps> = ({ team }) 
       {team.map((member, i) => (
         <m.div
           key={member.id}
-          className="bg-white p-8 rounded-[2.5rem] border-2 border-zinc-100 shadow-sm hover:shadow-xl transition duration-300 flex flex-col sm:flex-row items-center sm:items-start gap-6 text-center sm:text-left"
+          className="bg-white p-8 rounded-2xl shadow-float hover:shadow-float-lg transition duration-300 flex flex-col sm:flex-row items-center sm:items-start gap-6 text-center sm:text-left"
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true }}
@@ -59,9 +59,9 @@ export const ConsultoresSection: React.FC<ConsultoresSectionProps> = ({ team }) 
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label={`Instagram de ${member.name}`}
-                    className="size-9 rounded-full bg-anhanga-action/10 text-anhanga-action flex items-center justify-center hover:bg-anhanga-action hover:text-white transition-colors"
+                    className="size-11 rounded-full bg-anhanga-action/10 text-anhanga-action flex items-center justify-center hover:bg-anhanga-action hover:text-white transition-colors"
                   >
-                    <InstagramLogo className="size-4" weight="fill" />
+                    <InstagramLogo className="size-4" weight="fill" aria-hidden="true" />
                   </a>
                 )}
                 {member.social.linkedin && (
@@ -70,9 +70,9 @@ export const ConsultoresSection: React.FC<ConsultoresSectionProps> = ({ team }) 
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label={`LinkedIn de ${member.name}`}
-                    className="size-9 rounded-full bg-anhanga-action/10 text-anhanga-action flex items-center justify-center hover:bg-anhanga-action hover:text-white transition-colors"
+                    className="size-11 rounded-full bg-anhanga-action/10 text-anhanga-action flex items-center justify-center hover:bg-anhanga-action hover:text-white transition-colors"
                   >
-                    <LinkedinLogo className="size-4" weight="fill" />
+                    <LinkedinLogo className="size-4" weight="fill" aria-hidden="true" />
                   </a>
                 )}
               </div>

--- a/components/about/CtaSection.tsx
+++ b/components/about/CtaSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { m } from 'framer-motion';
+import { Link } from 'react-router-dom';
 import { Sparkles } from 'lucide-react';
 import { openContactModal } from '../../utils/contactForm';
 import { Button } from '../ui/Button';
@@ -13,9 +14,10 @@ export const CtaSection: React.FC = () => (
     whileInView="visible"
     viewport={{ once: true }}
     variants={fadeUp}
+    custom={0}
   >
-    <div className="bg-brand-cyan/5 rounded-[3rem] p-12 md:p-20 border-2 border-dashed border-brand-cyan/20">
-      <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-6">Pronto para sua próxima história?</h2>
+    <div className="bg-anhanga-action/5 rounded-[3rem] p-12 md:p-20">
+      <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6">Pronto para sua próxima história?</h2>
       <p className="text-zinc-600 text-lg font-medium mb-10 max-w-xl mx-auto">
         Seja para um festival épico ou um refúgio relaxante, nós desenhamos a viagem perfeita para você.
       </p>
@@ -25,12 +27,18 @@ export const CtaSection: React.FC = () => (
           size="lg"
           onClick={() => openContactModal({ source: 'about' })}
           className="btn-whatsapp btn-specialist font-black"
-          rightIcon={<Sparkles className="size-5" />}
+          rightIcon={<Sparkles className="size-5" aria-hidden="true" />}
           data-tracking="footer-about"
         >
           Começar Planejamento
         </Button>
       </div>
+      <p className="mt-6 text-sm text-zinc-500 font-medium">
+        Viagem corporativa ou em grupo?{' '}
+        <Link to="/corporativo" className="text-anhanga-action font-bold hover:underline">
+          Conheça o atendimento para empresas
+        </Link>
+      </p>
     </div>
   </m.section>
 );

--- a/components/about/ExpertiseSection.tsx
+++ b/components/about/ExpertiseSection.tsx
@@ -8,19 +8,19 @@ const EXPERTISE_ITEMS = [
     icon: Users,
     title: 'Atendimento Humano',
     desc: 'O chat com IA no site faz a triagem inicial, mas quem desenha seu roteiro é sempre um especialista humano.',
-    color: 'bg-orange-100 text-orange-600',
+    color: 'bg-anhanga-action/10 text-anhanga-action',
   },
   {
     icon: Sparkles,
     title: 'Curadoria Premium',
     desc: 'Selecionamos hotéis e experiências que fogem do óbvio, garantindo que sua viagem seja única.',
-    color: 'bg-brand-cyan/10 text-brand-cyan',
+    color: 'bg-anhanga-blue/10 text-anhanga-blue',
   },
   {
     icon: ShieldCheck,
     title: 'Suporte 24/7',
     desc: 'Durante sua viagem, nossa equipe está a um WhatsApp de distância para resolver qualquer imprevisto.',
-    color: 'bg-emerald-100 text-emerald-600',
+    color: 'bg-anhanga-action/10 text-anhanga-action',
   },
 ];
 
@@ -35,7 +35,7 @@ export const ExpertiseSection: React.FC = () => (
       variants={fadeUp}
       custom={0}
     >
-      <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-4">Por que viajar com a Anhangá?</h2>
+      <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4">Por que viajar com a Anhangá?</h2>
       <p className="text-zinc-500 font-medium">O que nos torna diferentes no mercado de turismo.</p>
     </m.div>
 
@@ -43,7 +43,7 @@ export const ExpertiseSection: React.FC = () => (
       {EXPERTISE_ITEMS.map((item, i) => (
         <m.div
           key={item.title}
-          className="bg-white p-10 rounded-[2.5rem] border-2 border-zinc-100 shadow-sm hover:shadow-xl transition duration-300"
+          className="bg-white p-10 rounded-2xl shadow-float hover:shadow-float-lg transition duration-300"
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true }}
@@ -51,9 +51,9 @@ export const ExpertiseSection: React.FC = () => (
           custom={i + 1}
         >
           <div className={`size-14 rounded-2xl ${item.color} flex items-center justify-center mb-6`}>
-            <item.icon className="size-8" />
+            <item.icon className="size-8" aria-hidden="true" />
           </div>
-          <h3 className="text-xl font-black text-brand-dark mb-4">{item.title}</h3>
+          <h3 className="text-xl font-black text-anhanga-dark mb-4">{item.title}</h3>
           <p className="text-zinc-500 font-medium leading-relaxed">{item.desc}</p>
         </m.div>
       ))}

--- a/components/about/HeroSection.tsx
+++ b/components/about/HeroSection.tsx
@@ -15,14 +15,14 @@ export const HeroSection: React.FC = () => (
     custom={0}
   >
     <div className="inline-block relative mb-6">
-      <span className="absolute inset-0 bg-brand-cyan/20 transform -skew-x-12 rounded-lg"></span>
-      <span className="relative px-4 py-1 text-brand-dark font-black uppercase tracking-widest text-sm flex items-center gap-2">
-        <Sparkles className="size-4 text-brand-cyan" /> Nossa Essência
+      <span className="absolute inset-0 bg-anhanga-action/20 transform -skew-x-12 rounded-lg"></span>
+      <span className="relative px-4 py-1 text-anhanga-dark font-black uppercase tracking-widest text-sm flex items-center gap-2">
+        <Sparkles className="size-4 text-anhanga-action" aria-hidden="true" /> Nossa Essência
       </span>
     </div>
-    <h1 className="text-5xl md:text-6xl font-black text-brand-dark mb-6 leading-tight">
+    <h1 className="text-5xl md:text-6xl font-black text-anhanga-dark mb-6 leading-tight">
       Viagens com alma, <br />
-      <span className="text-brand-cyan">
+      <span className="text-anhanga-action">
         design e zero estresse.
       </span>
     </h1>
@@ -35,7 +35,7 @@ export const HeroSection: React.FC = () => (
         size="lg"
         onClick={() => openContactModal({ source: 'about' })}
         className="btn-whatsapp btn-specialist font-black"
-        rightIcon={<Sparkles className="size-5" />}
+        rightIcon={<Sparkles className="size-5" aria-hidden="true" />}
         data-tracking="hero-about"
       >
         Solicitar Orçamento

--- a/components/about/HistoriaSection.tsx
+++ b/components/about/HistoriaSection.tsx
@@ -17,7 +17,7 @@ export const HistoriaSection: React.FC = () => (
         custom={1}
       >
         <div className="relative">
-          <div className="absolute -top-4 -left-4 size-24 bg-brand-yellow/30 rounded-full blur-2xl z-0"></div>
+          <div className="absolute -top-4 -left-4 size-24 bg-anhanga-yellow/30 rounded-full blur-2xl z-0"></div>
           <div className="relative rounded-3xl overflow-hidden border-8 border-white shadow-2xl rotate-2 hover:rotate-0 transition-transform duration-500">
             <LazyImage
               src="images/about/equipe-anhanga.jpg"
@@ -27,14 +27,14 @@ export const HistoriaSection: React.FC = () => (
               className="w-full h-auto object-cover aspect-[4/3]"
             />
           </div>
-          <div className="absolute -bottom-6 -right-6 bg-white p-6 rounded-2xl shadow-xl border border-zinc-100 hidden md:block">
+          <div className="absolute -bottom-6 -right-6 bg-white p-6 rounded-2xl shadow-float-lg hidden md:block">
             <div className="flex items-center gap-4">
-              <div className="size-12 bg-brand-cyan/10 rounded-full flex items-center justify-center text-brand-cyan">
-                <Heart className="size-6 fill-current" />
+              <div className="size-12 bg-anhanga-action/10 rounded-full flex items-center justify-center text-anhanga-action">
+                <Heart className="size-6 fill-current" aria-hidden="true" />
               </div>
               <div>
                 <p className="text-xs font-bold text-zinc-400 uppercase tracking-wider">Paixão por</p>
-                <p className="text-lg font-black text-brand-dark leading-none">Pessoas</p>
+                <p className="text-lg font-black text-anhanga-dark leading-none">Pessoas</p>
               </div>
             </div>
           </div>
@@ -49,7 +49,7 @@ export const HistoriaSection: React.FC = () => (
         variants={fadeUp}
         custom={2}
       >
-        <h2 className="text-3xl md:text-4xl font-black text-brand-dark mb-6">Nossa História</h2>
+        <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6">Nossa História</h2>
         <div className="space-y-4 text-zinc-600 font-medium leading-relaxed text-lg">
           <p>
             A Anhangá Viagens nasceu em São Paulo com um propósito claro: resgatar o prazer de planejar uma viagem sem as dores de cabeça da burocracia digital e dos roteiros engessados.

--- a/components/about/TrustFaqSection.tsx
+++ b/components/about/TrustFaqSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { m } from 'framer-motion';
+import { ChevronDown } from 'lucide-react';
 import { fadeUp } from './aboutMotion';
 
 interface TrustFaqItem {
@@ -31,18 +32,21 @@ export const TrustFaqSection: React.FC<TrustFaqSectionProps> = ({ items }) => (
 
     <div className="max-w-3xl mx-auto space-y-5">
       {items.map((item, i) => (
-        <m.div
+        <m.details
           key={item.question}
-          className="bg-white p-8 rounded-3xl border-2 border-zinc-100 shadow-sm"
+          className="group bg-white rounded-2xl shadow-float [&_summary::-webkit-details-marker]:hidden"
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true }}
           variants={fadeUp}
           custom={i + 1}
         >
-          <h3 className="text-lg md:text-xl font-black text-anhanga-dark mb-3">{item.question}</h3>
-          <p className="text-zinc-600 font-medium leading-relaxed">{item.answer}</p>
-        </m.div>
+          <summary className="flex items-center justify-between gap-4 p-8 cursor-pointer list-none font-black text-lg md:text-xl text-anhanga-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action rounded-2xl">
+            {item.question}
+            <ChevronDown className="size-5 shrink-0 text-anhanga-action transition-transform duration-300 group-open:rotate-180" aria-hidden="true" />
+          </summary>
+          <p className="px-8 pb-8 -mt-2 text-zinc-600 font-medium leading-relaxed">{item.answer}</p>
+        </m.details>
       ))}
     </div>
   </section>

--- a/components/about/TrustSection.tsx
+++ b/components/about/TrustSection.tsx
@@ -1,41 +1,56 @@
 import React from 'react';
-import { Award, Anchor, Ship, Coffee } from 'lucide-react';
+import { m } from 'framer-motion';
+import { Award, Anchor, Ship, MapPin } from 'lucide-react';
+import { fadeUp } from './aboutMotion';
+
+const CREDENTIAL_BADGES = [
+  { icon: Award, title: 'Beto Carrero World', subtitle: 'Agente credenciado' },
+  { icon: Award, title: 'Hopi Hari', subtitle: 'Agente credenciado' },
+  { icon: Anchor, title: 'Norwegian Cruise Line', subtitle: 'Parceira (NCL)' },
+  { icon: MapPin, title: 'São Paulo - SP', subtitle: 'Atendimento presencial' },
+];
 
 // Seção "Agência Certificada": credenciamentos como fatos verificáveis em texto
 // (Cadastur, Beto Carrero, Hopi Hari, NCL) — os mesmos sinais que o JSON-LD de
-// entidade em pages/About.tsx expõe para motores de resposta.
+// entidade em pages/About.tsx expõe para motores de resposta. Sem cards
+// isolados em contexto dark (DESIGN.md): os badges vivem direto no fundo da
+// seção, sem card individual próprio.
 export const TrustSection: React.FC = () => (
-  <section id="certificacoes" className="bg-brand-dark rounded-[3rem] p-12 md:p-20 text-white overflow-hidden relative">
-    <div className="absolute top-0 right-0 size-64 bg-brand-vibrant/20 blur-[100px] rounded-full"></div>
-    <div className="absolute bottom-0 left-0 size-64 bg-brand-cyan/10 blur-[100px] rounded-full"></div>
-
-    <div className="relative z-10 flex flex-col lg:flex-row gap-16 items-center">
+  <section id="certificacoes" className="bg-anhanga-dark rounded-[3rem] p-12 md:p-20 text-white/90">
+    <m.div
+      className="flex flex-col lg:flex-row gap-16 items-center"
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+      variants={fadeUp}
+      custom={0}
+    >
       <div className="w-full lg:w-1/2">
-        <div className="inline-flex items-center gap-2 px-4 py-1 bg-white/10 rounded-full text-brand-cyan text-sm font-bold mb-6">
-          <Award className="size-4" /> Credibilidade & Confiança
+        <div className="inline-flex items-center gap-2 px-4 py-1 bg-white/10 rounded-full text-anhanga-action text-sm font-bold mb-6">
+          <Award className="size-4" aria-hidden="true" /> Credibilidade & Confiança
         </div>
         <h2 className="text-3xl md:text-4xl font-black mb-6">Agência Certificada</h2>
-        <p className="text-zinc-300 text-lg font-medium leading-relaxed mb-8">
+        <p className="text-white/70 text-lg font-medium leading-relaxed mb-8">
           Sua segurança é nossa prioridade. A Anhangá Viagens é uma empresa devidamente registrada nos órgãos competentes, garantindo total conformidade legal para suas férias.
         </p>
 
         <ul className="space-y-6">
           <li className="flex items-start gap-4">
-            <div className="size-6 rounded-full bg-brand-cyan/20 flex items-center justify-center shrink-0 mt-1">
-              <div className="size-2 rounded-full bg-brand-cyan"></div>
+            <div className="size-6 rounded-full bg-anhanga-action/20 flex items-center justify-center shrink-0 mt-1">
+              <div className="size-2 rounded-full bg-anhanga-action"></div>
             </div>
             <div>
               <p className="font-bold text-lg leading-none mb-1">Cadastur Oficial</p>
-              <p className="text-zinc-400">Registro MTUR: 37.036.732/0001-41</p>
+              <p className="text-white/60">Registro MTUR: 37.036.732/0001-41</p>
             </div>
           </li>
           <li className="flex items-start gap-4">
-            <div className="size-6 rounded-full bg-brand-cyan/20 flex items-center justify-center shrink-0 mt-1">
-              <div className="size-2 rounded-full bg-brand-cyan"></div>
+            <div className="size-6 rounded-full bg-anhanga-action/20 flex items-center justify-center shrink-0 mt-1">
+              <div className="size-2 rounded-full bg-anhanga-action"></div>
             </div>
             <div>
               <p className="font-bold text-lg leading-none mb-1">Sede Própria em São Paulo</p>
-              <p className="text-zinc-400">Av. Dom Pedro I, 773 - Vila Monumento, CEP 01552-001</p>
+              <p className="text-white/60">Av. Dom Pedro I, 773 - Vila Monumento, CEP 01552-001</p>
             </div>
           </li>
           <li className="flex items-start gap-4">
@@ -44,7 +59,7 @@ export const TrustSection: React.FC = () => (
             </div>
             <div>
               <p className="font-bold text-lg leading-none mb-1">Agente Credenciado</p>
-              <p className="text-zinc-400">Beto Carrero World e Hopi Hari</p>
+              <p className="text-white/60">Beto Carrero World e Hopi Hari</p>
             </div>
           </li>
           <li className="flex items-start gap-4">
@@ -53,49 +68,21 @@ export const TrustSection: React.FC = () => (
             </div>
             <div>
               <p className="font-bold text-lg leading-none mb-1">Parceira Norwegian Cruise Line</p>
-              <p className="text-zinc-400">Cruzeiros nacionais e internacionais (NCL)</p>
+              <p className="text-white/60">Cruzeiros nacionais e internacionais (NCL)</p>
             </div>
           </li>
         </ul>
       </div>
 
-      <div className="w-full lg:w-1/2 grid grid-cols-2 gap-4">
-        <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
-          <Award className="size-12 text-brand-cyan mb-4" />
-          <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Membro Oficial</p>
-          <p className="font-black text-xl">Beto Carrero World</p>
-          <p className="text-xs text-brand-cyan mt-1">Agente Credenciado</p>
-        </div>
-        <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
-          <Anchor className="size-12 text-anhanga-action mb-4" />
-          <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Membro Oficial</p>
-          <p className="font-black text-xl">Hopi Hari</p>
-          <p className="text-xs text-anhanga-action mt-1">Agente Credenciado</p>
-        </div>
-        <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
-          <Ship className="size-12 text-anhanga-action mb-4" />
-          <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Parceira</p>
-          <p className="font-black text-xl">Norwegian Cruise Line</p>
-          <p className="text-xs text-anhanga-action mt-1">Cruzeiros NCL</p>
-        </div>
-        <div className="bg-white/5 backdrop-blur-sm p-8 rounded-3xl border border-white/10 flex flex-col items-center text-center">
-          <Coffee className="size-12 text-brand-yellow mb-4" />
-          <p className="text-sm font-bold uppercase tracking-tighter opacity-50 mb-2">Localizada em</p>
-          <p className="font-black text-xl">São Paulo - SP</p>
-          <p className="text-xs text-brand-yellow mt-1">Atendimento Presencial</p>
-        </div>
-        <div className="col-span-2 bg-white/5 backdrop-blur-sm p-6 rounded-3xl border border-white/10 flex items-center justify-center gap-6">
-          <div className="text-center">
-            <p className="text-3xl font-black text-brand-vibrant">4.9/5</p>
-            <p className="text-[10px] font-bold uppercase tracking-widest opacity-50">Avaliação Média</p>
+      <div className="w-full lg:w-1/2 grid grid-cols-2 gap-x-6 gap-y-8">
+        {CREDENTIAL_BADGES.map((badge) => (
+          <div key={badge.title} className="flex flex-col items-center text-center">
+            <badge.icon className="size-10 text-anhanga-action mb-3" aria-hidden="true" />
+            <p className="text-[10px] font-bold uppercase tracking-[0.1em] text-white/50 mb-1">{badge.subtitle}</p>
+            <p className="font-black text-lg leading-tight">{badge.title}</p>
           </div>
-          <div className="h-10 w-px bg-white/10"></div>
-          <div className="text-center">
-            <p className="text-3xl font-black text-brand-cyan">100%</p>
-            <p className="text-[10px] font-bold uppercase tracking-widest opacity-50">Roteiros sob medida</p>
-          </div>
-        </div>
+        ))}
       </div>
-    </div>
+    </m.div>
   </section>
 );

--- a/components/about/TrustSection.tsx
+++ b/components/about/TrustSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { m } from 'framer-motion';
-import { Award, Anchor, Ship, MapPin } from 'lucide-react';
+import { Award, Anchor, MapPin } from 'lucide-react';
 import { fadeUp } from './aboutMotion';
 
 const CREDENTIAL_BADGES = [

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -53,6 +53,11 @@ const TRUST_FAQ_ITEMS = [
     answer:
       'Sim. A sede fica na Av. Dom Pedro I, 773 — Vila Monumento, São Paulo (SP), CEP 01552-001. O atendimento pode ser presencial, por WhatsApp no (11) 5283-3309 ou pelo chat com IA disponível no site.',
   },
+  {
+    question: 'A Anhangá atende viagens corporativas e em grupo?',
+    answer:
+      'Sim. Além do atendimento consultivo para viajantes individuais e famílias, a Anhangá organiza viagens corporativas, eventos e viagens de incentivo para empresas e grupos, com um consultor dedicado cuidando de logística, orçamento e prazos. Conheça o atendimento corporativo em anhanga.tur.br/corporativo.',
+  },
 ];
 
 // Consultores expostos como entidades Person (E-E-A-T) ligados à organização.

--- a/tests/about-entity-authority.test.ts
+++ b/tests/about-entity-authority.test.ts
@@ -42,6 +42,18 @@ test('About FAQ de confiança cobre as queries de entidade', async () => {
   assert.match(source, /<TrustFaqSection items=\{TRUST_FAQ_ITEMS\}/, 'FAQ visível não recebe a mesma fonte do schema');
 });
 
+test('About FAQ dá presença ao segmento Corporativo/Eventos (PRODUCT.md)', async () => {
+  const source = await readRepoFile('pages/About.tsx');
+  assert.match(source, /atende viagens corporativas e em grupo\?/, 'Falta a pergunta sobre viagens corporativas/em grupo');
+  assert.match(source, /corporativas, eventos e viagens de incentivo/, 'Resposta não cobre corporativo/eventos/incentivo');
+});
+
+test('CtaSection da /sobre sinaliza o atendimento corporativo', async () => {
+  const source = await readRepoFile('components/about/CtaSection.tsx');
+  assert.match(source, /to="\/corporativo"/, 'CtaSection não linka para /corporativo');
+  assert.match(source, /corporativa ou em grupo/i, 'CtaSection não menciona viagem corporativa/em grupo');
+});
+
 test('seções visíveis extraídas renderizam a partir da fonte compartilhada', async () => {
   const faqSection = await readRepoFile('components/about/TrustFaqSection.tsx');
   assert.match(faqSection, /items\.map/, 'TrustFaqSection não renderiza os itens');

--- a/tests/e2e/about.spec.ts
+++ b/tests/e2e/about.spec.ts
@@ -48,4 +48,19 @@ test.describe('Sobre Page E-E-A-T Verification', () => {
 
     await expect(page).toHaveURL(/\/sobre/);
   });
+
+  test('FAQ accordion expands and collapses a question on click', async ({ page }) => {
+    await page.goto('/sobre');
+
+    const firstItem = page.locator('#perguntas-frequentes details').first();
+    await expect(firstItem).not.toHaveAttribute('open', '');
+
+    const summary = firstItem.locator('summary');
+    await summary.click();
+    await expect(firstItem).toHaveAttribute('open', '');
+    await expect(firstItem.locator('p')).toBeVisible();
+
+    await summary.click();
+    await expect(firstItem).not.toHaveAttribute('open', '');
+  });
 });

--- a/tests/tailwind-brand-namespace-guard.test.ts
+++ b/tests/tailwind-brand-namespace-guard.test.ts
@@ -45,9 +45,10 @@ function collectRootFiles(): string[] {
     .map((entry) => path.join(ROOT, entry.name));
 }
 
-// Baseline medido em 2026-06-21 (commit e14a6cd-descendant). Ao migrar
-// usos de brand-* para anhanga-*, ABAIXE este número para travar o ganho.
-const BRAND_NAMESPACE_BASELINE = 629;
+// Baseline medido em 2026-07-05 (migração de components/about/* para
+// anhanga-* nos fixes de /impeccable critique). Ao migrar usos de brand-*
+// para anhanga-*, ABAIXE este número para travar o ganho.
+const BRAND_NAMESPACE_BASELINE = 594;
 
 test('legacy brand-* namespace does not grow (ratchet)', () => {
   const files = [...SCAN_DIRS.flatMap(collectTailwindFiles), ...collectRootFiles()];


### PR DESCRIPTION
## Summary

Segue a crítica `/impeccable` (dual-agent) rodada na `/sobre` após o PR #1086, focada nos itens P2 remanescentes + 2 P1 novos encontrados nessa passada mais profunda.

- **TrustSection (P1)**: removidos 2 blobs de blur decorativos, 5 cards de vidro isolados em fundo dark (contra a regra explícita do DESIGN.md) e um stat tile `4.9/5 + 100%` hardcoded que nem batia com os dados reais de `reviewSummary` (hoje 5/5, 2 avaliações). Credenciamentos agora vivem direto no fundo da seção, sem card isolado.
- **Público Corporativo (P1)**: um dos dois segmentos nomeados no PRODUCT.md não tinha nenhuma presença na página — novo item de FAQ (mesma fonte do `FAQPageSchema`) + link discreto no CTA final para `/corporativo`.
- **Consistência (P2)**: border removido de todo card (contra "Border: Nenhuma" do DESIGN.md), raio padronizado em `rounded-2xl`, `brand-*` migrado para `anhanga-*` em `components/about/` (baseline do guard baixado de 629 → 594), cores fora da paleta (`orange-100`/`emerald-100`) substituídas.
- **Acessibilidade/motion (P2)**: touch targets sociais de 36px → 44px, `aria-hidden` em ícones decorativos, FAQ virou accordion nativo (`<details>`/`<summary>`, conteúdo permanece no DOM para SEO/GEO), corrigido bug de delay `NaN` em `CtaSection` (faltava `custom={0}`).

Snapshot da crítica em `.impeccable/critique/2026-07-05T03-10-56Z__pages-about-tsx.md`.

## Test plan

- [x] `pnpm typecheck` limpo
- [x] `pnpm test:regression` — 796/796 passando (inclui o guard de `brand-*` com baseline atualizado)
- [x] `pnpm exec playwright test tests/e2e/about.spec.ts` — 2/2 passando
- [x] Verificação visual manual (screenshot com scroll real) confirmando TrustSection, FAQ accordion e link corporativo renderizando corretamente
- [x] Teste manual do accordion do FAQ (expande/recolhe no clique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rAYDipfJJsMkwscswo2JY