### PR TITLE
feat: registra origem do CTA no lead de contato no Odoo

### DIFF
--- a/lib/odoo-lead-mapping.ts
+++ b/lib/odoo-lead-mapping.ts
@@ -70,6 +70,8 @@ export interface OdooLeadInput {
     destinationTagIds?: RegionTagId[];
     destination?: string | null;
     bantSummary?: string | null;
+    /** Which on-site CTA opened the form (e.g. 'header', 'blog-sidebar') — visibility only, not a UTM source. */
+    ctaSource?: string | null;
     referred?: string | null;
     empresa?: string | null;
     cargo?: string | null;
@@ -157,6 +159,7 @@ function buildDescriptionHtml(input: OdooLeadInput): string {
 
     push('BANT', input.bantSummary);
     push('Destino', input.destination);
+    push('Origem (CTA)', input.ctaSource);
     push('Indicado por', input.referred);
     push('Empresa', input.empresa);
     push('Cargo', input.cargo);
@@ -245,6 +248,7 @@ export function leadInputFromSubmitContact(data: SubmitContactRequest): OdooLead
         marketingOptIn: data.emailOptIn === true,
         destination: data.destination ?? null,
         destinationTagIds: resolveRegionTagsFromText(data.destination ?? null),
+        ctaSource: data.source ?? null,
         eventId: data.eventId ?? null,
         utms: data.utms,
         tracking: data.tracking,

--- a/tests/odoo-lead-mapping.test.ts
+++ b/tests/odoo-lead-mapping.test.ts
@@ -128,6 +128,16 @@ test('buildLeadFields — opportunity shape with partner_id and resolved source/
     assert.match(String(fields.description), /<li>Destino: Orlando<\/li>/);
 });
 
+test('buildLeadFields — inclui Origem (CTA) na descrição quando presente', () => {
+    const fields = buildLeadFields(baseInput({ ctaSource: 'blog-sidebar' }), 5);
+    assert.match(String(fields.description), /<li>Origem \(CTA\): blog-sidebar<\/li>/);
+});
+
+test('buildLeadFields — omite Origem (CTA) quando ausente', () => {
+    const fields = buildLeadFields(baseInput({ bantSummary: 'Need: X' }), 5);
+    assert.doesNotMatch(String(fields.description), /Origem \(CTA\)/);
+});
+
 test('buildLeadFields — maps empresa/cargo and referred when present', () => {
     const fields = buildLeadFields(baseInput({ empresa: 'ACME', cargo: 'CTO', referred: 'João' }), 5);
     assert.equal(fields.partner_name, 'ACME');
@@ -198,6 +208,22 @@ test('leadInputFromSubmitContact — creates a lead, emailOptIn → marketingOpt
     } as never);
     assert.equal(input.createsLead, true);
     assert.equal(input.marketingOptIn, true);
+});
+
+test('leadInputFromSubmitContact — carries the CTA source through to ctaSource', () => {
+    const input = leadInputFromSubmitContact({
+        firstName: 'Ana', whatsapp: '+5511999990000', emailOptIn: false,
+        source: 'blog-sidebar', utms: EMPTY_UTMS,
+    } as never);
+    assert.equal(input.ctaSource, 'blog-sidebar');
+});
+
+test('leadInputFromSubmitContact — missing source maps to null', () => {
+    const input = leadInputFromSubmitContact({
+        firstName: 'Ana', whatsapp: '+5511999990000', emailOptIn: false,
+        utms: EMPTY_UTMS,
+    } as never);
+    assert.equal(input.ctaSource, null);
 });
 
 test('leadInputFromSubmitQuiz — partner only (no lead), carries profileKey + quiz signal', () => {


### PR DESCRIPTION
## Summary
- `leadInputFromSubmitContact` recebia `data.source` (o CTA que abriu o modal — header, blog-sidebar, about, landing pages, etc.) mas nunca repassava para o Odoo; o campo era descartado antes do mapeamento
- Adiciona `ctaSource` ao `OdooLeadInput` e escreve uma linha "Origem (CTA)" na descrição do `crm.lead`, no mesmo padrão já usado para `gclid`/`fbclid`/`utm_term`
- Não é retroativo (leads antigos não têm essa info) e não é campo estruturado no Odoo — é texto livre na nota do lead, suficiente para contagem manual por enquanto

## Contexto
Investigando um lead sem `crm.lead` correspondente no Odoo, percebemos que não havia como saber de qual CTA do site ele veio. O campo já existia no payload validado (`SubmitContactRequest.source`) e já ia pro dataLayer do GTM (`cta_source`), mas nunca chegava ao CRM.

## Test plan
- [x] `tsx --test tests/odoo-lead-mapping.test.ts` — 28/28 passando (4 testes novos)
- [x] `pnpm typecheck` — sem erros
- [ ] CI (`build-and-test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)