### PR TITLE
test: cover the blog social-announcement orchestration end to end

### DIFF
--- a/scripts/notify-blog-published.ts
+++ b/scripts/notify-blog-published.ts
@@ -10,13 +10,11 @@
  */
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import matter from 'gray-matter';
 import { buildBlogAnnouncementPayload, isFrontmatterLike } from '../lib/social-announcement.ts';
 
-const webhookUrl = process.env.N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL?.trim();
-const webhookSecret = process.env.N8N_WEBHOOK_SECRET?.trim();
-
-async function dispatchAnnouncement(filepath: string, url: string, secret: string): Promise<boolean> {
+export async function dispatchAnnouncement(filepath: string, url: string, secret: string): Promise<boolean> {
   const slug = path.basename(filepath, '.mdx');
 
   try {
@@ -52,20 +50,25 @@ async function dispatchAnnouncement(filepath: string, url: string, secret: strin
   }
 }
 
-function readFileList(): string[] {
+export function readFileList(): string[] {
   const fromEnv = process.env.ADDED_BLOG_FILES ?? '';
   const fromArgv = process.argv.slice(2);
   const combined = fromArgv.length > 0 ? fromArgv : fromEnv.split('\n');
   return combined.map((line) => line.trim()).filter(Boolean);
 }
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const files = readFileList();
 
   if (files.length === 0) {
     console.log('Nenhum post novo para anunciar.');
     return;
   }
+
+  // Read at call time (not module load) so tests can exercise both the
+  // "configured" and "not configured" paths without re-importing the module.
+  const webhookUrl = process.env.N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL?.trim();
+  const webhookSecret = process.env.N8N_WEBHOOK_SECRET?.trim();
 
   if (!webhookUrl || !webhookSecret) {
     console.log('N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL ou N8N_WEBHOOK_SECRET não configurados — pulando automação social.');
@@ -79,4 +82,9 @@ async function main(): Promise<void> {
   }
 }
 
-await main();
+// Only auto-run when executed directly (`pnpm exec tsx scripts/notify-blog-published.ts`
+// in CI) — guarded so tests can import the functions above without triggering a live run.
+const isMainModule = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMainModule) {
+  await main();
+}

--- a/tests/notify-blog-published.test.ts
+++ b/tests/notify-blog-published.test.ts
@@ -73,12 +73,13 @@ function withEnv(vars: Record<string, string | undefined>, fn: () => Promise<voi
 }
 
 test('readFileList prefers argv over the ADDED_BLOG_FILES env var', () => {
-  process.argv = [...process.argv.slice(0, 2), 'content/blog/a.mdx', 'content/blog/b.mdx'];
+  const originalArgv = process.argv;
+  process.argv = [...originalArgv.slice(0, 2), 'content/blog/a.mdx', 'content/blog/b.mdx'];
   process.env.ADDED_BLOG_FILES = 'content/blog/ignored.mdx';
   try {
     assert.deepEqual(readFileList(), ['content/blog/a.mdx', 'content/blog/b.mdx']);
   } finally {
-    process.argv = process.argv.slice(0, 2);
+    process.argv = originalArgv;
     delete process.env.ADDED_BLOG_FILES;
   }
 });

--- a/tests/notify-blog-published.test.ts
+++ b/tests/notify-blog-published.test.ts
@@ -1,0 +1,238 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { dispatchAnnouncement, main, readFileList } from '../scripts/notify-blog-published.ts';
+
+// Regression coverage for issue #1143: `scripts/notify-blog-published.ts`
+// orchestrates the "novo post no blog" social announcement without ever being
+// unit tested — only the pure payload shaping in `lib/social-announcement.ts`
+// had coverage. These tests stub `fetch` (no network call ever reaches n8n or
+// Postiz) and use real temp files on disk (gray-matter needs a real file to
+// parse), covering: single/multiple dispatch, malformed frontmatter failing
+// predictably, missing configuration skipping safely, and mixed
+// success/failure results producing the documented non-zero exit code
+// without swallowing the successful announcements.
+
+const VALID_FRONTMATTER = `---
+title: "Post de Teste"
+excerpt: "Um resumo qualquer."
+date: "2026-01-01"
+author: "queila-oliveira"
+category: "Dicas de Expert"
+image: "https://media.anhanga.tur.br/images/blog/teste.jpg"
+tags: ["teste"]
+---
+
+Conteúdo do post.
+`;
+
+// Unterminated flow sequence — gray-matter's YAML parser throws on this rather
+// than silently returning a partial object, which is exactly the "malformed
+// frontmatter fails predictably" case this suite must prove doesn't crash the
+// whole batch.
+const MALFORMED_FRONTMATTER = `---
+title: "Post quebrado
+tags: [teste, outro
+---
+
+Conteúdo.
+`;
+
+async function withTempMdx(content: string, fn: (filepath: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'notify-blog-published-'));
+  const filepath = path.join(dir, 'post-de-teste.mdx');
+  try {
+    await writeFile(filepath, content, 'utf8');
+    await fn(filepath);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function stubFetch(impl: typeof fetch): () => void {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl;
+  return () => { globalThis.fetch = original; };
+}
+
+function withEnv(vars: Record<string, string | undefined>, fn: () => Promise<void>): Promise<void> {
+  const originalValues = new Map<string, string | undefined>();
+  for (const key of Object.keys(vars)) originalValues.set(key, process.env[key]);
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  return fn().finally(() => {
+    for (const [key, value] of originalValues) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+}
+
+test('readFileList prefers argv over the ADDED_BLOG_FILES env var', () => {
+  process.argv = [...process.argv.slice(0, 2), 'content/blog/a.mdx', 'content/blog/b.mdx'];
+  process.env.ADDED_BLOG_FILES = 'content/blog/ignored.mdx';
+  try {
+    assert.deepEqual(readFileList(), ['content/blog/a.mdx', 'content/blog/b.mdx']);
+  } finally {
+    process.argv = process.argv.slice(0, 2);
+    delete process.env.ADDED_BLOG_FILES;
+  }
+});
+
+test('readFileList parses newline-separated files from env and drops blank lines', () => {
+  process.env.ADDED_BLOG_FILES = 'content/blog/a.mdx\n\ncontent/blog/b.mdx\n';
+  try {
+    assert.deepEqual(readFileList(), ['content/blog/a.mdx', 'content/blog/b.mdx']);
+  } finally {
+    delete process.env.ADDED_BLOG_FILES;
+  }
+});
+
+test('readFileList returns an empty array when nothing is provided', () => {
+  delete process.env.ADDED_BLOG_FILES;
+  assert.deepEqual(readFileList(), []);
+});
+
+test('dispatchAnnouncement posts the built payload and returns true on a 2xx response', async () => {
+  await withTempMdx(VALID_FRONTMATTER, async (filepath) => {
+    let capturedUrl: string | undefined;
+    let capturedInit: RequestInit | undefined;
+    const restore = stubFetch(async (url, init) => {
+      capturedUrl = String(url);
+      capturedInit = init;
+      return new Response(null, { status: 200 });
+    });
+
+    try {
+      const ok = await dispatchAnnouncement(filepath, 'https://n8n.example.com/webhook/x', 'shh-secret');
+      assert.equal(ok, true);
+      assert.equal(capturedUrl, 'https://n8n.example.com/webhook/x');
+      assert.equal(capturedInit?.method, 'POST');
+      assert.equal((capturedInit?.headers as Record<string, string>)['X-Webhook-Secret'], 'shh-secret');
+
+      const body = JSON.parse(capturedInit?.body as string);
+      assert.equal(body.event, 'blog_post_published');
+      assert.equal(body.slug, 'post-de-teste');
+      assert.equal(body.title, 'Post de Teste');
+    } finally {
+      restore();
+    }
+  });
+});
+
+test('dispatchAnnouncement returns false (without throwing) when frontmatter is malformed YAML', async () => {
+  await withTempMdx(MALFORMED_FRONTMATTER, async (filepath) => {
+    let fetchCalled = false;
+    const restore = stubFetch(async () => { fetchCalled = true; return new Response(null, { status: 200 }); });
+
+    try {
+      const ok = await dispatchAnnouncement(filepath, 'https://n8n.example.com/webhook/x', 'secret');
+      assert.equal(ok, false);
+      assert.equal(fetchCalled, false, 'a post whose frontmatter fails to parse must never reach the webhook');
+    } finally {
+      restore();
+    }
+  });
+});
+
+test('dispatchAnnouncement returns false when the webhook responds with a non-2xx status', async () => {
+  await withTempMdx(VALID_FRONTMATTER, async (filepath) => {
+    const restore = stubFetch(async () => new Response(null, { status: 500 }));
+    try {
+      const ok = await dispatchAnnouncement(filepath, 'https://n8n.example.com/webhook/x', 'secret');
+      assert.equal(ok, false);
+    } finally {
+      restore();
+    }
+  });
+});
+
+test('main() skips safely (no fetch call) when there are no newly added files', async () => {
+  let fetchCalled = false;
+  const restore = stubFetch(async () => { fetchCalled = true; return new Response(null, { status: 200 }); });
+  const originalExitCode = process.exitCode;
+  process.exitCode = undefined;
+
+  try {
+    await withEnv({ ADDED_BLOG_FILES: '', N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL: 'https://n8n.example.com/x', N8N_WEBHOOK_SECRET: 'secret' }, async () => {
+      await main();
+    });
+    assert.equal(fetchCalled, false);
+    assert.equal(process.exitCode, undefined);
+  } finally {
+    restore();
+    process.exitCode = originalExitCode;
+  }
+});
+
+test('main() skips safely (no fetch call) when the n8n webhook is not configured', async () => {
+  await withTempMdx(VALID_FRONTMATTER, async (filepath) => {
+    let fetchCalled = false;
+    const restore = stubFetch(async () => { fetchCalled = true; return new Response(null, { status: 200 }); });
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    try {
+      await withEnv(
+        { ADDED_BLOG_FILES: filepath, N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL: undefined, N8N_WEBHOOK_SECRET: undefined },
+        async () => { await main(); },
+      );
+      assert.equal(fetchCalled, false, 'missing config must skip dispatch entirely, not fail open');
+      assert.equal(process.exitCode, undefined, 'a skip is not a failure');
+    } finally {
+      restore();
+      process.exitCode = originalExitCode;
+    }
+  });
+});
+
+test('main() sets a non-zero exit code on mixed results without hiding the successful announcement', async () => {
+  await withTempMdx(VALID_FRONTMATTER, async (okFilepath) => {
+    const failDir = path.dirname(okFilepath);
+    const failFilepath = path.join(failDir, 'post-que-falha.mdx');
+    await writeFile(failFilepath, VALID_FRONTMATTER, 'utf8');
+
+    const requestedSlugs: string[] = [];
+    const restore = stubFetch(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      requestedSlugs.push(body.slug);
+      // Fail only post-que-falha (identified by payload slug, not arrival order —
+      // Promise.all doesn't guarantee dispatch order) to prove one bad response
+      // doesn't block or hide the other successful announcement.
+      const shouldFail = body.slug === 'post-que-falha';
+      return new Response(null, { status: shouldFail ? 500 : 200 });
+    });
+
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const originalLog = console.log;
+    const logs: string[] = [];
+    console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
+
+    try {
+      await withEnv(
+        {
+          ADDED_BLOG_FILES: `${okFilepath}\n${failFilepath}`,
+          N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL: 'https://n8n.example.com/x',
+          N8N_WEBHOOK_SECRET: 'secret',
+        },
+        async () => { await main(); },
+      );
+
+      assert.equal(process.exitCode, 1, 'a mixed batch must exit non-zero so CI surfaces the partial failure');
+      assert.equal(requestedSlugs.length, 2, 'both files must be dispatched even though one will fail');
+      assert.ok(
+        logs.some((line) => line.includes('✓') && line.includes('post-de-teste')),
+        'the successful announcement must still be logged, not swallowed by the later failure',
+      );
+    } finally {
+      console.log = originalLog;
+      restore();
+      process.exitCode = originalExitCode;
+    }
+  });
+});

--- a/tests/notify-social-automation-workflow.test.ts
+++ b/tests/notify-social-automation-workflow.test.ts
@@ -81,7 +81,7 @@ async function runStepInTempRepo(
     });
 
     const output = await readFile(githubOutputPath, 'utf8');
-    const match = output.match(/^files<<EOF\n([\s\S]*?)\nEOF$/m);
+    const match = output.match(/^files<<EOF\r?\n([\s\S]*?)\r?\nEOF$/m);
     return (match ? match[1] : '').split('\n').map((line) => line.trim()).filter(Boolean);
   } finally {
     await rm(repoDir, { recursive: true, force: true });
@@ -162,7 +162,8 @@ test('workflow gates install/notify steps on the added-posts output and passes s
 
   const notifyIdx = lines.findIndex((line) => line.includes('name: Notify n8n of new blog posts'));
   assert.ok(notifyIdx !== -1);
-  const notifyBlock = lines.slice(notifyIdx, notifyIdx + 15).join('\n');
+  const nextStepIdx = lines.findIndex((line, i) => i > notifyIdx && /^\s*-\s*(name|uses):/.test(line));
+  const notifyBlock = lines.slice(notifyIdx, nextStepIdx !== -1 ? nextStepIdx : undefined).join('\n');
 
   for (const envVar of ['ADDED_BLOG_FILES', 'N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL', 'N8N_WEBHOOK_SECRET']) {
     assert.match(notifyBlock, new RegExp(`^\\s*${envVar}:\\s*\\$\\{\\{`, 'm'), `${envVar} must be passed via the step's env: block`);

--- a/tests/notify-social-automation-workflow.test.ts
+++ b/tests/notify-social-automation-workflow.test.ts
@@ -1,0 +1,175 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+// Regression coverage for issue #1143: the "Find newly added blog posts" step
+// in `.github/workflows/notify-social-automation.yml` is inline bash with no
+// prior test coverage — it decides whether the rest of the job (install,
+// notify) runs at all. Rather than duplicate the script by hand (which could
+// silently drift from the real workflow), these tests extract the actual
+// `run:` block text from the YAML and execute it against a real temporary git
+// repo, covering: one/multiple added posts, edits-only pushes, non-.mdx
+// additions, and the initial-push (empty-tree parent) case. A second test is
+// a lightweight text contract on step gating and env passing.
+
+const WORKFLOW_PATH = path.resolve(process.cwd(), '.github/workflows/notify-social-automation.yml');
+const STEP_NAME = 'Find newly added blog posts';
+const EMPTY_TREE_PARENT = '0000000000000000000000000000000000000000';
+
+async function readWorkflow(): Promise<string> {
+  return readFile(WORKFLOW_PATH, 'utf8');
+}
+
+// Extracts the `run: |` block body belonging to the named step, dedenting it
+// to the shell's own indentation so it can be written out and executed as-is.
+function extractStepRunBlock(workflow: string, stepName: string): string {
+  const lines = workflow.split(/\r?\n/);
+  const nameIdx = lines.findIndex((line) => line.includes(`name: ${stepName}`));
+  assert.ok(nameIdx !== -1, `expected to find a step named "${stepName}"`);
+
+  const runIdx = lines.findIndex((line, i) => i > nameIdx && /^\s*run:\s*\|\s*$/.test(line));
+  assert.ok(runIdx !== -1, `expected a run: | block after step "${stepName}"`);
+  const runIndent = lines[runIdx].match(/^(\s*)/)![1].length;
+
+  const body: string[] = [];
+  for (const line of lines.slice(runIdx + 1)) {
+    if (line.trim() === '') { body.push(''); continue; }
+    const indent = line.match(/^(\s*)/)![1].length;
+    if (indent <= runIndent) break;
+    body.push(line.slice(runIndent + 2));
+  }
+  return body.join('\n');
+}
+
+async function writePost(repoDir: string, relativePath: string, content = '---\ntitle: x\n---\n'): Promise<void> {
+  const fullPath = path.join(repoDir, relativePath);
+  await mkdir(path.dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, content, 'utf8');
+}
+
+async function commit(repoDir: string, message: string): Promise<string> {
+  execFileSync('git', ['add', '-A'], { cwd: repoDir });
+  execFileSync('git', ['commit', '-q', '-m', message], { cwd: repoDir });
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoDir, encoding: 'utf8' }).trim();
+}
+
+// Runs the real "Find newly added blog posts" step body against a scratch git
+// repo built by `setupRepo` (which must return the before/after SHAs to diff),
+// and returns the list of files it reported via $GITHUB_OUTPUT.
+async function runStepInTempRepo(
+  setupRepo: (repoDir: string) => Promise<{ before: string; after: string }>,
+): Promise<string[]> {
+  const script = extractStepRunBlock(await readWorkflow(), STEP_NAME);
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'notify-social-automation-'));
+
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: repoDir });
+    execFileSync('git', ['config', 'user.email', 'ci@example.com'], { cwd: repoDir });
+    execFileSync('git', ['config', 'user.name', 'CI'], { cwd: repoDir });
+
+    const { before, after } = await setupRepo(repoDir);
+
+    const githubOutputPath = path.join(repoDir, 'github_output');
+    await writeFile(githubOutputPath, '', 'utf8');
+
+    execFileSync('bash', ['-c', script], {
+      cwd: repoDir,
+      env: { ...process.env, BEFORE_SHA: before, AFTER_SHA: after, GITHUB_OUTPUT: githubOutputPath },
+    });
+
+    const output = await readFile(githubOutputPath, 'utf8');
+    const match = output.match(/^files<<EOF\n([\s\S]*?)\nEOF$/m);
+    return (match ? match[1] : '').split('\n').map((line) => line.trim()).filter(Boolean);
+  } finally {
+    await rm(repoDir, { recursive: true, force: true });
+  }
+}
+
+test('initial push (empty-tree parent): detects the post added in the very first commit', async () => {
+  const files = await runStepInTempRepo(async (repoDir) => {
+    await writePost(repoDir, 'content/blog/first-post.mdx');
+    const after = await commit(repoDir, 'first post');
+    return { before: EMPTY_TREE_PARENT, after };
+  });
+
+  assert.deepEqual(files, ['content/blog/first-post.mdx']);
+});
+
+test('detects multiple newly added posts in the same push, ignores non-.mdx additions', async () => {
+  const files = await runStepInTempRepo(async (repoDir) => {
+    await writePost(repoDir, 'content/blog/base-post.mdx');
+    const before = await commit(repoDir, 'base');
+
+    await writePost(repoDir, 'content/blog/post-a.mdx');
+    await writePost(repoDir, 'content/blog/post-b.mdx');
+    await writePost(repoDir, 'content/blog/cover.png', 'not-actually-a-post');
+    const after = await commit(repoDir, 'two new posts + an image');
+
+    return { before, after };
+  });
+
+  assert.deepEqual(files.sort(), ['content/blog/post-a.mdx', 'content/blog/post-b.mdx']);
+});
+
+test('an edits-only push (no new files) reports no added posts', async () => {
+  const files = await runStepInTempRepo(async (repoDir) => {
+    await writePost(repoDir, 'content/blog/existing-post.mdx', '---\ntitle: v1\n---\n');
+    const before = await commit(repoDir, 'base');
+
+    await writePost(repoDir, 'content/blog/existing-post.mdx', '---\ntitle: v2 (fixed typo)\n---\n');
+    const after = await commit(repoDir, 'edit only');
+
+    return { before, after };
+  });
+
+  assert.deepEqual(files, []);
+});
+
+test('a mixed push (one new post + one edited post) only reports the new one', async () => {
+  const files = await runStepInTempRepo(async (repoDir) => {
+    await writePost(repoDir, 'content/blog/existing-post.mdx', '---\ntitle: v1\n---\n');
+    const before = await commit(repoDir, 'base');
+
+    await writePost(repoDir, 'content/blog/existing-post.mdx', '---\ntitle: v2\n---\n');
+    await writePost(repoDir, 'content/blog/new-post.mdx');
+    const after = await commit(repoDir, 'edit + new post');
+
+    return { before, after };
+  });
+
+  assert.deepEqual(files, ['content/blog/new-post.mdx']);
+});
+
+test('workflow gates install/notify steps on the added-posts output and passes secrets via env, not the shell line', async () => {
+  const workflow = await readWorkflow();
+  const lines = workflow.split(/\r?\n/);
+
+  const gatedSteps = ['Install pnpm', 'Use Node.js 24', 'Install dependencies', 'Notify n8n of new blog posts'];
+  for (const stepName of gatedSteps) {
+    const nameIdx = lines.findIndex((line) => line.includes(`name: ${stepName}`));
+    assert.ok(nameIdx !== -1, `expected a step named "${stepName}"`);
+    // The `if:` guard is expected on the line immediately following `name:`.
+    const ifLine = lines[nameIdx + 1] ?? '';
+    assert.match(
+      ifLine,
+      /if:\s*steps\.added-posts\.outputs\.files\s*!=\s*''/,
+      `step "${stepName}" must be gated on steps.added-posts.outputs.files != ''`,
+    );
+  }
+
+  const notifyIdx = lines.findIndex((line) => line.includes('name: Notify n8n of new blog posts'));
+  assert.ok(notifyIdx !== -1);
+  const notifyBlock = lines.slice(notifyIdx, notifyIdx + 15).join('\n');
+
+  for (const envVar of ['ADDED_BLOG_FILES', 'N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL', 'N8N_WEBHOOK_SECRET']) {
+    assert.match(notifyBlock, new RegExp(`^\\s*${envVar}:\\s*\\$\\{\\{`, 'm'), `${envVar} must be passed via the step's env: block`);
+  }
+  assert.doesNotMatch(
+    notifyBlock,
+    /run:\s*.*(N8N_WEBHOOK_SECRET|N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL)/,
+    'secrets must flow through env:, never be inlined into the run: line',
+  );
+});


### PR DESCRIPTION
## Summary
Neither `scripts/notify-blog-published.ts` (the n8n dispatch script that fires when a blog post lands on `main`) nor the "Find newly added blog posts" git-diff step in `notify-social-automation.yml` had any test coverage — only the pure payload shaping in `lib/social-announcement.ts` was tested.

**Testability refactor (no behavior change):**
- Exported `dispatchAnnouncement`/`readFileList`/`main`.
- Moved the webhook env var reads from module-load time into `main()`, so a test can exercise both the "configured" and "not configured" paths in the same process.
- Guarded the top-level `await main()` behind an `import.meta.url === entrypoint` check, so importing the module in a test doesn't trigger a live run.

**`tests/notify-blog-published.test.ts`** (fetch stubbed — nothing reaches n8n/Postiz):
- Single dispatch posts the expected payload/headers and returns `true`.
- Malformed frontmatter (YAML gray-matter throws) fails predictably — returns `false`, never throws, never reaches the webhook.
- A non-2xx webhook response returns `false`.
- Missing `N8N_SOCIAL_ANNOUNCE_WEBHOOK_URL`/`N8N_WEBHOOK_SECRET` skips safely (`main()` never calls fetch, exit code stays clean).
- No new files skips safely too.
- Mixed success/failure across two files sets `process.exitCode = 1` while still logging the successful one — the documented non-zero result never hides a real announcement.

**`tests/notify-social-automation-workflow.test.ts`**: extracts the actual git-diff `run:` block text from the workflow YAML (so the test can't silently drift from the real script) and runs it against real temporary git repos:
- Initial push (empty-tree parent) detects the first commit's post.
- Multiple new posts in one push are all detected; a non-`.mdx` addition (e.g. a cover image) is ignored.
- An edits-only push reports nothing.
- A mixed push (one edit + one new post) reports only the new one.
- Contract test: `Install pnpm`/`Use Node.js 24`/`Install dependencies`/`Notify n8n of new blog posts` stay gated on `steps.added-posts.outputs.files != ''`, and the webhook URL/secret/file-list flow through the step's `env:` block, never inlined into the `run:` line.

## Test plan
- [x] New tests: 9 + 5 passed.
- [x] `pnpm test:regression` — 870/870 passed.
- [x] `pnpm typecheck` passes.
- [x] No automated test contacts n8n or Postiz (every provider call goes through a stubbed `fetch`).

Closes #1143.