### PR TITLE
fix(ci): reforça uso de comentário inline por achado no claude-review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -118,6 +118,8 @@ jobs:
 
             Não repita o que já é coberto por lint, typecheck ou CI. Não comente sobre estilo já garantido por ferramentas automatizadas. Poste um resumo curto e comentários inline apenas onde houver um problema real e acionável — prefira silêncio a ruído.
 
+            Para cada achado específico e acionável (bug, risco de segurança, convenção violada), use `create_inline_comment` ancorado na linha exata — não descreva o achado só em prosa no resumo. Reserve o resumo (sticky comment) para visão geral, contexto entre achados e itens que não têm uma linha específica para ancorar (ex.: padrão repetido em vários arquivos). Um achado por comentário inline, mesmo quando o diff tem muitos arquivos.
+
             Você não tem acesso a Bash além de comandos git de plumbing (add/commit/rm) e não tem `gh` disponível. Não tente instalar dependências, nem rodar lint/typecheck/build/testes — isso já roda no CI e você não tem permissão para executá-los. Revise usando apenas Read/Grep/Glob no checkout e reporte via comentário/inline comment.
 
           claude_args: |


### PR DESCRIPTION
## Contexto

Na PR #1091 o `claude-review` encontrou 2 bugs reais de alto impacto (last name vazio indo pro Odoo em `ContactModal`/`CtaBody` e no quiz `PreLeadScreen`) mas postou tudo como prosa no resumo sticky — não usou `create_inline_comment` nenhuma vez.

Confirmei nos logs que **não é regressão da config**: `Auto-detected mode: tag` e o `allowedTools` da sessão incluía `mcp__github_inline_comment__create_inline_comment` normalmente. O log final mostra `No buffered inline comments` — a ferramenta estava disponível, só não foi chamada nenhuma vez nessa execução. Na PR #1089 (diff menor, mesmo config), o mesmo job usou 3 comentários inline sem problema. É variação de julgamento do modelo por execução/diff, não um bug de setup.

## Mudança

Adiciona instrução explícita no `prompt`:

> Para cada achado específico e acionável (bug, risco de segurança, convenção violada), use `create_inline_comment` ancorado na linha exata — não descreva o achado só em prosa no resumo. Reserve o resumo (sticky comment) para visão geral, contexto entre achados e itens que não têm uma linha específica para ancorar. Um achado por comentário inline, mesmo quando o diff tem muitos arquivos.

## Limitação de teste conhecida

Esta PR edita o próprio `claude.yml` — não se autovalida (bloqueio OIDC documentado em felipewilliam2/AV-SITE#1088). Validar numa PR seguinte, depois do merge.

## Test plan

- [ ] Após merge, confirmar numa PR com achados reais que o `claude-review` usa `create_inline_comment` para cada achado específico, não só prosa no resumo

🤖 Generated with [Claude Code](https://claude.com/claude-code)