### PR TITLE
feat: usa campaign_id nativo do Odoo em vez de texto livre para utm_campaign

### DIFF
--- a/lib/odoo-lead-mapping.ts
+++ b/lib/odoo-lead-mapping.ts
@@ -171,7 +171,8 @@ function buildDescriptionHtml(input: OdooLeadInput): string {
     push('fbc', t?.fbc);
     push('GA cid', t?.cid);
     push('GA sid', t?.sid);
-    push('utm_campaign', input.utms.utm_campaign);
+    // utm_campaign is deliberately omitted here — it's resolved to the native
+    // crm.lead.campaign_id (utm.campaign) upstream in odoo-submit-handler.ts.
     push('utm_term', input.utms.utm_term);
     push('utm_content', input.utms.utm_content);
     push('event_id', input.eventId);

--- a/lib/odoo-submit-handler.ts
+++ b/lib/odoo-submit-handler.ts
@@ -17,6 +17,7 @@ import {
 } from './n8n-submit-handler';
 import { buildLeadFields, buildPartnerFields, type OdooLeadInput } from './odoo-lead-mapping';
 import { getOdooConfig, openOdooSession } from '../services/odoo';
+import { logger } from './logger';
 
 // services/odoo.ts encodes failures as `ODOO_ERROR:<status>:<detail>`.
 const ODOO_ERROR_PATTERN = /^ODOO_ERROR:(\d+):(.*)$/s;
@@ -58,7 +59,17 @@ async function sendToOdoo(input: OdooLeadInput): Promise<void> {
         // model (find-or-create) instead of a hardcoded id.
         const campaignName = input.utms.utm_campaign?.trim();
         if (campaignName) {
-            leadFields.campaign_id = await session.resolveCampaignId(campaignName);
+            // Enrichment, not essential: a hiccup resolving the campaign must not
+            // cost the lead itself (which already succeeded via upsertPartner).
+            try {
+                leadFields.campaign_id = await session.resolveCampaignId(campaignName);
+            } catch (error) {
+                logger.warn('ODOO_CAMPAIGN_RESOLVE', {
+                    stage: 'campaign_resolve_failed',
+                    campaignName,
+                    detail: error instanceof Error ? error.message : String(error),
+                });
+            }
         }
         await session.createLead(leadFields);
     }

--- a/lib/odoo-submit-handler.ts
+++ b/lib/odoo-submit-handler.ts
@@ -52,7 +52,15 @@ async function sendToOdoo(input: OdooLeadInput): Promise<void> {
     });
 
     if (input.createsLead) {
-        await session.createLead(buildLeadFields(input, partnerId));
+        const leadFields = buildLeadFields(input, partnerId);
+        // utm_campaign is highly variable (one per ad campaign), unlike the fixed
+        // source/medium table, so it's resolved against Odoo's native utm.campaign
+        // model (find-or-create) instead of a hardcoded id.
+        const campaignName = input.utms.utm_campaign?.trim();
+        if (campaignName) {
+            leadFields.campaign_id = await session.resolveCampaignId(campaignName);
+        }
+        await session.createLead(leadFields);
     }
 }
 

--- a/services/odoo.ts
+++ b/services/odoo.ts
@@ -234,7 +234,9 @@ export async function openOdooSession(config: OdooConfig): Promise<OdooSession> 
         async resolveCampaignId(name) {
             const trimmed = name.trim();
 
-            async function findByName(): Promise<number | null> {
+            // Ordered by id so every concurrent caller that reaches this query
+            // converges on the same (oldest) row, even if more than one exists.
+            async function findCanonicalByName(): Promise<number | null> {
                 const rows = await executeKw<{ id: number }[]>(
                     config,
                     uid,
@@ -242,26 +244,33 @@ export async function openOdooSession(config: OdooConfig): Promise<OdooSession> 
                     'search_read',
                     [[['name', '=', trimmed]], ['id']],
                     deadline,
-                    { limit: 1 },
+                    { limit: 1, order: 'id asc' },
                 );
                 return rows[0]?.id ?? null;
             }
 
-            const existingId = await findByName();
+            const existingId = await findCanonicalByName();
             if (existingId) return existingId;
 
-            // Not atomic: two concurrent requests for the same brand-new campaign
-            // name can both miss this search and both attempt create. If Odoo
-            // rejects the second create (unique constraint) or a duplicate slips
-            // through, re-checking by name once recovers the id another request
-            // just created instead of surfacing a spurious failure.
+            // Not atomic, and Odoo's stock utm.campaign has no unique constraint
+            // on name: two concurrent requests for the same brand-new campaign can
+            // both miss the search above. Whichever way the create lands — it
+            // throws (a constraint conflict) or silently succeeds alongside a
+            // duplicate another request just created — re-resolving by name
+            // afterward (oldest id wins) means every concurrent caller returns the
+            // same campaign_id instead of fragmenting leads across duplicate rows.
             try {
-                return await executeKw<number>(config, uid, 'utm.campaign', 'create', [{ name: trimmed }], deadline);
+                await executeKw<number>(config, uid, 'utm.campaign', 'create', [{ name: trimmed }], deadline);
             } catch (error) {
-                const raceWinnerId = await findByName();
-                if (raceWinnerId) return raceWinnerId;
+                const canonicalId = await findCanonicalByName();
+                if (canonicalId) return canonicalId;
                 throw error;
             }
+
+            const canonicalId = await findCanonicalByName();
+            if (canonicalId) return canonicalId;
+            // Unreachable in practice: create just succeeded for this exact name.
+            throw new Error('utm.campaign create succeeded but could not be resolved afterward');
         },
     };
 }

--- a/services/odoo.ts
+++ b/services/odoo.ts
@@ -9,9 +9,10 @@
  *
  * Auth flow: `common.authenticate` → uid, then `object.execute_kw` for ORM calls.
  * Module-level state does not persist across requests on Workers, so each submit
- * re-authenticates. A lead submit makes up to 4 sequential round-trips
- * (auth → partner search → partner write/create → lead create); a shared deadline
- * bounds the worst case so an upstream stall never hangs the form.
+ * re-authenticates. A lead submit makes up to 5 sequential round-trips
+ * (auth → partner search → partner write/create → campaign find-or-create →
+ * lead create); a shared deadline bounds the worst case so an upstream stall
+ * never hangs the form.
  *
  * Errors are normalized to `ODOO_ERROR:<status>:<detail>` so the submit-handler
  * factory classifies them uniformly (see lib/odoo-submit-handler.ts).
@@ -165,6 +166,8 @@ export interface UpsertPartnerOptions {
 export interface OdooSession {
     upsertPartner: (fields: OdooPartnerFields, options?: UpsertPartnerOptions) => Promise<number>;
     createLead: (fields: Record<string, unknown>) => Promise<number>;
+    /** Finds a `utm.campaign` by exact name, creating one if none matches. */
+    resolveCampaignId: (name: string) => Promise<number>;
 }
 
 export async function openOdooSession(config: OdooConfig): Promise<OdooSession> {
@@ -227,6 +230,20 @@ export async function openOdooSession(config: OdooConfig): Promise<OdooSession> 
         },
         createLead(fields) {
             return executeKw<number>(config, uid, 'crm.lead', 'create', [fields], deadline);
+        },
+        async resolveCampaignId(name) {
+            const trimmed = name.trim();
+            const rows = await executeKw<{ id: number }[]>(
+                config,
+                uid,
+                'utm.campaign',
+                'search_read',
+                [[['name', '=', trimmed]], ['id']],
+                deadline,
+                { limit: 1 },
+            );
+            if (rows[0]) return rows[0].id;
+            return executeKw<number>(config, uid, 'utm.campaign', 'create', [{ name: trimmed }], deadline);
         },
     };
 }

--- a/services/odoo.ts
+++ b/services/odoo.ts
@@ -233,17 +233,35 @@ export async function openOdooSession(config: OdooConfig): Promise<OdooSession> 
         },
         async resolveCampaignId(name) {
             const trimmed = name.trim();
-            const rows = await executeKw<{ id: number }[]>(
-                config,
-                uid,
-                'utm.campaign',
-                'search_read',
-                [[['name', '=', trimmed]], ['id']],
-                deadline,
-                { limit: 1 },
-            );
-            if (rows[0]) return rows[0].id;
-            return executeKw<number>(config, uid, 'utm.campaign', 'create', [{ name: trimmed }], deadline);
+
+            async function findByName(): Promise<number | null> {
+                const rows = await executeKw<{ id: number }[]>(
+                    config,
+                    uid,
+                    'utm.campaign',
+                    'search_read',
+                    [[['name', '=', trimmed]], ['id']],
+                    deadline,
+                    { limit: 1 },
+                );
+                return rows[0]?.id ?? null;
+            }
+
+            const existingId = await findByName();
+            if (existingId) return existingId;
+
+            // Not atomic: two concurrent requests for the same brand-new campaign
+            // name can both miss this search and both attempt create. If Odoo
+            // rejects the second create (unique constraint) or a duplicate slips
+            // through, re-checking by name once recovers the id another request
+            // just created instead of surfacing a spurious failure.
+            try {
+                return await executeKw<number>(config, uid, 'utm.campaign', 'create', [{ name: trimmed }], deadline);
+            } catch (error) {
+                const raceWinnerId = await findByName();
+                if (raceWinnerId) return raceWinnerId;
+                throw error;
+            }
         },
     };
 }

--- a/tests/odoo-lead-mapping.test.ts
+++ b/tests/odoo-lead-mapping.test.ts
@@ -128,6 +128,14 @@ test('buildLeadFields — opportunity shape with partner_id and resolved source/
     assert.match(String(fields.description), /<li>Destino: Orlando<\/li>/);
 });
 
+test('buildLeadFields — não duplica utm_campaign na descrição (vira campaign_id a montante)', () => {
+    const fields = buildLeadFields(
+        baseInput({ bantSummary: 'Need: X', utms: utms({ utm_campaign: 'verao2026' }) }),
+        5,
+    );
+    assert.doesNotMatch(String(fields.description), /utm_campaign/);
+});
+
 test('buildLeadFields — inclui Origem (CTA) na descrição quando presente', () => {
     const fields = buildLeadFields(baseInput({ ctaSource: 'blog-sidebar' }), 5);
     assert.match(String(fields.description), /<li>Origem \(CTA\): blog-sidebar<\/li>/);

--- a/tests/odoo-mock.ts
+++ b/tests/odoo-mock.ts
@@ -138,6 +138,10 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
     } = options;
 
     const calls: OdooExecuteCall[] = [];
+    // Stateful: once utm.campaign.create succeeds, subsequent search_read calls
+    // for that model must find it (mirrors real Odoo, and resolveCampaignId now
+    // always re-queries after create to converge on a canonical row).
+    let campaignId = existingCampaignId;
 
     const fetchMock = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
         if (hang) return new Promise<Response>(() => {});
@@ -161,9 +165,13 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
             return jsonRpcError('duplicate key value violates unique constraint "utm_campaign_name_uniq"');
         }
         if (ormMethod === 'search_read') {
-            return jsonRpcResponse(searchReadResult(model, { existingPartnerId, existingComment, existingFields, existingCampaignId }));
+            return jsonRpcResponse(searchReadResult(model, { existingPartnerId, existingComment, existingFields, existingCampaignId: campaignId }));
         }
-        if (ormMethod === 'create') return jsonRpcResponse(createResult(model, { leadId, newPartnerId, newCampaignId }));
+        if (ormMethod === 'create') {
+            const result = createResult(model, { leadId, newPartnerId, newCampaignId });
+            if (model === 'utm.campaign') campaignId = newCampaignId;
+            return jsonRpcResponse(result);
+        }
         if (ormMethod === 'write') return jsonRpcResponse(true);
         return jsonRpcResponse(false);
     }) as typeof fetch;

--- a/tests/odoo-mock.ts
+++ b/tests/odoo-mock.ts
@@ -44,6 +44,8 @@ export interface OdooMockOptions {
     existingCampaignId?: number | null;
     /** id returned by utm.campaign.create when no existing campaign matches. */
     newCampaignId?: number;
+    /** Makes utm.campaign.create return a JSON-RPC error (simulates a concurrent-create conflict). */
+    campaignCreateShouldFail?: boolean;
     /** Force every RPC to fail with this HTTP status. */
     failStatus?: number;
     failDetail?: string;
@@ -105,6 +107,20 @@ function createResult(model: string, d: CreateDefaults): number {
     return d.newPartnerId;
 }
 
+function jsonRpcResponse(result: unknown): Response {
+    return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+function jsonRpcError(message: string): Response {
+    return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { message } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
 export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
     const {
         uid = 7,
@@ -115,6 +131,7 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
         leadId = 555,
         existingCampaignId = null,
         newCampaignId = 900,
+        campaignCreateShouldFail = false,
         failStatus,
         failDetail = 'odoo upstream failed',
         hang = false,
@@ -131,30 +148,24 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
         };
         const { service, method, args } = body.params;
 
-        let result: unknown = false;
+        if (service === 'common' && method === 'authenticate') return jsonRpcResponse(uid);
+        if (service !== 'object' || method !== 'execute_kw') return jsonRpcResponse(false);
 
-        if (service === 'common' && method === 'authenticate') {
-            result = uid;
-        } else if (service === 'object' && method === 'execute_kw') {
-            const model = args[3] as string;
-            const ormMethod = args[4] as string;
-            const ormArgs = (args[5] as unknown[]) ?? [];
-            const kwargs = (args[6] as Record<string, unknown>) ?? {};
-            calls.push({ model, method: ormMethod, args: ormArgs, kwargs });
+        const model = args[3] as string;
+        const ormMethod = args[4] as string;
+        const ormArgs = (args[5] as unknown[]) ?? [];
+        const kwargs = (args[6] as Record<string, unknown>) ?? {};
+        calls.push({ model, method: ormMethod, args: ormArgs, kwargs });
 
-            if (ormMethod === 'search_read') {
-                result = searchReadResult(model, { existingPartnerId, existingComment, existingFields, existingCampaignId });
-            } else if (ormMethod === 'create') {
-                result = createResult(model, { leadId, newPartnerId, newCampaignId });
-            } else if (ormMethod === 'write') {
-                result = true;
-            }
+        if (ormMethod === 'create' && model === 'utm.campaign' && campaignCreateShouldFail) {
+            return jsonRpcError('duplicate key value violates unique constraint "utm_campaign_name_uniq"');
         }
-
-        return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-        });
+        if (ormMethod === 'search_read') {
+            return jsonRpcResponse(searchReadResult(model, { existingPartnerId, existingComment, existingFields, existingCampaignId }));
+        }
+        if (ormMethod === 'create') return jsonRpcResponse(createResult(model, { leadId, newPartnerId, newCampaignId }));
+        if (ormMethod === 'write') return jsonRpcResponse(true);
+        return jsonRpcResponse(false);
     }) as typeof fetch;
 
     return {

--- a/tests/odoo-mock.ts
+++ b/tests/odoo-mock.ts
@@ -77,6 +77,34 @@ function ormFields(call: OdooExecuteCall | undefined): Record<string, unknown> |
     return fields as Record<string, unknown> | undefined;
 }
 
+interface SearchReadDefaults {
+    existingPartnerId: number | null;
+    existingComment: string | false;
+    existingFields: Record<string, unknown>;
+    existingCampaignId: number | null;
+}
+
+/** `search_read` result per model: dedup row for res.partner, find-or-create lookup for utm.campaign. */
+function searchReadResult(model: string, d: SearchReadDefaults): unknown[] {
+    if (model === 'utm.campaign') {
+        return d.existingCampaignId ? [{ id: d.existingCampaignId }] : [];
+    }
+    return d.existingPartnerId ? [{ id: d.existingPartnerId, comment: d.existingComment, ...d.existingFields }] : [];
+}
+
+interface CreateDefaults {
+    leadId: number;
+    newPartnerId: number;
+    newCampaignId: number;
+}
+
+/** `create` result id per model. */
+function createResult(model: string, d: CreateDefaults): number {
+    if (model === 'crm.lead') return d.leadId;
+    if (model === 'utm.campaign') return d.newCampaignId;
+    return d.newPartnerId;
+}
+
 export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
     const {
         uid = 7,
@@ -115,15 +143,9 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
             calls.push({ model, method: ormMethod, args: ormArgs, kwargs });
 
             if (ormMethod === 'search_read') {
-                if (model === 'utm.campaign') {
-                    result = existingCampaignId ? [{ id: existingCampaignId }] : [];
-                } else {
-                    result = existingPartnerId
-                        ? [{ id: existingPartnerId, comment: existingComment, ...existingFields }]
-                        : [];
-                }
+                result = searchReadResult(model, { existingPartnerId, existingComment, existingFields, existingCampaignId });
             } else if (ormMethod === 'create') {
-                result = model === 'crm.lead' ? leadId : model === 'utm.campaign' ? newCampaignId : newPartnerId;
+                result = createResult(model, { leadId, newPartnerId, newCampaignId });
             } else if (ormMethod === 'write') {
                 result = true;
             }

--- a/tests/odoo-mock.ts
+++ b/tests/odoo-mock.ts
@@ -40,6 +40,10 @@ export interface OdooMockOptions {
     existingFields?: Record<string, unknown>;
     newPartnerId?: number;
     leadId?: number;
+    /** utm.campaign search_read result: id of an existing campaign, or null/absent for none (default: none). */
+    existingCampaignId?: number | null;
+    /** id returned by utm.campaign.create when no existing campaign matches. */
+    newCampaignId?: number;
     /** Force every RPC to fail with this HTTP status. */
     failStatus?: number;
     failDetail?: string;
@@ -81,6 +85,8 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
         existingFields = {},
         newPartnerId = 101,
         leadId = 555,
+        existingCampaignId = null,
+        newCampaignId = 900,
         failStatus,
         failDetail = 'odoo upstream failed',
         hang = false,
@@ -109,11 +115,15 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
             calls.push({ model, method: ormMethod, args: ormArgs, kwargs });
 
             if (ormMethod === 'search_read') {
-                result = existingPartnerId
-                    ? [{ id: existingPartnerId, comment: existingComment, ...existingFields }]
-                    : [];
+                if (model === 'utm.campaign') {
+                    result = existingCampaignId ? [{ id: existingCampaignId }] : [];
+                } else {
+                    result = existingPartnerId
+                        ? [{ id: existingPartnerId, comment: existingComment, ...existingFields }]
+                        : [];
+                }
             } else if (ormMethod === 'create') {
-                result = model === 'crm.lead' ? leadId : newPartnerId;
+                result = model === 'crm.lead' ? leadId : model === 'utm.campaign' ? newCampaignId : newPartnerId;
             } else if (ormMethod === 'write') {
                 result = true;
             }

--- a/tests/odoo-service.test.ts
+++ b/tests/odoo-service.test.ts
@@ -192,6 +192,54 @@ test('resolveCampaignId — creates a new utm.campaign when none matches', async
     assert.equal((create!.args[0] as Record<string, unknown>).name, 'Campanha Nova');
 });
 
+test('resolveCampaignId — recovers from a concurrent create conflict via retry search', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+
+    // Bespoke stateful mock: the shared createOdooMock returns a fixed
+    // search_read result regardless of call order, but this scenario needs the
+    // *first* search_read to miss and the *retry* (after the failed create) to
+    // find the id a concurrent request just created.
+    let createAttempted = false;
+    global.fetch = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { params: { service: string; method: string; args: unknown[] } };
+        const { service, method, args } = body.params;
+        if (service === 'common' && method === 'authenticate') {
+            return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: 7 }), { status: 200 });
+        }
+        const ormMethod = args[4] as string;
+        if (ormMethod === 'search_read') {
+            const result = createAttempted ? [{ id: 77 }] : [];
+            return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), { status: 200 });
+        }
+        if (ormMethod === 'create') {
+            createAttempted = true;
+            return new Response(
+                JSON.stringify({ jsonrpc: '2.0', id: 1, error: { message: 'duplicate key value violates unique constraint' } }),
+                { status: 200 },
+            );
+        }
+        throw new Error(`unexpected ORM call: ${ormMethod}`);
+    }) as typeof fetch;
+
+    const session = await openOdooSession(config());
+    const id = await session.resolveCampaignId('Lançamento Verão');
+
+    assert.equal(id, 77, 'should recover the id the concurrent request created, not throw');
+});
+
+test('resolveCampaignId — rethrows when the retry search also finds nothing', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+    const mock = createOdooMock({ existingCampaignId: null, campaignCreateShouldFail: true });
+    global.fetch = mock.fetch;
+
+    const session = await openOdooSession(config());
+
+    await assert.rejects(
+        () => session.resolveCampaignId('Campanha Fantasma'),
+        (e: unknown) => e instanceof Error && e.message.startsWith('ODOO_ERROR:502:'),
+    );
+});
+
 test('openOdooSession — rejects with ODOO_ERROR:401 when auth fails', async (t) => {
     t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
     global.fetch = createOdooMock({ uid: 0 }).fetch;

--- a/tests/odoo-service.test.ts
+++ b/tests/odoo-service.test.ts
@@ -166,6 +166,32 @@ test('createLead — issues a crm.lead.create and returns the id', async (t) => 
     assert.ok(mock.createdLead());
 });
 
+test('resolveCampaignId — returns the existing utm.campaign id when the name matches', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+    const mock = createOdooMock({ existingCampaignId: 42 });
+    global.fetch = mock.fetch;
+
+    const session = await openOdooSession(config());
+    const id = await session.resolveCampaignId('Verão 2026');
+
+    assert.equal(id, 42);
+    assert.equal(mock.calls.some((c) => c.model === 'utm.campaign' && c.method === 'create'), false);
+});
+
+test('resolveCampaignId — creates a new utm.campaign when none matches', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+    const mock = createOdooMock({ existingCampaignId: null, newCampaignId: 88 });
+    global.fetch = mock.fetch;
+
+    const session = await openOdooSession(config());
+    const id = await session.resolveCampaignId('  Campanha Nova  ');
+
+    assert.equal(id, 88);
+    const create = mock.calls.find((c) => c.model === 'utm.campaign' && c.method === 'create');
+    assert.ok(create, 'should create a utm.campaign');
+    assert.equal((create!.args[0] as Record<string, unknown>).name, 'Campanha Nova');
+});
+
 test('openOdooSession — rejects with ODOO_ERROR:401 when auth fails', async (t) => {
     t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
     global.fetch = createOdooMock({ uid: 0 }).fetch;

--- a/tests/odoo-service.test.ts
+++ b/tests/odoo-service.test.ts
@@ -192,6 +192,39 @@ test('resolveCampaignId — creates a new utm.campaign when none matches', async
     assert.equal((create!.args[0] as Record<string, unknown>).name, 'Campanha Nova');
 });
 
+test('resolveCampaignId — after a successful create, converges on the canonical (oldest) row instead of trusting the create id', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+
+    // utm.campaign has no unique constraint on name in stock Odoo: a concurrent
+    // request can create a same-named row *before* this one, and this one's
+    // create can still succeed — it must not return its own id blindly.
+    let searchReadCalls = 0;
+    global.fetch = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { params: { service: string; method: string; args: unknown[] } };
+        const { service, method, args } = body.params;
+        if (service === 'common' && method === 'authenticate') {
+            return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: 7 }), { status: 200 });
+        }
+        const ormMethod = args[4] as string;
+        if (ormMethod === 'search_read') {
+            searchReadCalls += 1;
+            // 1st search (before create): nothing found yet. 2nd (after create):
+            // a concurrent request's earlier row is now visible.
+            const result = searchReadCalls === 1 ? [] : [{ id: 10 }];
+            return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), { status: 200 });
+        }
+        if (ormMethod === 'create') {
+            return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: 500 }), { status: 200 });
+        }
+        throw new Error(`unexpected ORM call: ${ormMethod}`);
+    }) as typeof fetch;
+
+    const session = await openOdooSession(config());
+    const id = await session.resolveCampaignId('Lançamento Verão');
+
+    assert.equal(id, 10, 'must converge to the canonical row, not the id this create call returned');
+});
+
 test('resolveCampaignId — recovers from a concurrent create conflict via retry search', async (t) => {
     t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
 

--- a/tests/submit-contact.test.ts
+++ b/tests/submit-contact.test.ts
@@ -89,6 +89,21 @@ test('sets campaign_id on the crm.lead when utm_campaign is present', async () =
     assert.equal(lead.campaign_id, 9);
 });
 
+test('still creates the lead when campaign resolution fails (non-essential enrichment)', async () => {
+    setOdooEnv();
+    const mock = createOdooMock({ existingCampaignId: null, campaignCreateShouldFail: true });
+    global.fetch = mock.fetch;
+
+    const res = await handler(buildRequest(validBody({
+        utms: { utm_source: 'google', utm_medium: 'cpc', utm_campaign: 'verao2026' },
+    })));
+    assert.equal(res.status, 200);
+
+    assert.ok(mock.createdLead(), 'the lead must still be created despite the campaign_id failure');
+    const lead = mock.leadFields()!;
+    assert.equal('campaign_id' in lead, false);
+});
+
 test('omits campaign_id when utm_campaign is absent', async () => {
     setOdooEnv();
     const mock = createOdooMock();

--- a/tests/submit-contact.test.ts
+++ b/tests/submit-contact.test.ts
@@ -75,6 +75,32 @@ test('returns 200 and creates a partner + crm.lead on valid request', async () =
     assert.match(String(lead.name), /Orlando/);
 });
 
+test('sets campaign_id on the crm.lead when utm_campaign is present', async () => {
+    setOdooEnv();
+    const mock = createOdooMock({ existingCampaignId: 9 });
+    global.fetch = mock.fetch;
+
+    const res = await handler(buildRequest(validBody({
+        utms: { utm_source: 'google', utm_medium: 'cpc', utm_campaign: 'verao2026' },
+    })));
+    assert.equal(res.status, 200);
+
+    const lead = mock.leadFields()!;
+    assert.equal(lead.campaign_id, 9);
+});
+
+test('omits campaign_id when utm_campaign is absent', async () => {
+    setOdooEnv();
+    const mock = createOdooMock();
+    global.fetch = mock.fetch;
+
+    const res = await handler(buildRequest(validBody()));
+    assert.equal(res.status, 200);
+
+    const lead = mock.leadFields()!;
+    assert.equal('campaign_id' in lead, false);
+});
+
 test('returns 502 when Odoo fails', async () => {
     setOdooEnv();
     global.fetch = createOdooMock({ failStatus: 500 }).fetch;


### PR DESCRIPTION
## Summary
- `utm_campaign` já chegava no `crm.lead`, mas só como linha de texto solta na descrição — não dava pra filtrar/agrupar por campanha no Odoo
- Adiciona `OdooSession.resolveCampaignId()` (find-or-create em `utm.campaign` por nome exato) e passa a escrever `crm.lead.campaign_id` (campo nativo do módulo UTM do Odoo) quando `utm_campaign` está presente
- Remove a linha `utm_campaign` da descrição em texto livre (agora redundante — vira campo estruturado)
- `utm_term`/`utm_content` continuam como texto livre (Odoo não tem campo nativo pra eles no `crm.lead`)

## Por que find-or-create em vez de tabela fixa
`source_id`/`medium_id` usam uma tabela fixa de IDs (poucos valores possíveis: Google Ads, Meta Ads, Site, etc.). `utm_campaign` é uma string arbitrária definida por quem cria os anúncios — uma por campanha — então não dá pra mapear numa tabela fixa; a sessão do Odoo resolve por nome exato, criando o registro na primeira vez que aparece.

## Contexto
Investigando como reportar "qual CTA/campanha converte mais" (ver discussão relacionada a #1113), notamos que `utm_campaign` ficava preso em texto livre sem valor de relatório. Isso prepara o terreno pra uma iniciativa maior de conversão offline (subir gclid/fbclid/msclkid pro Google/Meta/Microsoft Ads quando o deal fecha) — plano ainda a ser desenhado.

## Test plan
- [x] `tsx --test tests/odoo-lead-mapping.test.ts tests/odoo-service.test.ts tests/submit-contact.test.ts tests/submit-lead.test.ts tests/submit-quiz.test.ts tests/submit-waitlist.test.ts tests/submit-nps.test.ts` — 128/128 passando
- [x] `pnpm test:regression` — 844/844 passando
- [x] `pnpm typecheck` — sem erros
- [ ] CI (`build-and-test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)