### PR TITLE
feat: notifica n8n/Postiz quando um novo post do blog é publicado

### DIFF
--- a/.github/workflows/notify-social-automation.yml
+++ b/.github/workflows/notify-social-automation.yml
@@ -1,0 +1,74 @@
+name: Notify Social Automation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "content/blog/**.mdx"
+
+# Padrão sem escopo: o job só lê o histórico do git e chama um webhook externo.
+permissions:
+  contents: read
+
+jobs:
+  notify-new-posts:
+    name: Anunciar novos posts do blog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Histórico completo: precisamos do commit anterior ao push para
+          # diferenciar posts novos de posts só editados.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Find newly added blog posts
+        id: added-posts
+        env:
+          # github.event.before/after são SHAs de commit, mas passamos via env
+          # (não interpolados no shell) seguindo o mesmo padrão exigido para
+          # qualquer contexto de evento — ver tests/workflow-command-injection-guard.test.ts.
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+        run: |
+          BEFORE="$BEFORE_SHA"
+          AFTER="$AFTER_SHA"
+          EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="$EMPTY_TREE"
+          fi
+
+          ADDED_FILES="$(git diff --name-status --diff-filter=A "$BEFORE" "$AFTER" -- content/blog | awk '{print $2}' | grep '\.mdx$' || true)"
+          echo "$ADDED_FILES"
+          {
+            echo "files<<EOF"
+            echo "$ADDED_FILES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install pnpm
+        if: steps.added-posts.outputs.files != ''
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Use Node.js 24
+        if: steps.added-posts.outputs.files != ''
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        if: steps.added-posts.outputs.files != ''
+        run: pnpm install --frozen-lockfile
+
+      - name: Notify n8n of new blog posts
+        if: steps.added-posts.outputs.files != ''
+        env:
+          # Passado via env (não interpolado no shell) para evitar script
+          # injection a partir de nomes de arquivo — ver docs/standards/security.md.
+          ADDED_BLOG_FILES: ${{ steps.added-posts.outputs.files }}
+          N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL: ${{ secrets.N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL }}
+          N8N_WEBHOOK_SECRET: ${{ secrets.N8N_WEBHOOK_SECRET }}
+        run: pnpm exec tsx scripts/notify-blog-published.ts

--- a/docs/ops/social-automation.md
+++ b/docs/ops/social-automation.md
@@ -1,0 +1,54 @@
+# Automação de posts sociais no publish do blog
+
+## Escopo
+
+Só o publish de um novo post do blog é automatizado. Posts sociais avulsos
+(sem artigo por trás) são agendados direto no calendário do
+[Postiz](https://github.com/gitroomhq/postiz-app) — sem pipeline custom, para
+não duplicar o que a própria ferramenta já resolve.
+
+## Fluxo
+
+1. `.github/workflows/notify-social-automation.yml` dispara em todo `push` em
+   `main` que toca `content/blog/**.mdx`.
+2. O job diferencia arquivos **novos** (`git diff --diff-filter=A`) dos só
+   editados — só posts novos disparam anúncio.
+3. `scripts/notify-blog-published.ts` lê o frontmatter de cada post novo,
+   monta o payload via `lib/social-announcement.ts` e faz `POST` para o
+   webhook do n8n, autenticado com o mesmo header `X-Webhook-Secret` usado
+   pelos outros webhooks do site (`N8N_WEBHOOK_SECRET`).
+4. Do lado do n8n: o workflow recebe o payload, monta a copy por rede e chama
+   a API pública do Postiz (ou o nó nativo N8N→Postiz) para agendar o
+   anúncio no calendário editorial.
+
+Se `N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL` ou `N8N_WEBHOOK_SECRET` não estiverem
+configurados, o script loga e sai sem erro — a automação é opcional até o
+workflow do n8n existir do outro lado.
+
+## Payload enviado ao n8n
+
+```json
+{
+  "event": "blog_post_published",
+  "slug": "5-segredos-da-disney-que-ninguem-conta",
+  "title": "5 Segredos da Disney que Ninguém Conta",
+  "excerpt": "Descubra como furar filas legalmente...",
+  "url": "https://www.anhanga.tur.br/blog/5-segredos-da-disney-que-ninguem-conta/",
+  "image": "https://media.anhanga.tur.br/images/blog/5-segredos-disney.jpg",
+  "category": "Dicas de Expert",
+  "tags": ["disney", "orlando"],
+  "publishedAt": "2025-12-12"
+}
+```
+
+## Secrets necessários (GitHub Actions → Settings → Secrets)
+
+| Secret | Descrição |
+|---|---|
+| `N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL` | URL do webhook trigger do workflow n8n que agenda o post no Postiz |
+| `N8N_WEBHOOK_SECRET` | Já existente — reaproveitado como segredo compartilhado nesta chamada de saída |
+
+Este é o único uso de `N8N_WEBHOOK_SECRET` fora do runtime da aplicação (os
+demais handlers em `api/` o validam como segredo **de entrada**; aqui o
+workflow do GitHub Actions o envia como segredo **de saída**, e o workflow do
+n8n do outro lado deve validar o mesmo header antes de processar).

--- a/lib/social-announcement.ts
+++ b/lib/social-announcement.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure payload-building for the "novo post no blog" social announcement
+ * webhook. `scripts/notify-blog-published.ts` is the only caller today; kept
+ * here (rather than inline in the script) so the shaping logic is unit
+ * testable without touching the filesystem or network.
+ */
+import type { BlogPostFrontmatter } from '../types/blog';
+
+const DEFAULT_SITE_BASE_URL = 'https://www.anhanga.tur.br';
+
+export interface SocialAnnouncementPayload {
+  event: 'blog_post_published';
+  slug: string;
+  title: string;
+  excerpt: string;
+  url: string;
+  image: string;
+  category: string;
+  tags: string[];
+  publishedAt: string;
+}
+
+function normalizeTags(tags: BlogPostFrontmatter['tags']): string[] {
+  return Array.isArray(tags) ? tags.filter((tag): tag is string => typeof tag === 'string' && tag.trim().length > 0) : [];
+}
+
+export function buildBlogAnnouncementPayload(
+  slug: string,
+  frontmatter: BlogPostFrontmatter,
+  siteBaseUrl: string = DEFAULT_SITE_BASE_URL,
+): SocialAnnouncementPayload {
+  return {
+    event: 'blog_post_published',
+    slug,
+    title: frontmatter.title.trim(),
+    excerpt: frontmatter.excerpt.trim(),
+    url: new URL(`/blog/${slug}/`, siteBaseUrl).toString(),
+    image: frontmatter.image,
+    category: frontmatter.category,
+    tags: normalizeTags(frontmatter.tags),
+    publishedAt: frontmatter.date,
+  };
+}

--- a/lib/social-announcement.ts
+++ b/lib/social-announcement.ts
@@ -24,6 +24,18 @@ function normalizeTags(tags: BlogPostFrontmatter['tags']): string[] {
   return Array.isArray(tags) ? tags.filter((tag): tag is string => typeof tag === 'string' && tag.trim().length > 0) : [];
 }
 
+/**
+ * Frontmatter comes from a dynamically parsed MDX file, so required fields
+ * aren't guaranteed at runtime even though the type says they are. This guard
+ * only confirms gray-matter handed back an object (not `null`/a scalar) —
+ * `scripts/notify-blog-published.ts` uses it instead of an unchecked `as` cast
+ * before calling `buildBlogAnnouncementPayload`, which itself falls back to
+ * `''` for any individual missing field below.
+ */
+export function isFrontmatterLike(value: unknown): value is BlogPostFrontmatter {
+  return typeof value === 'object' && value !== null;
+}
+
 export function buildBlogAnnouncementPayload(
   slug: string,
   frontmatter: BlogPostFrontmatter,
@@ -32,12 +44,12 @@ export function buildBlogAnnouncementPayload(
   return {
     event: 'blog_post_published',
     slug,
-    title: frontmatter.title.trim(),
-    excerpt: frontmatter.excerpt.trim(),
+    title: frontmatter.title?.trim() ?? '',
+    excerpt: frontmatter.excerpt?.trim() ?? '',
     url: new URL(`/blog/${slug}/`, siteBaseUrl).toString(),
-    image: frontmatter.image,
-    category: frontmatter.category,
+    image: frontmatter.image ?? '',
+    category: frontmatter.category ?? '',
     tags: normalizeTags(frontmatter.tags),
-    publishedAt: frontmatter.date,
+    publishedAt: frontmatter.date ?? '',
   };
 }

--- a/scripts/notify-blog-published.ts
+++ b/scripts/notify-blog-published.ts
@@ -1,0 +1,71 @@
+/**
+ * Notifies the social-media automation pipeline when a new blog post lands on
+ * `main`. Invoked by `.github/workflows/notify-social-automation.yml` with the
+ * list of newly added `content/blog/*.mdx` paths (newline-separated in
+ * `ADDED_BLOG_FILES` — passed via env rather than interpolated into the shell
+ * command to avoid script injection from file names); posts one announcement
+ * payload per file to the n8n webhook that schedules the post in Postiz.
+ *
+ * Not wired into `pnpm build`/`pnpm dev` — this only runs in CI, after merge.
+ */
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+import { buildBlogAnnouncementPayload } from '../lib/social-announcement.ts';
+import type { BlogPostFrontmatter } from '../types/blog';
+
+const webhookUrl = process.env.N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL?.trim();
+const webhookSecret = process.env.N8N_WEBHOOK_SECRET?.trim();
+
+async function dispatchAnnouncement(filepath: string, url: string, secret: string): Promise<boolean> {
+  const slug = path.basename(filepath, '.mdx');
+  const raw = await readFile(filepath, 'utf8');
+  const { data } = matter(raw);
+  const payload = buildBlogAnnouncementPayload(slug, data as BlogPostFrontmatter);
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Webhook-Secret': secret,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    console.error(`✗ ${slug}: n8n respondeu ${response.status}`);
+    return false;
+  }
+
+  console.log(`✓ ${slug}: anúncio enviado para o n8n`);
+  return true;
+}
+
+function readFileList(): string[] {
+  const fromEnv = process.env.ADDED_BLOG_FILES ?? '';
+  const fromArgv = process.argv.slice(2);
+  const combined = fromArgv.length > 0 ? fromArgv : fromEnv.split('\n');
+  return combined.map((line) => line.trim()).filter(Boolean);
+}
+
+async function main(): Promise<void> {
+  const files = readFileList();
+
+  if (files.length === 0) {
+    console.log('Nenhum post novo para anunciar.');
+    return;
+  }
+
+  if (!webhookUrl || !webhookSecret) {
+    console.log('N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL ou N8N_WEBHOOK_SECRET não configurados — pulando automação social.');
+    return;
+  }
+
+  const results = await Promise.all(files.map((filepath) => dispatchAnnouncement(filepath, webhookUrl, webhookSecret)));
+
+  if (results.some((ok) => !ok)) {
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/scripts/notify-blog-published.ts
+++ b/scripts/notify-blog-published.ts
@@ -11,34 +11,45 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import matter from 'gray-matter';
-import { buildBlogAnnouncementPayload } from '../lib/social-announcement.ts';
-import type { BlogPostFrontmatter } from '../types/blog';
+import { buildBlogAnnouncementPayload, isFrontmatterLike } from '../lib/social-announcement.ts';
 
 const webhookUrl = process.env.N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL?.trim();
 const webhookSecret = process.env.N8N_WEBHOOK_SECRET?.trim();
 
 async function dispatchAnnouncement(filepath: string, url: string, secret: string): Promise<boolean> {
   const slug = path.basename(filepath, '.mdx');
-  const raw = await readFile(filepath, 'utf8');
-  const { data } = matter(raw);
-  const payload = buildBlogAnnouncementPayload(slug, data as BlogPostFrontmatter);
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Webhook-Secret': secret,
-    },
-    body: JSON.stringify(payload),
-  });
+  try {
+    const raw = await readFile(filepath, 'utf8');
+    const { data } = matter(raw);
 
-  if (!response.ok) {
-    console.error(`✗ ${slug}: n8n respondeu ${response.status}`);
+    if (!isFrontmatterLike(data)) {
+      console.error(`✗ ${slug}: frontmatter inválido ou ausente`);
+      return false;
+    }
+
+    const payload = buildBlogAnnouncementPayload(slug, data);
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Webhook-Secret': secret,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      console.error(`✗ ${slug}: n8n respondeu ${response.status}`);
+      return false;
+    }
+
+    console.log(`✓ ${slug}: anúncio enviado para o n8n`);
+    return true;
+  } catch (error) {
+    console.error(`✗ ${slug}: erro ao processar ou enviar`, error);
     return false;
   }
-
-  console.log(`✓ ${slug}: anúncio enviado para o n8n`);
-  return true;
 }
 
 function readFileList(): string[] {

--- a/tests/social-announcement.test.ts
+++ b/tests/social-announcement.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildBlogAnnouncementPayload } from '../lib/social-announcement.ts';
+import { buildBlogAnnouncementPayload, isFrontmatterLike } from '../lib/social-announcement.ts';
 import type { BlogPostFrontmatter } from '../types/blog';
 
 const baseFrontmatter: BlogPostFrontmatter = {
@@ -54,4 +54,32 @@ test('buildBlogAnnouncementPayload drops non-string tags and defaults missing ta
 test('buildBlogAnnouncementPayload respects a custom site base URL', () => {
   const payload = buildBlogAnnouncementPayload('slug', baseFrontmatter, 'https://staging.anhanga.tur.br');
   assert.equal(payload.url, 'https://staging.anhanga.tur.br/blog/slug/');
+});
+
+test('buildBlogAnnouncementPayload falls back to empty strings for missing optional fields', () => {
+  const sparse = {
+    ...baseFrontmatter,
+    title: undefined,
+    excerpt: undefined,
+    image: undefined,
+    category: undefined,
+    date: undefined,
+  } as unknown as BlogPostFrontmatter;
+
+  const payload = buildBlogAnnouncementPayload('slug', sparse);
+
+  assert.equal(payload.title, '');
+  assert.equal(payload.excerpt, '');
+  assert.equal(payload.image, '');
+  assert.equal(payload.category, '');
+  assert.equal(payload.publishedAt, '');
+});
+
+test('isFrontmatterLike accepts objects and rejects null/scalars', () => {
+  assert.equal(isFrontmatterLike(baseFrontmatter), true);
+  assert.equal(isFrontmatterLike({}), true);
+  assert.equal(isFrontmatterLike(null), false);
+  assert.equal(isFrontmatterLike(undefined), false);
+  assert.equal(isFrontmatterLike('not an object'), false);
+  assert.equal(isFrontmatterLike(42), false);
 });

--- a/tests/social-announcement.test.ts
+++ b/tests/social-announcement.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildBlogAnnouncementPayload } from '../lib/social-announcement.ts';
+import type { BlogPostFrontmatter } from '../types/blog';
+
+const baseFrontmatter: BlogPostFrontmatter = {
+  title: '5 Segredos da Disney que Ninguém Conta',
+  excerpt: 'Descubra como furar filas legalmente.',
+  date: '2025-12-12',
+  author: 'queila-oliveira',
+  category: 'Dicas de Expert',
+  image: 'https://media.anhanga.tur.br/images/blog/5-segredos-disney.jpg',
+  tags: ['disney', 'orlando'],
+};
+
+test('buildBlogAnnouncementPayload builds the announcement shape from frontmatter', () => {
+  const payload = buildBlogAnnouncementPayload('5-segredos-da-disney-que-ninguem-conta', baseFrontmatter);
+
+  assert.deepEqual(payload, {
+    event: 'blog_post_published',
+    slug: '5-segredos-da-disney-que-ninguem-conta',
+    title: '5 Segredos da Disney que Ninguém Conta',
+    excerpt: 'Descubra como furar filas legalmente.',
+    url: 'https://www.anhanga.tur.br/blog/5-segredos-da-disney-que-ninguem-conta/',
+    image: 'https://media.anhanga.tur.br/images/blog/5-segredos-disney.jpg',
+    category: 'Dicas de Expert',
+    tags: ['disney', 'orlando'],
+    publishedAt: '2025-12-12',
+  });
+});
+
+test('buildBlogAnnouncementPayload trims title/excerpt whitespace', () => {
+  const payload = buildBlogAnnouncementPayload('slug', {
+    ...baseFrontmatter,
+    title: '  Título com espaços  ',
+    excerpt: '  Resumo com espaços  ',
+  });
+
+  assert.equal(payload.title, 'Título com espaços');
+  assert.equal(payload.excerpt, 'Resumo com espaços');
+});
+
+test('buildBlogAnnouncementPayload drops non-string tags and defaults missing tags to an empty array', () => {
+  const withoutTags = buildBlogAnnouncementPayload('slug', { ...baseFrontmatter, tags: undefined });
+  assert.deepEqual(withoutTags.tags, []);
+
+  const withMessyTags = buildBlogAnnouncementPayload('slug', {
+    ...baseFrontmatter,
+    tags: ['disney', '', '  ', 42 as unknown as string],
+  });
+  assert.deepEqual(withMessyTags.tags, ['disney']);
+});
+
+test('buildBlogAnnouncementPayload respects a custom site base URL', () => {
+  const payload = buildBlogAnnouncementPayload('slug', baseFrontmatter, 'https://staging.anhanga.tur.br');
+  assert.equal(payload.url, 'https://staging.anhanga.tur.br/blog/slug/');
+});


### PR DESCRIPTION
## Resumo

- **O que muda:** adiciona um workflow do GitHub Actions que detecta posts novos em `content/blog/**.mdx` no push para `main` e dispara um webhook para o n8n com título/excerpt/URL/imagem/tags do post, para o n8n agendar o anúncio social no calendário do [Postiz](https://github.com/gitroomhq/postiz-app).
- **Por quê:** discutido com o usuário — quer usar o Postiz para agendar/automatizar postagens em redes sociais. Decisão registrada na conversa: o blog é a única fonte automatizada (evento determinístico de publish); posts sociais avulsos continuam sendo agendados direto na UI do Postiz, sem pipeline custom.
- **Impacto para o usuário:** nenhum no site em si; passa a existir uma notificação automática para o time de marketing quando um post novo do blog é publicado, reduzindo o trabalho manual de divulgar nas redes.
- **Nível de risco:** baixo — a automação é opt-in via secrets do GitHub Actions; sem `N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL`/`N8N_WEBHOOK_SECRET` configurados o script apenas loga e sai sem erro.

## Issue relacionada

Sem issue — solicitado diretamente na conversa sobre automatizar o calendário de postagens sociais com o Postiz.

## Tipo de mudança

- [x] ✨ Feature
- [x] ⚙️ Infra / CI
- [x] 📚 Documentação

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only)
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível)

Comandos executados:

```text
pnpm exec tsx --test tests/social-announcement.test.ts
pnpm exec tsc --noEmit
pnpm exec tsx --test tests/*.test.ts   # suite completa, 852/852 ok
```

## API & Segurança

- [ ] Não se aplica
- [x] Inputs validados/sanitizados na borda, antes de side effects ou chamadas a providers — o payload é montado a partir do frontmatter do próprio repo (revisado via PR), não de input de usuário
- [x] Respostas e códigos de erro permanecem estruturados; helpers compartilhados reutilizados — reaproveita o padrão `X-Webhook-Secret` + `N8N_WEBHOOK_SECRET` já usado por `api/purchase-dispatch.ts`
- [x] Sem secrets ou PII bruta em logs
- [x] `dangerouslySetInnerHTML` não foi introduzido sem fonte controlada e justificativa

Nota adicional de segurança: `tests/workflow-command-injection-guard.test.ts` já cobre workflows contra interpolação direta de `${{ github.event.* }}` em blocos `run:`; o novo workflow segue o padrão exigido (contexto passado via `env:`, referenciado como `$VAR` no shell).

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`feat:`, `fix:`, `chore:`, `docs:`, `perf:`, `test:`, `refactor:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

- `N8N_WEBHOOK_SECRET` é reaproveitado como segredo de **saída** aqui (o workflow do GitHub Actions o envia no header); em todo o resto do repo ele é validado como segredo de **entrada** (`api/purchase-dispatch.ts`). Documentado em `docs/ops/social-automation.md`.
- Falta configurar, do lado de fora deste repo: o secret `N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL` e o workflow do n8n que recebe o payload e chama a API do Postiz — isso não é código deste repositório.


---
_Generated by [Claude Code](https://claude.ai/code/session_0164ynBiVfeQMfuYfDow9hYU)_