### PR TITLE
[codex] Improve form CRO instrumentation

### DIFF
--- a/components/ChatLeadForm.tsx
+++ b/components/ChatLeadForm.tsx
@@ -1,9 +1,10 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useEffect, useRef, useState } from 'react';
 import { CheckCircle2, ExternalLink, Loader2 } from 'lucide-react';
 import { createLeadEventId, pushGenerateLeadDataLayerEvent } from '../hooks/useLeadCapture';
 import type { SubmitLeadRequest } from '../types/leadCapture';
 import { normalizeWhatsappNumber } from '../lib/lead-logic';
 import { triggerHaptic } from '../utils/haptics';
+import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
 
 export interface LeadFinalizePayload {
   firstName: string;
@@ -186,6 +187,62 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
   const [notice, setNotice] = useState<string | null>(null);
   const [isLocallySubmitting, setIsLocallySubmitting] = useState(false);
   const isProcessingRef = React.useRef(false);
+  const startedRef = useRef(false);
+  const completedFields = useRef<Set<string> | null>(null);
+
+  useEffect(() => {
+    pushFormAnalyticsEvent({
+      event: 'form_view',
+      formType: 'ai_chatbot_lead',
+      formId: 'chat-lead-form',
+      destination,
+    });
+  }, [destination]);
+
+  function trackField(fieldName: keyof FieldErrors, value: string | boolean) {
+    if (!startedRef.current) {
+      startedRef.current = true;
+      pushFormAnalyticsEvent({
+        event: 'form_start',
+        formType: 'ai_chatbot_lead',
+        formId: 'chat-lead-form',
+        destination,
+      });
+    }
+
+    const completed = typeof value === 'boolean' ? value : value.trim().length > 0;
+    const trackedFields = completedFields.current ?? (completedFields.current = new Set());
+    if (completed && !trackedFields.has(fieldName)) {
+      trackedFields.add(fieldName);
+      pushFormAnalyticsEvent({
+        event: 'field_complete',
+        formType: 'ai_chatbot_lead',
+        formId: 'chat-lead-form',
+        fieldName,
+        destination,
+      });
+    }
+  }
+
+  const buildDirectWhatsAppPayload = (): LeadFinalizePayload => ({
+    firstName: firstName.trim() || 'Viajante',
+    lastName: lastName.trim(),
+    email: email.trim().toLowerCase(),
+    whatsapp: normalizeWhatsappNumber(whatsapp, countryCode) ?? '',
+    bantSummary: defaultBantSummary || 'Não informado',
+    destination: destination?.trim() || 'roteiro personalizado',
+  });
+
+  const openDirectWhatsApp = () => {
+    void triggerHaptic('light');
+    pushFormAnalyticsEvent({
+      event: 'whatsapp_opened',
+      formType: 'ai_chatbot_direct_whatsapp',
+      formId: 'chat-lead-direct-whatsapp',
+      destination,
+    });
+    openWhatsAppWindow(getWhatsAppUrl(buildDirectWhatsAppPayload()));
+  };
 
   const submitLeadForm = async (e: React.MouseEvent<HTMLButtonElement>) => {
     if (isSubmittingLead || isLocallySubmitting || isProcessingRef.current) return;
@@ -195,6 +252,12 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
     setLocalError(null);
     setNotice(null);
     setFieldErrors({});
+    pushFormAnalyticsEvent({
+      event: 'submit_attempt',
+      formType: 'ai_chatbot_lead',
+      formId: 'chat-lead-form',
+      destination,
+    });
 
     const validation = validateLeadForm({
       firstName,
@@ -210,6 +273,17 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
     if (validation.ok === false) {
       setFieldErrors(validation.fieldErrors || {});
       setLocalError(validation.localError);
+      const firstErrorField = validation.fieldErrors
+        ? (Object.keys(validation.fieldErrors)[0] as keyof FieldErrors | undefined)
+        : undefined;
+      pushFormAnalyticsEvent({
+        event: 'field_error',
+        formType: 'ai_chatbot_lead',
+        formId: 'chat-lead-form',
+        fieldName: firstErrorField,
+        errorType: firstErrorField ?? 'validation',
+        destination,
+      });
       setIsLocallySubmitting(false);
       isProcessingRef.current = false;
       return;
@@ -228,15 +302,36 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
     pushGenerateLeadDataLayerEvent(submitPayload);
 
     // Open WhatsApp synchronously in the click handler to prevent popup blockers on mobile/Safari
+    pushFormAnalyticsEvent({
+      event: 'whatsapp_opened',
+      formType: 'ai_chatbot_lead',
+      formId: 'chat-lead-form',
+      destination,
+    });
     openWhatsAppWindow(getWhatsAppUrl(payload));
 
     // Submit lead data in the background — user is already heading to WhatsApp
     try {
       const result = await onFinalizeLead(submitPayload);
       if (!result.ok) {
+        pushFormAnalyticsEvent({
+          event: 'submit_failure',
+          formType: 'ai_chatbot_lead',
+          formId: 'chat-lead-form',
+          errorType: result.error ? 'api' : 'unknown',
+          destination,
+        });
         console.warn('Background lead submission failed:', { error: result.error, requestId: result.requestId });
-      } else if (result.notice) {
-        setNotice(result.notice);
+      } else {
+        pushFormAnalyticsEvent({
+          event: 'submit_success',
+          formType: 'ai_chatbot_lead',
+          formId: 'chat-lead-form',
+          destination,
+        });
+        if (result.notice) {
+          setNotice(result.notice);
+        }
       }
     } finally {
       setIsLocallySubmitting(false);
@@ -265,7 +360,10 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
             value={firstName}
             placeholder="Nome"
             error={fieldErrors.firstName}
-            onChange={setFirstName}
+            onChange={(value) => {
+              setFirstName(value);
+              trackField('firstName', value);
+            }}
           />
 
           <TextField
@@ -275,7 +373,10 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
             value={lastName}
             placeholder="Sobrenome"
             error={fieldErrors.lastName}
-            onChange={setLastName}
+            onChange={(value) => {
+              setLastName(value);
+              trackField('lastName', value);
+            }}
           />
 
           <TextField
@@ -285,7 +386,10 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
             value={email}
             placeholder="E-mail"
             error={fieldErrors.email}
-            onChange={setEmail}
+            onChange={(value) => {
+              setEmail(value);
+              trackField('email', value);
+            }}
           />
 
           <div className="space-y-1">
@@ -310,7 +414,10 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
                 value={whatsapp}
                 placeholder="WhatsApp"
                 error={fieldErrors.whatsapp}
-                onChange={setWhatsapp}
+                onChange={(value) => {
+                  setWhatsapp(value);
+                  trackField('whatsapp', value);
+                }}
               />
             </div>
           </div>
@@ -321,7 +428,10 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
                 <input
                   type="checkbox"
                   checked={acceptedLGPD}
-                  onChange={(e) => setAcceptedLGPD(e.target.checked)}
+                  onChange={(e) => {
+                    setAcceptedLGPD(e.target.checked);
+                    trackField('lgpd', e.target.checked);
+                  }}
                   aria-invalid={fieldErrors.lgpd ? true : undefined}
                   aria-describedby={fieldErrors.lgpd ? 'lead-lgpd-error' : undefined}
                   className="peer size-4 cursor-pointer appearance-none rounded border border-zinc-300 bg-white checked:bg-brand-vibrant checked:border-brand-vibrant transition focus:ring-2 focus:ring-brand-vibrant/20"
@@ -364,6 +474,13 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
               <ExternalLink className="size-4 group-hover:scale-110 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-transform" />
             </>
           )}
+        </button>
+        <button
+          type="button"
+          onClick={openDirectWhatsApp}
+          className="mt-3 w-full rounded-xl border border-zinc-200 bg-white px-4 py-3 text-sm font-bold text-zinc-700 transition hover:border-brand-vibrant hover:text-brand-vibrant focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant/30"
+        >
+          Ir direto para o WhatsApp
         </button>
       </div>
     </div>

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { CheckCircle, X } from '@phosphor-icons/react';
 import { useContactForm } from '../hooks/useContactForm';
 import type { ContactModalOptions } from '../utils/contactForm';
+import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
 
 const ContactModal: React.FC = () => {
     const [isOpen, setIsOpen] = useState(false);
@@ -38,6 +39,11 @@ const ContactModal: React.FC = () => {
         if (!dialog) return;
 
         if (isOpen && !dialog.open) {
+            pushFormAnalyticsEvent({
+                event: 'form_view',
+                formType: 'contact_modal',
+                formId: options.source ?? 'contact-modal',
+            });
             previousBodyOverflow.current = document.body.style.overflow;
             document.body.style.overflow = 'hidden';
             dialog.showModal();
@@ -50,7 +56,7 @@ const ContactModal: React.FC = () => {
         return () => {
             document.body.style.overflow = previousBodyOverflow.current;
         };
-    }, [isOpen]);
+    }, [isOpen, options.source]);
 
     useEffect(() => {
         if (submitted) closeButtonRef.current?.focus();
@@ -134,37 +140,21 @@ const ContactModal: React.FC = () => {
                     >
                         {/* Honeypot: hidden from humans, blind form-fillers populate it. */}
                         <input {...honeypotProps} />
-                        <div className="flex gap-3">
-                            <div className="flex-1">
-                                <label htmlFor="contact-firstName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
-                                    Nome *
-                                </label>
-                                <input
-                                    ref={firstFieldRef}
-                                    id="contact-firstName"
-                                    type="text"
-                                    autoComplete="given-name"
-                                    value={fields.firstName}
-                                    onChange={(event) => setField('firstName', event.target.value)}
-                                    required
-                                    className="w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
-                                    placeholder="ex: Maria"
-                                />
-                            </div>
-                            <div className="flex-1">
-                                <label htmlFor="contact-lastName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
-                                    Sobrenome
-                                </label>
-                                <input
-                                    id="contact-lastName"
-                                    type="text"
-                                    autoComplete="family-name"
-                                    value={fields.lastName}
-                                    onChange={(event) => setField('lastName', event.target.value)}
-                                    className="w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
-                                    placeholder="ex: Silva"
-                                />
-                            </div>
+                        <div>
+                            <label htmlFor="contact-firstName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
+                                Nome *
+                            </label>
+                            <input
+                                ref={firstFieldRef}
+                                id="contact-firstName"
+                                type="text"
+                                autoComplete="name"
+                                value={fields.firstName}
+                                onChange={(event) => setField('firstName', event.target.value)}
+                                required
+                                className="w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                                placeholder="ex: Maria Silva"
+                            />
                         </div>
 
                         <div>

--- a/components/MobileHeroForm.tsx
+++ b/components/MobileHeroForm.tsx
@@ -1,7 +1,8 @@
-import React, { useState, memo, useRef } from 'react';
+import React, { useEffect, useState, memo, useRef } from 'react';
 import { X } from 'lucide-react';
 import { openAiChat } from '../utils/aiChat';
 import { triggerHaptic } from '../utils/haptics';
+import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
 
 /**
  * MobileHeroForm Component - Optimized with React.memo
@@ -14,15 +15,52 @@ import { triggerHaptic } from '../utils/haptics';
 const MobileHeroForm: React.FC = memo(() => {
   const [mobileDestination, setMobileDestination] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    pushFormAnalyticsEvent({
+      event: 'form_view',
+      formType: 'home_search',
+      formId: 'hero-search-mobile',
+    });
+  }, []);
+
+  const trackStart = (value: string) => {
+    if (!value.trim() || startedRef.current) return;
+    startedRef.current = true;
+    pushFormAnalyticsEvent({
+      event: 'form_start',
+      formType: 'home_search',
+      formId: 'hero-search-mobile',
+    });
+    pushFormAnalyticsEvent({
+      event: 'field_complete',
+      formType: 'home_search',
+      formId: 'hero-search-mobile',
+      fieldName: 'destination',
+    });
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     void triggerHaptic('light');
+    pushFormAnalyticsEvent({
+      event: 'submit_attempt',
+      formType: 'home_search',
+      formId: 'hero-search-mobile',
+      destination: mobileDestination,
+    });
     openAiChat({
       haptic: 'none',
       message: mobileDestination.trim()
         ? `Olá! Tenho interesse em viajar para ${mobileDestination.trim()}. Podem me ajudar com um orçamento?`
         : 'Olá! Gostaria de montar um roteiro personalizado. Podem me ajudar?',
+    });
+    pushFormAnalyticsEvent({
+      event: 'submit_success',
+      formType: 'home_search',
+      formId: 'hero-search-mobile',
+      destination: mobileDestination,
     });
   };
 
@@ -44,7 +82,10 @@ const MobileHeroForm: React.FC = memo(() => {
             ref={inputRef}
             type="text"
             value={mobileDestination}
-            onChange={(e) => setMobileDestination(e.target.value)}
+            onChange={(e) => {
+              setMobileDestination(e.target.value);
+              trackStart(e.target.value);
+            }}
             placeholder="Para onde você quer ir?"
             aria-label="Destino"
             className="flex-1 outline-none text-zinc-800 font-semibold placeholder-zinc-400 bg-transparent text-base"

--- a/components/SearchForm.tsx
+++ b/components/SearchForm.tsx
@@ -16,6 +16,7 @@ import SearchButton from './search/SearchButton';
 import { buildSearchMessage, getGuestSummary, isDateInPast } from './search/helpers';
 import { useSearchFormDismiss, type PanelRegistryEntry } from './search/useSearchFormDismiss';
 import type { DestinationOption, OpenPanel } from './search/types';
+import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
 
 type ActivePanel = Exclude<OpenPanel, null>;
 
@@ -38,6 +39,37 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
   const [isSearchLoading, setIsSearchLoading] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
   const errorTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const startedRef = useRef(false);
+  const completedFields = useRef<Set<'destination' | 'date' | 'budget'> | null>(null);
+
+  useEffect(() => {
+    pushFormAnalyticsEvent({
+      event: 'form_view',
+      formType: 'home_search',
+      formId: 'hero-search',
+    });
+  }, []);
+
+  const markStarted = useCallback((fieldName: 'destination' | 'date' | 'budget') => {
+    if (!startedRef.current) {
+      startedRef.current = true;
+      pushFormAnalyticsEvent({
+        event: 'form_start',
+        formType: 'home_search',
+        formId: 'hero-search',
+      });
+    }
+    const trackedFields = completedFields.current ?? (completedFields.current = new Set());
+    if (!trackedFields.has(fieldName)) {
+      trackedFields.add(fieldName);
+      pushFormAnalyticsEvent({
+        event: 'field_complete',
+        formType: 'home_search',
+        formId: 'hero-search',
+        fieldName,
+      });
+    }
+  }, []);
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -90,6 +122,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
   const handleDestinationChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
     setInputValue(value);
+    if (value.trim()) markStarted('destination');
     setOpenPanel('dest');
     setActiveSuggestionIndex(-1);
 
@@ -99,7 +132,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
     ));
 
     onDestinationMatch(exactMatch ? exactMatch.city : null);
-  }, [onDestinationMatch]);
+  }, [onDestinationMatch, markStarted]);
 
   const handleDestinationSelect = useCallback((destination: DestinationOption) => {
     setInputValue(destination.label);
@@ -173,6 +206,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
     if (!startDate || endDate) {
       setStartDate(date);
       setEndDate(null);
+      markStarted('date');
       return;
     }
 
@@ -184,7 +218,7 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
 
     setEndDate(date);
     closePanel('calendar');
-  }, [startDate, endDate, closePanel]);
+  }, [startDate, endDate, closePanel, markStarted]);
 
   const isDateSelected = useCallback((date: Date) => {
     if (!startDate) return false;
@@ -229,29 +263,34 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
 
   const handleBudgetSelect = useCallback((label: string) => {
     setBudget(label);
+    markStarted('budget');
     closePanel('budget');
-  }, [closePanel]);
+  }, [closePanel, markStarted]);
 
   const handleSearch = useCallback(() => {
     if (!inputValue.trim()) {
       if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current);
       setValidationError("Por favor, informe o destino.");
+      pushFormAnalyticsEvent({
+        event: 'field_error',
+        formType: 'home_search',
+        formId: 'hero-search',
+        fieldName: 'destination',
+        errorType: 'required',
+      });
       import('../utils/haptics').then(m => m.triggerHaptic('medium'));
-      errorTimeoutRef.current = setTimeout(() => setValidationError(null), 4000);
-      return;
-    }
-
-    if (!startDate) {
-      if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current);
-      setValidationError("Por favor, selecione a data de ida.");
-      import('../utils/haptics').then(m => m.triggerHaptic('medium'));
-      setOpenPanel('calendar');
       errorTimeoutRef.current = setTimeout(() => setValidationError(null), 4000);
       return;
     }
 
     setIsSearchLoading(true);
     setValidationError(null);
+    pushFormAnalyticsEvent({
+      event: 'submit_attempt',
+      formType: 'home_search',
+      formId: 'hero-search',
+      destination: inputValue,
+    });
 
     openAiChat({
       haptic: 'medium',
@@ -265,6 +304,12 @@ const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
         tripType,
         budget,
       }),
+    });
+    pushFormAnalyticsEvent({
+      event: 'submit_success',
+      formType: 'home_search',
+      formId: 'hero-search',
+      destination: inputValue,
     });
 
     setTimeout(() => {

--- a/components/cta/CtaBody.tsx
+++ b/components/cta/CtaBody.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { WhatsappLogo, SpinnerGap, CheckCircle } from '@phosphor-icons/react';
 import { useContactForm } from '../../hooks/useContactForm';
+import { pushFormAnalyticsEvent } from '../../utils/formAnalytics';
 
 export function CtaBody() {
   const [formOpen, setFormOpen] = useState(false);
@@ -34,38 +35,30 @@ export function CtaBody() {
           Seus dados para contato
         </p>
 
-        <div className="flex gap-3">
-          <div className="flex-1">
-            <label htmlFor="cta-firstName" className="sr-only">Nome</label>
-            <input
-              id="cta-firstName"
-              type="text"
-              placeholder="Nome *"
-              value={fields.firstName}
-              onChange={(event) => setField('firstName', event.target.value)}
-              required
-              className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400"
-            />
-          </div>
-          <div className="flex-1">
-            <label htmlFor="cta-lastName" className="sr-only">Sobrenome</label>
-            <input
-              id="cta-lastName"
-              type="text"
-              placeholder="Sobrenome"
-              value={fields.lastName}
-              onChange={(event) => setField('lastName', event.target.value)}
-              className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400"
-            />
-          </div>
+        <div>
+          <label htmlFor="cta-firstName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
+            Nome *
+          </label>
+          <input
+            id="cta-firstName"
+            type="text"
+            placeholder="ex: João Silva"
+            autoComplete="name"
+            value={fields.firstName}
+            onChange={(event) => setField('firstName', event.target.value)}
+            required
+            className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400"
+          />
         </div>
 
         <div>
-          <label htmlFor="cta-whatsapp" className="sr-only">WhatsApp</label>
+          <label htmlFor="cta-whatsapp" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
+            WhatsApp *
+          </label>
           <input
             id="cta-whatsapp"
             type="tel"
-            placeholder="WhatsApp *"
+            placeholder="(11) 99999-9999"
             value={fields.whatsapp}
             onChange={(event) => setField('whatsapp', event.target.value)}
             required
@@ -74,11 +67,13 @@ export function CtaBody() {
         </div>
 
         <div>
-          <label htmlFor="cta-email" className="sr-only">E-mail</label>
+          <label htmlFor="cta-email" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
+            E-mail
+          </label>
           <input
             id="cta-email"
             type="email"
-            placeholder="E-mail (opcional)"
+            placeholder="voce@email.com (opcional)"
             value={fields.email}
             onChange={(event) => setField('email', event.target.value)}
             className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400"
@@ -94,12 +89,16 @@ export function CtaBody() {
             className="mt-0.5 size-4 rounded border-2 border-brand-vibrant accent-brand-vibrant cursor-pointer flex-shrink-0"
           />
           <label htmlFor="cta-optIn" className="text-xs text-blue-700 leading-relaxed cursor-pointer">
-            Quero receber novidades por e-mail.{' '}
-            <a href="/politica-privacidade/" target="_blank" rel="noopener noreferrer" className="underline">
-              Política de Privacidade
-            </a>
+            Quero receber novidades por e-mail.
           </label>
         </div>
+
+        <p className="text-xs text-zinc-500 leading-relaxed">
+          Seus dados serão usados para retornar seu contato.{' '}
+          <a href="/politica-privacidade/" target="_blank" rel="noopener noreferrer" className="underline hover:text-zinc-700">
+            Política de Privacidade
+          </a>.
+        </p>
 
         {error && (
           <p className="text-red-500 text-xs font-medium" role="alert">{error}</p>
@@ -145,7 +144,14 @@ export function CtaBody() {
       </div>
       <button
         type="button"
-        onClick={() => setFormOpen(true)}
+        onClick={() => {
+          setFormOpen(true);
+          pushFormAnalyticsEvent({
+            event: 'form_view',
+            formType: 'contact_modal',
+            formId: 'cta-homepage',
+          });
+        }}
         className="btn-specialist flex items-center gap-3 bg-brand-dark text-white text-lg font-bold px-8 py-4 rounded-xl shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition self-start"
         data-tracking="cta-home-footer"
       >

--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -144,7 +144,7 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
     }
 
     const showError = state.phase === 'error' && state.message && (!state.field || state.field === 'lgpd');
-    const lgpdError = state.phase === 'error' && !state.acceptedLGPD;
+    const lgpdError = state.phase === 'error' && state.field === 'lgpd';
     const busy = state.phase === 'submitting' || isSubmitting;
 
     return (

--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { m } from 'framer-motion';
 import { AirplaneTilt, PaperPlaneTilt, SpinnerGap } from '@phosphor-icons/react';
 import { useLeadCapture, createLeadEventId } from '@/hooks/useLeadCapture';
@@ -8,6 +8,7 @@ import { CorpFormFields } from './CorpFormFields';
 import { CorpLgpdConsent } from './CorpLgpdConsent';
 import { CorpSuccessState } from './CorpSuccessState';
 import { fadeUp } from './constants';
+import { pushFormAnalyticsEvent } from '@/utils/formAnalytics';
 
 interface CorpContactFormProps {
     whatsappUrl: string;
@@ -16,14 +17,77 @@ interface CorpContactFormProps {
 export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
     const { submitLead, isSubmitting, honeypotProps } = useLeadCapture();
     const { state, dispatch, isSubmittingRef, handleField, toggleLgpd } = useCorpFormReducer();
+    const startedRef = useRef(false);
+    const completedFields = useRef<Set<string> | null>(null);
+
+    useEffect(() => {
+        pushFormAnalyticsEvent({
+            event: 'form_view',
+            formType: 'corporate_lead',
+            formId: 'corporativo-contact-form',
+            destination: 'Corporativo',
+        });
+    }, []);
+
+    function trackField(fieldName: string, value: string | boolean) {
+        if (!startedRef.current) {
+            startedRef.current = true;
+            pushFormAnalyticsEvent({
+                event: 'form_start',
+                formType: 'corporate_lead',
+                formId: 'corporativo-contact-form',
+                destination: 'Corporativo',
+            });
+        }
+
+        const completed = typeof value === 'boolean' ? value : value.trim().length > 0;
+        const trackedFields = completedFields.current ?? (completedFields.current = new Set());
+        if (completed && !trackedFields.has(fieldName)) {
+            trackedFields.add(fieldName);
+            pushFormAnalyticsEvent({
+                event: 'field_complete',
+                formType: 'corporate_lead',
+                formId: 'corporativo-contact-form',
+                fieldName,
+                destination: 'Corporativo',
+            });
+        }
+    }
+
+    const handleTrackedField = (field: Parameters<typeof handleField>[0]) => {
+        const baseHandler = handleField(field);
+        return (event: React.ChangeEvent<HTMLInputElement>) => {
+            baseHandler(event);
+            trackField(field, event.target.value);
+        };
+    };
+
+    function handleTrackedLgpd(value: boolean) {
+        toggleLgpd(value);
+        trackField('lgpd', value);
+    }
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
         if (isSubmittingRef.current) return;
+        pushFormAnalyticsEvent({
+            event: 'submit_attempt',
+            formType: 'corporate_lead',
+            formId: 'corporativo-contact-form',
+            destination: 'Corporativo',
+        });
 
         const validation = validateCorpForm(state.form, state.acceptedLGPD);
         if (!validation.ok) {
             dispatch({ type: 'submit-error', message: validation.message, field: validation.field });
+            pushFormAnalyticsEvent({
+                event: 'field_error',
+                formType: 'corporate_lead',
+                formId: 'corporativo-contact-form',
+                fieldName: validation.field,
+                errorType: validation.field,
+                destination: 'Corporativo',
+            });
             return;
         }
 
@@ -45,8 +109,21 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
             );
 
             if (result.ok) {
+                pushFormAnalyticsEvent({
+                    event: 'submit_success',
+                    formType: 'corporate_lead',
+                    formId: 'corporativo-contact-form',
+                    destination: 'Corporativo',
+                });
                 dispatch({ type: 'submit-success' });
             } else {
+                pushFormAnalyticsEvent({
+                    event: 'submit_failure',
+                    formType: 'corporate_lead',
+                    formId: 'corporativo-contact-form',
+                    errorType: result.code,
+                    destination: 'Corporativo',
+                });
                 dispatch({
                     type: 'submit-error',
                     message: result.error || 'Ocorreu um erro ao enviar. Tente novamente.',
@@ -54,12 +131,19 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                 isSubmittingRef.current = false;
             }
         } catch {
+            pushFormAnalyticsEvent({
+                event: 'submit_failure',
+                formType: 'corporate_lead',
+                formId: 'corporativo-contact-form',
+                errorType: 'unexpected',
+                destination: 'Corporativo',
+            });
             dispatch({ type: 'submit-error', message: 'Ocorreu um erro inesperado. Tente novamente.' });
             isSubmittingRef.current = false;
         }
     }
 
-    const showError = state.phase === 'error' && state.message;
+    const showError = state.phase === 'error' && state.message && (!state.field || state.field === 'lgpd');
     const lgpdError = state.phase === 'error' && !state.acceptedLGPD;
     const busy = state.phase === 'submitting' || isSubmitting;
 
@@ -86,11 +170,16 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                     </div>
 
                     <div className="p-6 sm:p-8 space-y-5">
-                        <CorpFormFields form={state.form} onField={handleField} />
+                        <CorpFormFields
+                            form={state.form}
+                            onField={handleTrackedField}
+                            errorField={state.phase === 'error' ? state.field : undefined}
+                            errorMessage={state.phase === 'error' ? state.message : undefined}
+                        />
 
                         <CorpLgpdConsent
                             checked={state.acceptedLGPD}
-                            onChange={toggleLgpd}
+                            onChange={handleTrackedLgpd}
                             error={lgpdError}
                         />
 

--- a/components/landings/corporativo/CorpFormFields.tsx
+++ b/components/landings/corporativo/CorpFormFields.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
-import type { FormFields } from './useCorpFormReducer';
+import type { ErrorField, FormFields } from './useCorpFormReducer';
 
 interface CorpFormFieldsProps {
     form: FormFields;
     onField: (field: keyof FormFields) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+    errorField?: ErrorField;
+    errorMessage?: string;
 }
 
 const INPUT_CLASS =
-    'w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-500';
+    'w-full px-4 py-2.5 rounded-xl border-2 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors duration-150 placeholder-zinc-500';
 
-export function CorpFormFields({ form, onField }: CorpFormFieldsProps) {
+function fieldClass(hasError: boolean): string {
+    return `${INPUT_CLASS} ${hasError ? 'border-red-400' : 'border-zinc-200'}`;
+}
+
+function FieldError({ show, message }: { show: boolean; message?: string }) {
+    if (!show || !message) return null;
+    return <span className="mt-1 block text-xs font-semibold text-red-500" role="alert">{message}</span>;
+}
+
+export function CorpFormFields({ form, onField, errorField, errorMessage }: CorpFormFieldsProps) {
+    const isError = (field: keyof FormFields) => errorField === field;
+
     return (
         <>
             <div className="grid grid-cols-2 gap-4">
@@ -25,8 +38,10 @@ export function CorpFormFields({ form, onField }: CorpFormFieldsProps) {
                         value={form.firstName}
                         onChange={onField('firstName')}
                         required
-                        className={INPUT_CLASS}
+                        aria-invalid={isError('firstName') || undefined}
+                        className={fieldClass(isError('firstName'))}
                     />
+                    <FieldError show={isError('firstName')} message={errorMessage} />
                 </div>
                 <div>
                     <label htmlFor="lastName" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
@@ -40,14 +55,16 @@ export function CorpFormFields({ form, onField }: CorpFormFieldsProps) {
                         value={form.lastName}
                         onChange={onField('lastName')}
                         required
-                        className={INPUT_CLASS}
+                        aria-invalid={isError('lastName') || undefined}
+                        className={fieldClass(isError('lastName'))}
                     />
+                    <FieldError show={isError('lastName')} message={errorMessage} />
                 </div>
             </div>
 
             <div>
                 <label htmlFor="email" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
-                    E-mail corporativo <span className="text-brand-cyan">*</span>
+                    E-mail profissional <span className="text-brand-cyan">*</span>
                 </label>
                 <input
                     id="email"
@@ -57,8 +74,10 @@ export function CorpFormFields({ form, onField }: CorpFormFieldsProps) {
                     value={form.email}
                     onChange={onField('email')}
                     required
-                    className={INPUT_CLASS}
+                    aria-invalid={isError('email') || undefined}
+                    className={fieldClass(isError('email'))}
                 />
+                <FieldError show={isError('email')} message={errorMessage} />
             </div>
 
             <div>
@@ -73,8 +92,10 @@ export function CorpFormFields({ form, onField }: CorpFormFieldsProps) {
                     value={form.whatsapp}
                     onChange={onField('whatsapp')}
                     required
-                    className={INPUT_CLASS}
+                    aria-invalid={isError('whatsapp') || undefined}
+                    className={fieldClass(isError('whatsapp'))}
                 />
+                <FieldError show={isError('whatsapp')} message={errorMessage} />
             </div>
 
             <div className="grid grid-cols-2 gap-4">
@@ -89,7 +110,7 @@ export function CorpFormFields({ form, onField }: CorpFormFieldsProps) {
                         autoComplete="organization"
                         value={form.empresa}
                         onChange={onField('empresa')}
-                        className={INPUT_CLASS}
+                        className={fieldClass(false)}
                     />
                 </div>
                 <div>
@@ -103,7 +124,7 @@ export function CorpFormFields({ form, onField }: CorpFormFieldsProps) {
                         autoComplete="organization-title"
                         value={form.cargo}
                         onChange={onField('cargo')}
-                        className={INPUT_CLASS}
+                        className={fieldClass(false)}
                     />
                 </div>
             </div>

--- a/components/landings/corporativo/useCorpFormReducer.ts
+++ b/components/landings/corporativo/useCorpFormReducer.ts
@@ -10,7 +10,7 @@ export type FormFields = {
     cargo: string;
 };
 
-type ErrorField = 'required' | 'email' | 'whatsapp' | 'lgpd';
+export type ErrorField = keyof FormFields | 'lgpd';
 
 type IdleState = { phase: 'idle'; form: FormFields; acceptedLGPD: boolean };
 type SubmittingState = { phase: 'submitting'; form: FormFields; acceptedLGPD: boolean };
@@ -83,12 +83,21 @@ type ValidationResult =
     | { ok: false; message: string; field: ErrorField };
 
 export function validateCorpForm(form: FormFields, acceptedLGPD: boolean): ValidationResult {
-    if (!form.firstName.trim() || !form.lastName.trim() || !form.email.trim() || !form.whatsapp.trim()) {
-        return { ok: false, message: 'Preencha todos os campos obrigatórios', field: 'required' };
+    if (!form.firstName.trim()) {
+        return { ok: false, message: 'Informe seu nome.', field: 'firstName' };
+    }
+    if (!form.lastName.trim()) {
+        return { ok: false, message: 'Informe seu sobrenome.', field: 'lastName' };
+    }
+    if (!form.email.trim()) {
+        return { ok: false, message: 'Informe seu e-mail profissional.', field: 'email' };
+    }
+    if (!form.whatsapp.trim()) {
+        return { ok: false, message: 'Informe seu WhatsApp.', field: 'whatsapp' };
     }
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(form.email.trim())) {
-        return { ok: false, message: 'Insira um e-mail corporativo válido', field: 'email' };
+        return { ok: false, message: 'Insira um e-mail profissional válido', field: 'email' };
     }
     if (!normalizeWhatsappNumber(form.whatsapp)) {
         return { ok: false, message: 'Insira um número de WhatsApp válido', field: 'whatsapp' };

--- a/components/landings/lollapalooza/WaitlistSection.tsx
+++ b/components/landings/lollapalooza/WaitlistSection.tsx
@@ -1,8 +1,9 @@
-import React, { useReducer } from 'react';
+import React, { useEffect, useReducer, useRef } from 'react';
 import { BellRing, CheckCircle2, Loader2, Mail, TicketX, ArrowRight, Zap } from 'lucide-react';
 import { m, AnimatePresence } from 'framer-motion';
 import { useWaitlistCapture } from '../../../hooks/useWaitlistCapture';
 import { WAITLIST_SECTION_ID } from './constants';
+import { pushFormAnalyticsEvent } from '../../../utils/formAnalytics';
 
 const CONTAINER_VARIANTS = {
   hidden: { opacity: 0 },
@@ -60,18 +61,62 @@ const WaitlistSection: React.FC = () => {
   const { submitWaitlist, isSubmitting, error, honeypotProps } = useWaitlistCapture();
   const [state, dispatch] = useReducer(waitlistReducer, WAITLIST_INITIAL_STATE);
   const { name, email, acceptedLgpd, localError, successMessage, warningMessage } = state;
+  const startedRef = useRef(false);
+  const completedFields = useRef<Set<string> | null>(null);
+
+  useEffect(() => {
+    pushFormAnalyticsEvent({
+      event: 'form_view',
+      formType: 'waitlist',
+      formId: 'lolla-waitlist-2027',
+      destination: 'Lollapalooza Brasil',
+    });
+  }, []);
+
+  function trackField(fieldName: 'name' | 'email' | 'marketingOptIn', value: string | boolean) {
+    if (!startedRef.current) {
+      startedRef.current = true;
+      pushFormAnalyticsEvent({
+        event: 'form_start',
+        formType: 'waitlist',
+        formId: 'lolla-waitlist-2027',
+        destination: 'Lollapalooza Brasil',
+      });
+    }
+
+    const completed = typeof value === 'boolean' ? value : value.trim().length > 0;
+    const trackedFields = completedFields.current ?? (completedFields.current = new Set());
+    if (completed && !trackedFields.has(fieldName)) {
+      trackedFields.add(fieldName);
+      pushFormAnalyticsEvent({
+        event: 'field_complete',
+        formType: 'waitlist',
+        formId: 'lolla-waitlist-2027',
+        fieldName,
+        destination: 'Lollapalooza Brasil',
+      });
+    }
+  }
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     dispatch({ type: 'CLEAR_MESSAGES' });
+    pushFormAnalyticsEvent({
+      event: 'submit_attempt',
+      formType: 'waitlist',
+      formId: 'lolla-waitlist-2027',
+      destination: 'Lollapalooza Brasil',
+    });
 
     if (!name.trim() || !email.trim()) {
       dispatch({ type: 'SET_ERROR', value: 'Preencha nome completo e e-mail para entrar na lista.' });
-      return;
-    }
-
-    if (!acceptedLgpd) {
-      dispatch({ type: 'SET_ERROR', value: 'Você precisa aceitar a política de privacidade para continuar.' });
+      pushFormAnalyticsEvent({
+        event: 'field_error',
+        formType: 'waitlist',
+        formId: 'lolla-waitlist-2027',
+        errorType: 'required',
+        destination: 'Lollapalooza Brasil',
+      });
       return;
     }
 
@@ -86,9 +131,22 @@ const WaitlistSection: React.FC = () => {
 
     if (result.ok === false) {
       dispatch({ type: 'SET_ERROR', value: result.error });
+      pushFormAnalyticsEvent({
+        event: 'submit_failure',
+        formType: 'waitlist',
+        formId: 'lolla-waitlist-2027',
+        errorType: result.code,
+        destination: 'Lollapalooza Brasil',
+      });
       return;
     }
 
+    pushFormAnalyticsEvent({
+      event: 'submit_success',
+      formType: 'waitlist',
+      formId: 'lolla-waitlist-2027',
+      destination: 'Lollapalooza Brasil',
+    });
     dispatch({ type: 'SUBMIT_SUCCESS', success: 'Você entrou na lista de espera para o Lollapalooza 2027.', warning: result.warning || null });
   };
 
@@ -187,7 +245,10 @@ const WaitlistSection: React.FC = () => {
                       id="lolla-waitlist-name"
                       type="text"
                       value={name}
-                      onChange={(event) => dispatch({ type: 'SET_NAME', value: event.target.value })}
+                      onChange={(event) => {
+                        dispatch({ type: 'SET_NAME', value: event.target.value });
+                        trackField('name', event.target.value);
+                      }}
                       className="peer w-full bg-anhanga-darkBlue/80 border-l-2 border-white/10 px-6 py-4 text-white placeholder-white/50 outline-none transition duration-300 focus:border-anhanga-yellow focus:bg-anhanga-yellow/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-anhanga-yellow focus-visible:outline-offset-2"
                       placeholder="EX: SABRINA CARPENTER"
                       autoComplete="name"
@@ -207,7 +268,10 @@ const WaitlistSection: React.FC = () => {
                       id="lolla-waitlist-email"
                       type="email"
                       value={email}
-                      onChange={(event) => dispatch({ type: 'SET_EMAIL', value: event.target.value })}
+                      onChange={(event) => {
+                        dispatch({ type: 'SET_EMAIL', value: event.target.value });
+                        trackField('email', event.target.value);
+                      }}
                       className="peer w-full bg-anhanga-darkBlue/80 border-l-2 border-white/10 px-6 py-4 text-white placeholder-white/50 outline-none transition duration-300 focus:border-anhanga-blue focus:bg-anhanga-blue/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-anhanga-blue focus-visible:outline-offset-2"
                       placeholder="VOICE@EXEMPLO.COM"
                       autoComplete="email"
@@ -224,14 +288,22 @@ const WaitlistSection: React.FC = () => {
                       id="lolla-waitlist-lgpd"
                       type="checkbox"
                       checked={acceptedLgpd}
-                      onChange={(event) => dispatch({ type: 'SET_LGPD', value: event.target.checked })}
+                      onChange={(event) => {
+                        dispatch({ type: 'SET_LGPD', value: event.target.checked });
+                        trackField('marketingOptIn', event.target.checked);
+                      }}
                       className="peer sr-only"
                     />
                     <div className="size-5 border-2 border-white/20 peer-checked:border-anhanga-yellow peer-checked:bg-anhanga-yellow transition duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-anhanga-yellow peer-focus-visible:outline-offset-2" />
                     <CheckCircle2 size={12} className="absolute text-black opacity-0 peer-checked:opacity-100 transition-opacity" />
                   </div>
                   <span className="text-xs text-zinc-400 leading-snug group-hover:text-zinc-300 transition-colors">
-                    Autorizo a Anhangá a me enviar novidades exclusivas conforme a{' '}
+                    Quero receber novidades exclusivas da Anhangá por e-mail.
+                  </span>
+                </label>
+
+                <p className="text-xs text-zinc-500 leading-relaxed">
+                  Ao entrar na lista, seus dados serão usados para avisos sobre pacotes do Lollapalooza. Consulte a{' '}
                     <a
                       href="/politica-privacidade/"
                       target="_blank"
@@ -240,8 +312,7 @@ const WaitlistSection: React.FC = () => {
                     >
                       Política de Privacidade
                     </a>.
-                  </span>
-                </label>
+                </p>
 
                 <AnimatePresence mode="wait">
                   {(localError || error) && (

--- a/components/landings/quiz/PreLeadScreen.tsx
+++ b/components/landings/quiz/PreLeadScreen.tsx
@@ -20,7 +20,7 @@ interface PreLeadScreenProps {
 export function PreLeadScreen({ profile, onSubmit, onBack, isSubmitting, initialValues, honeypotProps }: PreLeadScreenProps) {
     const [form, setForm] = useState<LeadForm>(() => ({
         nome: initialValues?.nome ?? '',
-        sobrenome: '',
+        sobrenome: initialValues?.sobrenome ?? '',
         email: initialValues?.email ?? '',
         aceite: false,
     }));

--- a/components/landings/quiz/PreLeadScreen.tsx
+++ b/components/landings/quiz/PreLeadScreen.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { LeadForm, TravelerProfile } from '../../../data/quiz';
 import type { HoneypotProps } from '../../../hooks/useAntiBot';
+import { pushFormAnalyticsEvent } from '../../../utils/formAnalytics';
 
 interface PreLeadScreenProps {
     profile: TravelerProfile;
@@ -19,24 +20,79 @@ interface PreLeadScreenProps {
 export function PreLeadScreen({ profile, onSubmit, onBack, isSubmitting, initialValues, honeypotProps }: PreLeadScreenProps) {
     const [form, setForm] = useState<LeadForm>(() => ({
         nome: initialValues?.nome ?? '',
-        sobrenome: initialValues?.sobrenome ?? '',
+        sobrenome: '',
         email: initialValues?.email ?? '',
         aceite: false,
     }));
     const [errors, setErrors] = useState<Partial<Record<keyof LeadForm, string>>>({});
+    const startedRef = useRef(false);
+    const completedFields = useRef<Set<string> | null>(null);
+
+    useEffect(() => {
+        pushFormAnalyticsEvent({
+            event: 'form_view',
+            formType: 'quiz_lead',
+            formId: 'quiz-anhanga',
+            destination: profile.name,
+        });
+    }, [profile.name]);
+
+    function trackField(fieldName: 'name' | 'email' | 'marketingOptIn', value: string | boolean) {
+        if (!startedRef.current) {
+            startedRef.current = true;
+            pushFormAnalyticsEvent({
+                event: 'form_start',
+                formType: 'quiz_lead',
+                formId: 'quiz-anhanga',
+                destination: profile.name,
+            });
+        }
+
+        const completed = typeof value === 'boolean' ? value : value.trim().length > 0;
+        const trackedFields = completedFields.current ?? (completedFields.current = new Set());
+        if (completed && !trackedFields.has(fieldName)) {
+            trackedFields.add(fieldName);
+            pushFormAnalyticsEvent({
+                event: 'field_complete',
+                formType: 'quiz_lead',
+                formId: 'quiz-anhanga',
+                fieldName,
+                destination: profile.name,
+            });
+        }
+    }
 
     function update<K extends keyof LeadForm>(k: K, v: LeadForm[K]) {
         setForm((f) => ({ ...f, [k]: v }));
         setErrors((e) => ({ ...e, [k]: undefined }));
+        if (k === 'nome') trackField('name', String(v));
+        if (k === 'email') trackField('email', String(v));
+        if (k === 'aceite') trackField('marketingOptIn', Boolean(v));
     }
 
     function submit(e: React.FormEvent) {
         e.preventDefault();
+        pushFormAnalyticsEvent({
+            event: 'submit_attempt',
+            formType: 'quiz_lead',
+            formId: 'quiz-anhanga',
+            destination: profile.name,
+        });
         const errs: typeof errors = {};
         if (!form.nome.trim()) errs.nome = 'Conta pra gente seu nome';
-        if (!form.sobrenome.trim()) errs.sobrenome = 'E o sobrenome?';
         if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(form.email)) errs.email = 'E-mail inválido';
-        if (Object.keys(errs).length) { setErrors(errs); return; }
+        if (Object.keys(errs).length) {
+            setErrors(errs);
+            pushFormAnalyticsEvent({
+                event: 'field_error',
+                formType: 'quiz_lead',
+                formId: 'quiz-anhanga',
+                errorType: errs.email ? 'email' : 'required',
+                fieldName: errs.email ? 'email' : 'name',
+                destination: profile.name,
+            });
+            return;
+        }
         onSubmit(form);
     }
 
@@ -82,20 +138,6 @@ export function PreLeadScreen({ profile, onSubmit, onBack, isSubmitting, initial
                             autoComplete="given-name"
                         />
                         {errors.nome && <span className="quiz-err">{errors.nome}</span>}
-                    </div>
-
-                    <div className="quiz-field">
-                        <label htmlFor="quiz-sobrenome">Sobrenome</label>
-                        <input
-                            id="quiz-sobrenome"
-                            type="text"
-                            placeholder="Seu sobrenome"
-                            value={form.sobrenome}
-                            onChange={(e) => update('sobrenome', e.target.value)}
-                            className={errors.sobrenome ? 'has-error' : ''}
-                            autoComplete="family-name"
-                        />
-                        {errors.sobrenome && <span className="quiz-err">{errors.sobrenome}</span>}
                     </div>
 
                     <div className="quiz-field">

--- a/components/landings/quiz/WhatsAppUpgrade.tsx
+++ b/components/landings/quiz/WhatsAppUpgrade.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { getWhatsAppLink } from '../../../utils/whatsapp';
+import { pushFormAnalyticsEvent } from '../../../utils/formAnalytics';
 
 interface WhatsAppUpgradeProps {
     profileName: string;
@@ -33,8 +34,24 @@ export function WhatsAppUpgrade({ profileName, mainDestName, firstName, baseWaUr
 
     function handleSubmit() {
         if (!isValid || submitted) return;
+        pushFormAnalyticsEvent({
+            event: 'field_complete',
+            formType: 'quiz_lead',
+            formId: 'quiz-whatsapp-enrichment',
+            fieldName: 'whatsapp',
+            destination: mainDestName,
+        });
         onPhoneSubmit(phone);
         setSubmitted(true);
+    }
+
+    function trackWhatsAppOpened() {
+        pushFormAnalyticsEvent({
+            event: 'whatsapp_opened',
+            formType: 'quiz_lead',
+            formId: 'quiz-whatsapp-enrichment',
+            destination: mainDestName,
+        });
     }
 
     const waUrl = isValid && submitted
@@ -56,6 +73,7 @@ export function WhatsAppUpgrade({ profileName, mainDestName, firstName, baseWaUr
                     href={waUrl}
                     target="_blank"
                     rel="noopener noreferrer"
+                    onClick={trackWhatsAppOpened}
                     data-tracking="result-quiz-whatsapp"
                 >
                     Montar minha viagem
@@ -93,6 +111,7 @@ export function WhatsAppUpgrade({ profileName, mainDestName, firstName, baseWaUr
                 href={baseWaUrl}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={trackWhatsAppOpened}
                 data-tracking="result-quiz-skip"
             >
                 Ir pro WhatsApp sem deixar número →

--- a/components/search/helpers.ts
+++ b/components/search/helpers.ts
@@ -17,7 +17,7 @@ export const getGuestSummary = (adults: number, children: number): string => {
 
 export const buildSearchMessage = (params: {
   inputValue: string;
-  startDate: Date;
+  startDate: Date | null;
   endDate: Date | null;
   adults: number;
   children: number;
@@ -25,7 +25,7 @@ export const buildSearchMessage = (params: {
   tripType: string;
   budget: string;
 }): string => {
-  const startStr = params.startDate.toLocaleDateString('pt-BR');
+  const startStr = params.startDate ? params.startDate.toLocaleDateString('pt-BR') : 'Datas flexíveis';
   const endStr = params.endDate ? params.endDate.toLocaleDateString('pt-BR') : 'A definir';
   const childAgesStr = params.children > 0
     ? ` (${params.childAges.map((age) => age ? `${age} anos` : 'Idade N/I').join(', ')})`

--- a/docs/superpowers/plans/2026-07-05-form-cro-dashboards.md
+++ b/docs/superpowers/plans/2026-07-05-form-cro-dashboards.md
@@ -1,0 +1,371 @@
+# Form CRO Dashboards Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build trustworthy dashboards for form conversion, field friction, validation errors, and WhatsApp-vs-saved-lead behavior.
+
+**Architecture:** Use GA4/Looker Studio first as a fast event-quality and marketing sanity check, then make Metabase the durable CRO decision layer once form events are available in a queryable warehouse/table. Do not rely on Metabase directly against brittle GA4 ad hoc exports; Metabase should read clean modeled event data.
+
+**Tech Stack:** GTM/dataLayer, GA4 custom dimensions, optional GA4 BigQuery export or first-party event sink, PostgreSQL/BigQuery-compatible modeled table, Metabase self-hosted, Looker Studio for short-term validation.
+
+---
+
+## Scope
+
+This plan starts after the V1 form CRO instrumentation is deployed. The site already emits non-PII form events through `pushFormAnalyticsEvent`.
+
+Events expected:
+- `form_view`
+- `form_start`
+- `field_complete`
+- `field_error`
+- `submit_attempt`
+- `submit_success`
+- `submit_failure`
+- `whatsapp_opened`
+
+Dimensions expected:
+- `form_type`
+- `form_id`
+- `field_name`
+- `error_type`
+- `destination`
+- `page_location`
+
+Important constraint: `destination` and `page_location` may become high-cardinality dimensions. Use them for diagnosis, not as primary executive dashboard dimensions.
+
+---
+
+## File/Data Structure
+
+No site code changes are required for the first dashboard pass unless event delivery gaps are found.
+
+Target modeled table for Metabase:
+
+```sql
+create table form_events (
+  id bigserial primary key,
+  event_name text not null,
+  form_type text not null,
+  form_id text not null,
+  field_name text,
+  error_type text,
+  destination text,
+  page_location text,
+  session_id text,
+  anonymous_id text,
+  device_type text,
+  utm_source text,
+  utm_medium text,
+  utm_campaign text,
+  created_at timestamptz not null
+);
+
+create index form_events_created_at_idx on form_events (created_at);
+create index form_events_form_idx on form_events (form_type, form_id, created_at);
+create index form_events_error_idx on form_events (form_id, field_name, error_type, created_at);
+create index form_events_session_idx on form_events (session_id, created_at);
+```
+
+If using BigQuery instead of Postgres, keep the same logical columns and partition by `created_at`.
+
+---
+
+## Chunk 1: GA4/Looker Studio Sanity Check
+
+### Task 1: Configure GA4 Custom Dimensions
+
+**Files:**
+- No repo file changes expected.
+- Configure in GA4 Admin.
+
+- [ ] **Step 1: Register event-scoped custom dimensions**
+
+Create event-scoped dimensions:
+- `form_type`
+- `form_id`
+- `field_name`
+- `error_type`
+- `destination`
+- `page_location`
+
+- [ ] **Step 2: Confirm events arrive from production/staging**
+
+Use GA4 DebugView or Realtime after interacting with:
+- contact modal
+- footer CTA
+- chat lead form
+- direct WhatsApp chat CTA
+- quiz pre-result form
+- quiz WhatsApp enrichment
+- Lollapalooza waitlist
+- corporate form
+- NPS
+- home search
+
+Expected: each interaction emits the relevant event with `form_type` and `form_id`.
+
+- [ ] **Step 3: Create Looker Studio MVP**
+
+Create pages:
+- Resumo CRO
+- Funil por Formulário
+- Erros por Campo
+- WhatsApp vs Lead Salvo
+- Qualidade dos Eventos
+
+Expected: dashboards show data segmented by `form_type` and `form_id`.
+
+### Task 2: Add Event Quality Checks
+
+**Files:**
+- No repo file changes expected.
+
+- [ ] **Step 1: Build quality scorecards**
+
+Metrics:
+- events missing `form_type`
+- events missing `form_id`
+- events with unexpected `event_name`
+- events with unexpected `field_name`
+- events with unexpected `error_type`
+
+- [ ] **Step 2: Review cardinality**
+
+Check whether `destination` or `page_location` creates noisy reports.
+
+Expected: executive pages rely mainly on `form_type` and `form_id`; detailed exploration can use `destination` and `page_location`.
+
+---
+
+## Chunk 2: Metabase Data Model
+
+### Task 3: Choose the Event Source
+
+**Files:**
+- Possible future repo changes if building a first-party endpoint:
+  - Create: `api/submit-form-event.ts`
+  - Create: `lib/schemas/form-event.ts`
+  - Modify: `utils/formAnalytics.ts`
+  - Test: `tests/form-event-schema.test.ts`
+
+- [ ] **Step 1: Decide between GA4 BigQuery export and first-party sink**
+
+Recommended order:
+1. Use GA4/Looker Studio to validate events.
+2. If GA4 BigQuery export is available, model form events from BigQuery first.
+3. If BigQuery is unavailable or too indirect, build a first-party event sink.
+
+Expected: one reliable source feeds Metabase.
+
+- [ ] **Step 2: Reject direct Metabase-over-GA4 as the main path**
+
+Do not make the official CRO dashboard depend on brittle GA4 connector behavior or manually exported reports.
+
+Expected: Metabase reads a stable SQL source.
+
+### Task 4: Create the `form_events` Model
+
+**Files:**
+- If using Postgres migrations, add migration in the repo-specific migration location.
+- If using BigQuery, create a scheduled model/query outside the app repo and document it.
+
+- [ ] **Step 1: Create the modeled table/view**
+
+Use the logical schema from the File/Data Structure section.
+
+- [ ] **Step 2: Backfill recent data**
+
+Backfill at least 14 days if available.
+
+Expected: Metabase can query recent events by form and timestamp.
+
+- [ ] **Step 3: Create a data freshness check**
+
+Query:
+
+```sql
+select max(created_at) as latest_event_at
+from form_events;
+```
+
+Expected: latest event is recent during active traffic periods.
+
+---
+
+## Chunk 3: Metabase Dashboards
+
+### Task 5: Build Executive Dashboard
+
+**Files:**
+- No repo file changes expected.
+
+- [ ] **Step 1: Create core funnel cards**
+
+Metrics by `form_type` and `form_id`:
+- views: `form_view`
+- starts: `form_start`
+- attempts: `submit_attempt`
+- successes: `submit_success`
+- failures: `submit_failure`
+- WhatsApp opens: `whatsapp_opened`
+
+- [ ] **Step 2: Create conversion-rate cards**
+
+SQL pattern:
+
+```sql
+select
+  form_type,
+  form_id,
+  count(*) filter (where event_name = 'form_view') as views,
+  count(*) filter (where event_name = 'form_start') as starts,
+  count(*) filter (where event_name = 'submit_attempt') as attempts,
+  count(*) filter (where event_name = 'submit_success') as successes,
+  count(*) filter (where event_name = 'submit_failure') as failures,
+  count(*) filter (where event_name = 'whatsapp_opened') as whatsapp_opens,
+  count(*) filter (where event_name = 'form_start')::numeric
+    / nullif(count(*) filter (where event_name = 'form_view'), 0) as start_rate,
+  count(*) filter (where event_name = 'submit_success')::numeric
+    / nullif(count(*) filter (where event_name = 'submit_attempt'), 0) as success_rate
+from form_events
+where created_at >= now() - interval '30 days'
+group by form_type, form_id
+order by starts desc;
+```
+
+Expected: the team can compare forms without opening GA4.
+
+### Task 6: Build Field/Error Diagnostic Dashboard
+
+**Files:**
+- No repo file changes expected.
+
+- [ ] **Step 1: Create errors by field table**
+
+SQL pattern:
+
+```sql
+select
+  form_type,
+  form_id,
+  field_name,
+  error_type,
+  count(*) as error_events
+from form_events
+where event_name = 'field_error'
+  and created_at >= now() - interval '30 days'
+group by form_type, form_id, field_name, error_type
+order by error_events desc;
+```
+
+- [ ] **Step 2: Create errors as share of starts**
+
+SQL pattern:
+
+```sql
+with starts as (
+  select form_id, count(*) as starts
+  from form_events
+  where event_name = 'form_start'
+    and created_at >= now() - interval '30 days'
+  group by form_id
+),
+errors as (
+  select form_id, field_name, error_type, count(*) as errors
+  from form_events
+  where event_name = 'field_error'
+    and created_at >= now() - interval '30 days'
+  group by form_id, field_name, error_type
+)
+select
+  errors.form_id,
+  errors.field_name,
+  errors.error_type,
+  errors.errors,
+  starts.starts,
+  errors.errors::numeric / nullif(starts.starts, 0) as errors_per_start
+from errors
+join starts using (form_id)
+order by errors_per_start desc;
+```
+
+Expected: top friction points are obvious.
+
+### Task 7: Build WhatsApp vs Lead Saved Dashboard
+
+**Files:**
+- No repo file changes expected.
+
+- [ ] **Step 1: Compare direct WhatsApp and backend-backed paths**
+
+Track:
+- `form_type = ai_chatbot_lead`
+- `form_type = ai_chatbot_direct_whatsapp`
+- `whatsapp_opened`
+- `submit_success`
+- `submit_failure`
+
+- [ ] **Step 2: Flag lead leakage intentionally**
+
+Create a card showing direct WhatsApp opens that did not have a matching saved-lead success in the same session.
+
+Expected: the team can see whether the direct path is increasing conversations at the cost of CRM-captured leads.
+
+---
+
+## Chunk 4: Operationalization
+
+### Task 8: Add Alerts
+
+**Files:**
+- No repo file changes expected unless alerts are codified elsewhere.
+
+- [ ] **Step 1: Add failure-rate alert**
+
+Alert when:
+- `submit_failure / submit_attempt > 10%` over the last 24 hours for any form with at least 20 attempts.
+
+- [ ] **Step 2: Add event-quality alert**
+
+Alert when:
+- events missing `form_type` or `form_id` exceed 1% in the last 24 hours.
+
+Expected: instrumentation breakage is caught quickly.
+
+### Task 9: Review Cadence
+
+**Files:**
+- No repo file changes expected.
+
+- [ ] **Step 1: Schedule weekly CRO review**
+
+Review:
+- highest-abandonment form
+- top field errors
+- direct WhatsApp vs saved lead trend
+- mobile vs desktop gap
+- paid vs organic gap
+
+- [ ] **Step 2: Convert findings into experiments**
+
+Each action should become either:
+- copy/layout change
+- validation change
+- field reduction
+- backend reliability task
+- A/B test
+
+Expected: dashboard insights turn into shipped improvements, not passive reporting.
+
+---
+
+## Validation Checklist
+
+- [ ] GA4 receives all expected events.
+- [ ] Looker Studio sanity dashboard has no missing `form_type`/`form_id` issues.
+- [ ] Metabase queries refresh from a stable SQL source.
+- [ ] Executive dashboard answers which forms convert.
+- [ ] Diagnostic dashboard answers which fields/errors create friction.
+- [ ] WhatsApp dashboard separates saved leads from direct conversations.
+- [ ] Alerts catch backend failure and instrumentation breakage.

--- a/hooks/useContactForm.ts
+++ b/hooks/useContactForm.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState, useRef } from 'react';
 import { useAntiBot } from './useAntiBot';
-import { cleanString } from '../lib/lead-logic';
+import { cleanString, splitFullName } from '../lib/lead-logic';
 import { getTrackingDataObject, getWhatsAppLink } from '../utils/whatsapp';
 import { createLeadEventId, extractUtms } from './useLeadCapture';
 import type { ContactFormFields, SubmitContactRequest, SubmitContactResponse } from '../types/contactCapture';
@@ -179,9 +179,13 @@ export function useContactForm(options: ContactModalOptions = {}) {
                 window.open(whatsappUrl, '_blank', 'noopener,noreferrer');
             }
 
+            // The UI dropped the separate sobrenome input (ContactModal/CtaBody now
+            // ask for the full name in `firstName`), so split it here to keep the
+            // last name flowing into the CRM instead of leaving it empty.
+            const { firstName, lastName } = splitFullName(fields.firstName, fields.lastName);
             const requestBody: SubmitContactRequest = {
-                firstName: cleanString(fields.firstName),
-                lastName: cleanString(fields.lastName) || undefined,
+                firstName: cleanString(firstName),
+                lastName: cleanString(lastName) || undefined,
                 whatsapp: cleanString(fields.whatsapp),
                 email: cleanString(fields.email) || undefined,
                 emailOptIn: fields.emailOptIn,

--- a/hooks/useContactForm.ts
+++ b/hooks/useContactForm.ts
@@ -6,6 +6,7 @@ import { createLeadEventId, extractUtms } from './useLeadCapture';
 import type { ContactFormFields, SubmitContactRequest, SubmitContactResponse } from '../types/contactCapture';
 import type { LeadTracking } from '../types/leadCapture';
 import type { ContactModalOptions } from '../utils/contactForm';
+import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
 
 const EMPTY_FIELDS: ContactFormFields = {
     firstName: '',
@@ -102,17 +103,40 @@ export function useContactForm(options: ContactModalOptions = {}) {
     const [fields, setFieldsState] = useState<ContactFormFields>(EMPTY_FIELDS);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const isLocallySubmitting = useRef(false);
+    const hasStarted = useRef(false);
+    const completedFields = useRef<Set<keyof ContactFormFields>>(new Set());
     const [error, setError] = useState<string | null>(null);
     const [submitted, setSubmitted] = useState(false);
 
     const isValid = Boolean(fields.firstName.trim() && fields.whatsapp.trim());
+    const formId = options.source ?? 'contact-modal';
 
     const setField = useCallback(
         (key: keyof ContactFormFields, value: string | boolean) => {
             setFieldsState((prev) => ({ ...prev, [key]: value }));
             setError(null);
+
+            if (!hasStarted.current) {
+                hasStarted.current = true;
+                pushFormAnalyticsEvent({
+                    event: 'form_start',
+                    formType: 'contact_modal',
+                    formId,
+                });
+            }
+
+            const completed = typeof value === 'boolean' ? value : value.trim().length > 0;
+            if (completed && !completedFields.current.has(key)) {
+                completedFields.current.add(key);
+                pushFormAnalyticsEvent({
+                    event: 'field_complete',
+                    formType: 'contact_modal',
+                    formId,
+                    fieldName: key,
+                });
+            }
         },
-        [],
+        [formId],
     );
 
     const reset = useCallback(() => {
@@ -120,6 +144,8 @@ export function useContactForm(options: ContactModalOptions = {}) {
         setIsSubmitting(false);
         setError(null);
         setSubmitted(false);
+        hasStarted.current = false;
+        completedFields.current.clear();
     }, []);
 
     const submit = useCallback(
@@ -129,6 +155,12 @@ export function useContactForm(options: ContactModalOptions = {}) {
             isLocallySubmitting.current = true;
             setIsSubmitting(true);
             setError(null);
+            pushFormAnalyticsEvent({
+                event: 'submit_attempt',
+                formType: 'contact_modal',
+                formId,
+                destination: action,
+            });
 
             const eventId = createLeadEventId();
             const { tracking, utms } = collectTracking();
@@ -138,6 +170,12 @@ export function useContactForm(options: ContactModalOptions = {}) {
             const whatsappUrl = getWhatsAppLink(whatsappMessage, { appendTrackingRef: true });
 
             if (action === 'whatsapp') {
+                pushFormAnalyticsEvent({
+                    event: 'whatsapp_opened',
+                    formType: 'contact_modal',
+                    formId,
+                    destination: action,
+                });
                 window.open(whatsappUrl, '_blank', 'noopener,noreferrer');
             }
 
@@ -168,28 +206,62 @@ export function useContactForm(options: ContactModalOptions = {}) {
                     const errData = data as Extract<SubmitContactResponse, { ok: false }>;
                     if (action === 'whatsapp') {
                         console.warn('[submit-contact] tracking failed:', errData.code);
+                        pushFormAnalyticsEvent({
+                            event: 'submit_failure',
+                            formType: 'contact_modal',
+                            formId,
+                            errorType: errData.code,
+                            destination: action,
+                        });
                         setSubmitted(true);
                     } else {
                         setError(errData.error || 'Não foi possível enviar. Tente novamente.');
+                        pushFormAnalyticsEvent({
+                            event: 'submit_failure',
+                            formType: 'contact_modal',
+                            formId,
+                            errorType: errData.code,
+                            destination: action,
+                        });
                     }
                     return;
                 }
 
                 pushContactDataLayerEvent(eventId, action, options.source);
+                pushFormAnalyticsEvent({
+                    event: 'submit_success',
+                    formType: 'contact_modal',
+                    formId,
+                    destination: action,
+                });
                 setSubmitted(true);
             } catch {
                 if (action === 'whatsapp') {
                     console.warn('[submit-contact] fetch failed after opening WhatsApp');
+                    pushFormAnalyticsEvent({
+                        event: 'submit_failure',
+                        formType: 'contact_modal',
+                        formId,
+                        errorType: 'network',
+                        destination: action,
+                    });
                     setSubmitted(true);
                 } else {
                     setError('Erro de conexão. Verifique sua internet e tente novamente.');
+                    pushFormAnalyticsEvent({
+                        event: 'submit_failure',
+                        formType: 'contact_modal',
+                        formId,
+                        errorType: 'network',
+                        destination: action,
+                    });
                 }
             } finally {
                 setIsSubmitting(false);
                 isLocallySubmitting.current = false;
             }
         },
-        [fields, isValid, options, getAntiBotFields],
+        [fields, isValid, options, getAntiBotFields, formId],
     );
 
     return { fields, setField, isValid, isSubmitting, error, submitted, submit, reset, honeypotProps };

--- a/lib/api-catalog.ts
+++ b/lib/api-catalog.ts
@@ -228,7 +228,7 @@ const API_ENDPOINTS: readonly ApiEndpointDefinition[] = [
                 'application/json': {
                     schema: {
                         type: 'object',
-                        required: ['firstname', 'email', 'score', 'reason'],
+                        required: ['firstname', 'email', 'score'],
                         properties: {
                             firstname: { type: 'string' },
                             email: { type: 'string', format: 'email' },

--- a/lib/lead-logic.ts
+++ b/lib/lead-logic.ts
@@ -55,6 +55,23 @@ export function cleanString(value: unknown): string {
 }
 
 /**
+ * Splits a single "full name" field into first/last name, preserving an
+ * explicit last name when one is provided. Several forms collapsed the
+ * nome+sobrenome pair into one field to cut friction, so a full name typed
+ * there ("João Silva") would otherwise drop everything past the first token
+ * before reaching the CRM. Falls back to the remaining tokens as the last name.
+ */
+export function splitFullName(
+    fullName: string,
+    explicitLastName = '',
+): { firstName: string; lastName: string } {
+    const parts = fullName.trim().split(/\s+/).filter(Boolean);
+    const firstName = parts[0] ?? '';
+    const lastName = explicitLastName.trim() || parts.slice(1).join(' ');
+    return { firstName, lastName };
+}
+
+/**
  * Normalizes a string or returns null if empty.
  * Includes a maximum length check to prevent DoS via excessive regex execution.
  */

--- a/lib/odoo-lead-mapping.ts
+++ b/lib/odoo-lead-mapping.ts
@@ -299,7 +299,7 @@ const EMPTY_UTMS: LeadUtms = {
  */
 export function leadInputFromSubmitNps(data: SubmitNpsRequest): OdooLeadInput {
     const contextNote = buildContextNote([
-        `NPS ${data.score}/10 — ${data.reason}`,
+        data.reason ? `NPS ${data.score}/10 — ${data.reason}` : `NPS ${data.score}/10`,
         data.highlight ? `Momento marcante: ${data.highlight}` : null,
     ]);
 

--- a/lib/quiz-logic.ts
+++ b/lib/quiz-logic.ts
@@ -3,6 +3,21 @@ import type { SubmitQuizRequest } from '../types/quiz';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/** Derives firstName/lastName from the quiz form, whose UI collapsed
+ *  nome+sobrenome into a single "nome" field to cut friction. Keeps an
+ *  explicit `sobrenome` when present (e.g. prefilled from the URL); otherwise
+ *  falls back to the remaining tokens of the full name ("João Silva" → "Silva")
+ *  so the last name is not silently dropped before it reaches the CRM. */
+export function deriveQuizLeadName(
+    nome: string,
+    sobrenome: string,
+): { firstName: string; lastName: string } {
+    const nameParts = nome.trim().split(/\s+/).filter(Boolean);
+    const firstName = nameParts[0] || 'Viajante';
+    const lastName = sobrenome.trim() || nameParts.slice(1).join(' ');
+    return { firstName, lastName };
+}
+
 export function validateQuizPayload(
     payload: unknown,
 ): { valid: true; data: SubmitQuizRequest } | { valid: false; error: string } {

--- a/lib/quiz-logic.ts
+++ b/lib/quiz-logic.ts
@@ -1,21 +1,17 @@
-import { cleanString, normalizeNullable, normalizeTracking, normalizeUtms, normalizeWhatsappNumber } from './lead-logic';
+import { cleanString, normalizeNullable, normalizeTracking, normalizeUtms, normalizeWhatsappNumber, splitFullName } from './lead-logic';
 import type { SubmitQuizRequest } from '../types/quiz';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-/** Derives firstName/lastName from the quiz form, whose UI collapsed
- *  nome+sobrenome into a single "nome" field to cut friction. Keeps an
- *  explicit `sobrenome` when present (e.g. prefilled from the URL); otherwise
- *  falls back to the remaining tokens of the full name ("João Silva" → "Silva")
- *  so the last name is not silently dropped before it reaches the CRM. */
+/** Derives firstName/lastName from the quiz form via {@link splitFullName},
+ *  applying the quiz-specific "Viajante" fallback when the name is empty so the
+ *  WhatsApp copy and CRM payload always have a first name. */
 export function deriveQuizLeadName(
     nome: string,
     sobrenome: string,
 ): { firstName: string; lastName: string } {
-    const nameParts = nome.trim().split(/\s+/).filter(Boolean);
-    const firstName = nameParts[0] || 'Viajante';
-    const lastName = sobrenome.trim() || nameParts.slice(1).join(' ');
-    return { firstName, lastName };
+    const { firstName, lastName } = splitFullName(nome, sobrenome);
+    return { firstName: firstName || 'Viajante', lastName };
 }
 
 export function validateQuizPayload(

--- a/lib/schemas/submit-nps.ts
+++ b/lib/schemas/submit-nps.ts
@@ -18,9 +18,8 @@ export const SubmitNpsBodySchema = z.object({
     firstname: z.string().trim().min(1).max(100).transform(cleanString).refine((v) => v.length <= 100, { message: 'Nome inválido.' }),
     email:     z.email().max(254),
     score:     z.number().int().min(0).max(10),
-    reason:    z.string().trim().min(1).max(2000).transform(cleanString),
+    reason:    z.string().trim().max(2000).default('').transform(cleanString),
     highlight: z.string().trim().max(2000).default('').transform(cleanString),
 });
 
 export type SubmitNpsRequest = z.infer<typeof SubmitNpsBodySchema>;
-

--- a/pages/NpsPage.tsx
+++ b/pages/NpsPage.tsx
@@ -1,5 +1,5 @@
 import type { FormEvent } from 'react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { BRAND_LOGO_WHITE_URL } from '../lib/media-assets';
 import { NpsTextarea } from '../components/nps/NpsTextarea';
@@ -8,6 +8,7 @@ import { NpsThankPromoter } from '../components/nps/NpsThankPromoter';
 import { NpsThankOther } from '../components/nps/NpsThankOther';
 import { Seo } from '../components/Seo';
 import { useAntiBot } from '../hooks/useAntiBot';
+import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
 
 type PageState = 'form' | 'thank-promoter' | 'thank-other';
 
@@ -75,6 +76,8 @@ export default function NpsPage() {
   const [errorMessage, setErrorMessage] = useState('');
   const [year] = useState(() => new Date().getFullYear());
   const { getAntiBotFields, honeypotProps } = useAntiBot();
+  const startedRef = useRef(false);
+  const completedFields = useRef<Set<string> | null>(null);
 
   useEffect(() => {
     const prev = document.title;
@@ -82,12 +85,46 @@ export default function NpsPage() {
     return () => { document.title = prev; };
   }, []);
 
+  useEffect(() => {
+    pushFormAnalyticsEvent({
+      event: 'form_view',
+      formType: 'nps',
+      formId: 'post-trip-nps',
+    });
+  }, []);
+
+  function markStarted(fieldName: 'score' | 'reason' | 'highlight') {
+    if (!startedRef.current) {
+      startedRef.current = true;
+      pushFormAnalyticsEvent({
+        event: 'form_start',
+        formType: 'nps',
+        formId: 'post-trip-nps',
+      });
+    }
+    const trackedFields = completedFields.current ?? (completedFields.current = new Set());
+    if (!trackedFields.has(fieldName)) {
+      trackedFields.add(fieldName);
+      pushFormAnalyticsEvent({
+        event: 'field_complete',
+        formType: 'nps',
+        formId: 'post-trip-nps',
+        fieldName,
+      });
+    }
+  }
+
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (score === null) return;
 
     setSubmitting(true);
     setErrorMessage('');
+    pushFormAnalyticsEvent({
+      event: 'submit_attempt',
+      formType: 'nps',
+      formId: 'post-trip-nps',
+    });
 
     try {
       const res = await fetch('/api/submit-nps', {
@@ -110,15 +147,26 @@ export default function NpsPage() {
         );
       }
 
+      pushFormAnalyticsEvent({
+        event: 'submit_success',
+        formType: 'nps',
+        formId: 'post-trip-nps',
+      });
       setPageState(score >= 9 ? 'thank-promoter' : 'thank-other');
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : 'Erro inesperado. Tente novamente.');
+      pushFormAnalyticsEvent({
+        event: 'submit_failure',
+        formType: 'nps',
+        formId: 'post-trip-nps',
+        errorType: 'api',
+      });
     } finally {
       setSubmitting(false);
     }
   }
 
-  const submitEnabled = score !== null && !!reason.trim() && !submitting;
+  const submitEnabled = score !== null && !submitting;
 
   return (
     <>
@@ -157,7 +205,10 @@ export default function NpsPage() {
 
                 <NpsScoreSelector
                   score={score}
-                  onSelect={setScore}
+                  onSelect={(nextScore) => {
+                    setScore(nextScore);
+                    markStarted('score');
+                  }}
                 />
 
                 <div className="mb-8">
@@ -165,17 +216,22 @@ export default function NpsPage() {
                     htmlFor="nps-reason"
                     className="block text-xs font-black uppercase tracking-[0.15em] text-slate-400 mb-2.5"
                   >
-                    O que te levou a dar essa nota?
+                    Quer contar o motivo?
+                    <span className="normal-case font-normal tracking-normal text-slate-600">
+                      {' '}(opcional)
+                    </span>
                   </label>
                   <NpsTextarea
                     id="nps-reason"
                     value={reason}
-                    onChange={setReason}
+                    onChange={(value) => {
+                      setReason(value);
+                      if (value.trim()) markStarted('reason');
+                    }}
                     placeholder="Conte-nos sua experiência..."
                     rows={4}
-                    required
                     maxLength={2000}
-                    aria-label="O que te levou a dar essa nota?"
+                    aria-label="Quer contar o motivo?"
                   />
                 </div>
 
@@ -192,7 +248,10 @@ export default function NpsPage() {
                   <NpsTextarea
                     id="nps-highlight"
                     value={highlight}
-                    onChange={setHighlight}
+                    onChange={(value) => {
+                      setHighlight(value);
+                      if (value.trim()) markStarted('highlight');
+                    }}
                     placeholder="Um momento especial que ficou na memória..."
                     rows={3}
                     maxLength={2000}

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -4,6 +4,7 @@ import { BreadcrumbSchema } from '../../components/schemas/BreadcrumbSchema';
 import { useQuizCapture } from '../../hooks/useQuizCapture';
 import type { HoneypotProps } from '../../hooks/useAntiBot';
 import { getWhatsAppLink } from '../../utils/whatsapp';
+import { pushFormAnalyticsEvent } from '../../utils/formAnalytics';
 import { matchProfile, type ProfileKey } from '../../lib/quiz-scoring';
 import {
     selectMainDestination,
@@ -268,7 +269,21 @@ export default function QuizAnhangaLanding() {
         submittingRef.current = false;
 
         if (!result.ok) {
+            pushFormAnalyticsEvent({
+                event: 'submit_failure',
+                formType: 'quiz_lead',
+                formId: 'quiz-anhanga',
+                errorType: result.code,
+                destination: mainDest.name,
+            });
             dispatch({ type: 'SUBMIT_FAILED' });
+        } else {
+            pushFormAnalyticsEvent({
+                event: 'submit_success',
+                formType: 'quiz_lead',
+                formId: 'quiz-anhanga',
+                destination: mainDest.name,
+            });
         }
     }
 

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -6,6 +6,7 @@ import type { HoneypotProps } from '../../hooks/useAntiBot';
 import { getWhatsAppLink } from '../../utils/whatsapp';
 import { pushFormAnalyticsEvent } from '../../utils/formAnalytics';
 import { matchProfile, type ProfileKey } from '../../lib/quiz-scoring';
+import { deriveQuizLeadName } from '../../lib/quiz-logic';
 import {
     selectMainDestination,
     selectInspirationDestinations,
@@ -181,8 +182,7 @@ function buildQuizSubmitInput(
 ): QuizSubmitInput {
     const profile = TRAVELER_PROFILES[pKey];
     const mainDest = selectMainDestination(pKey, answers.destino ?? []);
-    const firstName = form.nome.trim().split(/\s+/)[0] || 'Viajante';
-    const lastName = form.sobrenome.trim();
+    const { firstName, lastName } = deriveQuizLeadName(form.nome, form.sobrenome);
     const bantSummary = `Quiz Anhangá · Perfil: ${profile.name} · Destino: ${mainDest.name} · ${buildAnswersSummary(answers)}`;
 
     return {

--- a/tests/chat-lead-form-a11y.test.ts
+++ b/tests/chat-lead-form-a11y.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { TextField, validateLeadForm } from '../components/ChatLeadForm.tsx';
+import { ChatLeadForm, TextField, validateLeadForm } from '../components/ChatLeadForm.tsx';
 
 const baseProps = {
   id: 'lead-email',
@@ -65,4 +65,34 @@ test('validateLeadForm — sem aceite de LGPD a submissão é bloqueada', () => 
     assert.ok(result.fieldErrors);
     assert.equal(result.fieldErrors.lgpd, 'Você deve aceitar os termos');
   }
+});
+
+test('ChatLeadForm oferece caminho direto para WhatsApp sem salvar lead', () => {
+  const html = renderToStaticMarkup(
+    React.createElement(ChatLeadForm, {
+      destination: 'Orlando',
+      defaultBantSummary: 'Need: Disney',
+      getWhatsAppUrl: () => 'https://wa.me/5511999999999',
+      prepareLeadSubmitPayload: () => ({
+        firstName: 'Ana',
+        lastName: 'Silva',
+        email: 'ana@example.com',
+        whatsapp: '+5511999999999',
+        bantSummary: 'Need: Disney',
+        destination: 'Orlando',
+        event_id: 'lead_test',
+        utms: {
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_term: null,
+          utm_content: null,
+        },
+      }),
+      isSubmittingLead: false,
+      onFinalizeLead: async () => ({ ok: true }),
+    }),
+  );
+
+  assert.match(html, /Ir direto para o WhatsApp/);
 });

--- a/tests/corp-form-reducer.test.ts
+++ b/tests/corp-form-reducer.test.ts
@@ -23,8 +23,8 @@ describe('validateCorpForm', () => {
         const result = validateCorpForm({ ...VALID_FORM, firstName: '' }, true);
         assert.equal(result.ok, false);
         if (!result.ok) {
-            assert.equal(result.field, 'required');
-            assert.equal(result.message, 'Preencha todos os campos obrigatórios');
+            assert.equal(result.field, 'firstName');
+            assert.equal(result.message, 'Informe seu nome.');
         }
     });
 
@@ -32,7 +32,7 @@ describe('validateCorpForm', () => {
         const result = validateCorpForm({ ...VALID_FORM, email: '   ' }, true);
         assert.equal(result.ok, false);
         if (!result.ok) {
-            assert.equal(result.field, 'required');
+            assert.equal(result.field, 'email');
         }
     });
 
@@ -41,7 +41,7 @@ describe('validateCorpForm', () => {
         assert.equal(result.ok, false);
         if (!result.ok) {
             assert.equal(result.field, 'email');
-            assert.equal(result.message, 'Insira um e-mail corporativo válido');
+            assert.equal(result.message, 'Insira um e-mail profissional válido');
         }
     });
 
@@ -67,7 +67,7 @@ describe('validateCorpForm', () => {
         const result = validateCorpForm({ ...VALID_FORM, firstName: '', email: 'bad' }, true);
         assert.equal(result.ok, false);
         if (!result.ok) {
-            assert.equal(result.field, 'required');
+            assert.equal(result.field, 'firstName');
         }
     });
 

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -68,6 +68,7 @@ test.describe('Corporativo Landing Page', () => {
     await landing.submit();
 
     await landing.expectError('Informe seu nome.');
+    await expect(page.getByText('Aceite obrigatório')).toHaveCount(0);
   });
 
   test('should block submit when LGPD consent is not accepted', async ({ page }) => {

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -67,7 +67,7 @@ test.describe('Corporativo Landing Page', () => {
 
     await landing.submit();
 
-    await landing.expectError('Preencha todos os campos obrigatórios');
+    await landing.expectError('Informe seu nome.');
   });
 
   test('should block submit when LGPD consent is not accepted', async ({ page }) => {

--- a/tests/e2e/lollapalooza-waitlist.spec.ts
+++ b/tests/e2e/lollapalooza-waitlist.spec.ts
@@ -1,14 +1,5 @@
 import { expect, test } from '@playwright/test';
 
-async function acceptLgpd(page: import('@playwright/test').Page) {
-  await page.locator('input[type="checkbox"]').first().evaluate((element) => {
-    const input = element as HTMLInputElement;
-    if (!input.checked) {
-      input.click();
-    }
-  });
-}
-
 test.describe('Lollapalooza evergreen landing waitlist', () => {
   test('should redirect the legacy year route to the evergreen route', async ({ page }) => {
     await page.goto('/lollapalooza-2026');
@@ -41,7 +32,6 @@ test.describe('Lollapalooza evergreen landing waitlist', () => {
 
     await page.locator('#lolla-waitlist-name').fill('Felipe William');
     await page.locator('#lolla-waitlist-email').fill('felipe@example.com');
-    await acceptLgpd(page);
 
     await page.getByRole('button', { name: /entrar na lista/i }).click();
 
@@ -51,6 +41,7 @@ test.describe('Lollapalooza evergreen landing waitlist', () => {
     expect(submitPayload).toMatchObject({
       name: 'Felipe William',
       email: 'felipe@example.com',
+      emailOptIn: false,
       sourcePage: '/lollapalooza',
       utms: {
         utm_source: 'google',

--- a/tests/e2e/pages/ContactModal.ts
+++ b/tests/e2e/pages/ContactModal.ts
@@ -4,7 +4,6 @@ export class ContactModal {
   readonly page: Page;
   readonly modal: Locator;
   readonly firstNameInput: Locator;
-  readonly lastNameInput: Locator;
   readonly whatsappInput: Locator;
   readonly emailInput: Locator;
   readonly optInCheckbox: Locator;
@@ -16,7 +15,6 @@ export class ContactModal {
     this.page = page;
     this.modal = page.getByRole('dialog', { name: 'Fale com um especialista' });
     this.firstNameInput = page.locator('#contact-firstName');
-    this.lastNameInput = page.locator('#contact-lastName');
     this.whatsappInput = page.locator('#contact-whatsapp');
     this.emailInput = page.locator('#contact-email');
     this.optInCheckbox = page.locator('#contact-optIn');
@@ -27,13 +25,11 @@ export class ContactModal {
 
   async fillForm(data: {
     firstName: string;
-    lastName?: string;
     whatsapp: string;
     email?: string;
     optIn?: boolean;
   }) {
     await this.firstNameInput.fill(data.firstName);
-    if (data.lastName) await this.lastNameInput.fill(data.lastName);
     await this.whatsappInput.fill(data.whatsapp);
     if (data.email) await this.emailInput.fill(data.email);
     if (data.optIn) {

--- a/tests/e2e/pages/CorporativoPage.ts
+++ b/tests/e2e/pages/CorporativoPage.ts
@@ -26,7 +26,7 @@ export class CorporativoPage {
     this.lgpdCheckbox = page.locator('#lgpd-corp');
     this.submitBtn = page.locator('button[type="submit"]');
     this.successHeading = page.locator('h3:has-text("Mensagem recebida!")');
-    this.errorAlert = page.locator('p[role="alert"]');
+    this.errorAlert = page.locator('[role="alert"]');
     this.whatsappCta = page.locator('a[data-contact-intent]').first();
     this.contactAnchor = page.locator('a[href="#contato"]');
   }

--- a/tests/e2e/pages/LollapaloozaPage.ts
+++ b/tests/e2e/pages/LollapaloozaPage.ts
@@ -35,7 +35,7 @@ export class LollapaloozaPage {
 
     if (data.acceptLgpd !== false) {
       // Direct label click is most reliable for sr-only inputs
-      await this.page.locator('label').filter({ hasText: 'Autorizo a Anhangá' }).click();
+      await this.page.locator('label').filter({ hasText: 'Quero receber novidades' }).click();
 
       // If click doesn't work (e.g. mobile overlap), fallback to evaluate but wait for React
       const isChecked = await this.lgpdCheckbox.isChecked();

--- a/tests/e2e/quiz-double-submit.spec.ts
+++ b/tests/e2e/quiz-double-submit.spec.ts
@@ -50,7 +50,6 @@ test.describe('Quiz — proteção contra duplo envio do lead', () => {
         // Tela de lead.
         await expect(page.locator('#quiz-nome')).toBeVisible();
         await page.locator('#quiz-nome').fill('Maria');
-        await page.locator('#quiz-sobrenome').fill('Silva');
         await page.locator('#quiz-email').fill('maria@example.com');
 
         // Dispara dois cliques no mesmo tick, antes de qualquer re-render do React.

--- a/tests/e2e/quiz-whatsapp.spec.ts
+++ b/tests/e2e/quiz-whatsapp.spec.ts
@@ -43,7 +43,6 @@ test.describe('Quiz — captura de WhatsApp no resultado', () => {
         // Tela de lead.
         await expect(page.locator('#quiz-nome')).toBeVisible();
         await page.locator('#quiz-nome').fill('Maria');
-        await page.locator('#quiz-sobrenome').fill('Silva');
         await page.locator('#quiz-email').fill('maria@example.com');
         await page.getByRole('button', { name: /revelar meu perfil/i }).click();
 

--- a/tests/form-analytics.test.ts
+++ b/tests/form-analytics.test.ts
@@ -43,6 +43,38 @@ test('pushFormAnalyticsEvent sends a non-PII form event to dataLayer', () => {
   });
 });
 
+test('pushFormAnalyticsEvent redige todos os e-mails/telefones no fallback de URL malformada', () => {
+  const pushed: unknown[] = [];
+  const previousWindow = globalThis.window;
+  // href sem origin válido força o catch de currentPageLocation (new URL() lança),
+  // exercitando o fallback baseado em regex global — que deve redigir TODAS as
+  // ocorrências, não só a primeira.
+  Object.defineProperty(globalThis, 'window', {
+    value: {
+      location: { href: 'a@b.com and c@d.com and +5511999999999' },
+      dataLayer: { push: (event: unknown) => pushed.push(event) },
+    },
+    configurable: true,
+  });
+
+  try {
+    pushFormAnalyticsEvent({
+      event: 'form_view',
+      formType: 'quiz_lead',
+      formId: 'quiz-anhanga',
+    });
+  } finally {
+    Object.defineProperty(globalThis, 'window', {
+      value: previousWindow,
+      configurable: true,
+    });
+  }
+
+  const pageLocation = (pushed[0] as Record<string, string>).page_location;
+  assert.doesNotMatch(pageLocation, /@/, 'nenhum e-mail deve sobrar');
+  assert.doesNotMatch(pageLocation, /\d{5,}/, 'nenhum telefone deve sobrar');
+});
+
 test('pushFormAnalyticsEvent ignores unknown field names and sensitive destinations', () => {
   const pushed: unknown[] = [];
   const previousWindow = globalThis.window;

--- a/tests/form-analytics.test.ts
+++ b/tests/form-analytics.test.ts
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  pushFormAnalyticsEvent,
+  type FormAnalyticsEvent,
+} from '../utils/formAnalytics.ts';
+
+test('pushFormAnalyticsEvent sends a non-PII form event to dataLayer', () => {
+  const pushed: unknown[] = [];
+  const previousWindow = globalThis.window;
+  Object.defineProperty(globalThis, 'window', {
+    value: {
+      location: { href: 'https://www.anhanga.tur.br/?email=ana@example.com' },
+      dataLayer: { push: (event: unknown) => pushed.push(event) },
+    },
+    configurable: true,
+  });
+
+  try {
+    const event: FormAnalyticsEvent = {
+      event: 'field_complete',
+      formType: 'contact_modal',
+      formId: 'contact-modal',
+      fieldName: 'email',
+      destination: 'ana@example.com',
+    };
+
+    pushFormAnalyticsEvent(event);
+  } finally {
+    Object.defineProperty(globalThis, 'window', {
+      value: previousWindow,
+      configurable: true,
+    });
+  }
+
+  assert.equal(pushed.length, 1);
+  assert.deepEqual(pushed[0], {
+    event: 'field_complete',
+    form_type: 'contact_modal',
+    form_id: 'contact-modal',
+    field_name: 'email',
+    page_location: 'https://www.anhanga.tur.br/?email=redacted',
+  });
+});
+
+test('pushFormAnalyticsEvent ignores unknown field names and sensitive destinations', () => {
+  const pushed: unknown[] = [];
+  const previousWindow = globalThis.window;
+  Object.defineProperty(globalThis, 'window', {
+    value: {
+      location: { href: 'https://www.anhanga.tur.br/quiz/' },
+      dataLayer: { push: (event: unknown) => pushed.push(event) },
+    },
+    configurable: true,
+  });
+
+  try {
+    pushFormAnalyticsEvent({
+      event: 'submit_failure',
+      formType: 'quiz_lead',
+      formId: 'quiz-anhanga',
+      fieldName: 'full_email',
+      errorType: 'validation',
+      destination: '+5511999999999',
+    });
+  } finally {
+    Object.defineProperty(globalThis, 'window', {
+      value: previousWindow,
+      configurable: true,
+    });
+  }
+
+  assert.deepEqual(pushed[0], {
+    event: 'submit_failure',
+    form_type: 'quiz_lead',
+    form_id: 'quiz-anhanga',
+    error_type: 'validation',
+    page_location: 'https://www.anhanga.tur.br/quiz/',
+  });
+});

--- a/tests/lib-lead-logic.test.ts
+++ b/tests/lib-lead-logic.test.ts
@@ -6,10 +6,41 @@ import {
     maskPhone,
     maskName,
     cleanString,
+    splitFullName,
     normalizeNullable,
     normalizeUtms,
     normalizeTracking,
 } from '../lib/lead-logic.ts';
+
+// ─── splitFullName ────────────────────────────────────────────────────────────
+
+test('splitFullName preserva um sobrenome explícito quando fornecido', () => {
+    assert.deepEqual(splitFullName('João', 'Silva'), { firstName: 'João', lastName: 'Silva' });
+});
+
+test('splitFullName deriva o sobrenome do nome completo quando não há explícito', () => {
+    assert.deepEqual(splitFullName('Maria Silva'), { firstName: 'Maria', lastName: 'Silva' });
+});
+
+test('splitFullName junta os tokens restantes como sobrenome', () => {
+    assert.deepEqual(splitFullName('Ana Maria de Souza'), { firstName: 'Ana', lastName: 'Maria de Souza' });
+});
+
+test('splitFullName dá precedência ao sobrenome explícito sobre o nome completo', () => {
+    assert.deepEqual(splitFullName('João Silva', 'Souza'), { firstName: 'João', lastName: 'Souza' });
+});
+
+test('splitFullName colapsa espaços múltiplos e faz trim', () => {
+    assert.deepEqual(splitFullName('  João   Pedro  ', ''), { firstName: 'João', lastName: 'Pedro' });
+});
+
+test('splitFullName com só o primeiro nome resulta em sobrenome vazio', () => {
+    assert.deepEqual(splitFullName('João', ''), { firstName: 'João', lastName: '' });
+});
+
+test('splitFullName com nome vazio não inventa nome (sem fallback)', () => {
+    assert.deepEqual(splitFullName('   ', '  '), { firstName: '', lastName: '' });
+});
 
 // ─── cleanString ──────────────────────────────────────────────────────────────
 

--- a/tests/quiz-prelead-prefill.test.ts
+++ b/tests/quiz-prelead-prefill.test.ts
@@ -29,7 +29,7 @@ test('pré-preenche os campos com os valores da URL', () => {
     const html = renderScreen({ nome: 'João', sobrenome: 'Silva', email: 'joao@example.com' });
 
     assert.match(html, /id="quiz-nome"[^>]*value="João"/);
-    assert.match(html, /id="quiz-sobrenome"[^>]*value="Silva"/);
+    assert.doesNotMatch(html, /id="quiz-sobrenome"/);
     assert.match(html, /id="quiz-email"[^>]*value="joao@example.com"/);
 });
 
@@ -37,7 +37,7 @@ test('sem initialValues, o formulário inicia vazio (sem regressão)', () => {
     const html = renderScreen();
 
     assert.match(html, /id="quiz-nome"[^>]*value=""/);
-    assert.match(html, /id="quiz-sobrenome"[^>]*value=""/);
+    assert.doesNotMatch(html, /id="quiz-sobrenome"/);
     assert.match(html, /id="quiz-email"[^>]*value=""/);
 });
 

--- a/tests/search-message.test.ts
+++ b/tests/search-message.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSearchMessage } from '../components/search/helpers.ts';
+
+test('buildSearchMessage uses flexible dates when no start date is selected', () => {
+  const message = buildSearchMessage({
+    inputValue: 'Orlando',
+    startDate: null,
+    endDate: null,
+    adults: 2,
+    children: 0,
+    childAges: [],
+    tripType: '',
+    budget: '',
+  });
+
+  assert.match(message, /Destino:\* Orlando/);
+  assert.match(message, /Ida:\* Datas flexíveis/);
+});

--- a/tests/submit-nps-schema.test.ts
+++ b/tests/submit-nps-schema.test.ts
@@ -74,9 +74,12 @@ test('rejeita firstname acima de 100 chars', () => {
     assert.equal(result.success, false);
 });
 
-test('rejeita reason vazia', () => {
+test('aceita reason vazia e normaliza para string vazia', () => {
     const result = SubmitNpsBodySchema.safeParse({ ...VALID, reason: '' });
-    assert.equal(result.success, false);
+    assert.equal(result.success, true);
+    if (result.success) {
+        assert.equal(result.data.reason, '');
+    }
 });
 
 test('rejeita reason acima de 2000 chars', () => {
@@ -104,9 +107,12 @@ test('rejeita whitespace-only firstname', () => {
     assert.equal(result.success, false);
 });
 
-test('rejeita whitespace-only reason', () => {
+test('aceita whitespace-only reason e normaliza para string vazia', () => {
     const result = SubmitNpsBodySchema.safeParse({ ...VALID, reason: '   ' });
-    assert.equal(result.success, false);
+    assert.equal(result.success, true);
+    if (result.success) {
+        assert.equal(result.data.reason, '');
+    }
 });
 
 test('escapa angle brackets em reason (sanitização de fronteira)', () => {

--- a/tests/submit-nps.test.ts
+++ b/tests/submit-nps.test.ts
@@ -182,16 +182,27 @@ test('submit-nps returns 400 for non-numeric score', async (t) => {
     assert.equal(body.code, 'VALIDATION_ERROR');
 });
 
-test('submit-nps returns 400 for empty reason', async (t) => {
+test('submit-nps accepts empty reason', async (t) => {
     t.after(restore);
     setOdooEnv();
     global.fetch = createOdooMock().fetch;
 
     const response = await handler(buildRequest(validBody({ reason: '' })));
-    const body = await response.json() as Record<string, unknown>;
+    assert.equal(response.status, 201);
+});
 
-    assert.equal(response.status, 400);
-    assert.equal(body.code, 'VALIDATION_ERROR');
+test('submit-nps writes a clean comment when reason is empty', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    const mock = createOdooMock();
+    global.fetch = mock.fetch;
+
+    const response = await handler(buildRequest(validBody({ reason: '', highlight: '' })));
+    assert.equal(response.status, 201);
+
+    const partner = mock.partnerFields()!;
+    assert.match(String(partner.comment), /NPS 9\/10/);
+    assert.doesNotMatch(String(partner.comment), /—\s*$/);
 });
 
 test('submit-nps returns 400 for reason over 2000 characters', async (t) => {

--- a/tests/submit-quiz.test.ts
+++ b/tests/submit-quiz.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { validateQuizPayload } from '../lib/quiz-logic.ts';
+import { validateQuizPayload, deriveQuizLeadName } from '../lib/quiz-logic.ts';
 import quizHandler from '../api/submit-quiz.ts';
 import { createOdooMock, setOdooEnv, clearOdooEnv } from './odoo-mock.ts';
 
@@ -14,6 +14,35 @@ const BASE_PAYLOAD = {
     sourcePage: '/quiz',
     utms: { utm_source: null, utm_medium: null, utm_campaign: null, utm_term: null, utm_content: null },
 };
+
+// --- deriveQuizLeadName — split single "nome" field into first/last name ------
+
+test('deriveQuizLeadName — sobrenome explícito é preservado (prefill via URL)', () => {
+    assert.deepEqual(deriveQuizLeadName('João', 'Silva'), { firstName: 'João', lastName: 'Silva' });
+});
+
+test('deriveQuizLeadName — nome completo no campo único deriva o sobrenome', () => {
+    assert.deepEqual(deriveQuizLeadName('João Silva', ''), { firstName: 'João', lastName: 'Silva' });
+});
+
+test('deriveQuizLeadName — sobrenome tem precedência sobre o nome completo', () => {
+    assert.deepEqual(deriveQuizLeadName('João Silva', 'Souza'), { firstName: 'João', lastName: 'Souza' });
+});
+
+test('deriveQuizLeadName — nome com múltiplos sobrenomes junta o restante', () => {
+    assert.deepEqual(
+        deriveQuizLeadName('  Ana   Maria de Souza  ', ''),
+        { firstName: 'Ana', lastName: 'Maria de Souza' },
+    );
+});
+
+test('deriveQuizLeadName — só primeiro nome resulta em sobrenome vazio', () => {
+    assert.deepEqual(deriveQuizLeadName('João', ''), { firstName: 'João', lastName: '' });
+});
+
+test('deriveQuizLeadName — nome vazio usa o fallback "Viajante"', () => {
+    assert.deepEqual(deriveQuizLeadName('   ', '  '), { firstName: 'Viajante', lastName: '' });
+});
 
 // --- validateQuizPayload (lib/quiz-logic) — unchanged by the Odoo cut-over ----
 

--- a/utils/formAnalytics.ts
+++ b/utils/formAnalytics.ts
@@ -1,0 +1,95 @@
+export type FormAnalyticsEventName =
+  | 'form_view'
+  | 'form_start'
+  | 'field_complete'
+  | 'field_error'
+  | 'submit_attempt'
+  | 'submit_success'
+  | 'submit_failure'
+  | 'whatsapp_opened';
+
+export interface FormAnalyticsEvent {
+  event: FormAnalyticsEventName;
+  formType: string;
+  formId: string;
+  fieldName?: string;
+  errorType?: string;
+  destination?: string;
+}
+
+const SAFE_FIELD_NAMES = new Set([
+  'name',
+  'firstName',
+  'lastName',
+  'email',
+  'whatsapp',
+  'phone',
+  'lgpd',
+  'marketingOptIn',
+  'emailOptIn',
+  'destination',
+  'date',
+  'score',
+  'reason',
+  'highlight',
+  'company',
+  'empresa',
+  'role',
+  'cargo',
+]);
+
+const SENSITIVE_QUERY_KEYS = /(?:email|mail|phone|telefone|whatsapp|name|nome|sobrenome|firstname|lastname)/i;
+const EMAIL_PATTERN = /[^\s@]+@[^\s@]+\.[^\s@]+/;
+const PHONE_PATTERN = /\+?\d[\d\s().-]{7,}\d/;
+
+function currentPageLocation(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+
+  try {
+    const url = new URL(window.location.href);
+    for (const key of Array.from(url.searchParams.keys())) {
+      if (SENSITIVE_QUERY_KEYS.test(key)) {
+        url.searchParams.set(key, 'redacted');
+      }
+    }
+    return url.toString();
+  } catch {
+    return window.location.href.replace(EMAIL_PATTERN, 'redacted').replace(PHONE_PATTERN, 'redacted');
+  }
+}
+
+function isSafeDestination(value: string): boolean {
+  return !EMAIL_PATTERN.test(value) && !PHONE_PATTERN.test(value);
+}
+
+function safePayload(input: FormAnalyticsEvent): Record<string, string> {
+  const payload: Record<string, string> = {
+    event: input.event,
+    form_type: input.formType,
+    form_id: input.formId,
+  };
+
+  if (input.fieldName && SAFE_FIELD_NAMES.has(input.fieldName)) {
+    payload.field_name = input.fieldName;
+  }
+
+  if (input.errorType) {
+    payload.error_type = input.errorType;
+  }
+
+  if (input.destination && isSafeDestination(input.destination)) {
+    payload.destination = input.destination;
+  }
+
+  const pageLocation = currentPageLocation();
+  if (pageLocation) {
+    payload.page_location = pageLocation;
+  }
+
+  return payload;
+}
+
+export function pushFormAnalyticsEvent(input: FormAnalyticsEvent): void {
+  if (typeof window === 'undefined' || !window.dataLayer) return;
+  window.dataLayer.push(safePayload(input));
+}

--- a/utils/formAnalytics.ts
+++ b/utils/formAnalytics.ts
@@ -54,7 +54,12 @@ function currentPageLocation(): string | undefined {
     }
     return url.toString();
   } catch {
-    return window.location.href.replace(EMAIL_PATTERN, 'redacted').replace(PHONE_PATTERN, 'redacted');
+    // Non-global shared regexes only redact the first match; instantiate global
+    // copies on the fly so every email/phone in the URL is scrubbed, without
+    // making the shared patterns stateful (a global `lastIndex` breaks `.test()`).
+    return window.location.href
+      .replace(new RegExp(EMAIL_PATTERN, 'g'), 'redacted')
+      .replace(new RegExp(PHONE_PATTERN, 'g'), 'redacted');
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds a shared non-PII form analytics helper and instruments the main lead/contact/search/NPS/quiz/waitlist/corporate form paths.
- Reduces friction in contact, CTA, quiz, NPS, waitlist, and home search flows while keeping `/api/submit-lead` unchanged for V1.
- Saves a follow-up Metabase/Looker Studio dashboard implementation plan at `docs/superpowers/plans/2026-07-05-form-cro-dashboards.md`.

## Validation
- `pnpm typecheck`
- `pnpm test:regression` (801/801)
- `pnpm exec playwright test tests/e2e/contact-form.spec.ts tests/e2e/chatbot-lead-submit.spec.ts tests/e2e/quiz-whatsapp.spec.ts tests/e2e/quiz-double-submit.spec.ts tests/e2e/lollapalooza-waitlist.spec.ts tests/e2e/corporativo.spec.ts tests/e2e/hero_ux.spec.ts --project=chromium` (27/27)
- `pnpm exec playwright test tests/e2e/contact-form.spec.ts tests/e2e/lollapalooza-waitlist.spec.ts tests/e2e/quiz-whatsapp.spec.ts tests/e2e/quiz-double-submit.spec.ts --project="Mobile Chrome"` (14/14)
- `pnpm exec react-doctor --verbose --scope changed` (exit 0; remaining warnings are large-component maintainability in `ChatLeadFormBase` and `WaitlistSection`)

## Notes
- `gh auth status` is currently invalid locally, so this PR was created through the GitHub connector after pushing the branch with git.
- Direct WhatsApp from the chatbot intentionally bypasses backend lead creation and is tracked separately as `ai_chatbot_direct_whatsapp`.