### PR TITLE
fix(crm): make Odoo opportunity creation idempotent

### DIFF
--- a/lib/odoo-lead-idempotency.ts
+++ b/lib/odoo-lead-idempotency.ts
@@ -4,16 +4,21 @@
  * A single Odoo `crm.lead` model has no unique constraint to lean on, so two
  * requests racing to create the same logical lead (retry, double-submit,
  * duplicate delivery) can both miss a find-before-create check and both
- * create a record. This lock serializes that narrow window: the loser waits
- * briefly and re-runs its own find-before-create instead of creating blind —
- * long enough to outlast the winner's Odoo round trip, not to guarantee the
- * record already exists.
+ * create a record. This lock serializes that narrow window: the loser polls
+ * for the lock to free up — actually waiting for the winner's Odoo round trip
+ * to finish, not just a fixed pause — and only proceeds without it as a last
+ * resort once the poll budget is exhausted.
  */
 import { logger } from './logger';
 import { getRedisClient, isEdgeRuntime } from './redis-client';
 
 const LOCK_TTL_SECONDS = 15;
-const WAIT_AFTER_LOCK_MISS_MS = 300;
+const LOCK_POLL_INTERVAL_MS = 200;
+// A winner's find-before-create can take up to PER_CALL_TIMEOUT_MS
+// (services/odoo.ts) per round trip; this budget gives the loser a real
+// chance to outlast it while still leaving headroom in the caller's overall
+// TOTAL_DEADLINE_MS for its own find-before-create afterward.
+const LOCK_MAX_WAIT_MS = 3500;
 
 // Local-dev-only fallback (mirrors lib/rate-limit.ts): module state resets per
 // request on edge runtimes, so this Map is not a real lock there — it only
@@ -37,10 +42,24 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Repeatedly calls `tryAcquire` until it succeeds or `LOCK_MAX_WAIT_MS`
+ * elapses. Returns whether the lock was ultimately acquired.
+ */
+async function pollForLock(tryAcquire: () => Promise<boolean> | boolean): Promise<boolean> {
+    const pollDeadline = Date.now() + LOCK_MAX_WAIT_MS;
+    for (;;) {
+        if (await tryAcquire()) return true;
+        if (Date.now() >= pollDeadline) return false;
+        await sleep(LOCK_POLL_INTERVAL_MS);
+    }
+}
+
+/**
  * Runs `fn` under a short-lived lock keyed by `idempotencyKey`. When the lock
- * is already held by a concurrent call, waits briefly and still invokes `fn`
- * — callers must implement `fn` as find-before-create so the delayed call
- * converges on the winner's record instead of creating a duplicate.
+ * is already held by a concurrent call, polls for up to `LOCK_MAX_WAIT_MS`
+ * before giving up and invoking `fn` unlocked — callers must implement `fn`
+ * as find-before-create so a call that never got the lock still converges on
+ * the winner's record instead of creating a duplicate.
  */
 export async function withLeadIdempotencyLock<T>(idempotencyKey: string, fn: () => Promise<T>): Promise<T> {
     const lockKey = `odoo:lead:lock:${idempotencyKey}`;
@@ -50,8 +69,9 @@ export async function withLeadIdempotencyLock<T>(idempotencyKey: string, fn: () 
         if (isEdgeRuntime()) {
             logger.warn('ODOO_LEAD_IDEMPOTENCY: Redis unavailable on edge runtime; concurrency lock is a no-op', { idempotencyKey });
         }
-        if (!acquireInMemoryLock(lockKey)) {
-            await sleep(WAIT_AFTER_LOCK_MISS_MS);
+        const acquired = await pollForLock(() => acquireInMemoryLock(lockKey));
+        if (!acquired) {
+            logger.warn('ODOO_LEAD_IDEMPOTENCY: in-memory lock still held after max wait; proceeding without it', { idempotencyKey });
             return fn();
         }
         try {
@@ -61,9 +81,9 @@ export async function withLeadIdempotencyLock<T>(idempotencyKey: string, fn: () 
         }
     }
 
-    const acquired = await redis.set(lockKey, '1', { nx: true, ex: LOCK_TTL_SECONDS });
-    if (acquired !== 'OK') {
-        await sleep(WAIT_AFTER_LOCK_MISS_MS);
+    const acquired = await pollForLock(async () => (await redis.set(lockKey, '1', { nx: true, ex: LOCK_TTL_SECONDS })) === 'OK');
+    if (!acquired) {
+        logger.warn('ODOO_LEAD_IDEMPOTENCY: Redis lock still held after max wait; proceeding without it', { idempotencyKey });
         return fn();
     }
 

--- a/lib/odoo-lead-idempotency.ts
+++ b/lib/odoo-lead-idempotency.ts
@@ -1,0 +1,75 @@
+/**
+ * Short-lived distributed lock keyed by a lead's idempotency key (issue #1136).
+ *
+ * A single Odoo `crm.lead` model has no unique constraint to lean on, so two
+ * requests racing to create the same logical lead (retry, double-submit,
+ * duplicate delivery) can both miss a find-before-create check and both
+ * create a record. This lock serializes that narrow window: the loser waits
+ * briefly and re-runs its own find-before-create instead of creating blind —
+ * long enough to outlast the winner's Odoo round trip, not to guarantee the
+ * record already exists.
+ */
+import { logger } from './logger';
+import { getRedisClient, isEdgeRuntime } from './redis-client';
+
+const LOCK_TTL_SECONDS = 15;
+const WAIT_AFTER_LOCK_MISS_MS = 300;
+
+// Local-dev-only fallback (mirrors lib/rate-limit.ts): module state resets per
+// request on edge runtimes, so this Map is not a real lock there — it only
+// helps within a single Node process (tests, `pnpm dev`).
+const inMemoryLocks = new Map<string, number>();
+
+function acquireInMemoryLock(key: string): boolean {
+    const now = Date.now();
+    const expiry = inMemoryLocks.get(key);
+    if (expiry && expiry > now) return false;
+    inMemoryLocks.set(key, now + LOCK_TTL_SECONDS * 1000);
+    return true;
+}
+
+function releaseInMemoryLock(key: string): void {
+    inMemoryLocks.delete(key);
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Runs `fn` under a short-lived lock keyed by `idempotencyKey`. When the lock
+ * is already held by a concurrent call, waits briefly and still invokes `fn`
+ * — callers must implement `fn` as find-before-create so the delayed call
+ * converges on the winner's record instead of creating a duplicate.
+ */
+export async function withLeadIdempotencyLock<T>(idempotencyKey: string, fn: () => Promise<T>): Promise<T> {
+    const lockKey = `odoo:lead:lock:${idempotencyKey}`;
+    const redis = await getRedisClient();
+
+    if (!redis) {
+        if (isEdgeRuntime()) {
+            logger.warn('ODOO_LEAD_IDEMPOTENCY: Redis unavailable on edge runtime; concurrency lock is a no-op', { idempotencyKey });
+        }
+        if (!acquireInMemoryLock(lockKey)) {
+            await sleep(WAIT_AFTER_LOCK_MISS_MS);
+            return fn();
+        }
+        try {
+            return await fn();
+        } finally {
+            releaseInMemoryLock(lockKey);
+        }
+    }
+
+    const acquired = await redis.set(lockKey, '1', { nx: true, ex: LOCK_TTL_SECONDS });
+    if (acquired !== 'OK') {
+        await sleep(WAIT_AFTER_LOCK_MISS_MS);
+        return fn();
+    }
+
+    try {
+        return await fn();
+    } finally {
+        await redis.del(lockKey).catch(() => undefined);
+    }
+}

--- a/lib/odoo-lead-mapping.ts
+++ b/lib/odoo-lead-mapping.ts
@@ -149,7 +149,13 @@ export function buildPartnerFields(input: OdooLeadInput): Record<string, unknown
     return fields;
 }
 
-function buildDescriptionHtml(input: OdooLeadInput): string {
+// Odoo has no dedicated idempotency field on crm.lead (issue #1136), so the
+// resolved key is written as a description line and re-queried via a `like`
+// domain before create. Exported so services/odoo.ts builds the exact same
+// search marker it was written with.
+export const IDEMPOTENCY_KEY_LABEL = 'idempotency_key';
+
+function buildDescriptionHtml(input: OdooLeadInput, idempotencyKey?: string): string {
     // Values arrive already sanitized (cleanString/normalizeNullable escape `<`/`>`
     // at validation), so they are inserted as-is — re-escaping would double-encode.
     const items: string[] = [];
@@ -175,7 +181,7 @@ function buildDescriptionHtml(input: OdooLeadInput): string {
     // crm.lead.campaign_id (utm.campaign) upstream in odoo-submit-handler.ts.
     push('utm_term', input.utms.utm_term);
     push('utm_content', input.utms.utm_content);
-    push('event_id', input.eventId);
+    push(IDEMPOTENCY_KEY_LABEL, idempotencyKey);
 
     return items.length > 0 ? `<ul>${items.join('')}</ul>` : '';
 }
@@ -186,7 +192,7 @@ function buildDescriptionHtml(input: OdooLeadInput): string {
  * structured `x_destino` field (Studio, added for the Contato/Oportunidade/
  * Chamado field redesign) in addition to the human-readable description line.
  */
-export function buildLeadFields(input: OdooLeadInput, partnerId: number): Record<string, unknown> {
+export function buildLeadFields(input: OdooLeadInput, partnerId: number, idempotencyKey?: string): Record<string, unknown> {
     const name = fullName(input.firstName, input.lastName);
     const title = input.destination ? `Lead Site — ${name} (${input.destination})` : `Lead Site — ${name}`;
     const { source_id, medium_id } = resolveSourceMedium(input.utms, input.originSignal);
@@ -209,7 +215,7 @@ export function buildLeadFields(input: OdooLeadInput, partnerId: number): Record
     if (input.cargo) fields.function = input.cargo;
     if (input.destination) fields.x_destino = input.destination;
 
-    const description = buildDescriptionHtml(input);
+    const description = buildDescriptionHtml(input, idempotencyKey);
     if (description) fields.description = description;
 
     return fields;

--- a/lib/odoo-submit-handler.ts
+++ b/lib/odoo-submit-handler.ts
@@ -42,6 +42,28 @@ export interface CreateOdooSubmitHandlerOptions<TData> {
     onError?: (params: { data: TData; requestId: string; classification: N8nErrorClassification }) => Record<string, unknown> | void;
 }
 
+/**
+ * Resolves the stable idempotency key a lead-producing submission carries
+ * through the server boundary (issue #1136). Prefers the client-supplied
+ * `event_id` (already generated once per submit attempt for Meta CAPI dedup —
+ * see hooks/useLeadCapture.ts's `createLeadEventId()`); older/other callers
+ * that omit it still get a stable key derived from the submission's own
+ * identifying content, so a byte-identical retry still converges on the same
+ * key without merging two genuinely distinct submissions from the same
+ * customer (different destination/BANT text hashes differently).
+ */
+async function resolveIdempotencyKey(input: OdooLeadInput): Promise<string> {
+    const eventId = input.eventId?.trim();
+    if (eventId) return eventId;
+
+    const material = [input.email, input.phone, input.destination, input.bantSummary, input.firstName, input.lastName]
+        .map((value) => (value ?? '').trim().toLowerCase())
+        .join('|');
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(material));
+    const hex = Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, '0')).join('');
+    return `hash_${hex}`;
+}
+
 /** Persists an Odoo input: upsert partner (dedup by e-mail), then optional lead. */
 async function sendToOdoo(input: OdooLeadInput): Promise<void> {
     const config = getOdooConfig();
@@ -53,7 +75,8 @@ async function sendToOdoo(input: OdooLeadInput): Promise<void> {
     });
 
     if (input.createsLead) {
-        const leadFields = buildLeadFields(input, partnerId);
+        const idempotencyKey = await resolveIdempotencyKey(input);
+        const leadFields = buildLeadFields(input, partnerId, idempotencyKey);
         // utm_campaign is highly variable (one per ad campaign), unlike the fixed
         // source/medium table, so it's resolved against Odoo's native utm.campaign
         // model (find-or-create) instead of a hardcoded id.
@@ -71,7 +94,7 @@ async function sendToOdoo(input: OdooLeadInput): Promise<void> {
                 });
             }
         }
-        await session.createLead(leadFields);
+        await session.createLead(leadFields, idempotencyKey);
     }
 }
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,4 +1,5 @@
 import { logger } from './logger';
+import { getRedisClient, isEdgeRuntime } from './redis-client';
 
 export interface RateLimitResult {
   allowed: boolean;
@@ -13,58 +14,12 @@ interface RateLimitEntry {
   resetTime: number;
 }
 
-interface RedisLike {
-  pipeline(): { incr(key: string): void; ttl(key: string): void; exec(): Promise<unknown[]> };
-  expire(key: string, seconds: number): Promise<unknown>;
-}
-
 // On Vercel Edge Runtime, each request runs in an isolated V8 context.
 // Module-level state does NOT persist across concurrent requests, making
 // this Map non-functional as a shared rate limiter without Redis.
 // It is kept only as a local-dev convenience (single-process, single-isolate).
 const inMemoryStore = new Map<string, RateLimitEntry>();
 const IN_MEMORY_MAX_ENTRIES = 2500;
-
-// True when running inside a managed serverless edge runtime where module-level
-// state resets per request. Both Vercel (VERCEL_ENV) and Cloudflare Pages
-// (CF_PAGES) are detected; local development has neither variable set.
-// Implemented as a function so tests can control env vars at call time.
-function isEdgeRuntime(): boolean {
-  return Boolean(process.env.VERCEL_ENV || process.env.CF_PAGES);
-}
-
-async function getRedisClient(): Promise<RedisLike | null> {
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-
-  if (!url || !token) {
-    if (isEdgeRuntime()) {
-      // Each serverless edge invocation (Vercel or Cloudflare) gets a fresh V8
-      // isolate — the in-memory Map above resets on every request and provides
-      // no real protection. Configure Upstash Redis to enable shared rate
-      // limiting across all edge instances.
-      logger.error(
-        'RateLimit: Upstash Redis not configured. ' +
-        'In-memory fallback is non-functional on edge runtimes (isolated V8 contexts per request). ' +
-        'Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN in your environment variables.'
-      );
-    }
-    return null;
-  }
-
-  try {
-    // CF Workers do not support the `cache` field on fetch RequestInit.
-    // The default entry point (`@upstash/redis`) passes `cache: 'no-store'`,
-    // which throws at runtime. The `/cloudflare` entry omits it.
-    const mod = process.env.CF_PAGES
-      ? await import('@upstash/redis/cloudflare')
-      : await import('@upstash/redis');
-    return new mod.Redis({ url, token });
-  } catch {
-    logger.warn('RateLimit: @upstash/redis not available, using in-memory fallback');
-    return null;
-  }
-}
 
 /**
  * Shared rate limiter that uses Upstash Redis if configured,

--- a/lib/redis-client.ts
+++ b/lib/redis-client.ts
@@ -1,0 +1,50 @@
+import { logger } from './logger';
+
+/** Subset of the Upstash Redis client surface used across `lib/` (rate limiting, idempotency locks). */
+export interface RedisClientLike {
+    pipeline(): { incr(key: string): void; ttl(key: string): void; exec(): Promise<unknown[]> };
+    expire(key: string, seconds: number): Promise<unknown>;
+    set(key: string, value: string, opts: { nx: true; ex: number }): Promise<string | null>;
+    del(key: string): Promise<unknown>;
+}
+
+// True when running inside a managed serverless edge runtime where module-level
+// state resets per request. Both Vercel (VERCEL_ENV) and Cloudflare Pages
+// (CF_PAGES) are detected; local development has neither variable set.
+// Implemented as a function so tests can control env vars at call time.
+export function isEdgeRuntime(): boolean {
+    return Boolean(process.env.VERCEL_ENV || process.env.CF_PAGES);
+}
+
+export async function getRedisClient(): Promise<RedisClientLike | null> {
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    if (!url || !token) {
+        if (isEdgeRuntime()) {
+            // Each serverless edge invocation (Vercel or Cloudflare) gets a fresh V8
+            // isolate — any module-level in-memory fallback resets on every request
+            // and provides no real protection. Configure Upstash Redis to enable
+            // shared state across all edge instances.
+            logger.error(
+                'RedisClient: Upstash Redis not configured. ' +
+                'In-memory fallback is non-functional on edge runtimes (isolated V8 contexts per request). ' +
+                'Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN in your environment variables.'
+            );
+        }
+        return null;
+    }
+
+    try {
+        // CF Workers do not support the `cache` field on fetch RequestInit.
+        // The default entry point (`@upstash/redis`) passes `cache: 'no-store'`,
+        // which throws at runtime. The `/cloudflare` entry omits it.
+        const mod = process.env.CF_PAGES
+            ? await import('@upstash/redis/cloudflare')
+            : await import('@upstash/redis');
+        return new mod.Redis({ url, token });
+    } catch {
+        logger.warn('RedisClient: @upstash/redis not available, using in-memory fallback');
+        return null;
+    }
+}

--- a/lib/redis-client.ts
+++ b/lib/redis-client.ts
@@ -16,6 +16,14 @@ export function isEdgeRuntime(): boolean {
     return Boolean(process.env.VERCEL_ENV || process.env.CF_PAGES);
 }
 
+// Cached by (url, token) so a warm isolate/process reuses the same client
+// instead of reconstructing it on every call, while still picking up a
+// credential rotation (or a test swapping env vars) instead of serving a
+// stale instance. On Cloudflare Workers this only helps requests that land on
+// an already-warm isolate — a fresh isolate still starts with no cache — but
+// costs nothing on the cold path either.
+let cachedClient: { url: string; token: string; instance: RedisClientLike } | null = null;
+
 export async function getRedisClient(): Promise<RedisClientLike | null> {
     const url = process.env.UPSTASH_REDIS_REST_URL;
     const token = process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -35,6 +43,10 @@ export async function getRedisClient(): Promise<RedisClientLike | null> {
         return null;
     }
 
+    if (cachedClient && cachedClient.url === url && cachedClient.token === token) {
+        return cachedClient.instance;
+    }
+
     try {
         // CF Workers do not support the `cache` field on fetch RequestInit.
         // The default entry point (`@upstash/redis`) passes `cache: 'no-store'`,
@@ -42,7 +54,9 @@ export async function getRedisClient(): Promise<RedisClientLike | null> {
         const mod = process.env.CF_PAGES
             ? await import('@upstash/redis/cloudflare')
             : await import('@upstash/redis');
-        return new mod.Redis({ url, token });
+        const instance = new mod.Redis({ url, token });
+        cachedClient = { url, token, instance };
+        return instance;
     } catch {
         logger.warn('RedisClient: @upstash/redis not available, using in-memory fallback');
         return null;

--- a/services/odoo.ts
+++ b/services/odoo.ts
@@ -17,6 +17,8 @@
  * Errors are normalized to `ODOO_ERROR:<status>:<detail>` so the submit-handler
  * factory classifies them uniformly (see lib/odoo-submit-handler.ts).
  */
+import { withLeadIdempotencyLock } from '../lib/odoo-lead-idempotency';
+import { IDEMPOTENCY_KEY_LABEL } from '../lib/odoo-lead-mapping';
 
 const PER_CALL_TIMEOUT_MS = 3000;
 const TOTAL_DEADLINE_MS = 8000;
@@ -165,7 +167,13 @@ export interface UpsertPartnerOptions {
 
 export interface OdooSession {
     upsertPartner: (fields: OdooPartnerFields, options?: UpsertPartnerOptions) => Promise<number>;
-    createLead: (fields: Record<string, unknown>) => Promise<number>;
+    /**
+     * Creates a `crm.lead`, or returns the id of one already created for the
+     * same `idempotencyKey` (issue #1136) — a retry, duplicate delivery, or a
+     * client that never saw the first attempt's response must not create a
+     * second opportunity.
+     */
+    createLead: (fields: Record<string, unknown>, idempotencyKey?: string) => Promise<number>;
     /** Finds a `utm.campaign` by exact name, creating one if none matches. */
     resolveCampaignId: (name: string) => Promise<number>;
 }
@@ -228,8 +236,34 @@ export async function openOdooSession(config: OdooConfig): Promise<OdooSession> 
             }
             return executeKw<number>(config, uid, 'res.partner', 'create', [fields], deadline);
         },
-        createLead(fields) {
-            return executeKw<number>(config, uid, 'crm.lead', 'create', [fields], deadline);
+        async createLead(fields, idempotencyKey) {
+            if (!idempotencyKey) {
+                return executeKw<number>(config, uid, 'crm.lead', 'create', [fields], deadline);
+            }
+
+            // Odoo has no unique constraint to lean on, so the lock below only
+            // narrows the concurrent-duplicate window — this find-before-create
+            // is what actually makes a sequential replay (or a client retry
+            // after a response was lost post-commit) idempotent.
+            async function findExisting(): Promise<number | null> {
+                const marker = `${IDEMPOTENCY_KEY_LABEL}: ${idempotencyKey}`;
+                const rows = await executeKw<{ id: number }[]>(
+                    config,
+                    uid,
+                    'crm.lead',
+                    'search_read',
+                    [[['description', 'like', marker]], ['id']],
+                    deadline,
+                    { limit: 1, order: 'id asc' },
+                );
+                return rows[0]?.id ?? null;
+            }
+
+            return withLeadIdempotencyLock(idempotencyKey, async () => {
+                const existingId = await findExisting();
+                if (existingId) return existingId;
+                return executeKw<number>(config, uid, 'crm.lead', 'create', [fields], deadline);
+            });
         },
         async resolveCampaignId(name) {
             const trimmed = name.trim();

--- a/services/odoo.ts
+++ b/services/odoo.ts
@@ -247,16 +247,25 @@ export async function openOdooSession(config: OdooConfig): Promise<OdooSession> 
             // after a response was lost post-commit) idempotent.
             async function findExisting(): Promise<number | null> {
                 const marker = `${IDEMPOTENCY_KEY_LABEL}: ${idempotencyKey}`;
-                const rows = await executeKw<{ id: number }[]>(
+                // Odoo's `like` wraps the value in `%...%` — an unanchored substring
+                // match. A key that's a literal prefix of another lead's key (e.g.
+                // "evt-trip" vs. "evt-trip-a") would otherwise match the wrong row,
+                // especially since idempotencyKey can be raw client-supplied
+                // event_id on a public, unauthenticated endpoint. `like` here is only
+                // a narrowing prefilter (bounded by `limit`); the exact, delimited
+                // line is what actually decides a match.
+                const exactMarker = `<li>${marker}</li>`;
+                const rows = await executeKw<{ id: number; description: string | false }[]>(
                     config,
                     uid,
                     'crm.lead',
                     'search_read',
-                    [[['description', 'like', marker]], ['id']],
+                    [[['description', 'like', marker]], ['id', 'description']],
                     deadline,
-                    { limit: 1, order: 'id asc' },
+                    { limit: 20, order: 'id asc' },
                 );
-                return rows[0]?.id ?? null;
+                const match = rows.find((row) => typeof row.description === 'string' && row.description.includes(exactMarker));
+                return match?.id ?? null;
             }
 
             return withLeadIdempotencyLock(idempotencyKey, async () => {

--- a/tests/odoo-lead-idempotency.test.ts
+++ b/tests/odoo-lead-idempotency.test.ts
@@ -63,6 +63,35 @@ test('withLeadIdempotencyLock serializes two concurrent calls for the same key',
     assert.ok(order.indexOf('first-end') < order.indexOf('second-start'));
 });
 
+test('withLeadIdempotencyLock polls until release for a winner slower than the old fixed pause', async (t) => {
+    useInMemoryFallback(t);
+    const key = `key-${uid()}`;
+    const order: string[] = [];
+
+    // 600ms is longer than the previous fixed 300ms wait — with the old
+    // implementation the loser would run its critical section blind at
+    // ~300ms, well before the winner (still running at 600ms) finished.
+    const first = withLeadIdempotencyLock(key, async () => {
+        order.push('first-start');
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        order.push('first-end');
+        return 'first';
+    });
+    // Let the first call actually acquire the lock before racing the second.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const second = withLeadIdempotencyLock(key, async () => {
+        order.push('second-start');
+        return 'second';
+    });
+
+    await Promise.all([first, second]);
+
+    assert.ok(
+        order.indexOf('first-end') < order.indexOf('second-start'),
+        `expected the loser to poll until real release, not a fixed pause — order was ${order.join(', ')}`,
+    );
+});
+
 test('withLeadIdempotencyLock releases the lock even when fn throws', async (t) => {
     useInMemoryFallback(t);
     const key = `key-${uid()}`;

--- a/tests/odoo-lead-idempotency.test.ts
+++ b/tests/odoo-lead-idempotency.test.ts
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { withLeadIdempotencyLock } from '../lib/odoo-lead-idempotency.ts';
+
+function useInMemoryFallback(t: { after: (fn: () => void) => void }): void {
+    const savedUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const savedToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    t.after(() => {
+        if (savedUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+        else process.env.UPSTASH_REDIS_REST_URL = savedUrl;
+        if (savedToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+        else process.env.UPSTASH_REDIS_REST_TOKEN = savedToken;
+    });
+}
+
+function uid(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+test('withLeadIdempotencyLock runs fn and returns its result when uncontended', async (t) => {
+    useInMemoryFallback(t);
+    const result = await withLeadIdempotencyLock(`key-${uid()}`, async () => 42);
+    assert.equal(result, 42);
+});
+
+test('withLeadIdempotencyLock releases the lock after fn resolves, allowing a later sequential call to acquire it immediately', async (t) => {
+    useInMemoryFallback(t);
+    const key = `key-${uid()}`;
+
+    await withLeadIdempotencyLock(key, async () => 'first');
+    const start = Date.now();
+    const second = await withLeadIdempotencyLock(key, async () => 'second');
+    const elapsed = Date.now() - start;
+
+    assert.equal(second, 'second');
+    assert.ok(elapsed < 250, `expected the second sequential call to acquire the lock immediately, took ${elapsed}ms`);
+});
+
+test('withLeadIdempotencyLock serializes two concurrent calls for the same key', async (t) => {
+    useInMemoryFallback(t);
+    const key = `key-${uid()}`;
+    const order: string[] = [];
+
+    const first = withLeadIdempotencyLock(key, async () => {
+        order.push('first-start');
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        order.push('first-end');
+        return 'first';
+    });
+    const second = withLeadIdempotencyLock(key, async () => {
+        order.push('second-start');
+        return 'second';
+    });
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    assert.equal(firstResult, 'first');
+    assert.equal(secondResult, 'second');
+    // The second call must not start its critical section before the first's
+    // finishes — it waited out the lock instead of racing in immediately.
+    assert.ok(order.indexOf('first-end') < order.indexOf('second-start'));
+});
+
+test('withLeadIdempotencyLock releases the lock even when fn throws', async (t) => {
+    useInMemoryFallback(t);
+    const key = `key-${uid()}`;
+
+    await assert.rejects(
+        withLeadIdempotencyLock(key, async () => {
+            throw new Error('boom');
+        }),
+        /boom/,
+    );
+
+    const start = Date.now();
+    const result = await withLeadIdempotencyLock(key, async () => 'recovered');
+    const elapsed = Date.now() - start;
+
+    assert.equal(result, 'recovered');
+    assert.ok(elapsed < 250, `expected the lock to be released after a throw, took ${elapsed}ms`);
+});
+
+test('withLeadIdempotencyLock keeps independent keys fully concurrent', async (t) => {
+    useInMemoryFallback(t);
+    const start = Date.now();
+
+    await Promise.all([
+        withLeadIdempotencyLock(`key-a-${uid()}`, async () => new Promise((resolve) => setTimeout(resolve, 50))),
+        withLeadIdempotencyLock(`key-b-${uid()}`, async () => new Promise((resolve) => setTimeout(resolve, 50))),
+    ]);
+
+    const elapsed = Date.now() - start;
+    assert.ok(elapsed < 150, `expected unrelated keys to run concurrently, took ${elapsed}ms`);
+});

--- a/tests/odoo-lead-mapping.test.ts
+++ b/tests/odoo-lead-mapping.test.ts
@@ -163,6 +163,16 @@ test('buildLeadFields — maps empresa/cargo and referred when present', () => {
     assert.equal(fields.referred, 'João');
 });
 
+test('buildLeadFields — writes the idempotency key to the description when provided (issue #1136)', () => {
+    const fields = buildLeadFields(baseInput({}), 5, 'evt-abc-123');
+    assert.match(String(fields.description), /<li>idempotency_key: evt-abc-123<\/li>/);
+});
+
+test('buildLeadFields — omits the idempotency_key line when no key is provided', () => {
+    const fields = buildLeadFields(baseInput({ bantSummary: 'Need: X' }), 5);
+    assert.doesNotMatch(String(fields.description), /idempotency_key/);
+});
+
 // --- per-form adapters -------------------------------------------------------
 
 test('leadInputFromSubmitLead — creates a lead, maps marketingOptIn', () => {

--- a/tests/odoo-mock.ts
+++ b/tests/odoo-mock.ts
@@ -40,6 +40,8 @@ export interface OdooMockOptions {
     existingFields?: Record<string, unknown>;
     newPartnerId?: number;
     leadId?: number;
+    /** crm.lead search_read (idempotency lookup) result: id of an already-created lead, or null/absent for none. */
+    existingLeadId?: number | null;
     /** utm.campaign search_read result: id of an existing campaign, or null/absent for none (default: none). */
     existingCampaignId?: number | null;
     /** id returned by utm.campaign.create when no existing campaign matches. */
@@ -84,12 +86,16 @@ interface SearchReadDefaults {
     existingComment: string | false;
     existingFields: Record<string, unknown>;
     existingCampaignId: number | null;
+    existingLeadId: number | null;
 }
 
-/** `search_read` result per model: dedup row for res.partner, find-or-create lookup for utm.campaign. */
+/** `search_read` result per model: dedup row for res.partner, find-or-create lookup for utm.campaign/crm.lead. */
 function searchReadResult(model: string, d: SearchReadDefaults): unknown[] {
     if (model === 'utm.campaign') {
         return d.existingCampaignId ? [{ id: d.existingCampaignId }] : [];
+    }
+    if (model === 'crm.lead') {
+        return d.existingLeadId ? [{ id: d.existingLeadId }] : [];
     }
     return d.existingPartnerId ? [{ id: d.existingPartnerId, comment: d.existingComment, ...d.existingFields }] : [];
 }
@@ -129,6 +135,7 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
         existingFields = {},
         newPartnerId = 101,
         leadId = 555,
+        existingLeadId = null,
         existingCampaignId = null,
         newCampaignId = 900,
         campaignCreateShouldFail = false,
@@ -138,10 +145,12 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
     } = options;
 
     const calls: OdooExecuteCall[] = [];
-    // Stateful: once utm.campaign.create succeeds, subsequent search_read calls
-    // for that model must find it (mirrors real Odoo, and resolveCampaignId now
-    // always re-queries after create to converge on a canonical row).
+    // Stateful: once utm.campaign.create/crm.lead.create succeeds, subsequent
+    // search_read calls for that model must find it (mirrors real Odoo, and
+    // both resolveCampaignId and the createLead idempotency lookup re-query
+    // to converge on the same row).
     let campaignId = existingCampaignId;
+    let leadIdState = existingLeadId;
 
     const fetchMock = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
         if (hang) return new Promise<Response>(() => {});
@@ -165,11 +174,18 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
             return jsonRpcError('duplicate key value violates unique constraint "utm_campaign_name_uniq"');
         }
         if (ormMethod === 'search_read') {
-            return jsonRpcResponse(searchReadResult(model, { existingPartnerId, existingComment, existingFields, existingCampaignId: campaignId }));
+            return jsonRpcResponse(searchReadResult(model, {
+                existingPartnerId,
+                existingComment,
+                existingFields,
+                existingCampaignId: campaignId,
+                existingLeadId: leadIdState,
+            }));
         }
         if (ormMethod === 'create') {
             const result = createResult(model, { leadId, newPartnerId, newCampaignId });
             if (model === 'utm.campaign') campaignId = newCampaignId;
+            if (model === 'crm.lead') leadIdState = leadId;
             return jsonRpcResponse(result);
         }
         if (ormMethod === 'write') return jsonRpcResponse(true);

--- a/tests/odoo-mock.ts
+++ b/tests/odoo-mock.ts
@@ -127,6 +127,48 @@ function jsonRpcError(message: string): Response {
     });
 }
 
+interface ExecuteKwState {
+    campaignId: number | null;
+    leadIdState: number | null;
+}
+
+/** Dispatches a single `execute_kw` ORM call to its mocked result, given the running state. */
+function handleExecuteKw(
+    model: string,
+    ormMethod: string,
+    state: ExecuteKwState,
+    options: {
+        existingPartnerId: number | null;
+        existingComment: string | false;
+        existingFields: Record<string, unknown>;
+        leadId: number;
+        newPartnerId: number;
+        newCampaignId: number;
+        campaignCreateShouldFail: boolean;
+    },
+): Response {
+    if (ormMethod === 'create' && model === 'utm.campaign' && options.campaignCreateShouldFail) {
+        return jsonRpcError('duplicate key value violates unique constraint "utm_campaign_name_uniq"');
+    }
+    if (ormMethod === 'search_read') {
+        return jsonRpcResponse(searchReadResult(model, {
+            existingPartnerId: options.existingPartnerId,
+            existingComment: options.existingComment,
+            existingFields: options.existingFields,
+            existingCampaignId: state.campaignId,
+            existingLeadId: state.leadIdState,
+        }));
+    }
+    if (ormMethod === 'create') {
+        const result = createResult(model, { leadId: options.leadId, newPartnerId: options.newPartnerId, newCampaignId: options.newCampaignId });
+        if (model === 'utm.campaign') state.campaignId = options.newCampaignId;
+        if (model === 'crm.lead') state.leadIdState = options.leadId;
+        return jsonRpcResponse(result);
+    }
+    if (ormMethod === 'write') return jsonRpcResponse(true);
+    return jsonRpcResponse(false);
+}
+
 export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
     const {
         uid = 7,
@@ -149,8 +191,7 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
     // search_read calls for that model must find it (mirrors real Odoo, and
     // both resolveCampaignId and the createLead idempotency lookup re-query
     // to converge on the same row).
-    let campaignId = existingCampaignId;
-    let leadIdState = existingLeadId;
+    const state: ExecuteKwState = { campaignId: existingCampaignId, leadIdState: existingLeadId };
 
     const fetchMock = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
         if (hang) return new Promise<Response>(() => {});
@@ -170,26 +211,15 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
         const kwargs = (args[6] as Record<string, unknown>) ?? {};
         calls.push({ model, method: ormMethod, args: ormArgs, kwargs });
 
-        if (ormMethod === 'create' && model === 'utm.campaign' && campaignCreateShouldFail) {
-            return jsonRpcError('duplicate key value violates unique constraint "utm_campaign_name_uniq"');
-        }
-        if (ormMethod === 'search_read') {
-            return jsonRpcResponse(searchReadResult(model, {
-                existingPartnerId,
-                existingComment,
-                existingFields,
-                existingCampaignId: campaignId,
-                existingLeadId: leadIdState,
-            }));
-        }
-        if (ormMethod === 'create') {
-            const result = createResult(model, { leadId, newPartnerId, newCampaignId });
-            if (model === 'utm.campaign') campaignId = newCampaignId;
-            if (model === 'crm.lead') leadIdState = leadId;
-            return jsonRpcResponse(result);
-        }
-        if (ormMethod === 'write') return jsonRpcResponse(true);
-        return jsonRpcResponse(false);
+        return handleExecuteKw(model, ormMethod, state, {
+            existingPartnerId,
+            existingComment,
+            existingFields,
+            leadId,
+            newPartnerId,
+            newCampaignId,
+            campaignCreateShouldFail,
+        });
     }) as typeof fetch;
 
     return {

--- a/tests/odoo-mock.ts
+++ b/tests/odoo-mock.ts
@@ -89,13 +89,24 @@ interface SearchReadDefaults {
     existingLeadId: number | null;
 }
 
-/** `search_read` result per model: dedup row for res.partner, find-or-create lookup for utm.campaign/crm.lead. */
-function searchReadResult(model: string, d: SearchReadDefaults): unknown[] {
+/**
+ * `search_read` result per model: dedup row for res.partner, find-or-create
+ * lookup for utm.campaign/crm.lead. For crm.lead, `domain` is the real
+ * `[['description', 'like', marker], ...]` the caller searched with —
+ * `services/odoo.ts` now requires the row's `description` to contain the
+ * exact `<li>marker</li>` line (not just the bare `like` match) before
+ * treating it as the same lead, so an existing lead's row must actually
+ * carry a description built from that same marker to be found — exactly
+ * like a real previously-created lead would.
+ */
+function searchReadResult(model: string, d: SearchReadDefaults, domain?: unknown[]): unknown[] {
     if (model === 'utm.campaign') {
         return d.existingCampaignId ? [{ id: d.existingCampaignId }] : [];
     }
     if (model === 'crm.lead') {
-        return d.existingLeadId ? [{ id: d.existingLeadId }] : [];
+        if (!d.existingLeadId) return [];
+        const marker = Array.isArray(domain) && Array.isArray(domain[0]) ? (domain[0] as unknown[])[2] as string : '';
+        return [{ id: d.existingLeadId, description: `<ul><li>${marker}</li></ul>` }];
     }
     return d.existingPartnerId ? [{ id: d.existingPartnerId, comment: d.existingComment, ...d.existingFields }] : [];
 }
@@ -136,6 +147,7 @@ interface ExecuteKwState {
 function handleExecuteKw(
     model: string,
     ormMethod: string,
+    ormArgs: unknown[],
     state: ExecuteKwState,
     options: {
         existingPartnerId: number | null;
@@ -151,13 +163,14 @@ function handleExecuteKw(
         return jsonRpcError('duplicate key value violates unique constraint "utm_campaign_name_uniq"');
     }
     if (ormMethod === 'search_read') {
+        const domain = ormArgs[0] as unknown[] | undefined;
         return jsonRpcResponse(searchReadResult(model, {
             existingPartnerId: options.existingPartnerId,
             existingComment: options.existingComment,
             existingFields: options.existingFields,
             existingCampaignId: state.campaignId,
             existingLeadId: state.leadIdState,
-        }));
+        }, domain));
     }
     if (ormMethod === 'create') {
         const result = createResult(model, { leadId: options.leadId, newPartnerId: options.newPartnerId, newCampaignId: options.newCampaignId });
@@ -211,7 +224,7 @@ export function createOdooMock(options: OdooMockOptions = {}): OdooMock {
         const kwargs = (args[6] as Record<string, unknown>) ?? {};
         calls.push({ model, method: ormMethod, args: ormArgs, kwargs });
 
-        return handleExecuteKw(model, ormMethod, state, {
+        return handleExecuteKw(model, ormMethod, ormArgs, state, {
             existingPartnerId,
             existingComment,
             existingFields,

--- a/tests/odoo-service.test.ts
+++ b/tests/odoo-service.test.ts
@@ -255,6 +255,59 @@ test('createLead — different idempotency keys never merge into the same lead',
     assert.notEqual(idA, idB, 'two genuinely distinct trip requests from the same customer must not be merged');
 });
 
+test("createLead — a key that is a literal prefix of another lead's key does not match it", async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+
+    // Odoo's `like` operator does an unanchored `%value%` substring match —
+    // this mock reproduces that (unlike createOdooMock, which never simulates
+    // real substring behavior) so the exact-match guard in services/odoo.ts
+    // actually gets exercised: "evt-trip" is a literal substring of
+    // "evt-trip-2", so a naive `like`-only lookup would wrongly return the
+    // first lead's id for the second, distinct request.
+    const leads: { id: number; description: string }[] = [];
+    let nextLeadId = 3000;
+    global.fetch = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { params: { service: string; method: string; args: unknown[] } };
+        const { service, method, args } = body.params;
+        if (service === 'common' && method === 'authenticate') {
+            return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: 7 }), { status: 200 });
+        }
+        const ormMethod = args[4] as string;
+        const ormArgs = args[5] as unknown[];
+        if (ormMethod === 'search_read') {
+            const domain = ormArgs[0] as [string, string, string][];
+            const [, , marker] = domain[0];
+            const matches = leads.filter((lead) => lead.description.includes(marker));
+            return new Response(
+                JSON.stringify({ jsonrpc: '2.0', id: 1, result: matches.map((l) => ({ id: l.id, description: l.description })) }),
+                { status: 200 },
+            );
+        }
+        if (ormMethod === 'create') {
+            nextLeadId += 1;
+            const fields = ormArgs[0] as Record<string, unknown>;
+            leads.push({ id: nextLeadId, description: String(fields.description ?? '') });
+            return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: nextLeadId }), { status: 200 });
+        }
+        throw new Error(`unexpected ORM call: ${ormMethod}`);
+    }) as typeof fetch;
+
+    // Create the longer key first so its stored description already contains
+    // the shorter key as a literal substring — the actual collision shape:
+    // searching for "evt-trip" afterward must not match "evt-trip-2"'s row.
+    const session = await openOdooSession(config());
+    const longerKeyId = await session.createLead(
+        { name: 'Lead B', description: '<ul><li>idempotency_key: evt-trip-2</li></ul>' },
+        'evt-trip-2',
+    );
+    const shortKeyId = await session.createLead(
+        { name: 'Lead A', description: '<ul><li>idempotency_key: evt-trip</li></ul>' },
+        'evt-trip',
+    );
+
+    assert.notEqual(shortKeyId, longerKeyId, "a key that is a substring prefix of another lead's key must not match it");
+});
+
 test('resolveCampaignId — returns the existing utm.campaign id when the name matches', async (t) => {
     t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
     const mock = createOdooMock({ existingCampaignId: 42 });

--- a/tests/odoo-service.test.ts
+++ b/tests/odoo-service.test.ts
@@ -166,6 +166,95 @@ test('createLead — issues a crm.lead.create and returns the id', async (t) => 
     assert.ok(mock.createdLead());
 });
 
+// --- createLead idempotency (issue #1136) -----------------------------------
+
+test('createLead — without an idempotency key, always creates (unchanged legacy behavior)', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+    const mock = createOdooMock({ leadId: 111 });
+    global.fetch = mock.fetch;
+
+    const session = await openOdooSession(config());
+    const id = await session.createLead({ name: 'Lead' });
+
+    assert.equal(id, 111);
+    assert.equal(mock.calls.some((c) => c.model === 'crm.lead' && c.method === 'search_read'), false);
+});
+
+test('createLead — sequential replay with the same idempotency key returns the already-created lead', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+    const mock = createOdooMock({ existingLeadId: 321 });
+    global.fetch = mock.fetch;
+
+    const session = await openOdooSession(config());
+    const id = await session.createLead({ name: 'Lead' }, 'evt-sequential-replay');
+
+    assert.equal(id, 321);
+    assert.equal(mock.createdLead(), false, 'must not create a duplicate crm.lead when one already matches the key');
+});
+
+test('createLead — a client-timeout replay (Odoo committed, response was lost) converges on the first id', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+    const mock = createOdooMock({ existingLeadId: null, leadId: 909 });
+    global.fetch = mock.fetch;
+
+    const session = await openOdooSession(config());
+    // First call: the client's real submission — Odoo commits successfully.
+    const firstId = await session.createLead({ name: 'Lead' }, 'evt-timeout-replay');
+    // Second call: the client never saw that response (perceived timeout) and
+    // retries with the same event_id.
+    const secondId = await session.createLead({ name: 'Lead' }, 'evt-timeout-replay');
+
+    assert.equal(firstId, 909);
+    assert.equal(secondId, 909);
+    const createCalls = mock.calls.filter((c) => c.model === 'crm.lead' && c.method === 'create');
+    assert.equal(createCalls.length, 1, 'only the first call should create a crm.lead');
+});
+
+test('createLead — two concurrent requests with the same idempotency key create only one crm.lead', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+    const mock = createOdooMock({ existingLeadId: null, leadId: 4242 });
+    global.fetch = mock.fetch;
+
+    const session = await openOdooSession(config());
+    const [id1, id2] = await Promise.all([
+        session.createLead({ name: 'Lead' }, 'evt-concurrent'),
+        session.createLead({ name: 'Lead' }, 'evt-concurrent'),
+    ]);
+
+    assert.equal(id1, 4242);
+    assert.equal(id2, 4242);
+    const createCalls = mock.calls.filter((c) => c.model === 'crm.lead' && c.method === 'create');
+    assert.equal(createCalls.length, 1, 'concurrent requests for the same key must not both create a lead');
+});
+
+test('createLead — different idempotency keys never merge into the same lead', async (t) => {
+    t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
+
+    let nextLeadId = 1000;
+    global.fetch = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { params: { service: string; method: string; args: unknown[] } };
+        const { service, method, args } = body.params;
+        if (service === 'common' && method === 'authenticate') {
+            return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: 7 }), { status: 200 });
+        }
+        const ormMethod = args[4] as string;
+        if (ormMethod === 'search_read') {
+            return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: [] }), { status: 200 });
+        }
+        if (ormMethod === 'create') {
+            nextLeadId += 1;
+            return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: nextLeadId }), { status: 200 });
+        }
+        throw new Error(`unexpected ORM call: ${ormMethod}`);
+    }) as typeof fetch;
+
+    const session = await openOdooSession(config());
+    const idA = await session.createLead({ name: 'Lead A' }, 'evt-trip-a');
+    const idB = await session.createLead({ name: 'Lead B' }, 'evt-trip-b');
+
+    assert.notEqual(idA, idB, 'two genuinely distinct trip requests from the same customer must not be merged');
+});
+
 test('resolveCampaignId — returns the existing utm.campaign id when the name matches', async (t) => {
     t.after(() => { global.fetch = originalFetch; clearOdooEnv(); });
     const mock = createOdooMock({ existingCampaignId: 42 });

--- a/tests/submit-lead.test.ts
+++ b/tests/submit-lead.test.ts
@@ -221,6 +221,27 @@ test('submit-lead maps corporate empresa/cargo to crm.lead partner_name/function
     assert.equal(lead.function, 'Diretora de Pessoas');
 });
 
+// --- idempotency (issue #1136) ----------------------------------------------
+
+test('submit-lead — a retry with the same event_id does not create a second crm.lead opportunity', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    const mock = createOdooMock({ newPartnerId: 101, leadId: 555 });
+    global.fetch = mock.fetch;
+
+    const payload = buildLeadPayloadFixture();
+    const first = await handler(buildRequest(payload, { headers: { 'x-real-ip': '127.0.0.50' } }));
+    assert.equal(first.status, 201);
+
+    // Simulates the client retrying after never seeing the first response
+    // (perceived timeout) — same event_id, same body.
+    const second = await handler(buildRequest(payload, { headers: { 'x-real-ip': '127.0.0.50' } }));
+    assert.equal(second.status, 201);
+
+    const leadCreateCalls = mock.calls.filter((c) => c.model === 'crm.lead' && c.method === 'create');
+    assert.equal(leadCreateCalls.length, 1, 'a retry with the same event_id must not create a duplicate opportunity');
+});
+
 // --- bot heuristics (honeypot + timing) -------------------------------------
 
 test('submit-lead silently accepts a filled honeypot without touching Odoo', async (t) => {


### PR DESCRIPTION
## Summary
- **Idempotency key resolution** (`lib/odoo-submit-handler.ts`): every lead-producing submission (lead/contato) now resolves a stable key — prefers the client's `event_id` (already generated once per attempt via `createLeadEventId()` for Meta CAPI dedup), falls back to a SHA-256 hash of the submission's own identifying fields when absent. A byte-identical retry always hashes/carries the same key; two genuinely distinct trips from the same customer (different destination/BANT text) do not collide.
- **Find-before-create in Odoo** (`services/odoo.ts`): `crm.lead` has no unique constraint or spare custom field to dedup on, so the key is written as a description line (`lib/odoo-lead-mapping.ts`, `IDEMPOTENCY_KEY_LABEL`) and re-queried via a `like` domain before every create — the same find-or-create idiom already used for `resolveCampaignId`/`utm.campaign`. This alone makes sequential replay and "client perceived a timeout but Odoo already committed" idempotent, with zero schema changes.
- **Concurrent duplicate requests**: `createLead` now runs its find-then-create under a new short-lived lock (`lib/odoo-lead-idempotency.ts`) so a losing concurrent request waits out the winner's Odoo round trip and finds the just-created record instead of creating a second one. Backed by Upstash Redis `SET NX EX` (same infra as rate limiting) with an in-memory fallback for local dev.
- `lib/redis-client.ts` extracts the existing Upstash client/edge-runtime-detection logic out of `lib/rate-limit.ts` (behavior unchanged, existing rate-limit tests still pass) so the new lock reuses it instead of a parallel implementation.
- Existing contact upsert (`upsertPartner`) and attribution/campaign-resolution behavior are untouched — only `createLead`'s call site gained an optional `idempotencyKey` parameter; callers that omit it get the exact prior behavior (plain create).

## Test plan
- [x] `tests/odoo-service.test.ts`: sequential replay, client-timeout replay (create once, replay converges on the same id), **concurrent replay** (`Promise.all` of two same-key calls → only one `crm.lead.create`), distinct keys never merge, and the no-key legacy path is unchanged.
- [x] `tests/odoo-lead-idempotency.test.ts`: the lock itself — uncontended run, sequential release, concurrent serialization (ordering assertion), release-on-throw, independent keys stay concurrent.
- [x] `tests/odoo-lead-mapping.test.ts`: `buildLeadFields` writes/omits the `idempotency_key` description line correctly.
- [x] `tests/submit-lead.test.ts`: full handler-level integration — two `POST /api/submit-lead` calls with the same `event_id` create only one `crm.lead`.
- [x] `pnpm test:regression` (869/869 passing, incl. unchanged `tests/lib-rate-limit.test.ts` after the `redis-client.ts` extraction)
- [x] `pnpm typecheck`
- [x] `pnpm build` + `pnpm test:size`

Closes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)