### PR TITLE
refactor(waitlist): quebrar WaitlistSection em subcomponentes

### DIFF
--- a/components/landings/lollapalooza/WaitlistSection.tsx
+++ b/components/landings/lollapalooza/WaitlistSection.tsx
@@ -1,22 +1,12 @@
 import React, { useEffect, useReducer, useRef } from 'react';
-import { BellRing, CheckCircle2, Loader2, Mail, TicketX, ArrowRight, Zap } from 'lucide-react';
-import { m, AnimatePresence } from 'framer-motion';
+import { m } from 'framer-motion';
 import { useWaitlistCapture } from '../../../hooks/useWaitlistCapture';
 import { WAITLIST_SECTION_ID } from './constants';
 import { pushFormAnalyticsEvent } from '../../../utils/formAnalytics';
-
-const CONTAINER_VARIANTS = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: { staggerChildren: 0.1, delayChildren: 0.2 }
-  }
-};
-
-const ITEM_VARIANTS = {
-  hidden: { y: 20, opacity: 0 },
-  visible: { y: 0, opacity: 1, transition: { type: 'spring', stiffness: 100 } as const }
-};
+import { WaitlistCopyPanel } from './waitlist/WaitlistCopyPanel';
+import { WaitlistFormFields } from './waitlist/WaitlistFormFields';
+import { WaitlistFormMessages } from './waitlist/WaitlistFormMessages';
+import { WaitlistSubmitButton } from './waitlist/WaitlistSubmitButton';
 
 interface WaitlistFormState {
   name: string;
@@ -166,57 +156,11 @@ const WaitlistSection: React.FC = () => {
 
       <div className="container mx-auto px-4 relative z-10">
         <div className="grid gap-12 lg:grid-cols-[1fr_minmax(400px,500px)] items-center">
-          
-          {/* Content Corner - Compressed Text */}
-          <m.div 
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true, margin: "-100px" }}
-            variants={CONTAINER_VARIANTS}
-            className="flex flex-col items-start text-left"
-          >
-            <m.div variants={ITEM_VARIANTS} className="inline-flex items-center gap-2 bg-anhanga-yellow text-black px-4 py-1 text-[10px] font-black uppercase tracking-[0.25em] ring-2 ring-anhanga-yellow ring-offset-4 ring-offset-black mb-10">
-              <TicketX size={14} strokeWidth={3} aria-hidden="true" />
-              Sold Out 2026
-            </m.div>
 
-            <m.h2 
-              variants={ITEM_VARIANTS}
-              id="waitlist-heading" 
-              className="text-4xl md:text-6xl lg:text-7xl font-black text-white leading-[0.9] uppercase italic tracking-tighter mb-8"
-            >
-              Não fique de fora do <span className="text-anhanga-yellow">Lolla 2027.</span>
-            </m.h2>
-
-            <m.p variants={ITEM_VARIANTS} className="text-lg md:text-xl text-zinc-400 font-medium leading-relaxed max-w-xl mb-12">
-              A jornada de 2026 lotou em tempo recorde. Garanta seu lugar na lista de prioridade para a edição 2027 e receba avisos antecipados sobre pacotes, logística e condições exclusivas Anhangá.
-            </m.p>
-
-            <div className="grid gap-6 w-full max-w-lg">
-              <m.div variants={ITEM_VARIANTS} className="group flex gap-4 p-6 bg-white/[0.03] border border-white/10 hover:border-anhanga-yellow transition-colors duration-300">
-                <div className="bg-anhanga-yellow text-black p-3 h-fit">
-                  <BellRing size={20} strokeWidth={3} aria-hidden="true" />
-                </div>
-                <div>
-                  <h3 className="font-black text-white uppercase tracking-wider mb-2">Prioridade Total</h3>
-                  <p className="text-sm text-zinc-500 leading-relaxed font-medium">Recepção de ofertas antes do lançamento público geral.</p>
-                </div>
-              </m.div>
-
-              <m.div variants={ITEM_VARIANTS} className="group flex gap-4 p-6 bg-white/[0.03] border border-white/10 hover:border-anhanga-blue transition-colors duration-300">
-                <div className="bg-anhanga-blue text-white p-3 h-fit">
-                  <Zap size={20} strokeWidth={3} aria-hidden="true" />
-                </div>
-                <div>
-                  <h3 className="font-black text-white uppercase tracking-wider mb-2">Logística Hardcore</h3>
-                  <p className="text-sm text-zinc-500 leading-relaxed font-medium">Saiba primeiro os hotéis mais próximos e as rotas mais eficientes.</p>
-                </div>
-              </m.div>
-            </div>
-          </m.div>
+          <WaitlistCopyPanel />
 
           {/* Form Block - The Asymmetric Tension */}
-          <m.div 
+          <m.div
             initial={{ opacity: 0, x: 20 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
@@ -236,145 +180,33 @@ const WaitlistSection: React.FC = () => {
               <form className="space-y-8" onSubmit={handleSubmit}>
                 {/* Honeypot: hidden from humans, blind form-fillers populate it. */}
                 <input {...honeypotProps} />
-                <div className="group relative space-y-2">
-                  <label htmlFor="lolla-waitlist-name" className="block text-[10px] font-black text-anhanga-yellow uppercase tracking-[0.2em] transition-colors group-focus-within:text-white">
-                    Nome completo
-                  </label>
-                  <div className="relative">
-                    <input
-                      id="lolla-waitlist-name"
-                      type="text"
-                      value={name}
-                      onChange={(event) => {
-                        dispatch({ type: 'SET_NAME', value: event.target.value });
-                        trackField('name', event.target.value);
-                      }}
-                      className="peer w-full bg-anhanga-darkBlue/80 border-l-2 border-white/10 px-6 py-4 text-white placeholder-white/50 outline-none transition duration-300 focus:border-anhanga-yellow focus:bg-anhanga-yellow/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-anhanga-yellow focus-visible:outline-offset-2"
-                      placeholder="EX: SABRINA CARPENTER"
-                      autoComplete="name"
-                    />
-                    {/* Focus geometric accent */}
-                    <div className="absolute left-0 bottom-0 h-0.5 w-0 bg-anhanga-yellow transition-[width] duration-500 peer-focus:w-full" />
-                    <div className="absolute -left-[2px] top-0 h-0 w-2.5 bg-anhanga-yellow transition-[height] duration-500 peer-focus:h-full" />
-                  </div>
-                </div>
 
-                <div className="group relative space-y-2">
-                  <label htmlFor="lolla-waitlist-email" className="block text-[10px] font-black text-anhanga-blue uppercase tracking-[0.2em] transition-colors group-focus-within:text-white">
-                    Seu melhor E-mail
-                  </label>
-                  <div className="relative">
-                    <input
-                      id="lolla-waitlist-email"
-                      type="email"
-                      value={email}
-                      onChange={(event) => {
-                        dispatch({ type: 'SET_EMAIL', value: event.target.value });
-                        trackField('email', event.target.value);
-                      }}
-                      className="peer w-full bg-anhanga-darkBlue/80 border-l-2 border-white/10 px-6 py-4 text-white placeholder-white/50 outline-none transition duration-300 focus:border-anhanga-blue focus:bg-anhanga-blue/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-anhanga-blue focus-visible:outline-offset-2"
-                      placeholder="VOICE@EXEMPLO.COM"
-                      autoComplete="email"
-                    />
-                    {/* Focus geometric accent */}
-                    <div className="absolute left-0 bottom-0 h-0.5 w-0 bg-anhanga-blue transition-[width] duration-500 peer-focus:w-full" />
-                    <div className="absolute -left-[2px] top-0 h-0 w-2.5 bg-anhanga-blue transition-[height] duration-500 peer-focus:h-full" />
-                  </div>
-                </div>
+                <WaitlistFormFields
+                  name={name}
+                  email={email}
+                  acceptedLgpd={acceptedLgpd}
+                  onNameChange={(value) => {
+                    dispatch({ type: 'SET_NAME', value });
+                    trackField('name', value);
+                  }}
+                  onEmailChange={(value) => {
+                    dispatch({ type: 'SET_EMAIL', value });
+                    trackField('email', value);
+                  }}
+                  onLgpdChange={(value) => {
+                    dispatch({ type: 'SET_LGPD', value });
+                    trackField('marketingOptIn', value);
+                  }}
+                />
 
-                <label className="flex items-start gap-4 cursor-pointer group pt-4">
-                  <div className="relative flex items-center justify-center">
-                    <input
-                      id="lolla-waitlist-lgpd"
-                      type="checkbox"
-                      checked={acceptedLgpd}
-                      onChange={(event) => {
-                        dispatch({ type: 'SET_LGPD', value: event.target.checked });
-                        trackField('marketingOptIn', event.target.checked);
-                      }}
-                      className="peer sr-only"
-                    />
-                    <div className="size-5 border-2 border-white/20 peer-checked:border-anhanga-yellow peer-checked:bg-anhanga-yellow transition duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-anhanga-yellow peer-focus-visible:outline-offset-2" />
-                    <CheckCircle2 size={12} className="absolute text-black opacity-0 peer-checked:opacity-100 transition-opacity" />
-                  </div>
-                  <span className="text-xs text-zinc-400 leading-snug group-hover:text-zinc-300 transition-colors">
-                    Quero receber novidades exclusivas da Anhangá por e-mail.
-                  </span>
-                </label>
+                <WaitlistFormMessages
+                  localError={localError}
+                  error={error}
+                  successMessage={successMessage}
+                  warningMessage={warningMessage}
+                />
 
-                <p className="text-xs text-zinc-500 leading-relaxed">
-                  Ao entrar na lista, seus dados serão usados para avisos sobre pacotes do Lollapalooza. Consulte a{' '}
-                    <a
-                      href="/politica-privacidade/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-white hover:text-anhanga-yellow underline underline-offset-4"
-                    >
-                      Política de Privacidade
-                    </a>.
-                </p>
-
-                <AnimatePresence mode="wait">
-                  {(localError || error) && (
-                    <m.div 
-                      initial={{ opacity: 0, height: 0 }}
-                      animate={{ opacity: 1, height: 'auto' }}
-                      exit={{ opacity: 0, height: 0 }}
-                      role="alert" 
-                      className="shadow-[inset_3px_0_0_rgb(239_68_68)] rounded-sm bg-red-500/10 px-4 py-3 text-xs font-bold text-red-400"
-                    >
-                      {localError || error}
-                    </m.div>
-                  )}
-
-                  {successMessage && (
-                    <m.div
-                      initial={{ opacity: 0, height: 0 }}
-                      animate={{ opacity: 1, height: 'auto' }}
-                      exit={{ opacity: 0, height: 0 }}
-                      role="status"
-                      className="shadow-[inset_3px_0_0_#FFD600] rounded-sm bg-anhanga-yellow/10 px-4 py-3 text-xs font-bold text-anhanga-yellow"
-                    >
-                      {successMessage}
-                    </m.div>
-                  )}
-
-                  {warningMessage && (
-                    <m.div
-                      initial={{ opacity: 0, height: 0 }}
-                      animate={{ opacity: 1, height: 'auto' }}
-                      exit={{ opacity: 0, height: 0 }}
-                      role="status"
-                      className="shadow-[inset_3px_0_0_rgb(245_158_11)] rounded-sm bg-amber-500/10 px-4 py-3 text-xs font-bold text-amber-400"
-                    >
-                      {warningMessage}
-                    </m.div>
-                  )}
-                </AnimatePresence>
-
-                <button
-                  id="lolla-waitlist-submit"
-                  type="submit"
-                  disabled={isSubmitting}
-                  className="group relative flex w-full items-center justify-center gap-3 rounded-[1px] bg-anhanga-yellow px-8 py-5 text-sm font-black text-black transition-[letter-spacing,opacity] duration-300 hover:tracking-[0.1em] disabled:cursor-wait disabled:opacity-50"
-                >
-                  <span className="relative z-10 flex items-center gap-2">
-                    {isSubmitting ? (
-                      <>
-                        <Loader2 size={18} className="animate-spin" />
-                        ENVIANDO…
-                      </>
-                    ) : (
-                      <>
-                        ENTRAR NA LISTA 2027
-                        <ArrowRight size={18} className="group-hover:translate-x-2 transition-transform duration-300" />
-                      </>
-                    )}
-                  </span>
-                  
-                  {/* Magnetic/Glow Background effect on hover */}
-                  <div className="absolute inset-0 bg-white opacity-0 group-hover:opacity-10 transition-opacity" />
-                </button>
+                <WaitlistSubmitButton isSubmitting={isSubmitting} />
               </form>
             </div>
           </m.div>

--- a/components/landings/lollapalooza/waitlist/WaitlistCopyPanel.tsx
+++ b/components/landings/lollapalooza/waitlist/WaitlistCopyPanel.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { BellRing, TicketX, Zap } from 'lucide-react';
+import { m } from 'framer-motion';
+
+const CONTAINER_VARIANTS = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.1, delayChildren: 0.2 }
+  }
+};
+
+const ITEM_VARIANTS = {
+  hidden: { y: 20, opacity: 0 },
+  visible: { y: 0, opacity: 1, transition: { type: 'spring', stiffness: 100 } as const }
+};
+
+export function WaitlistCopyPanel() {
+  return (
+    <m.div
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, margin: "-100px" }}
+      variants={CONTAINER_VARIANTS}
+      className="flex flex-col items-start text-left"
+    >
+      <m.div variants={ITEM_VARIANTS} className="inline-flex items-center gap-2 bg-anhanga-yellow text-black px-4 py-1 text-[10px] font-black uppercase tracking-[0.25em] ring-2 ring-anhanga-yellow ring-offset-4 ring-offset-black mb-10">
+        <TicketX size={14} strokeWidth={3} aria-hidden="true" />
+        Sold Out 2026
+      </m.div>
+
+      <m.h2
+        variants={ITEM_VARIANTS}
+        id="waitlist-heading"
+        className="text-4xl md:text-6xl lg:text-7xl font-black text-white leading-[0.9] uppercase italic tracking-tighter mb-8"
+      >
+        Não fique de fora do <span className="text-anhanga-yellow">Lolla 2027.</span>
+      </m.h2>
+
+      <m.p variants={ITEM_VARIANTS} className="text-lg md:text-xl text-zinc-400 font-medium leading-relaxed max-w-xl mb-12">
+        A jornada de 2026 lotou em tempo recorde. Garanta seu lugar na lista de prioridade para a edição 2027 e receba avisos antecipados sobre pacotes, logística e condições exclusivas Anhangá.
+      </m.p>
+
+      <div className="grid gap-6 w-full max-w-lg">
+        <m.div variants={ITEM_VARIANTS} className="group flex gap-4 p-6 bg-white/[0.03] border border-white/10 hover:border-anhanga-yellow transition-colors duration-300">
+          <div className="bg-anhanga-yellow text-black p-3 h-fit">
+            <BellRing size={20} strokeWidth={3} aria-hidden="true" />
+          </div>
+          <div>
+            <h3 className="font-black text-white uppercase tracking-wider mb-2">Prioridade Total</h3>
+            <p className="text-sm text-zinc-500 leading-relaxed font-medium">Recepção de ofertas antes do lançamento público geral.</p>
+          </div>
+        </m.div>
+
+        <m.div variants={ITEM_VARIANTS} className="group flex gap-4 p-6 bg-white/[0.03] border border-white/10 hover:border-anhanga-blue transition-colors duration-300">
+          <div className="bg-anhanga-blue text-white p-3 h-fit">
+            <Zap size={20} strokeWidth={3} aria-hidden="true" />
+          </div>
+          <div>
+            <h3 className="font-black text-white uppercase tracking-wider mb-2">Logística Hardcore</h3>
+            <p className="text-sm text-zinc-500 leading-relaxed font-medium">Saiba primeiro os hotéis mais próximos e as rotas mais eficientes.</p>
+          </div>
+        </m.div>
+      </div>
+    </m.div>
+  );
+}

--- a/components/landings/lollapalooza/waitlist/WaitlistFormFields.tsx
+++ b/components/landings/lollapalooza/waitlist/WaitlistFormFields.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { CheckCircle2 } from 'lucide-react';
+
+interface WaitlistFormFieldsProps {
+  name: string;
+  email: string;
+  acceptedLgpd: boolean;
+  onNameChange: (value: string) => void;
+  onEmailChange: (value: string) => void;
+  onLgpdChange: (value: boolean) => void;
+}
+
+export function WaitlistFormFields({
+  name,
+  email,
+  acceptedLgpd,
+  onNameChange,
+  onEmailChange,
+  onLgpdChange,
+}: WaitlistFormFieldsProps) {
+  return (
+    <>
+      <div className="group relative space-y-2">
+        <label htmlFor="lolla-waitlist-name" className="block text-[10px] font-black text-anhanga-yellow uppercase tracking-[0.2em] transition-colors group-focus-within:text-white">
+          Nome completo
+        </label>
+        <div className="relative">
+          <input
+            id="lolla-waitlist-name"
+            type="text"
+            value={name}
+            onChange={(event) => onNameChange(event.target.value)}
+            className="peer w-full bg-anhanga-darkBlue/80 border-l-2 border-white/10 px-6 py-4 text-white placeholder-white/50 outline-none transition duration-300 focus:border-anhanga-yellow focus:bg-anhanga-yellow/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-anhanga-yellow focus-visible:outline-offset-2"
+            placeholder="EX: SABRINA CARPENTER"
+            autoComplete="name"
+          />
+          {/* Focus geometric accent */}
+          <div className="absolute left-0 bottom-0 h-0.5 w-0 bg-anhanga-yellow transition-[width] duration-500 peer-focus:w-full" />
+          <div className="absolute -left-[2px] top-0 h-0 w-2.5 bg-anhanga-yellow transition-[height] duration-500 peer-focus:h-full" />
+        </div>
+      </div>
+
+      <div className="group relative space-y-2">
+        <label htmlFor="lolla-waitlist-email" className="block text-[10px] font-black text-anhanga-blue uppercase tracking-[0.2em] transition-colors group-focus-within:text-white">
+          Seu melhor E-mail
+        </label>
+        <div className="relative">
+          <input
+            id="lolla-waitlist-email"
+            type="email"
+            value={email}
+            onChange={(event) => onEmailChange(event.target.value)}
+            className="peer w-full bg-anhanga-darkBlue/80 border-l-2 border-white/10 px-6 py-4 text-white placeholder-white/50 outline-none transition duration-300 focus:border-anhanga-blue focus:bg-anhanga-blue/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-anhanga-blue focus-visible:outline-offset-2"
+            placeholder="VOICE@EXEMPLO.COM"
+            autoComplete="email"
+          />
+          {/* Focus geometric accent */}
+          <div className="absolute left-0 bottom-0 h-0.5 w-0 bg-anhanga-blue transition-[width] duration-500 peer-focus:w-full" />
+          <div className="absolute -left-[2px] top-0 h-0 w-2.5 bg-anhanga-blue transition-[height] duration-500 peer-focus:h-full" />
+        </div>
+      </div>
+
+      <label className="flex items-start gap-4 cursor-pointer group pt-4">
+        <div className="relative flex items-center justify-center">
+          <input
+            id="lolla-waitlist-lgpd"
+            type="checkbox"
+            checked={acceptedLgpd}
+            onChange={(event) => onLgpdChange(event.target.checked)}
+            className="peer sr-only"
+          />
+          <div className="size-5 border-2 border-white/20 peer-checked:border-anhanga-yellow peer-checked:bg-anhanga-yellow transition duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-anhanga-yellow peer-focus-visible:outline-offset-2" />
+          <CheckCircle2 size={12} className="absolute text-black opacity-0 peer-checked:opacity-100 transition-opacity" />
+        </div>
+        <span className="text-xs text-zinc-400 leading-snug group-hover:text-zinc-300 transition-colors">
+          Quero receber novidades exclusivas da Anhangá por e-mail.
+        </span>
+      </label>
+
+      <p className="text-xs text-zinc-500 leading-relaxed">
+        Ao entrar na lista, seus dados serão usados para avisos sobre pacotes do Lollapalooza. Consulte a{' '}
+          <a
+            href="/politica-privacidade/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-white hover:text-anhanga-yellow underline underline-offset-4"
+          >
+            Política de Privacidade
+          </a>.
+      </p>
+    </>
+  );
+}

--- a/components/landings/lollapalooza/waitlist/WaitlistFormMessages.tsx
+++ b/components/landings/lollapalooza/waitlist/WaitlistFormMessages.tsx
@@ -13,6 +13,7 @@ export function WaitlistFormMessages({ localError, error, successMessage, warnin
     <AnimatePresence mode="wait">
       {(localError || error) && (
         <m.div
+          key="error-message"
           initial={{ opacity: 0, height: 0 }}
           animate={{ opacity: 1, height: 'auto' }}
           exit={{ opacity: 0, height: 0 }}
@@ -25,6 +26,7 @@ export function WaitlistFormMessages({ localError, error, successMessage, warnin
 
       {successMessage && (
         <m.div
+          key="success-message"
           initial={{ opacity: 0, height: 0 }}
           animate={{ opacity: 1, height: 'auto' }}
           exit={{ opacity: 0, height: 0 }}
@@ -37,6 +39,7 @@ export function WaitlistFormMessages({ localError, error, successMessage, warnin
 
       {warningMessage && (
         <m.div
+          key="warning-message"
           initial={{ opacity: 0, height: 0 }}
           animate={{ opacity: 1, height: 'auto' }}
           exit={{ opacity: 0, height: 0 }}

--- a/components/landings/lollapalooza/waitlist/WaitlistFormMessages.tsx
+++ b/components/landings/lollapalooza/waitlist/WaitlistFormMessages.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { m, AnimatePresence } from 'framer-motion';
+
+interface WaitlistFormMessagesProps {
+  localError: string | null;
+  error: string | null;
+  successMessage: string | null;
+  warningMessage: string | null;
+}
+
+export function WaitlistFormMessages({ localError, error, successMessage, warningMessage }: WaitlistFormMessagesProps) {
+  return (
+    <AnimatePresence mode="wait">
+      {(localError || error) && (
+        <m.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          role="alert"
+          className="shadow-[inset_3px_0_0_rgb(239_68_68)] rounded-sm bg-red-500/10 px-4 py-3 text-xs font-bold text-red-400"
+        >
+          {localError || error}
+        </m.div>
+      )}
+
+      {successMessage && (
+        <m.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          role="status"
+          className="shadow-[inset_3px_0_0_#FFD600] rounded-sm bg-anhanga-yellow/10 px-4 py-3 text-xs font-bold text-anhanga-yellow"
+        >
+          {successMessage}
+        </m.div>
+      )}
+
+      {warningMessage && (
+        <m.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          role="status"
+          className="shadow-[inset_3px_0_0_rgb(245_158_11)] rounded-sm bg-amber-500/10 px-4 py-3 text-xs font-bold text-amber-400"
+        >
+          {warningMessage}
+        </m.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/landings/lollapalooza/waitlist/WaitlistSubmitButton.tsx
+++ b/components/landings/lollapalooza/waitlist/WaitlistSubmitButton.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ArrowRight, Loader2 } from 'lucide-react';
+
+interface WaitlistSubmitButtonProps {
+  isSubmitting: boolean;
+}
+
+export function WaitlistSubmitButton({ isSubmitting }: WaitlistSubmitButtonProps) {
+  return (
+    <button
+      id="lolla-waitlist-submit"
+      type="submit"
+      disabled={isSubmitting}
+      className="group relative flex w-full items-center justify-center gap-3 rounded-[1px] bg-anhanga-yellow px-8 py-5 text-sm font-black text-black transition-[letter-spacing,opacity] duration-300 hover:tracking-[0.1em] disabled:cursor-wait disabled:opacity-50"
+    >
+      <span className="relative z-10 flex items-center gap-2">
+        {isSubmitting ? (
+          <>
+            <Loader2 size={18} className="animate-spin" />
+            ENVIANDO…
+          </>
+        ) : (
+          <>
+            ENTRAR NA LISTA 2027
+            <ArrowRight size={18} className="group-hover:translate-x-2 transition-transform duration-300" />
+          </>
+        )}
+      </span>
+
+      {/* Magnetic/Glow Background effect on hover */}
+      <div className="absolute inset-0 bg-white opacity-0 group-hover:opacity-10 transition-opacity" />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Extrai `WaitlistCopyPanel`, `WaitlistFormFields`, `WaitlistFormMessages` e `WaitlistSubmitButton` para `components/landings/lollapalooza/waitlist/`, resolvendo o warning `react-doctor/no-giant-component` em `WaitlistSection` (antes ~330 linhas).
- Refactor puro — sem mudança de comportamento observável. IDs (`#lolla-waitlist-name`, `#lolla-waitlist-email`, `#lolla-waitlist-lgpd`, `#lolla-waitlist-submit`), roles e a estrutura da seção permanecem os mesmos.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:regression` (817 testes)
- [x] `pnpm exec playwright test tests/e2e/lollapalooza-waitlist.spec.ts` (10/10 em todos os browsers)
- [x] `npx react-doctor@latest --scope changed` → 100/100, sem issues

Refs #1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)