### PR TITLE
fix(security): protect NPS submissions with a signed invitation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -56,6 +56,9 @@ ODOO_API_KEY=                 # API key (entra no lugar da senha)
 # n8n Webhook (required in prod) — só purchase-dispatch após o cut-over Odoo (NPS também migrou pro Odoo)
 N8N_WEBHOOK_SECRET=           # Shared HMAC secret validado por /api/purchase-dispatch
 
+# NPS Invitation (required in prod): assina/verifica o link de convite de /api/submit-nps
+NPS_INVITE_SECRET=            # HMAC-SHA256 key (lib/nps-invite.ts) — ver docs/ops/nps-invite.md
+
 # Rate limiting (required in prod — module-level state resets per request on Cloudflare)
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
@@ -119,7 +122,7 @@ Handlers rodam como Cloudflare Pages Functions (via `functions/`). O campo `expo
 | `submit-lead.ts` | Lead capture (chatbot/corporativo) → Odoo `res.partner` + `crm.lead` |
 | `submit-contact.ts` | Quick contact form → Odoo `res.partner` + `crm.lead` |
 | `submit-waitlist.ts` | Event waitlist → Odoo `res.partner` (ToFu, sem oportunidade) |
-| `submit-nps.ts` | Post-trip NPS form → Odoo `res.partner` (`x_nps_score` + nota; sem oportunidade) |
+| `submit-nps.ts` | Post-trip NPS form → Odoo `res.partner` (`x_nps_score` + nota; sem oportunidade). Requer convite assinado (`token`, `lib/nps-invite.ts`) — identidade nunca vem do corpo da requisição |
 | `submit-quiz.ts` | Travel quiz results → Odoo `res.partner` (ToFu, sem oportunidade) |
 | `hubspot-webhook.ts` | Inbound HubSpot "Closed-Won" deal events |
 | `purchase-dispatch.ts` | Receives n8n purchase events; validates `N8N_WEBHOOK_SECRET` |

--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,15 @@ DEBUG=false
 N8N_WEBHOOK_SECRET=seu_segredo_aqui
 
 # =============================================================================
+# REQUIRED (prod) - NPS Invitation Secret (para /api/submit-nps)
+# =============================================================================
+# HMAC-SHA256 key usada para assinar/verificar o link de convite de NPS
+# (lib/nps-invite.ts). O link (?token=...) é gerado pelo fluxo operacional de
+# pós-venda (ver docs/ops/nps-invite.md) e vale por 30 dias, uso único.
+# Gere com: openssl rand -hex 32
+NPS_INVITE_SECRET=seu_segredo_aqui
+
+# =============================================================================
 # OPTIONAL - Meta Conversions API (CAPI) — eventos Lead / Purchase server-side
 # =============================================================================
 # Usado por /api/purchase-dispatch (lib/conversions/meta.ts) para enviar eventos

--- a/api/submit-nps.ts
+++ b/api/submit-nps.ts
@@ -2,23 +2,89 @@ import {
     classifyN8nSubmitError,
     type ClassifyN8nErrorOptions,
     type N8nErrorClassification,
+    type ValidationResult,
 } from '../lib/n8n-submit-handler';
 import { createOdooSubmitHandler } from '../lib/odoo-submit-handler';
 import { leadInputFromSubmitNps } from '../lib/odoo-lead-mapping';
-import { SubmitNpsBodySchema } from '../lib/schemas/submit-nps';
-import type { z } from 'zod';
+import { SubmitNpsBodySchema, type SubmitNpsRequest } from '../lib/schemas/submit-nps';
+import { cleanString } from '../lib/lead-logic';
+import { getNpsInviteSecret, verifyNpsInviteToken } from '../lib/nps-invite';
+import { consumeNpsInviteOnce } from '../lib/nps-invite-replay';
+import { logger } from '../lib/logger';
+import { z } from 'zod';
 
 const ODOO_ERROR_PATTERN = /^ODOO_ERROR:(\d+):(.*)$/s;
+
+// Deliberately generic: distinguishing "expired" from "already used" from
+// "tampered" to the caller would help an attacker probe the invitation
+// scheme (issue #1137). A real customer just needs to know to ask for a new link.
+const INVALID_INVITE_ERROR = 'Link de avaliação inválido ou expirado. Solicite um novo link.';
+const INVITE_EMAIL_SCHEMA = z.email().max(254);
 
 function mapNpsZodError(error: z.ZodError): string {
     const issue = error.issues[0];
     const path = issue?.path[0];
-    if (path === 'firstname') return 'Nome inválido.';
-    if (path === 'email') return 'E-mail inválido.';
+    if (path === 'token') return 'Link de avaliação ausente ou inválido.';
     if (path === 'score') return 'Nota deve ser um número inteiro entre 0 e 10.';
     if (path === 'reason') return 'O motivo da nota é obrigatório (máximo 2000 caracteres).';
     if (path === 'highlight') return 'Momento marcante deve ter no máximo 2000 caracteres.';
     return 'Payload inválido.';
+}
+
+/**
+ * Verifies the signed NPS invitation before trusting any identity: signature,
+ * expiry, and single-use replay (issue #1137). Identity (firstname/email) is
+ * read from the verified payload, never from the request body.
+ */
+async function validateNpsSubmission(rawBody: unknown): Promise<ValidationResult<SubmitNpsRequest>> {
+    const parsed = SubmitNpsBodySchema.safeParse(rawBody);
+    if (!parsed.success) {
+        return { ok: false, error: mapNpsZodError(parsed.error) };
+    }
+
+    // checkExtraConfig (below) already guarantees this is set before validate runs.
+    const secret = getNpsInviteSecret()!;
+    const verification = await verifyNpsInviteToken(parsed.data.token, secret);
+    if (!verification.valid) {
+        logger.warn('SUBMIT_NPS: invitation rejected', { reason: verification.reason });
+        return { ok: false, error: INVALID_INVITE_ERROR };
+    }
+
+    const { payload } = verification;
+    const remainingTtlSeconds = Math.max(1, Math.floor((payload.exp - Date.now()) / 1000));
+    const firstUse = await consumeNpsInviteOnce(payload.jti, remainingTtlSeconds);
+    if (!firstUse) {
+        logger.warn('SUBMIT_NPS: invitation replay rejected');
+        return { ok: false, error: INVALID_INVITE_ERROR };
+    }
+
+    // Same escape + post-escape length guard the old free-text firstname field
+    // used: cleanString turns each `<`/`>` into a 4-char entity, so a name full
+    // of angle brackets could quadruple past the 100-char res.partner.name limit.
+    const rawFirstname = payload.firstname.trim();
+    if (!rawFirstname || rawFirstname.length > 100) {
+        return { ok: false, error: INVALID_INVITE_ERROR };
+    }
+    const firstname = cleanString(rawFirstname);
+    if (firstname.length > 100) {
+        return { ok: false, error: INVALID_INVITE_ERROR };
+    }
+
+    const emailParsed = INVITE_EMAIL_SCHEMA.safeParse(payload.email);
+    if (!emailParsed.success) {
+        return { ok: false, error: INVALID_INVITE_ERROR };
+    }
+
+    return {
+        ok: true,
+        data: {
+            firstname,
+            email: emailParsed.data,
+            score: parsed.data.score,
+            reason: parsed.data.reason,
+            highlight: parsed.data.highlight,
+        },
+    };
 }
 
 const NPS_ERROR_OPTIONS: ClassifyN8nErrorOptions = {
@@ -45,15 +111,13 @@ export default createOdooSubmitHandler({
         keyPrefix: 'ratelimit:submit-nps',
         exceededError: 'Muitas tentativas. Tente novamente em breve.',
     },
+    checkExtraConfig: () =>
+        getNpsInviteSecret()
+            ? { ok: true }
+            : { ok: false, status: 500, error: 'Serviço de avaliação indisponível no momento.' },
     parse: { invalidJsonError: 'JSON inválido no corpo da requisição.' },
     methodNotAllowedError: 'Method not allowed',
-    validate: (rawBody) => {
-        const parsed = SubmitNpsBodySchema.safeParse(rawBody);
-        if (!parsed.success) {
-            return { ok: false, error: mapNpsZodError(parsed.error) };
-        }
-        return { ok: true, data: parsed.data };
-    },
+    validate: validateNpsSubmission,
     buildInput: leadInputFromSubmitNps,
     success: { status: 201, message: 'Avaliação registrada com sucesso.' },
     error: NPS_ERROR_OPTIONS,

--- a/api/submit-nps.ts
+++ b/api/submit-nps.ts
@@ -9,7 +9,7 @@ import { leadInputFromSubmitNps } from '../lib/odoo-lead-mapping';
 import { SubmitNpsBodySchema, type SubmitNpsRequest } from '../lib/schemas/submit-nps';
 import { cleanString } from '../lib/lead-logic';
 import { getNpsInviteSecret, verifyNpsInviteToken } from '../lib/nps-invite';
-import { consumeNpsInviteOnce } from '../lib/nps-invite-replay';
+import { consumeNpsInviteOnce, releaseNpsInvite } from '../lib/nps-invite-replay';
 import { logger } from '../lib/logger';
 import { z } from 'zod';
 
@@ -83,6 +83,7 @@ async function validateNpsSubmission(rawBody: unknown): Promise<ValidationResult
             score: parsed.data.score,
             reason: parsed.data.reason,
             highlight: parsed.data.highlight,
+            jti: payload.jti,
         },
     };
 }
@@ -121,4 +122,11 @@ export default createOdooSubmitHandler({
     buildInput: leadInputFromSubmitNps,
     success: { status: 201, message: 'Avaliação registrada com sucesso.' },
     error: NPS_ERROR_OPTIONS,
+    // validateNpsSubmission consumes the jti before the Odoo write (atomic,
+    // so concurrent double-submits are still rejected) — if the write then
+    // fails, release it so a legitimate retry with the same link succeeds
+    // instead of permanently burning a customer's single-use invite.
+    onSendFailure: async (data) => {
+        await releaseNpsInvite(data.jti);
+    },
 });

--- a/docs/ops/nps-invite.md
+++ b/docs/ops/nps-invite.md
@@ -1,0 +1,51 @@
+# NPS Invitation Links
+
+`/nps` (post-trip Net Promoter Score survey) requires a signed, expiring,
+single-use invitation token (issue #1137). Before this, the page trusted a
+caller-supplied `?firstname=&email=` — anyone who knew or guessed a
+customer's e-mail could submit a score/comment that mutates their
+`res.partner` record. The link is now `?token=...`, and the server derives
+identity from the verified token, never from the request body.
+
+## How it works
+
+- `lib/nps-invite.ts` issues and verifies the token: `base64url(JSON payload)
+  + "." + base64url(HMAC-SHA256 signature)`, signed with `NPS_INVITE_SECRET`.
+- The payload carries `email`, `firstname`, an expiry (`exp`, default 30
+  days), and a unique `jti`.
+- `lib/nps-invite-replay.ts` marks the `jti` consumed (Upstash Redis
+  `SET NX`) on the first successful submit — a captured/forwarded link can't
+  be replayed even before it expires.
+- `api/submit-nps.ts` verifies signature, expiry, and replay before any Odoo
+  side effect, then uses the token's `email`/`firstname` — the request body
+  only ever carries `score`/`reason`/`highlight`.
+
+## Generating a link
+
+Run once a trip is completed (manually, or wired into whatever ops workflow
+tracks trip completion):
+
+```bash
+pnpm tsx scripts/generate-nps-invite.ts --email cliente@example.com --firstname "Ana" [--days 30]
+```
+
+Prints the token and a ready-to-send URL, e.g.:
+
+```
+https://www.anhanga.tur.br/nps?token=<token>&firstname=Ana
+```
+
+`firstname` in the URL is display-only (the page's greeting) — it is never
+trusted as identity; only the verified token payload is.
+
+## Distribution
+
+Send the link via the channel already used for post-trip follow-up (e-mail).
+Each link is single-use and expires after 30 days by default — generate a
+fresh one if a customer needs to resubmit or the link is reported lost.
+
+## Configuration
+
+`NPS_INVITE_SECRET` is required in production (`openssl rand -hex 32`). Without
+it, `/api/submit-nps` returns `500 SERVER_CONFIG_ERROR` rather than accepting
+unverifiable submissions.

--- a/lib/form-v1-validation.ts
+++ b/lib/form-v1-validation.ts
@@ -12,7 +12,9 @@ export type ContactFormFieldErrors = Partial<Record<'firstName' | 'whatsapp' | '
 
 export type WaitlistFormFieldErrors = Partial<Record<'name' | 'email', string>>;
 
-export type NpsFormFieldErrors = Partial<Record<'firstname' | 'email' | 'score', string>>;
+// Identity (firstname/email) is bound server-side to the signed invitation
+// token (issue #1137) — the form only ever collects/validates the score.
+export type NpsFormFieldErrors = Partial<Record<'score', string>>;
 
 function cleanEmail(value: string | undefined): string {
   return (value ?? '').trim().toLowerCase();
@@ -63,23 +65,18 @@ export function validateWaitlistFormFields(input: { name: string; email: string 
   return { valid: true, normalized: { name, email }, errors };
 }
 
-export function validateNpsFormFields(input: { firstname: string; email: string; score: number | null }):
-  | { valid: true; normalized: { firstname: string; email: string; score: number }; errors: NpsFormFieldErrors }
-  | { valid: false; normalized: { firstname: string; email: string; score: number | null }; errors: NpsFormFieldErrors } {
-  const firstname = input.firstname.trim();
-  const email = cleanEmail(input.email);
+export function validateNpsFormFields(input: { score: number | null }):
+  | { valid: true; normalized: { score: number }; errors: NpsFormFieldErrors }
+  | { valid: false; normalized: { score: number | null }; errors: NpsFormFieldErrors } {
   const errors: NpsFormFieldErrors = {};
 
-  if (!firstname) errors.firstname = 'Informe seu nome.';
-  if (!email) errors.email = 'Informe seu e-mail.';
-  else if (!isValidEmail(email)) errors.email = 'Informe um e-mail válido.';
   if (input.score === null) errors.score = 'Escolha uma nota.';
 
   if (Object.keys(errors).length > 0) {
-    return { valid: false, normalized: { firstname, email, score: input.score }, errors };
+    return { valid: false, normalized: { score: input.score }, errors };
   }
 
-  return { valid: true, normalized: { firstname, email, score: input.score! }, errors };
+  return { valid: true, normalized: { score: input.score! }, errors };
 }
 
 export function isFieldCompleteForAnalytics(fieldName: string, value: string | boolean | number | null | undefined): boolean {

--- a/lib/n8n-submit-handler.ts
+++ b/lib/n8n-submit-handler.ts
@@ -105,6 +105,9 @@ export type ValidationResult<TData> =
     | { ok: true; data: TData }
     | { ok: false; error: string };
 
+/** Per-form validators may be async (e.g. NPS signed-invitation verification). */
+export type MaybeAsyncValidationResult<TData> = ValidationResult<TData> | Promise<ValidationResult<TData>>;
+
 /** Result of a per-request provider config check. */
 export type DispatchConfigCheck =
     | { ok: true }
@@ -148,7 +151,7 @@ export interface CreateSubmitHandlerOptions<TData, TPayload = unknown> {
     /** Client-facing message for the 405 method gate. */
     methodNotAllowedError: string;
     /** Validates and normalizes the raw body into the typed payload data. */
-    validate: (rawBody: unknown) => ValidationResult<TData>;
+    validate: (rawBody: unknown) => MaybeAsyncValidationResult<TData>;
     /** Provider plug-in (n8n or Odoo). */
     dispatch: SubmitDispatch<TData, TPayload>;
     success: {
@@ -315,7 +318,7 @@ export function createSubmitHandler<TData, TPayload = unknown>(
             );
         }
 
-        const validation = options.validate(rawBody);
+        const validation = await options.validate(rawBody);
         if (!validation.ok) {
             return buildJsonResponse(
                 { ok: false, requestId, code: 'VALIDATION_ERROR', error: validation.error },

--- a/lib/n8n-submit-handler.ts
+++ b/lib/n8n-submit-handler.ts
@@ -163,6 +163,13 @@ export interface CreateSubmitHandlerOptions<TData, TPayload = unknown> {
     onValidated?: (data: TData, requestId: string) => Record<string, unknown> | void;
     /** Optional extra fields (e.g. masked recovery data) for the error log. */
     onError?: (params: { data: TData; requestId: string; classification: N8nErrorClassification }) => Record<string, unknown> | void;
+    /**
+     * Runs only when `dispatch.send()` throws — for releasing a side effect
+     * that `validate()` optimistically applied (e.g. consuming a single-use
+     * token) so a transient provider failure doesn't permanently block a
+     * legitimate retry. Never runs on success or on a validation failure.
+     */
+    onSendFailure?: (data: TData, requestId: string) => void | Promise<void>;
 }
 
 /** Internal per-request state shared between the handler and its helpers. */
@@ -343,6 +350,7 @@ export function createSubmitHandler<TData, TPayload = unknown>(
             const payload = options.dispatch.buildPayload(data, requestId, ctx);
             await options.dispatch.send(requestId, payload);
         } catch (error: unknown) {
+            await options.onSendFailure?.(data, requestId);
             return buildWebhookErrorResponse(env, data, error);
         }
 

--- a/lib/nps-invite-replay.ts
+++ b/lib/nps-invite-replay.ts
@@ -1,0 +1,66 @@
+/**
+ * Single-use tracking for NPS invitation tokens (issue #1137). A signature +
+ * expiry check alone lets a captured link (forwarded e-mail, shared screen,
+ * leaked analytics referrer) be replayed indefinitely within its validity
+ * window; this marks a token's `jti` consumed on first successful submit so a
+ * replay is rejected even though the signature and expiry still check out.
+ */
+import { logger } from './logger';
+
+const KEY_PREFIX = 'nps:invite:used';
+
+interface RedisSetLike {
+    set(key: string, value: string, opts: { nx: true; ex: number }): Promise<string | null>;
+}
+
+// True when running inside a managed serverless edge runtime where module-level
+// state resets per request. Both Vercel (VERCEL_ENV) and Cloudflare Pages
+// (CF_PAGES) are detected; local development has neither variable set.
+function isEdgeRuntime(): boolean {
+    return Boolean(process.env.VERCEL_ENV || process.env.CF_PAGES);
+}
+
+async function getRedisClient(): Promise<RedisSetLike | null> {
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url || !token) return null;
+
+    try {
+        // CF Workers do not support the `cache` field on fetch RequestInit; the
+        // default entry point passes `cache: 'no-store'`, which throws there.
+        const mod = process.env.CF_PAGES
+            ? await import('@upstash/redis/cloudflare')
+            : await import('@upstash/redis');
+        return new mod.Redis({ url, token });
+    } catch {
+        return null;
+    }
+}
+
+// Local-dev-only fallback (mirrors lib/rate-limit.ts): module state resets per
+// request on edge runtimes, so this Set is not a real guard there — Upstash
+// Redis is required in production.
+const inMemoryConsumed = new Set<string>();
+
+/**
+ * Attempts to mark `jti` as consumed. Returns true the first time (the caller
+ * may proceed), false if it was already consumed (reject as replayed).
+ * `ttlSeconds` should cover the token's remaining validity window so the
+ * Redis key doesn't outlive a token that could never be replayed again anyway.
+ */
+export async function consumeNpsInviteOnce(jti: string, ttlSeconds: number): Promise<boolean> {
+    const key = `${KEY_PREFIX}:${jti}`;
+    const redis = await getRedisClient();
+
+    if (!redis) {
+        if (isEdgeRuntime()) {
+            logger.warn('NPS_INVITE_REPLAY: Redis unavailable on edge runtime; single-use guard is a no-op', { jti });
+        }
+        if (inMemoryConsumed.has(key)) return false;
+        inMemoryConsumed.add(key);
+        return true;
+    }
+
+    const result = await redis.set(key, '1', { nx: true, ex: Math.max(1, ttlSeconds) });
+    return result === 'OK';
+}

--- a/lib/nps-invite-replay.ts
+++ b/lib/nps-invite-replay.ts
@@ -11,6 +11,7 @@ const KEY_PREFIX = 'nps:invite:used';
 
 interface RedisSetLike {
     set(key: string, value: string, opts: { nx: true; ex: number }): Promise<string | null>;
+    del(key: string): Promise<unknown>;
 }
 
 // True when running inside a managed serverless edge runtime where module-level
@@ -63,4 +64,29 @@ export async function consumeNpsInviteOnce(jti: string, ttlSeconds: number): Pro
 
     const result = await redis.set(key, '1', { nx: true, ex: Math.max(1, ttlSeconds) });
     return result === 'OK';
+}
+
+/**
+ * Releases a `jti` marked consumed by `consumeNpsInviteOnce`. Call this only
+ * when the Odoo write that was supposed to follow actually failed — the token
+ * is consumed *before* the write (so concurrent double-submits are still
+ * rejected atomically), but a transient provider failure must not permanently
+ * burn a customer's single-use invite; releasing it lets a retry with the
+ * same link succeed instead of forcing a brand-new invitation to be issued.
+ */
+export async function releaseNpsInvite(jti: string): Promise<void> {
+    const key = `${KEY_PREFIX}:${jti}`;
+    const redis = await getRedisClient();
+
+    if (!redis) {
+        inMemoryConsumed.delete(key);
+        return;
+    }
+
+    await redis.del(key).catch((error) => {
+        logger.warn('NPS_INVITE_REPLAY: failed to release jti after a send failure', {
+            jti,
+            detail: error instanceof Error ? error.message : String(error),
+        });
+    });
 }

--- a/lib/nps-invite.ts
+++ b/lib/nps-invite.ts
@@ -1,0 +1,118 @@
+/**
+ * Signed, expiring, single-use NPS invitation (issue #1137).
+ *
+ * Before this, `/nps` trusted a caller-supplied `email`/`firstname` with no
+ * proof the requester was actually the invited customer — anyone who knew or
+ * guessed an e-mail could post a score/comment that mutates that customer's
+ * `res.partner` record. The invite link now carries a token that is:
+ *  - signed (HMAC-SHA256 over the payload, `NPS_INVITE_SECRET`) so it cannot
+ *    be forged or altered,
+ *  - expiring (`exp`, default 30 days — a post-trip survey window),
+ *  - bound to a subject (`email`/`firstname` are read FROM the verified
+ *    token server-side, never trusted from the request body), and
+ *  - single-use (`jti` is consumed via `lib/nps-invite-replay.ts` on the
+ *    first successful submit; a replayed link is rejected).
+ *
+ * Token shape: `base64url(JSON payload) + "." + base64url(HMAC signature)`.
+ * Not a JWT (no header, no alg negotiation) — this is an internal link
+ * format with a single fixed algorithm, so there is nothing for an attacker
+ * to downgrade.
+ */
+import { timingSafeEqual } from './security';
+
+const DEFAULT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+export interface NpsInvitePayload {
+    email: string;
+    firstname: string;
+    /** Expiry, epoch milliseconds. */
+    exp: number;
+    /** Unique id for single-use replay tracking. */
+    jti: string;
+}
+
+export type NpsInviteValidation =
+    | { valid: true; payload: NpsInvitePayload }
+    | { valid: false; reason: 'malformed' | 'signature_mismatch' | 'expired' };
+
+export function getNpsInviteSecret(): string | null {
+    const secret = process.env.NPS_INVITE_SECRET?.trim();
+    return secret ? secret : null;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+    let binary = '';
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(value: string): Uint8Array {
+    const padded = value.replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(value.length / 4) * 4, '=');
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+}
+
+async function hmacSign(secret: string, message: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey('raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(message));
+    return base64UrlEncode(new Uint8Array(signature));
+}
+
+/** Issues a signed invitation token. Used by the invite-generation flow (see docs), not by the public `/nps` page. */
+export async function createNpsInviteToken(
+    params: { email: string; firstname: string; expiresInMs?: number },
+    secret: string,
+): Promise<string> {
+    const payload: NpsInvitePayload = {
+        email: params.email.trim().toLowerCase(),
+        firstname: params.firstname.trim(),
+        exp: Date.now() + (params.expiresInMs ?? DEFAULT_MAX_AGE_MS),
+        jti: crypto.randomUUID(),
+    };
+    const payloadB64 = base64UrlEncode(new TextEncoder().encode(JSON.stringify(payload)));
+    const signature = await hmacSign(secret, payloadB64);
+    return `${payloadB64}.${signature}`;
+}
+
+function isNpsInvitePayload(value: unknown): value is NpsInvitePayload {
+    if (!value || typeof value !== 'object') return false;
+    const candidate = value as Record<string, unknown>;
+    return (
+        typeof candidate.email === 'string' &&
+        typeof candidate.firstname === 'string' &&
+        typeof candidate.exp === 'number' &&
+        typeof candidate.jti === 'string'
+    );
+}
+
+/** Verifies signature and expiry. Does not check single-use replay — see `lib/nps-invite-replay.ts`. */
+export async function verifyNpsInviteToken(token: string, secret: string): Promise<NpsInviteValidation> {
+    const parts = token.split('.');
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        return { valid: false, reason: 'malformed' };
+    }
+    const [payloadB64, signature] = parts;
+
+    let payload: unknown;
+    try {
+        payload = JSON.parse(new TextDecoder().decode(base64UrlDecode(payloadB64)));
+    } catch {
+        return { valid: false, reason: 'malformed' };
+    }
+    if (!isNpsInvitePayload(payload)) {
+        return { valid: false, reason: 'malformed' };
+    }
+
+    const expectedSignature = await hmacSign(secret, payloadB64);
+    if (!timingSafeEqual(expectedSignature, signature)) {
+        return { valid: false, reason: 'signature_mismatch' };
+    }
+    if (Date.now() > payload.exp) {
+        return { valid: false, reason: 'expired' };
+    }
+
+    return { valid: true, payload };
+}

--- a/lib/nps-invite.ts
+++ b/lib/nps-invite.ts
@@ -83,7 +83,11 @@ function isNpsInvitePayload(value: unknown): value is NpsInvitePayload {
     return (
         typeof candidate.email === 'string' &&
         typeof candidate.firstname === 'string' &&
+        // Number.isFinite (not just typeof === 'number') rejects NaN — otherwise
+        // a token with a corrupted/invalid exp would compare `Date.now() > NaN`,
+        // which is always false, and never expire.
         typeof candidate.exp === 'number' &&
+        Number.isFinite(candidate.exp) &&
         typeof candidate.jti === 'string'
     );
 }

--- a/lib/odoo-submit-handler.ts
+++ b/lib/odoo-submit-handler.ts
@@ -47,6 +47,8 @@ export interface CreateOdooSubmitHandlerOptions<TData> {
     checkExtraConfig?: () => DispatchConfigCheck;
     onValidated?: (data: TData, requestId: string) => Record<string, unknown> | void;
     onError?: (params: { data: TData; requestId: string; classification: N8nErrorClassification }) => Record<string, unknown> | void;
+    /** Runs only when the Odoo write throws — see CreateSubmitHandlerOptions.onSendFailure. */
+    onSendFailure?: (data: TData, requestId: string) => void | Promise<void>;
 }
 
 /** Persists an Odoo input: upsert partner (dedup by e-mail), then optional lead. */
@@ -96,6 +98,7 @@ export function createOdooSubmitHandler<TData>(
         success: options.success,
         onValidated: options.onValidated,
         onError: options.onError,
+        onSendFailure: options.onSendFailure,
         dispatch: {
             checkConfig: () => {
                 if (!getOdooConfig()) {

--- a/lib/odoo-submit-handler.ts
+++ b/lib/odoo-submit-handler.ts
@@ -12,8 +12,9 @@ import {
     createSubmitHandler,
     type ClassifyN8nErrorOptions,
     type CreateSubmitHandlerOptions,
+    type DispatchConfigCheck,
     type N8nErrorClassification,
-    type ValidationResult,
+    type MaybeAsyncValidationResult,
 } from './n8n-submit-handler';
 import { buildLeadFields, buildPartnerFields, type OdooLeadInput } from './odoo-lead-mapping';
 import { getOdooConfig, openOdooSession } from '../services/odoo';
@@ -30,7 +31,7 @@ export interface CreateOdooSubmitHandlerOptions<TData> {
     rateLimit: CreateSubmitHandlerOptions<TData, OdooLeadInput>['rateLimit'];
     parse: { invalidJsonError: string };
     methodNotAllowedError: string;
-    validate: (rawBody: unknown) => ValidationResult<TData>;
+    validate: (rawBody: unknown) => MaybeAsyncValidationResult<TData>;
     /** Per-form adapter: validated data → normalized Odoo input. */
     buildInput: (data: TData) => OdooLeadInput;
     success: { status: number; message?: string };
@@ -38,6 +39,12 @@ export interface CreateOdooSubmitHandlerOptions<TData> {
     error: Omit<ClassifyN8nErrorOptions, 'errorPattern'>;
     /** Client-facing message + status when Odoo env config is missing. */
     config?: { missingStatus?: number; missingError?: string };
+    /**
+     * Extra provider-agnostic config check run after the Odoo config check
+     * (e.g. a form-specific signing secret like NPS_INVITE_SECRET). Reuses
+     * the same SERVER_CONFIG_ERROR response shape instead of a parallel path.
+     */
+    checkExtraConfig?: () => DispatchConfigCheck;
     onValidated?: (data: TData, requestId: string) => Record<string, unknown> | void;
     onError?: (params: { data: TData; requestId: string; classification: N8nErrorClassification }) => Record<string, unknown> | void;
 }
@@ -90,14 +97,16 @@ export function createOdooSubmitHandler<TData>(
         onValidated: options.onValidated,
         onError: options.onError,
         dispatch: {
-            checkConfig: () =>
-                getOdooConfig()
-                    ? { ok: true }
-                    : {
+            checkConfig: () => {
+                if (!getOdooConfig()) {
+                    return {
                         ok: false,
                         status: options.config?.missingStatus ?? ODOO_CONFIG_MISSING_STATUS,
                         error: options.config?.missingError ?? ODOO_CONFIG_MISSING_ERROR,
-                    },
+                    };
+                }
+                return options.checkExtraConfig?.() ?? { ok: true };
+            },
             buildPayload: (data) => options.buildInput(data),
             send: (_requestId, input) => sendToOdoo(input),
             classifyError: (error) => classifyN8nSubmitError(error, errorOptions),

--- a/lib/schemas/submit-nps.ts
+++ b/lib/schemas/submit-nps.ts
@@ -29,4 +29,10 @@ export interface SubmitNpsRequest {
     score: number;
     reason: string;
     highlight: string;
+    /**
+     * The invitation token's jti, carried through internally so `onSendFailure`
+     * can release the single-use guard if the Odoo write fails — never sent to
+     * Odoo (leadInputFromSubmitNps destructures only the named fields above).
+     */
+    jti: string;
 }

--- a/lib/schemas/submit-nps.ts
+++ b/lib/schemas/submit-nps.ts
@@ -1,25 +1,32 @@
 import { z } from 'zod';
 import { cleanString } from '../lead-logic';
 
-// Free-text NPS fields feed res.partner.name/comment via the Odoo mapper, which
-// (unlike buildDescriptionHtml) assumes its inputs were already escaped at the
-// provider boundary — the same contract lead/contact/quiz/waitlist honor through
-// cleanString/normalizeNullable. Escaping angle brackets here keeps NPS on that
-// boundary so raw markup never reaches CRM notes. `.max()` bounds the raw input
-// before cleanString escapes, matching the other paths' order.
-//
-// `firstname` also re-checks the bound AFTER escaping: cleanString turns each
-// `<`/`>` into a 4-char entity, so a name full of angle brackets could quadruple
-// past the 100-char limit of the res.partner.name Char field. The contact path
-// applies the same post-sanitization guard (`if (firstName.length > 100)`).
-// reason/highlight target the unbounded `comment` Text field (and cleanString
-// self-caps at 10k), so they don't need the extra guard.
+// Wire-format body: identity (firstname/email) is never trusted from the
+// request — it is read from the verified, signed invitation `token` instead
+// (issue #1137). See lib/nps-invite.ts + api/submit-nps.ts's validate step.
 export const SubmitNpsBodySchema = z.object({
-    firstname: z.string().trim().min(1).max(100).transform(cleanString).refine((v) => v.length <= 100, { message: 'Nome inválido.' }),
-    email:     z.email().max(254),
+    token:     z.string().min(1).max(4096),
     score:     z.number().int().min(0).max(10),
     reason:    z.string().trim().max(2000).default('').transform(cleanString),
     highlight: z.string().trim().max(2000).default('').transform(cleanString),
 });
 
-export type SubmitNpsRequest = z.infer<typeof SubmitNpsBodySchema>;
+export type SubmitNpsBody = z.infer<typeof SubmitNpsBodySchema>;
+
+/**
+ * The validated shape leadInputFromSubmitNps consumes. `firstname`/`email`
+ * come from the verified invitation payload (api/submit-nps.ts), not from
+ * `SubmitNpsBodySchema` directly.
+ *
+ * Free-text fields feed res.partner.name/comment via the Odoo mapper, which
+ * (unlike buildDescriptionHtml) assumes its inputs were already escaped at the
+ * provider boundary — the same contract lead/contact/quiz/waitlist honor
+ * through cleanString/normalizeNullable.
+ */
+export interface SubmitNpsRequest {
+    firstname: string;
+    email: string;
+    score: number;
+    reason: string;
+    highlight: string;
+}

--- a/pages/NpsPage.tsx
+++ b/pages/NpsPage.tsx
@@ -9,7 +9,7 @@ import { NpsThankOther } from '../components/nps/NpsThankOther';
 import { Seo } from '../components/Seo';
 import { useAntiBot } from '../hooks/useAntiBot';
 import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
-import { isFieldCompleteForAnalytics, isValidEmail, validateNpsFormFields, type NpsFormFieldErrors } from '../lib/form-v1-validation';
+import { isFieldCompleteForAnalytics, validateNpsFormFields, type NpsFormFieldErrors } from '../lib/form-v1-validation';
 
 type PageState = 'form' | 'thank-promoter' | 'thank-other';
 
@@ -66,14 +66,13 @@ const PAGE_STYLES = `
 
 export default function NpsPage() {
   const [params] = useSearchParams();
-  const initialFirstname = params.get('firstname')?.trim() ?? '';
-  const initialEmail = params.get('email')?.trim() ?? '';
-  const isInitialEmailValid = initialEmail ? isValidEmail(initialEmail) : false;
-  const needsIdentityFields = !initialFirstname || !isInitialEmailValid;
+  // Identity is bound server-side to the signed invitation token (issue
+  // #1137) — `firstname` here is display-only (the greeting) and never sent
+  // to the API; the token is the only thing that proves who is answering.
+  const firstname = params.get('firstname')?.trim() ?? '';
+  const token = params.get('token')?.trim() ?? '';
 
   const [score, setScore] = useState<number | null>(null);
-  const [firstname, setFirstname] = useState(initialFirstname);
-  const [email, setEmail] = useState(initialEmail);
   const [reason, setReason] = useState('');
   const [highlight, setHighlight] = useState('');
   const [pageState, setPageState] = useState<PageState>('form');
@@ -99,7 +98,7 @@ export default function NpsPage() {
     });
   }, []);
 
-  function markStarted(fieldName: 'firstname' | 'email' | 'score' | 'reason' | 'highlight', value: string | number | null = '') {
+  function markStarted(fieldName: 'score' | 'reason' | 'highlight', value: string | number | null = '') {
     if (!startedRef.current) {
       startedRef.current = true;
       pushFormAnalyticsEvent({
@@ -122,7 +121,7 @@ export default function NpsPage() {
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    const validation = validateNpsFormFields({ firstname, email, score });
+    const validation = validateNpsFormFields({ score });
     if (!validation.valid) {
       setFieldErrors(validation.errors);
       setErrorMessage('Confira os campos destacados para enviar sua avaliação.');
@@ -150,8 +149,7 @@ export default function NpsPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          firstname: validation.normalized.firstname,
-          email: validation.normalized.email,
+          token,
           score: validation.normalized.score,
           reason: reason.trim(),
           highlight: highlight.trim(),
@@ -211,7 +209,16 @@ export default function NpsPage() {
         <main className="flex-1 flex flex-col items-center px-6 pb-16 pt-8">
           <div className="w-full max-w-lg">
 
-            {pageState === 'form' && (
+            {!token && (
+              <div className="nps-thank-card text-center">
+                <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight mb-3">Link inválido</h1>
+                <p className="text-base text-slate-400 leading-7">
+                  Este link de avaliação não é válido ou já expirou. Solicite um novo link à nossa equipe.
+                </p>
+              </div>
+            )}
+
+            {token && pageState === 'form' && (
               <form onSubmit={handleSubmit} noValidate>
                 {/* Honeypot: hidden from humans, blind form-fillers populate it. */}
                 <input {...honeypotProps} />
@@ -230,72 +237,6 @@ export default function NpsPage() {
                     markStarted('score', nextScore);
                   }}
                 />
-
-                {needsIdentityFields && (
-                  <div className="mb-8 grid gap-4 sm:grid-cols-2">
-                    {!initialFirstname && (
-                      <div>
-                        <label
-                          htmlFor="nps-firstname"
-                          className="block text-xs font-black uppercase tracking-[0.15em] text-slate-400 mb-2.5"
-                        >
-                          Seu nome
-                        </label>
-                        <input
-                          id="nps-firstname"
-                          type="text"
-                          value={firstname}
-                          onChange={(event) => {
-                            setFirstname(event.target.value);
-                            setFieldErrors((prev) => ({ ...prev, firstname: undefined }));
-                            markStarted('firstname', event.target.value);
-                          }}
-                          autoComplete="given-name"
-                          aria-invalid={fieldErrors.firstname ? true : undefined}
-                          aria-describedby={fieldErrors.firstname ? 'nps-firstname-error' : undefined}
-                          className="w-full rounded-xl px-4 py-3 text-sm font-sans bg-slate-800/60 text-slate-100 placeholder:text-slate-500 border-2 border-slate-600/40 outline-none focus:border-anhanga-action focus:shadow-[0_0_0_4px_rgba(14,165,233,0.15)]"
-                          placeholder="Como podemos te chamar?"
-                        />
-                        {fieldErrors.firstname && (
-                          <p id="nps-firstname-error" className="mt-1.5 text-xs font-semibold text-red-400" role="alert">
-                            {fieldErrors.firstname}
-                          </p>
-                        )}
-                      </div>
-                    )}
-
-                    {!isInitialEmailValid && (
-                      <div>
-                        <label
-                          htmlFor="nps-email"
-                          className="block text-xs font-black uppercase tracking-[0.15em] text-slate-400 mb-2.5"
-                        >
-                          Seu e-mail
-                        </label>
-                        <input
-                          id="nps-email"
-                          type="email"
-                          value={email}
-                          onChange={(event) => {
-                            setEmail(event.target.value);
-                            setFieldErrors((prev) => ({ ...prev, email: undefined }));
-                            markStarted('email', event.target.value);
-                          }}
-                          autoComplete="email"
-                          aria-invalid={fieldErrors.email ? true : undefined}
-                          aria-describedby={fieldErrors.email ? 'nps-email-error' : undefined}
-                          className="w-full rounded-xl px-4 py-3 text-sm font-sans bg-slate-800/60 text-slate-100 placeholder:text-slate-500 border-2 border-slate-600/40 outline-none focus:border-anhanga-action focus:shadow-[0_0_0_4px_rgba(14,165,233,0.15)]"
-                          placeholder="voce@email.com"
-                        />
-                        {fieldErrors.email && (
-                          <p id="nps-email-error" className="mt-1.5 text-xs font-semibold text-red-400" role="alert">
-                            {fieldErrors.email}
-                          </p>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                )}
 
                 {fieldErrors.score && (
                   <p className="mb-6 text-sm text-center rounded-xl px-4 py-3 text-red-400 bg-red-500/10 border border-red-500/20" role="alert">

--- a/scripts/generate-nps-invite.ts
+++ b/scripts/generate-nps-invite.ts
@@ -48,7 +48,15 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const expiresInMs = days ? Number(days) * 24 * 60 * 60 * 1000 : undefined;
+  let expiresInMs: number | undefined;
+  if (days !== undefined) {
+    const parsedDays = Number(days);
+    if (!Number.isFinite(parsedDays) || parsedDays <= 0) {
+      console.error(`--days must be a positive number, got "${days}".`);
+      process.exit(1);
+    }
+    expiresInMs = parsedDays * 24 * 60 * 60 * 1000;
+  }
   const token = await createNpsInviteToken({ email, firstname, expiresInMs }, secret);
   const url = new URL('/nps', SITE_URL);
   url.searchParams.set('token', token);

--- a/scripts/generate-nps-invite.ts
+++ b/scripts/generate-nps-invite.ts
@@ -1,0 +1,64 @@
+/**
+ * Generates a signed NPS invitation link (issue #1137). Run manually/from an
+ * ops workflow once a trip is completed:
+ *
+ *   pnpm tsx scripts/generate-nps-invite.ts --email cliente@example.com --firstname "Ana"
+ *
+ * Prints the token and the ready-to-send `/nps` URL. See docs/ops/nps-invite.md.
+ */
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createNpsInviteToken } from '../lib/nps-invite';
+
+for (const file of ['.env.local', '.env']) {
+  const path = resolve(process.cwd(), file);
+  if (existsSync(path) && typeof process.loadEnvFile === 'function') {
+    process.loadEnvFile(path);
+  }
+}
+
+const SITE_URL = process.env.ALLOWED_ORIGIN || 'https://www.anhanga.tur.br';
+
+function parseArgs(argv: string[]): { email?: string; firstname?: string; days?: string } {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const value = argv[i + 1];
+      if (value && !value.startsWith('--')) {
+        out[key] = value;
+        i += 1;
+      }
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const { email, firstname, days } = parseArgs(process.argv.slice(2));
+  const secret = process.env.NPS_INVITE_SECRET;
+
+  if (!secret) {
+    console.error('NPS_INVITE_SECRET is not set. Configure it in .env or .env.local before running this script.');
+    process.exit(1);
+  }
+  if (!email || !firstname) {
+    console.error('Usage: pnpm tsx scripts/generate-nps-invite.ts --email <email> --firstname <name> [--days <n>]');
+    process.exit(1);
+  }
+
+  const expiresInMs = days ? Number(days) * 24 * 60 * 60 * 1000 : undefined;
+  const token = await createNpsInviteToken({ email, firstname, expiresInMs }, secret);
+  const url = new URL('/nps', SITE_URL);
+  url.searchParams.set('token', token);
+  url.searchParams.set('firstname', firstname);
+
+  console.log(`Token: ${token}`);
+  console.log(`Link:  ${url.toString()}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/tests/e2e/nps-form.spec.ts
+++ b/tests/e2e/nps-form.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('NPS form', () => {
-  test('bloqueia submit com e-mail inválido vindo da URL e exibe campo editável', async ({ page }) => {
+  test('shows an invalid-link state and never renders the form when no token is present', async ({ page }) => {
     let submitCalls = 0;
     await page.route('**/api/submit-nps', route => {
       submitCalls += 1;
@@ -12,17 +12,37 @@ test.describe('NPS form', () => {
       });
     });
 
-    await page.goto('/nps?firstname=Ana&email=cliente@');
+    await page.goto('/nps?firstname=Ana');
 
-    const emailInput = page.locator('#nps-email');
-    await expect(emailInput).toBeVisible();
-    await expect(emailInput).toHaveValue('cliente@');
+    await expect(page.getByText('Link inválido')).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Enviar avaliação$/i })).toHaveCount(0);
+    expect(submitCalls).toBe(0);
+  });
+
+  test('submits token + score, with no identity fields on the page', async ({ page }) => {
+    let submittedBody: Record<string, unknown> | undefined;
+    await page.route('**/api/submit-nps', route => {
+      submittedBody = JSON.parse(route.request().postData() ?? '{}');
+      return route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, requestId: 'test-request-id', message: 'Avaliação registrada com sucesso.' }),
+      });
+    });
+
+    await page.goto('/nps?firstname=Ana&token=fake-signed-token');
+
+    await expect(page.locator('#nps-firstname')).toHaveCount(0);
+    await expect(page.locator('#nps-email')).toHaveCount(0);
+    await expect(page.getByText('Olá, Ana!')).toBeVisible();
 
     await page.getByRole('button', { name: /^Nota 10/ }).click();
     await page.getByRole('button', { name: /^Enviar avaliação$/i }).click();
 
-    await expect(emailInput).toHaveAttribute('aria-invalid', 'true');
-    await expect(page.getByText('Informe um e-mail válido.')).toBeVisible();
-    expect(submitCalls).toBe(0);
+    await expect(page.getByText(/Enviar avaliação/i)).toHaveCount(0);
+    expect(submittedBody?.token).toBe('fake-signed-token');
+    expect(submittedBody?.score).toBe(10);
+    expect(submittedBody).not.toHaveProperty('firstname');
+    expect(submittedBody).not.toHaveProperty('email');
   });
 });

--- a/tests/form-v1-validation.test.ts
+++ b/tests/form-v1-validation.test.ts
@@ -38,16 +38,18 @@ test('validateWaitlistFormFields blocks invalid email without requiring opt-in',
   assert.equal(valid.valid, true);
 });
 
-test('validateNpsFormFields requires missing URL identity fields locally', () => {
-  const result = validateNpsFormFields({
-    firstname: '',
-    email: '',
-    score: 10,
-  });
+test('validateNpsFormFields requires a chosen score', () => {
+  const result = validateNpsFormFields({ score: null });
 
   assert.equal(result.valid, false);
-  assert.equal(result.errors.firstname, 'Informe seu nome.');
-  assert.equal(result.errors.email, 'Informe seu e-mail.');
+  assert.equal(result.errors.score, 'Escolha uma nota.');
+});
+
+test('validateNpsFormFields accepts a chosen score', () => {
+  const result = validateNpsFormFields({ score: 10 });
+
+  assert.equal(result.valid, true);
+  if (result.valid) assert.equal(result.normalized.score, 10);
 });
 
 test('isFieldCompleteForAnalytics only completes contact fields when useful', () => {

--- a/tests/nps-invite-replay.test.ts
+++ b/tests/nps-invite-replay.test.ts
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { consumeNpsInviteOnce } from '../lib/nps-invite-replay.ts';
+
+function uid(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+test('consumeNpsInviteOnce allows the first use and rejects a replay', async () => {
+    const jti = `jti-${uid()}`;
+
+    const first = await consumeNpsInviteOnce(jti, 60);
+    const second = await consumeNpsInviteOnce(jti, 60);
+
+    assert.equal(first, true, 'first use should be allowed');
+    assert.equal(second, false, 'replay of the same jti should be rejected');
+});
+
+test('consumeNpsInviteOnce treats distinct jtis independently', async () => {
+    const jtiA = `jti-a-${uid()}`;
+    const jtiB = `jti-b-${uid()}`;
+
+    assert.equal(await consumeNpsInviteOnce(jtiA, 60), true);
+    assert.equal(await consumeNpsInviteOnce(jtiB, 60), true);
+});

--- a/tests/nps-invite-replay.test.ts
+++ b/tests/nps-invite-replay.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { consumeNpsInviteOnce } from '../lib/nps-invite-replay.ts';
+import { consumeNpsInviteOnce, releaseNpsInvite } from '../lib/nps-invite-replay.ts';
 
 function uid(): string {
     return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -22,4 +22,21 @@ test('consumeNpsInviteOnce treats distinct jtis independently', async () => {
 
     assert.equal(await consumeNpsInviteOnce(jtiA, 60), true);
     assert.equal(await consumeNpsInviteOnce(jtiB, 60), true);
+});
+
+test('releaseNpsInvite lets a consumed jti be used again — recovers from a failed downstream write', async () => {
+    const jti = `jti-${uid()}`;
+
+    assert.equal(await consumeNpsInviteOnce(jti, 60), true, 'first use should be allowed');
+    assert.equal(await consumeNpsInviteOnce(jti, 60), false, 'replay before release should be rejected');
+
+    await releaseNpsInvite(jti);
+
+    assert.equal(await consumeNpsInviteOnce(jti, 60), true, 'a retry after release must succeed, like the original request never happened');
+});
+
+test('releaseNpsInvite on a jti that was never consumed is a harmless no-op', async () => {
+    const jti = `jti-never-consumed-${uid()}`;
+    await releaseNpsInvite(jti);
+    assert.equal(await consumeNpsInviteOnce(jti, 60), true);
 });

--- a/tests/nps-invite.test.ts
+++ b/tests/nps-invite.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createNpsInviteToken, verifyNpsInviteToken } from '../lib/nps-invite.ts';
+
+const SECRET = 'a-test-secret';
+
+test('createNpsInviteToken + verifyNpsInviteToken round-trips a valid invitation', async () => {
+    const token = await createNpsInviteToken({ email: 'ana@example.com', firstname: 'Ana' }, SECRET);
+    const result = await verifyNpsInviteToken(token, SECRET);
+
+    assert.equal(result.valid, true);
+    if (!result.valid) return;
+    assert.equal(result.payload.email, 'ana@example.com');
+    assert.equal(result.payload.firstname, 'Ana');
+    assert.ok(result.payload.exp > Date.now());
+    assert.ok(result.payload.jti.length > 0);
+});
+
+test('createNpsInviteToken normalizes email to lowercase and trims firstname', async () => {
+    const token = await createNpsInviteToken({ email: '  Ana@EXAMPLE.com  ', firstname: '  Ana Silva  ' }, SECRET);
+    const result = await verifyNpsInviteToken(token, SECRET);
+
+    assert.equal(result.valid, true);
+    if (!result.valid) return;
+    assert.equal(result.payload.email, 'ana@example.com');
+    assert.equal(result.payload.firstname, 'Ana Silva');
+});
+
+test('verifyNpsInviteToken rejects a token signed with a different secret', async () => {
+    const token = await createNpsInviteToken({ email: 'ana@example.com', firstname: 'Ana' }, SECRET);
+    const result = await verifyNpsInviteToken(token, 'a-different-secret');
+
+    assert.equal(result.valid, false);
+    if (result.valid) return;
+    assert.equal(result.reason, 'signature_mismatch');
+});
+
+test('verifyNpsInviteToken rejects an altered payload even with a correct-looking signature', async () => {
+    const token = await createNpsInviteToken({ email: 'ana@example.com', firstname: 'Ana' }, SECRET);
+    const [payloadB64, signature] = token.split('.');
+    // Flip a character in the payload without re-signing.
+    const tampered = `${payloadB64.slice(0, -1)}${payloadB64.slice(-1) === 'a' ? 'b' : 'a'}.${signature}`;
+
+    const result = await verifyNpsInviteToken(tampered, SECRET);
+    assert.equal(result.valid, false);
+});
+
+test('verifyNpsInviteToken rejects an expired token', async () => {
+    const token = await createNpsInviteToken({ email: 'ana@example.com', firstname: 'Ana', expiresInMs: -1000 }, SECRET);
+    const result = await verifyNpsInviteToken(token, SECRET);
+
+    assert.equal(result.valid, false);
+    if (result.valid) return;
+    assert.equal(result.reason, 'expired');
+});
+
+test('verifyNpsInviteToken rejects a malformed token (wrong shape)', async () => {
+    for (const malformed of ['', 'no-dot-separator', 'a.b.c', '.', 'a.']) {
+        const result = await verifyNpsInviteToken(malformed, SECRET);
+        assert.equal(result.valid, false, `expected "${malformed}" to be rejected`);
+    }
+});
+
+test('verifyNpsInviteToken rejects a payload missing required fields', async () => {
+    const encoder = new TextEncoder();
+    const fakePayload = btoa(String.fromCharCode(...encoder.encode(JSON.stringify({ email: 'ana@example.com' }))))
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const result = await verifyNpsInviteToken(`${fakePayload}.somesignature`, SECRET);
+
+    assert.equal(result.valid, false);
+    if (result.valid) return;
+    assert.equal(result.reason, 'malformed');
+});
+
+test('each created token has a distinct jti', async () => {
+    const tokenA = await createNpsInviteToken({ email: 'ana@example.com', firstname: 'Ana' }, SECRET);
+    const tokenB = await createNpsInviteToken({ email: 'ana@example.com', firstname: 'Ana' }, SECRET);
+
+    const resultA = await verifyNpsInviteToken(tokenA, SECRET);
+    const resultB = await verifyNpsInviteToken(tokenB, SECRET);
+    assert.equal(resultA.valid, true);
+    assert.equal(resultB.valid, true);
+    if (!resultA.valid || !resultB.valid) return;
+    assert.notEqual(resultA.payload.jti, resultB.payload.jti);
+});

--- a/tests/nps-invite.test.ts
+++ b/tests/nps-invite.test.ts
@@ -72,6 +72,26 @@ test('verifyNpsInviteToken rejects a payload missing required fields', async () 
     assert.equal(result.reason, 'malformed');
 });
 
+test('verifyNpsInviteToken rejects a non-finite exp instead of treating it as never-expiring', async () => {
+    // `1e999` is valid JSON (a numeric literal that overflows on parse), and
+    // JSON.parse('{"exp":1e999}') yields `Infinity` — typeof 'number', but not
+    // finite. `Date.now() > Infinity` is always false, so a naive
+    // `typeof exp === 'number'` shape check would treat this token as never
+    // expiring. (A literal `NaN` can't survive this path: JSON has no NaN
+    // literal, and JSON.stringify(NaN) itself collapses to `null`, which the
+    // shape check already rejected before this fix — `1e999`/`Infinity` is
+    // the actual reachable case.)
+    const rawJson = '{"email":"ana@example.com","firstname":"Ana","exp":1e999,"jti":"fake-jti"}';
+    const encoder = new TextEncoder();
+    const payloadB64 = btoa(String.fromCharCode(...encoder.encode(rawJson)))
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const result = await verifyNpsInviteToken(`${payloadB64}.somesignature`, SECRET);
+
+    assert.equal(result.valid, false);
+    if (result.valid) return;
+    assert.equal(result.reason, 'malformed');
+});
+
 test('each created token has a distinct jti', async () => {
     const tokenA = await createNpsInviteToken({ email: 'ana@example.com', firstname: 'Ana' }, SECRET);
     const tokenB = await createNpsInviteToken({ email: 'ana@example.com', firstname: 'Ana' }, SECRET);

--- a/tests/nps-page-identity-fields.test.ts
+++ b/tests/nps-page-identity-fields.test.ts
@@ -15,16 +15,26 @@ function renderNpsPage(path: string): string {
   );
 }
 
-test('NpsPage renders email field when URL email is present but invalid', () => {
-  const html = renderNpsPage('/nps?firstname=Ana&email=cliente@');
+// Identity (firstname/email) is bound server-side to the signed invitation
+// token (issue #1137) — the page never collects them as free text.
 
-  assert.match(html, /id="nps-email"/);
-  assert.match(html, /value="cliente@"/);
+test('NpsPage shows an invalid-link state and no form when the token is missing', () => {
+  const html = renderNpsPage('/nps?firstname=Ana');
+
+  assert.match(html, /Link inválido/);
+  assert.doesNotMatch(html, /id="nps-reason"/);
 });
 
-test('NpsPage keeps identity fields hidden when URL name and email are valid', () => {
-  const html = renderNpsPage('/nps?firstname=Ana&email=ana%40example.com');
+test('NpsPage renders the score form when a token is present, with no identity inputs', () => {
+  const html = renderNpsPage('/nps?firstname=Ana&token=some-signed-token');
 
   assert.doesNotMatch(html, /id="nps-firstname"/);
   assert.doesNotMatch(html, /id="nps-email"/);
+  assert.match(html, /id="nps-reason"/);
+});
+
+test('NpsPage greets by the display-only firstname param without trusting it as identity', () => {
+  const html = renderNpsPage('/nps?firstname=Ana&token=some-signed-token');
+
+  assert.match(html, /Olá, Ana!/);
 });

--- a/tests/submit-nps-schema.test.ts
+++ b/tests/submit-nps-schema.test.ts
@@ -2,9 +2,12 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { SubmitNpsBodySchema } from '../lib/schemas/submit-nps.ts';
 
+// Identity (firstname/email) is no longer part of the wire-format body —
+// it's derived server-side from the verified invitation token (issue #1137).
+// See tests/submit-nps.test.ts for token verification and tests/nps-invite.test.ts
+// for the signing/verification module itself.
 const VALID = {
-    firstname: 'João',
-    email: 'joao@example.com',
+    token: 'opaque-signed-token-value',
     score: 9,
     reason: 'Ótimo atendimento',
     highlight: 'A viagem ao Japão',
@@ -54,23 +57,19 @@ test('rejeita score como string', () => {
     assert.equal(result.success, false);
 });
 
-test('rejeita email inválido', () => {
-    const result = SubmitNpsBodySchema.safeParse({ ...VALID, email: 'nao-e-email' });
+test('rejeita token ausente', () => {
+    const { token: _t, ...without } = VALID;
+    const result = SubmitNpsBodySchema.safeParse(without);
     assert.equal(result.success, false);
 });
 
-test('rejeita email acima de 254 chars', () => {
-    const result = SubmitNpsBodySchema.safeParse({ ...VALID, email: 'a'.repeat(245) + '@example.com' });
+test('rejeita token vazio', () => {
+    const result = SubmitNpsBodySchema.safeParse({ ...VALID, token: '' });
     assert.equal(result.success, false);
 });
 
-test('rejeita firstname vazio', () => {
-    const result = SubmitNpsBodySchema.safeParse({ ...VALID, firstname: '' });
-    assert.equal(result.success, false);
-});
-
-test('rejeita firstname acima de 100 chars', () => {
-    const result = SubmitNpsBodySchema.safeParse({ ...VALID, firstname: 'a'.repeat(101) });
+test('rejeita token acima de 4096 chars', () => {
+    const result = SubmitNpsBodySchema.safeParse({ ...VALID, token: 'a'.repeat(4097) });
     assert.equal(result.success, false);
 });
 
@@ -102,11 +101,6 @@ test('rejeita payload não-objeto', () => {
     assert.equal(result.success, false);
 });
 
-test('rejeita whitespace-only firstname', () => {
-    const result = SubmitNpsBodySchema.safeParse({ ...VALID, firstname: '   ' });
-    assert.equal(result.success, false);
-});
-
 test('aceita whitespace-only reason e normaliza para string vazia', () => {
     const result = SubmitNpsBodySchema.safeParse({ ...VALID, reason: '   ' });
     assert.equal(result.success, true);
@@ -128,24 +122,13 @@ test('escapa angle brackets em reason (sanitização de fronteira)', () => {
     }
 });
 
-test('rejeita firstname que excede 100 chars APÓS o escape', () => {
-    // 40 caracteres "<" → 160 chars após cleanString (cada "<" vira "&lt;").
-    const result = SubmitNpsBodySchema.safeParse({ ...VALID, firstname: '<'.repeat(40) });
-    assert.equal(result.success, false);
-    if (!result.success) {
-        assert.equal(result.error.issues[0]?.path[0], 'firstname');
-    }
-});
-
-test('escapa angle brackets em highlight e firstname', () => {
+test('escapa angle brackets em highlight', () => {
     const result = SubmitNpsBodySchema.safeParse({
         ...VALID,
-        firstname: 'João <b>',
         highlight: 'Japão <img src=x onerror=alert(1)>',
     });
     assert.equal(result.success, true);
     if (result.success) {
-        assert.equal(result.data.firstname, 'João &lt;b&gt;');
         assert.equal(result.data.highlight.includes('<'), false);
         assert.equal(result.data.highlight.includes('>'), false);
     }

--- a/tests/submit-nps.test.ts
+++ b/tests/submit-nps.test.ts
@@ -2,12 +2,23 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import handler, { classifySubmitNpsError } from '../api/submit-nps.ts';
 import { createOdooMock, setOdooEnv, clearOdooEnv } from './odoo-mock.ts';
+import { createNpsInviteToken } from '../lib/nps-invite.ts';
 
 const originalFetch = global.fetch;
+const NPS_INVITE_SECRET = 'test-nps-invite-secret';
+
+function setNpsInviteEnv() {
+    process.env.NPS_INVITE_SECRET = NPS_INVITE_SECRET;
+}
+
+function clearNpsInviteEnv() {
+    delete process.env.NPS_INVITE_SECRET;
+}
 
 function restore() {
     global.fetch = originalFetch;
     clearOdooEnv();
+    clearNpsInviteEnv();
 }
 
 function buildRequest(
@@ -28,10 +39,20 @@ function buildRequest(
     });
 }
 
-function validBody(overrides?: Record<string, unknown>) {
+async function buildToken(overrides?: { email?: string; firstname?: string; expiresInMs?: number }): Promise<string> {
+    return createNpsInviteToken(
+        {
+            email: overrides?.email ?? 'maria@example.com',
+            firstname: overrides?.firstname ?? 'Maria',
+            expiresInMs: overrides?.expiresInMs,
+        },
+        NPS_INVITE_SECRET,
+    );
+}
+
+async function validBody(overrides?: Record<string, unknown>) {
     return {
-        firstname: 'Maria',
-        email: 'maria@example.com',
+        token: await buildToken(),
         score: 9,
         reason: 'Atendimento excelente e viagem perfeita.',
         highlight: 'A visita às Cataratas do Iguaçu.',
@@ -44,11 +65,12 @@ function validBody(overrides?: Record<string, unknown>) {
 test('submit-nps returns 500 SERVER_CONFIG_ERROR when Odoo config is missing', async (t) => {
     t.after(restore);
     clearOdooEnv();
+    setNpsInviteEnv();
 
     let fetchCalled = false;
     global.fetch = (async () => { fetchCalled = true; throw new Error('should not run'); }) as typeof fetch;
 
-    const response = await handler(buildRequest(validBody()));
+    const response = await handler(buildRequest(await validBody()));
     const body = await response.json() as Record<string, unknown>;
 
     assert.equal(fetchCalled, false);
@@ -85,6 +107,7 @@ test('submit-nps returns 204 for OPTIONS preflight', async (t) => {
 test('submit-nps returns 400 VALIDATION_ERROR for malformed JSON body', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
     const response = await handler(buildRequest('{ not valid json', { headers: { 'x-real-ip': '127.0.0.1' } }));
@@ -95,51 +118,30 @@ test('submit-nps returns 400 VALIDATION_ERROR for malformed JSON body', async (t
     assert.equal(body.code, 'VALIDATION_ERROR');
 });
 
-// ─── Validation errors ───────────────────────────────────────────────────────
+// ─── Score/reason/highlight validation ──────────────────────────────────────
 
-test('submit-nps returns 400 for missing firstname', async (t) => {
+test('submit-nps returns 400 for missing token', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
-    const response = await handler(buildRequest(validBody({ firstname: '' })));
-    const body = await response.json() as Record<string, unknown>;
+    const body = await validBody();
+    const { token: _t, ...withoutToken } = body;
+    const response = await handler(buildRequest(withoutToken));
+    const json = await response.json() as Record<string, unknown>;
 
     assert.equal(response.status, 400);
-    assert.equal(body.ok, false);
-    assert.equal(body.code, 'VALIDATION_ERROR');
-});
-
-test('submit-nps returns 400 for firstname over 100 characters', async (t) => {
-    t.after(restore);
-    setOdooEnv();
-    global.fetch = createOdooMock().fetch;
-
-    const response = await handler(buildRequest(validBody({ firstname: 'A'.repeat(101) })));
-    const body = await response.json() as Record<string, unknown>;
-
-    assert.equal(response.status, 400);
-    assert.equal(body.code, 'VALIDATION_ERROR');
-});
-
-test('submit-nps returns 400 for invalid email', async (t) => {
-    t.after(restore);
-    setOdooEnv();
-    global.fetch = createOdooMock().fetch;
-
-    const response = await handler(buildRequest(validBody({ email: 'not-an-email' })));
-    const body = await response.json() as Record<string, unknown>;
-
-    assert.equal(response.status, 400);
-    assert.equal(body.code, 'VALIDATION_ERROR');
+    assert.equal(json.code, 'VALIDATION_ERROR');
 });
 
 test('submit-nps returns 400 for score below 0', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
-    const response = await handler(buildRequest(validBody({ score: -1 })));
+    const response = await handler(buildRequest(await validBody({ score: -1 })));
     const body = await response.json() as Record<string, unknown>;
 
     assert.equal(response.status, 400);
@@ -149,9 +151,10 @@ test('submit-nps returns 400 for score below 0', async (t) => {
 test('submit-nps returns 400 for score above 10', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
-    const response = await handler(buildRequest(validBody({ score: 11 })));
+    const response = await handler(buildRequest(await validBody({ score: 11 })));
     const body = await response.json() as Record<string, unknown>;
 
     assert.equal(response.status, 400);
@@ -161,9 +164,10 @@ test('submit-nps returns 400 for score above 10', async (t) => {
 test('submit-nps returns 400 for non-integer score', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
-    const response = await handler(buildRequest(validBody({ score: 7.5 })));
+    const response = await handler(buildRequest(await validBody({ score: 7.5 })));
     const body = await response.json() as Record<string, unknown>;
 
     assert.equal(response.status, 400);
@@ -173,9 +177,10 @@ test('submit-nps returns 400 for non-integer score', async (t) => {
 test('submit-nps returns 400 for non-numeric score', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
-    const response = await handler(buildRequest(validBody({ score: '9' })));
+    const response = await handler(buildRequest(await validBody({ score: '9' })));
     const body = await response.json() as Record<string, unknown>;
 
     assert.equal(response.status, 400);
@@ -185,19 +190,21 @@ test('submit-nps returns 400 for non-numeric score', async (t) => {
 test('submit-nps accepts empty reason', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
-    const response = await handler(buildRequest(validBody({ reason: '' })));
+    const response = await handler(buildRequest(await validBody({ reason: '' })));
     assert.equal(response.status, 201);
 });
 
 test('submit-nps writes a clean comment when reason is empty', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     const mock = createOdooMock();
     global.fetch = mock.fetch;
 
-    const response = await handler(buildRequest(validBody({ reason: '', highlight: '' })));
+    const response = await handler(buildRequest(await validBody({ reason: '', highlight: '' })));
     assert.equal(response.status, 201);
 
     const partner = mock.partnerFields()!;
@@ -208,9 +215,10 @@ test('submit-nps writes a clean comment when reason is empty', async (t) => {
 test('submit-nps returns 400 for reason over 2000 characters', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
-    const response = await handler(buildRequest(validBody({ reason: 'x'.repeat(2001) })));
+    const response = await handler(buildRequest(await validBody({ reason: 'x'.repeat(2001) })));
     const body = await response.json() as Record<string, unknown>;
 
     assert.equal(response.status, 400);
@@ -220,9 +228,118 @@ test('submit-nps returns 400 for reason over 2000 characters', async (t) => {
 test('submit-nps returns 400 for highlight over 2000 characters', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
-    const response = await handler(buildRequest(validBody({ highlight: 'x'.repeat(2001) })));
+    const response = await handler(buildRequest(await validBody({ highlight: 'x'.repeat(2001) })));
+    const body = await response.json() as Record<string, unknown>;
+
+    assert.equal(response.status, 400);
+    assert.equal(body.code, 'VALIDATION_ERROR');
+});
+
+// ─── Signed invitation (issue #1137) ─────────────────────────────────────────
+
+test('submit-nps returns 500 when NPS_INVITE_SECRET is not configured', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    clearNpsInviteEnv();
+    global.fetch = createOdooMock().fetch;
+
+    // Token is built with some secret, but the server has none configured.
+    const token = await createNpsInviteToken({ email: 'maria@example.com', firstname: 'Maria' }, 'any-secret');
+    const response = await handler(buildRequest({ token, score: 9, reason: '', highlight: '' }));
+    const body = await response.json() as Record<string, unknown>;
+
+    assert.equal(response.status, 500);
+    assert.equal(body.code, 'SERVER_CONFIG_ERROR');
+});
+
+test('submit-nps rejects a token signed with the wrong secret (tampered/forged)', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    setNpsInviteEnv();
+    global.fetch = createOdooMock().fetch;
+
+    const token = await createNpsInviteToken({ email: 'maria@example.com', firstname: 'Maria' }, 'wrong-secret');
+    const response = await handler(buildRequest({ token, score: 9, reason: '', highlight: '' }));
+    const body = await response.json() as Record<string, unknown>;
+
+    assert.equal(response.status, 400);
+    assert.equal(body.code, 'VALIDATION_ERROR');
+});
+
+test('submit-nps rejects a malformed token', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    setNpsInviteEnv();
+    global.fetch = createOdooMock().fetch;
+
+    const response = await handler(buildRequest({ token: 'not-a-real-token', score: 9, reason: '', highlight: '' }));
+    const body = await response.json() as Record<string, unknown>;
+
+    assert.equal(response.status, 400);
+    assert.equal(body.code, 'VALIDATION_ERROR');
+});
+
+test('submit-nps rejects an expired token', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    setNpsInviteEnv();
+    global.fetch = createOdooMock().fetch;
+
+    const token = await buildToken({ expiresInMs: -1000 });
+    const response = await handler(buildRequest({ token, score: 9, reason: '', highlight: '' }));
+    const body = await response.json() as Record<string, unknown>;
+
+    assert.equal(response.status, 400);
+    assert.equal(body.code, 'VALIDATION_ERROR');
+});
+
+test('submit-nps rejects a replayed token (already used)', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    setNpsInviteEnv();
+    global.fetch = createOdooMock().fetch;
+
+    const body = await validBody();
+    const first = await handler(buildRequest(body));
+    assert.equal(first.status, 201, 'first submission with a fresh token should succeed');
+
+    const second = await handler(buildRequest(body));
+    const secondBody = await second.json() as Record<string, unknown>;
+    assert.equal(second.status, 400, 'the same token must not be usable twice');
+    assert.equal(secondBody.code, 'VALIDATION_ERROR');
+});
+
+test('submit-nps derives firstname/email from the token, not from the request body', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    setNpsInviteEnv();
+    const mock = createOdooMock();
+    global.fetch = mock.fetch;
+
+    const token = await buildToken({ email: 'real-customer@example.com', firstname: 'Cliente Real' });
+    // Even if a client tried to smuggle a different identity in the body, the
+    // schema no longer accepts firstname/email fields at all — there is
+    // nothing to smuggle them through.
+    const response = await handler(buildRequest({ token, score: 9, reason: '', highlight: '', email: 'attacker@evil.com' }));
+    assert.equal(response.status, 201);
+
+    const partner = mock.partnerFields()!;
+    assert.equal(partner.email, 'real-customer@example.com');
+    assert.equal(partner.name, 'Cliente Real');
+});
+
+test('submit-nps rejects a token whose firstname exceeds 100 chars after escaping', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    setNpsInviteEnv();
+    global.fetch = createOdooMock().fetch;
+
+    // 40 "<" chars → 160 chars after cleanString escapes each to "&lt;".
+    const token = await buildToken({ firstname: '<'.repeat(40) });
+    const response = await handler(buildRequest({ token, score: 9, reason: '', highlight: '' }));
     const body = await response.json() as Record<string, unknown>;
 
     assert.equal(response.status, 400);
@@ -234,9 +351,10 @@ test('submit-nps returns 400 for highlight over 2000 characters', async (t) => {
 test('submit-nps creates a res.partner with x_nps_score and NO crm.lead when no match exists', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock({ newPartnerId: 909 }).fetch;
 
-    const response = await handler(buildRequest(validBody()));
+    const response = await handler(buildRequest(await validBody()));
     const body = await response.json() as Record<string, unknown>;
 
     assert.equal(response.status, 201);
@@ -248,27 +366,30 @@ test('submit-nps creates a res.partner with x_nps_score and NO crm.lead when no 
 test('submit-nps accepts score 0 (boundary)', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
-    const response = await handler(buildRequest(validBody({ score: 0 })));
+    const response = await handler(buildRequest(await validBody({ score: 0 })));
     assert.equal(response.status, 201);
 });
 
 test('submit-nps accepts score 10 (boundary)', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
-    const response = await handler(buildRequest(validBody({ score: 10 })));
+    const response = await handler(buildRequest(await validBody({ score: 10 })));
     assert.equal(response.status, 201);
 });
 
 test('submit-nps accepts empty highlight (optional field)', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
-    const response = await handler(buildRequest(validBody({ highlight: '' })));
+    const response = await handler(buildRequest(await validBody({ highlight: '' })));
     assert.equal(response.status, 201);
 });
 
@@ -277,10 +398,11 @@ test('submit-nps accepts empty highlight (optional field)', async (t) => {
 test('submit-nps writes x_nps_score and a comment with reason/highlight on the partner', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     const mock = createOdooMock();
     global.fetch = mock.fetch;
 
-    const response = await handler(buildRequest(validBody()));
+    const response = await handler(buildRequest(await validBody()));
     assert.equal(response.status, 201);
 
     assert.equal(mock.createdLead(), false, 'NPS is post-sale — no opportunity is created');
@@ -294,14 +416,17 @@ test('submit-nps writes x_nps_score and a comment with reason/highlight on the p
 test('submit-nps escapes angle brackets from free text before writing the partner comment', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     const mock = createOdooMock();
     global.fetch = mock.fetch;
 
-    const response = await handler(buildRequest(validBody({
-        firstname: 'Ana <b>',
+    const token = await buildToken({ firstname: 'Ana <b>' });
+    const response = await handler(buildRequest({
+        token,
+        score: 9,
         reason: '<script>alert(1)</script>',
         highlight: '<img src=x onerror=alert(2)>',
-    })));
+    }));
     assert.equal(response.status, 201);
 
     const partner = mock.partnerFields()!;
@@ -316,10 +441,12 @@ test('submit-nps escapes angle brackets from free text before writing the partne
 test('submit-nps does NOT overwrite the full name of an existing partner (firstname-only form)', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     const mock = createOdooMock({ existingPartnerId: 506 });
     global.fetch = mock.fetch;
 
-    const response = await handler(buildRequest(validBody({ firstname: 'Ana' })));
+    const token = await buildToken({ firstname: 'Ana' });
+    const response = await handler(buildRequest({ token, score: 9, reason: '', highlight: '' }));
     assert.equal(response.status, 201);
 
     const writeCall = mock.calls.find((c) => c.model === 'res.partner' && c.method === 'write');
@@ -332,10 +459,12 @@ test('submit-nps does NOT overwrite the full name of an existing partner (firstn
 test('submit-nps sets name on create when no existing partner matches', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     const mock = createOdooMock({ existingPartnerId: null });
     global.fetch = mock.fetch;
 
-    const response = await handler(buildRequest(validBody({ firstname: 'Ana' })));
+    const token = await buildToken({ firstname: 'Ana' });
+    const response = await handler(buildRequest({ token, score: 9, reason: '', highlight: '' }));
     assert.equal(response.status, 201);
 
     const createCall = mock.calls.find((c) => c.model === 'res.partner' && c.method === 'create');
@@ -349,9 +478,10 @@ test('submit-nps sets name on create when no existing partner matches', async (t
 test('submit-nps returns 502 ODOO_ERROR when upstream returns non-2xx', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock({ failStatus: 503 }).fetch;
 
-    const response = await handler(buildRequest(validBody()));
+    const response = await handler(buildRequest(await validBody()));
     const body = await response.json() as Record<string, unknown>;
 
     assert.equal(response.status, 502);
@@ -371,25 +501,26 @@ test('classifySubmitNpsError preserves unexpected internal failures', () => {
 test('submit-nps enforces rate limit after 3 requests from the same IP', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
     const uniqueIp = `10.${Math.floor(Math.random() * 254) + 1}.${Math.floor(Math.random() * 254) + 1}.1`;
 
-    function buildRateLimitRequest() {
+    async function buildRateLimitRequest() {
         return new Request('http://localhost/api/submit-nps', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
                 'x-real-ip': uniqueIp,
             },
-            body: JSON.stringify(validBody()),
+            body: JSON.stringify(await validBody()),
         });
     }
 
-    const r1 = await handler(buildRateLimitRequest());
-    const r2 = await handler(buildRateLimitRequest());
-    const r3 = await handler(buildRateLimitRequest());
-    const r4 = await handler(buildRateLimitRequest());
+    const r1 = await handler(await buildRateLimitRequest());
+    const r2 = await handler(await buildRateLimitRequest());
+    const r3 = await handler(await buildRateLimitRequest());
+    const r4 = await handler(await buildRateLimitRequest());
 
     assert.equal(r1.status, 201, 'first request should succeed');
     assert.equal(r2.status, 201, 'second request should succeed');
@@ -406,28 +537,29 @@ test('submit-nps enforces rate limit after 3 requests from the same IP', async (
 test('submit-nps enforces rate-limit even for invalid payloads (DoS protection)', async (t) => {
     t.after(restore);
     setOdooEnv();
+    setNpsInviteEnv();
     global.fetch = createOdooMock().fetch;
 
     const uniqueIp = `10.${Math.floor(Math.random() * 254) + 1}.${Math.floor(Math.random() * 254) + 1}.4`;
 
-    function buildFixedRequest(body: unknown, valid: boolean) {
+    async function buildFixedRequest(body: unknown, valid: boolean) {
         return new Request('http://localhost/api/submit-nps', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
                 'x-real-ip': uniqueIp,
             },
-            body: JSON.stringify(valid ? validBody() : body),
+            body: JSON.stringify(valid ? await validBody() : body),
         });
     }
 
     // 3 invalid requests should consume the bucket (limit is 3)
     for (let i = 0; i < 3; i++) {
-        const r = await handler(buildFixedRequest({ score: 'not-a-number' }, false));
+        const r = await handler(await buildFixedRequest({ score: 'not-a-number' }, false));
         assert.equal(r.status, 400);
     }
 
     // 4th request should be rate limited, even if it would be valid
-    const limitResponse = await handler(buildFixedRequest(null, true));
+    const limitResponse = await handler(await buildFixedRequest(null, true));
     assert.equal(limitResponse.status, 429, 'should be rate limited after 3 invalid attempts');
 });

--- a/tests/submit-nps.test.ts
+++ b/tests/submit-nps.test.ts
@@ -489,6 +489,30 @@ test('submit-nps returns 502 ODOO_ERROR when upstream returns non-2xx', async (t
     assert.equal(body.code, 'ODOO_ERROR');
 });
 
+test('submit-nps releases the invitation on an Odoo failure — the same link can be retried', async (t) => {
+    t.after(restore);
+    setOdooEnv();
+    setNpsInviteEnv();
+    const token = await buildToken();
+    const ip = '10.55.55.1';
+    const body = { token, score: 9, reason: 'Ótima viagem.', highlight: 'Cataratas.' };
+
+    // First attempt: Odoo is down. The invite must not be permanently burned.
+    global.fetch = createOdooMock({ failStatus: 503 }).fetch;
+    const firstResponse = await handler(buildRequest(body, { headers: { 'x-real-ip': ip } }));
+    assert.equal(firstResponse.status, 502);
+
+    // Second attempt, same token: Odoo is back up. If the invite had been
+    // permanently consumed on the first (failed) attempt, this would be
+    // rejected as a replay instead of succeeding.
+    global.fetch = createOdooMock({}).fetch;
+    const secondResponse = await handler(buildRequest(body, { headers: { 'x-real-ip': ip } }));
+    const secondBody = await secondResponse.json() as Record<string, unknown>;
+
+    assert.equal(secondResponse.status, 201, `expected the retry to succeed, got: ${JSON.stringify(secondBody)}`);
+    assert.equal(secondBody.ok, true);
+});
+
 test('classifySubmitNpsError preserves unexpected internal failures', () => {
     const classified = classifySubmitNpsError(new Error('unexpected database failure'));
     assert.equal(classified.code, 'INTERNAL_ERROR');


### PR DESCRIPTION
## Summary
- `/nps` accepted a caller-supplied `?firstname=&email=` as identity with no proof the requester was actually the invited customer — anyone who knew or guessed a customer's e-mail could post an NPS score/comment that mutates their `res.partner` record (via `upsertPartner`).
- The invite link now carries a signed token instead of raw identity: `lib/nps-invite.ts` (HMAC-SHA256, 30-day default expiry, opaque `base64url(payload).base64url(signature)` format) + `lib/nps-invite-replay.ts` (Upstash Redis `SET NX` single-use guard, in-memory fallback for local dev, same pattern as the rate limiter).
- `api/submit-nps.ts` verifies signature → expiry → single-use replay, in that order, before any Odoo side effect, and reads `email`/`firstname` from the **verified token payload** — the request body (`lib/schemas/submit-nps.ts`) no longer accepts those fields at all, so there's nothing to smuggle a different identity through.
- `pages/NpsPage.tsx` drops the free-text identity fallback entirely: no `token` → an "invalid link" state, never an open form. `firstname` in the URL is now display-only (the greeting), decoupled from security.
- `lib/n8n-submit-handler.ts` gained `MaybeAsyncValidationResult` (validators may now be async — needed for token verification) and `lib/odoo-submit-handler.ts` gained an optional `checkExtraConfig` hook so the missing-secret case reuses the existing `SERVER_CONFIG_ERROR` response shape instead of a parallel path. Both are backward compatible — every other form's synchronous validator is unaffected.
- `scripts/generate-nps-invite.ts` + `docs/ops/nps-invite.md` document how a link is generated and distributed today.

## Test plan
- [x] `tests/nps-invite.test.ts`: sign/verify round-trip, wrong-secret rejection, altered-payload rejection, expiry, malformed-token shapes, distinct `jti` per token.
- [x] `tests/nps-invite-replay.test.ts`: first-use allowed, replay rejected, independent tokens unaffected.
- [x] `tests/submit-nps.test.ts` (rewritten): missing/malformed/tampered/expired/replayed token all rejected with `VALIDATION_ERROR`; missing `NPS_INVITE_SECRET` → `SERVER_CONFIG_ERROR`; identity is derived from the token even when the body tries to smuggle a different `email`; existing escaping/partner-upsert/rate-limit coverage preserved.
- [x] `tests/submit-nps-schema.test.ts` (rewritten for the new `token`-based wire schema) + `tests/nps-page-identity-fields.test.ts` (rewritten: invalid-link state, no identity inputs, display-only greeting).
- [x] `tests/e2e/nps-form.spec.ts` (rewritten, run locally across all 5 Playwright projects — 10/10 passing): invalid-link state with no token, full submit with a token and no identity fields in the request body.
- [x] `pnpm test:regression` (870/870 passing)
- [x] `pnpm typecheck`
- [x] `pnpm build` + `pnpm test:size`

Closes #1137

🤖 Generated with [Claude Code](https://claude.com/claude-code)