### PR TITLE
chore(deps): update @ungap/structured-clone to 1.3.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   ws: ^8.21.0
   undici: ^7.28.0
   js-yaml@3: ^3.15.0
+  '@ungap/structured-clone@1': ^1.3.2
 
 importers:
 
@@ -2239,9 +2240,8 @@ packages:
     resolution: {integrity: sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+  '@ungap/structured-clone@1.3.2':
+    resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
 
   '@upstash/redis@1.38.0':
     resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
@@ -7143,7 +7143,7 @@ snapshots:
 
   '@typescript-eslint/types@8.62.0': {}
 
-  '@ungap/structured-clone@1.3.0': {}
+  '@ungap/structured-clone@1.3.2': {}
 
   '@upstash/redis@1.38.0':
     dependencies:
@@ -8905,7 +8905,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.2
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,11 @@ overrides:
   # Override escopado a "@3" de propósito: um override global rebaixaria a
   # árvore js-yaml@4.2.0 (cosmiconfig@9), que já está corrigida e usa a API v4.
   "js-yaml@3": "^3.15.0"
+  # Issue #1138 (high): @ungap/structured-clone < 1.3.1 tem resolução CWE-502
+  # depreciada. Transitivo via mdast-util-to-hast (react-markdown, caminho do
+  # chatbot, e @mdx-js/mdx, caminho do blog). 1.3.2 corrige; override escopado
+  # a "@1" porque só existe uma major (1.x) na árvore.
+  "@ungap/structured-clone@1": "^1.3.2"
 
 legacyPeerDeps: true
 nodeLinker: hoisted


### PR DESCRIPTION
## Summary
- Bumps the transitive `@ungap/structured-clone` resolution from 1.3.0 to 1.3.2 via a scoped pnpm override, removing the deprecated CWE-502 resolution on the chatbot (react-markdown) and blog (mdx) markdown rendering path.
- Override is scoped to the `1` major line per repo convention (only one major present in the tree today).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:regression` (856/856 passing, incl. `tests/ai-markdown-links.test.ts` and `tests/markdown-hardening.test.ts`)
- [x] `pnpm build`
- [x] `pnpm test:size`

Closes #1138

🤖 Generated with [Claude Code](https://claude.com/claude-code)