### PR TITLE
refactor: extrair FormField compartilhado de ContactModal e CtaBody

### DIFF
--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -3,6 +3,10 @@ import { CheckCircle, X } from '@phosphor-icons/react';
 import { useContactForm } from '../hooks/useContactForm';
 import type { ContactModalOptions } from '../utils/contactForm';
 import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
+import { FormField } from './forms/FormField';
+
+const FIELD_CLASSNAME =
+    'w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan';
 
 const ContactModal: React.FC = () => {
     const [isOpen, setIsOpen] = useState(false);
@@ -142,74 +146,43 @@ const ContactModal: React.FC = () => {
                     >
                         {/* Honeypot: hidden from humans, blind form-fillers populate it. */}
                         <input {...honeypotProps} />
-                        <div>
-                            <label htmlFor="contact-firstName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
-                                Nome *
-                            </label>
-                            <input
-                                ref={firstFieldRef}
-                                id="contact-firstName"
-                                type="text"
-                                autoComplete="name"
-                                value={fields.firstName}
-                                onChange={(event) => setField('firstName', event.target.value)}
-                                required
-                                className="w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
-                                placeholder="ex: Maria Silva"
-                                aria-invalid={fieldErrors.firstName ? true : undefined}
-                                aria-describedby={fieldErrors.firstName ? 'contact-firstName-error' : undefined}
-                            />
-                            {fieldErrors.firstName ? (
-                                <p id="contact-firstName-error" className="mt-1 text-xs font-semibold text-red-500" role="alert">
-                                    {fieldErrors.firstName}
-                                </p>
-                            ) : null}
-                        </div>
+                        <FormField
+                            inputRef={firstFieldRef}
+                            id="contact-firstName"
+                            label="Nome *"
+                            autoComplete="name"
+                            value={fields.firstName}
+                            onChange={(value) => setField('firstName', value)}
+                            required
+                            inputClassName={FIELD_CLASSNAME}
+                            placeholder="ex: Maria Silva"
+                            error={fieldErrors.firstName}
+                        />
 
-                        <div>
-                            <label htmlFor="contact-whatsapp" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
-                                WhatsApp *
-                            </label>
-                            <input
-                                id="contact-whatsapp"
-                                type="tel"
-                                autoComplete="tel"
-                                value={fields.whatsapp}
-                                onChange={(event) => setField('whatsapp', event.target.value)}
-                                required
-                                className="w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
-                                placeholder="+55 (11) 9 0000-0000"
-                                aria-invalid={fieldErrors.whatsapp ? true : undefined}
-                                aria-describedby={fieldErrors.whatsapp ? 'contact-whatsapp-error' : undefined}
-                            />
-                            {fieldErrors.whatsapp ? (
-                                <p id="contact-whatsapp-error" className="mt-1 text-xs font-semibold text-red-500" role="alert">
-                                    {fieldErrors.whatsapp}
-                                </p>
-                            ) : null}
-                        </div>
+                        <FormField
+                            id="contact-whatsapp"
+                            label="WhatsApp *"
+                            type="tel"
+                            autoComplete="tel"
+                            value={fields.whatsapp}
+                            onChange={(value) => setField('whatsapp', value)}
+                            required
+                            inputClassName={FIELD_CLASSNAME}
+                            placeholder="+55 (11) 9 0000-0000"
+                            error={fieldErrors.whatsapp}
+                        />
 
-                        <div>
-                            <label htmlFor="contact-email" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
-                                E-mail
-                            </label>
-                            <input
-                                id="contact-email"
-                                type="email"
-                                autoComplete="email"
-                                value={fields.email}
-                                onChange={(event) => setField('email', event.target.value)}
-                                className="w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan"
-                                placeholder="seu@email.com (opcional)"
-                                aria-invalid={fieldErrors.email ? true : undefined}
-                                aria-describedby={fieldErrors.email ? 'contact-email-error' : undefined}
-                            />
-                            {fieldErrors.email ? (
-                                <p id="contact-email-error" className="mt-1 text-xs font-semibold text-red-500" role="alert">
-                                    {fieldErrors.email}
-                                </p>
-                            ) : null}
-                        </div>
+                        <FormField
+                            id="contact-email"
+                            label="E-mail"
+                            type="email"
+                            autoComplete="email"
+                            value={fields.email}
+                            onChange={(value) => setField('email', value)}
+                            inputClassName={FIELD_CLASSNAME}
+                            placeholder="seu@email.com (opcional)"
+                            error={fieldErrors.email}
+                        />
 
                         <div className="flex items-start gap-2.5 rounded-xl border border-blue-100 bg-blue-50 px-3 py-2.5">
                             <input

--- a/components/cta/CtaBody.tsx
+++ b/components/cta/CtaBody.tsx
@@ -2,6 +2,10 @@ import { useState } from 'react';
 import { WhatsappLogo, SpinnerGap, CheckCircle } from '@phosphor-icons/react';
 import { useContactForm } from '../../hooks/useContactForm';
 import { pushFormAnalyticsEvent } from '../../utils/formAnalytics';
+import { FormField } from '../forms/FormField';
+
+const FIELD_CLASSNAME =
+  'w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400';
 
 export function CtaBody() {
   const [formOpen, setFormOpen] = useState(false);
@@ -37,65 +41,40 @@ export function CtaBody() {
           Seus dados para contato
         </p>
 
-        <div>
-          <label htmlFor="cta-firstName" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
-            Nome *
-          </label>
-          <input
-            id="cta-firstName"
-            type="text"
-            placeholder="ex: João Silva"
-            autoComplete="name"
-            value={fields.firstName}
-            onChange={(event) => setField('firstName', event.target.value)}
-            required
-            className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400"
-            aria-invalid={fieldErrors.firstName ? true : undefined}
-            aria-describedby={fieldErrors.firstName ? 'cta-firstName-error' : undefined}
-          />
-          {fieldErrors.firstName && (
-            <p id="cta-firstName-error" className="mt-1 text-xs font-semibold text-red-500" role="alert">{fieldErrors.firstName}</p>
-          )}
-        </div>
+        <FormField
+          id="cta-firstName"
+          label="Nome *"
+          autoComplete="name"
+          value={fields.firstName}
+          onChange={(value) => setField('firstName', value)}
+          required
+          inputClassName={FIELD_CLASSNAME}
+          placeholder="ex: João Silva"
+          error={fieldErrors.firstName}
+        />
 
-        <div>
-          <label htmlFor="cta-whatsapp" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
-            WhatsApp *
-          </label>
-          <input
-            id="cta-whatsapp"
-            type="tel"
-            placeholder="(11) 99999-9999"
-            value={fields.whatsapp}
-            onChange={(event) => setField('whatsapp', event.target.value)}
-            required
-            className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400"
-            aria-invalid={fieldErrors.whatsapp ? true : undefined}
-            aria-describedby={fieldErrors.whatsapp ? 'cta-whatsapp-error' : undefined}
-          />
-          {fieldErrors.whatsapp && (
-            <p id="cta-whatsapp-error" className="mt-1 text-xs font-semibold text-red-500" role="alert">{fieldErrors.whatsapp}</p>
-          )}
-        </div>
+        <FormField
+          id="cta-whatsapp"
+          label="WhatsApp *"
+          type="tel"
+          value={fields.whatsapp}
+          onChange={(value) => setField('whatsapp', value)}
+          required
+          inputClassName={FIELD_CLASSNAME}
+          placeholder="(11) 99999-9999"
+          error={fieldErrors.whatsapp}
+        />
 
-        <div>
-          <label htmlFor="cta-email" className="mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500">
-            E-mail
-          </label>
-          <input
-            id="cta-email"
-            type="email"
-            placeholder="voce@email.com (opcional)"
-            value={fields.email}
-            onChange={(event) => setField('email', event.target.value)}
-            className="w-full px-4 py-2.5 rounded-xl border-2 border-zinc-200 text-sm font-medium text-zinc-800 outline-none focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan transition-colors placeholder-zinc-400"
-            aria-invalid={fieldErrors.email ? true : undefined}
-            aria-describedby={fieldErrors.email ? 'cta-email-error' : undefined}
-          />
-          {fieldErrors.email && (
-            <p id="cta-email-error" className="mt-1 text-xs font-semibold text-red-500" role="alert">{fieldErrors.email}</p>
-          )}
-        </div>
+        <FormField
+          id="cta-email"
+          label="E-mail"
+          type="email"
+          value={fields.email}
+          onChange={(value) => setField('email', value)}
+          inputClassName={FIELD_CLASSNAME}
+          placeholder="voce@email.com (opcional)"
+          error={fieldErrors.email}
+        />
 
         <div className="flex items-start gap-2 px-3 py-2.5 bg-blue-50 rounded-xl border border-blue-100">
           <input

--- a/components/forms/FormField.tsx
+++ b/components/forms/FormField.tsx
@@ -1,0 +1,60 @@
+import type { Ref } from 'react';
+
+const LABEL_CLASSNAME = 'mb-1 block text-xs font-bold uppercase tracking-wider text-zinc-500';
+const ERROR_CLASSNAME = 'mt-1 text-xs font-semibold text-red-500';
+
+interface FormFieldProps {
+  id: string;
+  label: string;
+  type?: 'text' | 'tel' | 'email';
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+  placeholder?: string;
+  autoComplete?: string;
+  required?: boolean;
+  inputClassName: string;
+  inputRef?: Ref<HTMLInputElement>;
+}
+
+export function FormField({
+  id,
+  label,
+  type = 'text',
+  value,
+  onChange,
+  error,
+  placeholder,
+  autoComplete,
+  required,
+  inputClassName,
+  inputRef,
+}: FormFieldProps) {
+  const errorId = `${id}-error`;
+
+  return (
+    <div>
+      <label htmlFor={id} className={LABEL_CLASSNAME}>
+        {label}
+      </label>
+      <input
+        ref={inputRef}
+        id={id}
+        type={type}
+        autoComplete={autoComplete}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        required={required}
+        className={inputClassName}
+        placeholder={placeholder}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : undefined}
+      />
+      {error ? (
+        <p id={errorId} className={ERROR_CLASSNAME} role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extrai `components/forms/FormField.tsx`, um componente compartilhado de label + input + mensagem de erro (com `aria-invalid`/`aria-describedby`), usado pelos 3 campos (nome, WhatsApp, e-mail) de `ContactModal.tsx` e `CtaBody.tsx`.
- Elimina a duplicação real entre os dois componentes (blocos de campo quase idênticos, cada um com seu próprio `fieldErrors`/`aria-*`), reduzindo a complexidade sinalizada pelo CodeFactor ("Complex Method") em ambos os arquivos.
- Nenhuma mudança de comportamento, estilo ou texto visível: `inputClassName` preserva o padding específico de cada componente (`px-3` no modal, `px-4` no CTA), placeholders e IDs seguem os mesmos de antes.
- `NpsPage.tsx` fica fora deste PR — a issue marcou essa parte como "avaliar separadamente"; lá não há duplicação entre arquivos (é um único componente grande), então é uma decisão arquitetural distinta da deduplicação feita aqui.

## Testing
- `pnpm typecheck` — sem erros
- `pnpm test:regression` — 827/827 passando
- `npx playwright test tests/e2e/contact-form.spec.ts` — 55/55 passando (todos os browsers)
- `npx react-doctor@latest --verbose --scope changed` — 100/100, nenhum issue no diff

Closes #1100