### PR TITLE
fix(security): bound raw whatsapp length in lead schema

### DIFF
--- a/lib/lead-logic.ts
+++ b/lib/lead-logic.ts
@@ -5,6 +5,12 @@ import { isRecord } from './type-guards';
 
 const MIN_PHONE_DIGITS = 10;
 const MAX_PHONE_DIGITS = 15;
+// Hard cap on the raw phone string before any regex runs. A valid number is at
+// most MAX_PHONE_DIGITS digits plus formatting (+, spaces, parens, dashes), so
+// 64 is generous; anything beyond is malformed/abusive. Guarding here protects
+// every caller (lead/contact/quiz/waitlist) at the shared chokepoint, so an
+// unbounded body can't force regex work through the manually-validated handlers.
+const MAX_PHONE_RAW_LENGTH = 64;
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const KNOWN_TRACKING_KEYS = new Set([
@@ -97,6 +103,8 @@ export function normalizeNullable(value: unknown, maxLength = 255): string | nul
 
 export function normalizeWhatsappNumber(value: unknown, defaultCountryCode = '+55'): string | null {
     if (typeof value !== 'string') return null;
+    // Reject implausibly long input before running any regex passes over it.
+    if (value.length > MAX_PHONE_RAW_LENGTH) return null;
 
     const trimmed = value.trim();
     if (!trimmed) return null;

--- a/lib/schemas/submit-lead.ts
+++ b/lib/schemas/submit-lead.ts
@@ -35,7 +35,11 @@ export const SubmitLeadBodySchema = z.object({
     firstName:   z.string().min(1).max(100),
     lastName:    z.string().min(1).max(100),
     email:       z.email().max(254),
-    whatsapp:    z.string().min(1),
+    // Bound the raw phone at the boundary so oversized input is rejected before
+    // normalizeWhatsappNumber runs its regex passes over the full string. A valid
+    // number is at most 15 digits (MAX_PHONE_DIGITS) plus formatting (+, spaces,
+    // parens, dashes); 32 leaves generous room without allowing abuse.
+    whatsapp:    z.string().min(1).max(32),
     event_id:    z.string().max(128).optional(),
     bantSummary: z.string().min(1).max(5000),
     destination: z.string().min(1).max(255),

--- a/tests/lib-lead-logic.test.ts
+++ b/tests/lib-lead-logic.test.ts
@@ -111,6 +111,13 @@ test('normalizeWhatsappNumber returns null for a number with too many digits', (
     assert.equal(normalizeWhatsappNumber('1234567890123456'), null);
 });
 
+test('normalizeWhatsappNumber returns null for implausibly long input before regex runs', () => {
+    // Guards the raw-length cap (MAX_PHONE_RAW_LENGTH): an unbounded string must
+    // be rejected up front so no regex pass runs over it (DoS hardening). This is
+    // the shared chokepoint that also protects submit-contact and submit-quiz.
+    assert.equal(normalizeWhatsappNumber('+55' + '9'.repeat(4000)), null);
+});
+
 test('normalizeWhatsappNumber returns null for non-string input', () => {
     assert.equal(normalizeWhatsappNumber(null), null);
     assert.equal(normalizeWhatsappNumber(undefined), null);

--- a/tests/submit-lead.test.ts
+++ b/tests/submit-lead.test.ts
@@ -64,6 +64,19 @@ test('validatePayload should reject payloads with fields that exceed maximum len
     assert.equal(result.error, 'Entrada muito longa.');
 });
 
+test('validatePayload should reject an oversized whatsapp before normalization', () => {
+    // Guards the schema's whatsapp .max() bound: an unbounded phone string would
+    // otherwise be regex-normalized in full before being rejected (DoS hardening).
+    const result = validatePayload({
+        firstName: 'Felipe', lastName: 'William', email: 'felipe@example.com',
+        whatsapp: '+55' + '9'.repeat(4000),
+        bantSummary: 'Need: Praia', destination: 'Rio de Janeiro', utms: {}, tracking: {},
+    });
+    assert.equal(result.valid, false);
+    if (result.valid) return;
+    assert.equal(result.error, 'Entrada muito longa.');
+});
+
 test('validatePayload should reject payloads missing required text fields', () => {
     const result = validatePayload({
         firstName: 'Felipe', lastName: 'William', email: 'felipe@example.com', whatsapp: '+5511988314487',


### PR DESCRIPTION
## Resumo

- **O que muda:** Limita o comprimento do telefone bruto (`whatsapp`/`phone`) antes de qualquer normalização por regex, em dois níveis complementares:
  1. `.max(32)` no campo `whatsapp` de `SubmitLeadBodySchema` (`lib/schemas/submit-lead.ts`) — bound na borda do formulário de lead, consistente com o padrão de `.max()` dos campos irmãos.
  2. `MAX_PHONE_RAW_LENGTH` (64) no topo de `normalizeWhatsappNumber` (`lib/lead-logic.ts`) — guarda no **chokepoint compartilhado**, antes de qualquer regex rodar.
- **Por quê:** Sem limite, um telefone arbitrariamente grande passava na validação de schema e só era rejeitado **depois** de `normalizeWhatsappNumber` rodar seus passes de regex sobre a string bruta inteira (endurecimento contra DoS por input sem limite). Como `normalizeWhatsappNumber` também é chamado sobre o body bruto por `submit-contact` e `submit-quiz` — onde o check de comprimento rodava sobre a saída normalizada, ou não rodava —, um bound só no schema de lead seria contornável por um endpoint irmão. Guardar o chokepoint compartilhado protege todos os callers (lead/contact/quiz/waitlist) de uma vez.
- **Impacto para o usuário:** Nenhum para submissões legítimas — números reais (máx. `MAX_PHONE_DIGITS = 15` dígitos + formatação) ficam muito abaixo de 32/64 caracteres. Input malformado/abusivo é rejeitado cedo.
- **Nível de risco:** baixo

## Issue relacionada

Sem issue — varredura de segurança de rotina (Sentinel). A observação de escopo levantada no review deste PR (mesma classe de issue em `submit-contact`/`submit-quiz`) foi endereçada no segundo commit.

## Tipo de mudança

- [x] 🐛 Bug fix

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only)
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível)

Testes de regressão adicionados: (1) `tests/submit-lead.test.ts` — telefone de 4000+ chars rejeitado com `Entrada muito longa.` antes da normalização; (2) `tests/lib-lead-logic.test.ts` — `normalizeWhatsappNumber` retorna `null` para input longo demais antes de qualquer regex rodar.

Comandos executados:

```text
npx tsx --test tests/submit-lead.test.ts tests/lib-lead-logic.test.ts tests/lead-whatsapp.test.ts   # 73 pass / 0 fail
npx tsx --test tests/submit-contact.test.ts tests/submit-quiz.test.ts tests/submit-quiz-api.test.ts  # 30 pass / 0 fail
pnpm typecheck                                                                                        # exit 0
```

## API & Segurança

- [x] Inputs validados/sanitizados na borda, antes de side effects ou chamadas a providers
- [x] Respostas e códigos de erro permanecem estruturados; helpers compartilhados (`lib/network`, `lib/rate-limit`, `lib/schemas`) reutilizados
- [x] Sem secrets ou PII bruta em logs
- [x] `dangerouslySetInnerHTML` não foi introduzido sem fonte controlada e justificativa

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`fix:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

Nenhum desvio. A guarda foi colocada no chokepoint compartilhado (`normalizeWhatsappNumber`) em vez de repetir bounds por handler, mantendo a correção DRY e efetiva em todos os formulários que recebem telefone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)