### PR TITLE
fix(ci): claude-review estoura max-turns tentando rodar lint/build sem permissão

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -118,6 +118,8 @@ jobs:
 
             Não repita o que já é coberto por lint, typecheck ou CI. Não comente sobre estilo já garantido por ferramentas automatizadas. Poste um resumo curto e comentários inline apenas onde houver um problema real e acionável — prefira silêncio a ruído.
 
+            Você não tem acesso a Bash além de comandos git de plumbing (add/commit/rm) e não tem `gh` disponível. Não tente instalar dependências, nem rodar lint/typecheck/build/testes — isso já roda no CI e você não tem permissão para executá-los. Revise usando apenas Read/Grep/Glob no checkout e reporte via comentário/inline comment.
+
           claude_args: |
-            --max-turns 15
+            --max-turns 30
             --allowedTools "mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## Contexto

Follow-up do #1087 / PR #1088 (merged). Depois daquele fix, testei em uma PR real (#1089) e o `claude-review` **postou o comentário de tracking corretamente** (progresso confirmado — antes não postava nada), mas a execução real errou:

```json
{
  "type": "result",
  "subtype": "error_max_turns",
  "is_error": true,
  "duration_ms": 74797,
  "num_turns": 16,
  "total_cost_usd": 0.7955752,
  "permission_denials_count": 6
}
```

## Causa raiz

O modo "tag" do `claude-code-action` injeta instruções genéricas no system prompt orientando Claude a, entre outras coisas, "propor um plano incluindo passos de setup do repo e lint/testing... você pode precisar instalar dependências, rodar build commands". Mas o `--allowedTools` do job só libera `Bash(git add/commit/rm)` — nada de `pnpm`, `gh`, ou Bash genérico. Cada tentativa de `pnpm install`/`pnpm typecheck`/etc. era negada (6 permission denials), Claude insistia tentando variações, e estourou os 15 turns configurados antes de conseguir postar o resumo final — daí o comentário de erro genérico na PR em vez de uma review de verdade.

## Fix

- Instrução explícita no `prompt` dizendo que não há Bash além de git plumbing, que não há `gh` disponível, e que lint/typecheck/build já rodam no CI (não precisa e não deve tentar rodá-los).
- `--max-turns 15` → `30` como headroom extra para diffs maiores, já que revisar + potencialmente esbarrar em alguma tentativa negada consome mais turns do que o esperado.

## Limitação de teste (mesma do #1087)

PRs que editam `.github/workflows/claude.yml` não conseguem se autovalidar (GitHub bloqueia a troca OIDC→App-token quando o workflow rodando difere do default branch). Só dá pra confirmar de ponta a ponta numa PR seguinte, depois do merge — documentado na memória do projeto.

## Test plan

- [ ] Após merge, abrir/aguardar uma PR que não toque em `.github/workflows/` e confirmar que a review completa (sem `error_max_turns`) e posta um resumo real
- [ ] Confirmar que não há mais tentativas de `pnpm`/`gh` nos logs (nenhum permission denial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)