### PR TITLE
⚡ Bolt: precompute BlogList search index to cut per-keystroke work

### DIFF
--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { getAllPosts } from '../lib/mdx';
 import { AUTHORS } from '../data/blogData';
 import { User, ArrowRight, Search, BookOpen } from 'lucide-react';
 import { SocialShare } from '../components/SocialShare';
-import { getBlogPostUrl, getBlogHomeUrl, formatDate } from '../utils/blog';
+import { getBlogPostUrl, getBlogHomeUrl, formatDate, buildBlogSearchIndex, filterBlogSearchIndex } from '../utils/blog';
 import { optimizeRemoteImageUrl } from '../data/mediaConfig';
 import { getCategoryColor } from '../utils/categoryColors';
 import { Seo } from '../components/Seo';
@@ -20,15 +20,18 @@ import { openContactModal } from '../utils/contactForm';
  */
 
 const allPosts = getAllPosts();
+// Lowercased search haystacks are built once at module load, not per keystroke.
+const searchIndex = buildBlogSearchIndex(allPosts);
 
 const BlogList: React.FC = () => {
     const [searchTerm, setSearchTerm] = useState('');
 
-    const term = searchTerm.toLowerCase();
-    const filteredPosts = allPosts.filter(post =>
-        post.title.toLowerCase().includes(term) ||
-        post.category.toLowerCase().includes(term) ||
-        post.tags.some(tag => tag.toLowerCase().includes(term))
+    // Memoize the filtered list so it only recomputes when the term changes,
+    // and so each keystroke scans precomputed strings instead of re-lowercasing
+    // every post's title/category/tags.
+    const filteredPosts = useMemo(
+        () => filterBlogSearchIndex(searchIndex, searchTerm),
+        [searchTerm],
     );
 
     return (

--- a/tests/blog-search-index.test.ts
+++ b/tests/blog-search-index.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildBlogSearchIndex, filterBlogSearchIndex } from '../utils/blog.ts';
+
+interface FakePost {
+  title: string;
+  category: string;
+  tags: string[];
+}
+
+const POSTS: FakePost[] = [
+  { title: 'Dicas para Orlando', category: 'Destinos', tags: ['Disney', 'Parques'] },
+  { title: 'Roteiro de Lisboa', category: 'Europa', tags: ['Portugal', 'Cidade'] },
+  { title: 'Cruzeiros no Brasil', category: 'Curadoria', tags: ['Navio', 'Litoral'] },
+];
+
+// Reference implementation matching the previous per-field filter, used to prove
+// the indexed filter keeps identical matching semantics.
+function referenceFilter(posts: FakePost[], rawTerm: string): FakePost[] {
+  const term = rawTerm.toLowerCase();
+  return posts.filter(
+    (post) =>
+      post.title.toLowerCase().includes(term) ||
+      post.category.toLowerCase().includes(term) ||
+      post.tags.some((tag) => tag.toLowerCase().includes(term)),
+  );
+}
+
+test('empty term returns every post in original order', () => {
+  const index = buildBlogSearchIndex(POSTS);
+  assert.deepEqual(filterBlogSearchIndex(index, ''), POSTS);
+});
+
+test('matches by title, category, or tag, case-insensitively', () => {
+  const index = buildBlogSearchIndex(POSTS);
+
+  assert.deepEqual(filterBlogSearchIndex(index, 'orlando'), [POSTS[0]]);
+  assert.deepEqual(filterBlogSearchIndex(index, 'EUROPA'), [POSTS[1]]);
+  assert.deepEqual(filterBlogSearchIndex(index, 'navio'), [POSTS[2]]);
+});
+
+test('non-matching term returns an empty list', () => {
+  const index = buildBlogSearchIndex(POSTS);
+  assert.deepEqual(filterBlogSearchIndex(index, 'zzz-nada'), []);
+});
+
+test('a term never matches across two different fields', () => {
+  // "destinosdicas" would only match if fields were concatenated without a
+  // separator; the "\n" join must prevent a cross-field false positive.
+  const index = buildBlogSearchIndex(POSTS);
+  assert.deepEqual(filterBlogSearchIndex(index, 'destinosdicas'), []);
+});
+
+test('indexed filter matches the reference per-field filter for many terms', () => {
+  const index = buildBlogSearchIndex(POSTS);
+  const terms = ['', 'o', 'DI', 'lisboa', 'curadoria', 'parques', 'z', 'brasil', 'Cidade'];
+
+  for (const term of terms) {
+    assert.deepEqual(
+      filterBlogSearchIndex(index, term),
+      referenceFilter(POSTS, term),
+      `mismatch for term "${term}"`,
+    );
+  }
+});

--- a/utils/blog.ts
+++ b/utils/blog.ts
@@ -47,6 +47,14 @@ export function filterBlogSearchIndex<T>(
   rawTerm: string,
 ): T[] {
   const term = rawTerm.toLowerCase();
-  if (!term) return index.map((entry) => entry.post);
-  return index.filter((entry) => entry.haystack.includes(term)).map((entry) => entry.post);
+  const result: T[] = [];
+  // Single pass filters and maps at once, avoiding the double iteration and
+  // per-element callback overhead of chaining .filter().map() on each keystroke.
+  // An empty term short-circuits the `includes` scan and keeps every post.
+  for (const entry of index) {
+    if (!term || entry.haystack.includes(term)) {
+      result.push(entry.post);
+    }
+  }
+  return result;
 }

--- a/utils/blog.ts
+++ b/utils/blog.ts
@@ -14,3 +14,39 @@ export function formatDate(isoDate: string): string {
   const [, year, month, day] = match;
   return `${day}/${month}/${year}`;
 }
+
+interface SearchablePost {
+  title: string;
+  category: string;
+  tags: string[];
+}
+
+export interface BlogSearchEntry<T> {
+  post: T;
+  haystack: string;
+}
+
+// PERFORMANCE: precompute one lowercased "haystack" per post so the search box
+// filter doesn't re-lowercase every title/category/tag on each keystroke.
+// Fields are joined with "\n" so a term (which can never contain "\n" from an
+// <input>) can only match within a single field — identical semantics to the
+// previous per-field `.toLowerCase().includes()` / `tags.some()` checks.
+export function buildBlogSearchIndex<T extends SearchablePost>(
+  posts: readonly T[],
+): BlogSearchEntry<T>[] {
+  return posts.map((post) => ({
+    post,
+    haystack: `${post.title}\n${post.category}\n${post.tags.join('\n')}`.toLowerCase(),
+  }));
+}
+
+// Filters a prebuilt index by a search term. An empty term is a fast path that
+// returns every post without scanning any string.
+export function filterBlogSearchIndex<T>(
+  index: readonly BlogSearchEntry<T>[],
+  rawTerm: string,
+): T[] {
+  const term = rawTerm.toLowerCase();
+  if (!term) return index.map((entry) => entry.post);
+  return index.filter((entry) => entry.haystack.includes(term)).map((entry) => entry.post);
+}


### PR DESCRIPTION
## Resumo

- **O que muda:** O filtro de busca do `BlogList` agora usa um índice de busca pré-computado. Cada post tem um único "haystack" em minúsculas montado **uma vez** no carregamento do módulo (`buildBlogSearchIndex`), e a lista filtrada é memoizada (`useMemo`) para só recalcular quando o termo muda.
- **Por quê:** O código anterior chamava `.toLowerCase()` em `title`, `category` e em cada `tag` de **todo** post a cada tecla digitada (~125 chamadas `.toLowerCase()` para ~25 posts × ~3 tags), e re-filtrava em qualquer re-render não relacionado. Agora a filtragem por tecla varre strings já em minúsculas (um `.includes()` por post) e um termo vazio retorna a lista completa sem varrer nada.
- **Impacto para o usuário:** Digitação mais fluida na busca do blog, especialmente em mobile, sem mudança de comportamento visível. Semântica de correspondência idêntica: os campos são unidos por `"\n"`, que um termo vindo de um `<input>` nunca contém, então um termo continua só casando dentro de um único campo.
- **Nível de risco:** baixo

## Issue relacionada

Sem issue — melhoria de performance oportunista (rotina "Bolt"). Otimização isolada e coberta por teste.

## Tipo de mudança

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] ♻️ Refatoração (sem mudança de comportamento)
- [ ] ⚙️ Infra / CI
- [ ] 📚 Documentação
- [ ] 🔍 SEO / GEO
- [x] ⚡ Performance

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only)
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível)

Novo `tests/blog-search-index.test.ts` cobre: termo vazio → todos os posts na ordem original; casamento por título/categoria/tag case-insensitive; termo sem correspondência → lista vazia; ausência de falso-positivo cruzando campos (junção por `"\n"`); e equivalência com uma implementação de referência do filtro por-campo anterior, para vários termos.

Comandos executados:

```text
npx tsx --test tests/blog-search-index.test.ts   # 5/5 pass
pnpm typecheck                                    # ok
pnpm test:regression                              # 834/834 pass
```

## API & Segurança

- [x] Não se aplica

<!-- Sem handlers de api/ e sem input externo além do texto de busca já tratado no cliente. -->

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`perf:` no commit)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

Nenhum desvio. `pages/BlogList.tsx` foi tocado minimamente (import + índice em nível de módulo + `useMemo`); a lógica pura foi extraída para `utils/blog.ts` para permitir cobertura via `node:test`, seguindo o padrão do repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yT5X3ea8oPcEoAYRTWnPL

---
_Generated by [Claude Code](https://claude.ai/code/session_018yT5X3ea8oPcEoAYRTWnPL)_