### PR TITLE
fix(ci): claude-review estoura max-turns depois do reforço de inline comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -123,5 +123,5 @@ jobs:
             Você não tem acesso a Bash além de comandos git de plumbing (add/commit/rm) e não tem `gh` disponível. Não tente instalar dependências, nem rodar lint/typecheck/build/testes — isso já roda no CI e você não tem permissão para executá-los. Revise usando apenas Read/Grep/Glob no checkout e reporte via comentário/inline comment.
 
           claude_args: |
-            --max-turns 30
+            --max-turns 45
             --allowedTools "mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## Contexto

Depois do #1092 (reforço pedindo `create_inline_comment` por achado específico em vez de prosa no resumo), o re-run na PR #1091 passou a falhar:

```json
{"subtype": "error_max_turns", "is_error": true, "num_turns": 31, "total_cost_usd": 1.8791113, "permission_denials_count": 3}
```

O comentário sticky, que antes tinha uma review completa e útil (2 bugs reais encontrados), virou só "Claude encountered an error".

## Causa raiz

Pedir um `create_inline_comment` por achado (em vez de consolidar em prosa) significa mais chamadas de ferramenta — cada uma consome turns. Nessa PR grande/multi-arquivo, isso empurrou o custo total pra além do teto de `--max-turns 30`, e a sessão morreu em erro antes de conseguir postar qualquer coisa via `update_claude_comment`.

## Fix

`--max-turns 30` → `45`, dando headroom para o custo extra do reforço de inline comments em diffs maiores.

## Limitação de teste conhecida

Mesma de sempre: PR que edita o próprio `claude.yml` não se autovalida. Confirmar na próxima PR real depois do merge — idealmente reexecutando na própria #1091 de novo (comentando `@claude` ou fechando/reabrindo), já que é o caso real que expôs o problema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)