### PR TITLE
fix(privacy): stop logging chatbot conversation content on invalid handoff

### DIFF
--- a/api/generate.ts
+++ b/api/generate.ts
@@ -285,9 +285,11 @@ function containsWhatsAppUrl(text?: string): boolean {
     return /wa\.me|api\.whatsapp\.com/i.test(text);
 }
 
-export function containsInvalidTextualHandoff(text?: string): boolean {
-    if (!text) return false;
-    if (containsWhatsAppUrl(text)) return true;
+const WHATSAPP_URL_SIGNAL = 'whatsapp_url';
+
+function detectInvalidTextualHandoffSignal(text?: string): string | undefined {
+    if (!text) return undefined;
+    if (containsWhatsAppUrl(text)) return WHATSAPP_URL_SIGNAL;
 
     const normalized = normalizeText(text);
     const invalidSignals = [
@@ -300,7 +302,11 @@ export function containsInvalidTextualHandoff(text?: string): boolean {
         'orcamento personalizado',
     ];
 
-    return invalidSignals.some((signal) => normalized.includes(signal));
+    return invalidSignals.find((signal) => normalized.includes(signal));
+}
+
+export function containsInvalidTextualHandoff(text?: string): boolean {
+    return detectInvalidTextualHandoffSignal(text) !== undefined;
 }
 
 function stripUnsafeWhatsAppLinks(text: string): string {
@@ -442,11 +448,13 @@ async function repairTextualHandoff(
     response: ModelResponseShape,
     responseText: string,
     options: BuildGenerateSuccessOptions,
+    matchedSignal: string,
 ): Promise<GenerateSuccessBody | null> {
     logger.warn('SERVER: invalid textual handoff detected', {
         responseId: response.responseId,
         modelVersion: response.modelVersion,
-        preview: responseText.slice(0, 160),
+        outputLength: responseText.length,
+        matchedSignal,
     });
 
     const repairContents = [
@@ -505,10 +513,13 @@ export async function buildGenerateSuccessBody(
     const normalizedOutput = normalizeBudgetToolResponse(ensureResponseText(response, rawOutput));
     const handoff = buildStructuredHandoff(normalizedOutput.responseFunctionCall, 'tool');
 
-    if (!handoff && containsInvalidTextualHandoff(normalizedOutput.responseText)) {
-        const repaired = await repairTextualHandoff(response, normalizedOutput.responseText, options);
-        if (repaired) {
-            return repaired;
+    if (!handoff) {
+        const matchedSignal = detectInvalidTextualHandoffSignal(normalizedOutput.responseText);
+        if (matchedSignal) {
+            const repaired = await repairTextualHandoff(response, normalizedOutput.responseText, options, matchedSignal);
+            if (repaired) {
+                return repaired;
+            }
         }
     }
 

--- a/tests/api-generate-normalization.test.ts
+++ b/tests/api-generate-normalization.test.ts
@@ -127,6 +127,64 @@ test('buildGenerateSuccessBody should repair textual handoff into structured pay
     assert.doesNotMatch(body.text, /wa\.me/i);
 });
 
+test('buildGenerateSuccessBody should log only structural metadata for invalid textual handoff, never conversation content', async () => {
+    const originalWarn = console.warn;
+    const warnCalls: unknown[][] = [];
+    console.warn = (...args: unknown[]) => {
+        warnCalls.push(args);
+    };
+
+    const conversationSecret = 'Quero ir para Orlando em junho, meu nome é Maria da Silva';
+    const modelText = 'Clique aqui para receber seu orçamento personalizado: [WhatsApp](https://wa.me/5511999999999)';
+
+    try {
+        await buildGenerateSuccessBody(
+            {
+                responseId: 'resp-log-check',
+                modelVersion: 'gemini-test-version',
+                text: modelText,
+            },
+            {
+                apiKey: 'test-key',
+                modelName: 'test-model',
+                contents: [{ role: 'user', parts: [{ text: conversationSecret }] }],
+                repairModelResponse: async () => buildToolResponse({
+                    destination: 'Orlando',
+                    destination_city: 'Orlando',
+                    destination_region: 'Flórida',
+                    origin_city: 'Campinas',
+                    origin_region: 'SP',
+                    dates: 'junho de 2026',
+                    adults: 2,
+                    need_summary: 'Viagem em família',
+                    decision_role: 'casal',
+                    budget_range: 'R$ 20 mil+',
+                    timeline_window: 'junho de 2026',
+                    baggage_preference: 'bagagem despachada',
+                    iata_code: 'MCO',
+                }),
+            },
+        );
+    } finally {
+        console.warn = originalWarn;
+    }
+
+    const invalidHandoffCall = warnCalls.find(([, message]) => message === 'SERVER: invalid textual handoff detected');
+    assert.ok(invalidHandoffCall, 'expected an "invalid textual handoff" warning to be logged');
+
+    const serialized = JSON.stringify(invalidHandoffCall);
+    assert.doesNotMatch(serialized, /wa\.me/i);
+    assert.doesNotMatch(serialized, /orçamento personalizado/i);
+    assert.doesNotMatch(serialized, /Maria da Silva/i);
+    assert.doesNotMatch(serialized, /Orlando em junho/i);
+
+    const [, , payload] = invalidHandoffCall as [string, string, Record<string, unknown>];
+    assert.equal(payload.responseId, 'resp-log-check');
+    assert.equal(payload.modelVersion, 'gemini-test-version');
+    assert.equal(payload.outputLength, modelText.length);
+    assert.equal(typeof payload.matchedSignal, 'string');
+});
+
 test('buildGenerateSuccessBody should handle non-array parts from Gemini response gracefully', async () => {
     // Gemini can return non-array `parts` on certain safety stops
     const malformedResponse: ModelResponseShape = {


### PR DESCRIPTION
## Summary
- The invalid-textual-handoff warning in `api/generate.ts` logged a 160-char slice (`preview`) of raw model output text — which frequently echoes user-provided conversation content (BANT answers, names, destinations) — straight to console capture and the Sentry error tracker. No sanitizer field-name pattern catches an arbitrary key like `preview`.
- Replaced the preview with structural metadata only: `responseId`, `modelVersion`, `outputLength`, and `matchedSignal` (which invalid-CTA heuristic fired), matching the acceptance criteria in #1134.
- `containsInvalidTextualHandoff` keeps its existing public boolean signature (used elsewhere/tests); a new internal `detectInvalidTextualHandoffSignal` returns which signal matched, for logging only.

## Test plan
- [x] New regression test spies on `console.warn`, runs a real invalid-handoff/repair cycle with a conversation payload containing a name and destination, and asserts the logged payload contains none of that text — only the four structural fields.
- [x] `pnpm test:regression` (857/857 passing)
- [x] `pnpm typecheck`

Closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)