### PR TITLE
refactor: centralize the four capture hooks' attribution normalization

### DIFF
--- a/hooks/useContactForm.ts
+++ b/hooks/useContactForm.ts
@@ -7,7 +7,8 @@ import {
     type ContactFormFieldErrors,
 } from '../lib/form-v1-validation';
 import { getTrackingDataObject, getWhatsAppLink } from '../utils/whatsapp';
-import { createLeadEventId, extractUtms } from './useLeadCapture';
+import { createLeadEventId } from './useLeadCapture';
+import { extractUtms, normalizeLeadTracking } from '../lib/tracking-normalization';
 import type { ContactFormFields, SubmitContactRequest, SubmitContactResponse } from '../types/contactCapture';
 import type { LeadTracking } from '../types/leadCapture';
 import type { ContactModalOptions } from '../utils/contactForm';
@@ -21,59 +22,8 @@ const EMPTY_FIELDS: ContactFormFields = {
     emailOptIn: false,
 };
 
-const KNOWN_TRACKING_KEYS = new Set([
-    'utm_source',
-    'utm_medium',
-    'utm_campaign',
-    'utm_term',
-    'utm_content',
-    'cid',
-    'sid',
-    'gclid',
-    'fbclid',
-    'msclkid',
-    'ttclid',
-    'wbraid',
-    'gbraid',
-    'fbc',
-    'fbp',
-]);
-
-function toNullable(value: unknown): string | null {
-    if (typeof value !== 'string') return null;
-    const normalized = cleanString(value);
-    return normalized.length > 0 ? normalized : null;
-}
-
 function collectTracking(): { tracking: LeadTracking; utms: SubmitContactRequest['utms'] } {
-    const raw = getTrackingDataObject() ?? {};
-    const extras: Record<string, string> = {};
-
-    for (const [key, value] of Object.entries(raw)) {
-        if (KNOWN_TRACKING_KEYS.has(key)) continue;
-        const normalized = toNullable(value);
-        if (normalized) extras[key] = normalized;
-    }
-
-    const tracking: LeadTracking = {
-        utm_source: toNullable(raw.utm_source),
-        utm_medium: toNullable(raw.utm_medium),
-        utm_campaign: toNullable(raw.utm_campaign),
-        utm_term: toNullable(raw.utm_term),
-        utm_content: toNullable(raw.utm_content),
-        cid: toNullable(raw.cid),
-        sid: toNullable(raw.sid),
-        gclid: toNullable(raw.gclid),
-        fbclid: toNullable(raw.fbclid),
-        msclkid: toNullable(raw.msclkid),
-        ttclid: toNullable(raw.ttclid),
-        wbraid: toNullable(raw.wbraid),
-        gbraid: toNullable(raw.gbraid),
-        fbc: toNullable(raw.fbc),
-        fbp: toNullable(raw.fbp),
-        extras: Object.keys(extras).length > 0 ? extras : undefined,
-    };
-
+    const tracking = normalizeLeadTracking(getTrackingDataObject());
     return { tracking, utms: extractUtms(tracking) };
 }
 

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -3,6 +3,7 @@ import { useAntiBot } from './useAntiBot';
 import { getTrackingDataObject, getWhatsAppLink } from '../utils/whatsapp';
 import type { LeadTracking, LeadUtms, SubmitLeadRequest } from '../types/leadCapture';
 import { cleanString, normalizeWhatsappNumber } from '../lib/lead-logic';
+import { extractUtms, normalizeLeadTracking } from '../lib/tracking-normalization';
 
 export interface LeadDraft {
     firstName: string;
@@ -89,73 +90,8 @@ function parseResponseData(value: string): SubmitLeadResponseData {
     }
 }
 
-function toNullable(value: unknown): string | null {
-    if (typeof value !== 'string') return null;
-    const normalized = value.trim();
-    return normalized.length > 0 ? normalized : null;
-}
-
-export function extractUtms(tracking: LeadTracking): LeadUtms {
-    return {
-        utm_source: tracking.utm_source ?? null,
-        utm_medium: tracking.utm_medium ?? null,
-        utm_campaign: tracking.utm_campaign ?? null,
-        utm_term: tracking.utm_term ?? null,
-        utm_content: tracking.utm_content ?? null,
-    };
-}
-
 function captureInitialTracking(): LeadTracking {
-    const source = getTrackingDataObject() || {};
-
-    const knownKeys = new Set([
-        'utm_source',
-        'utm_medium',
-        'utm_campaign',
-        'utm_term',
-        'utm_content',
-        'cid',
-        'sid',
-        'gclid',
-        'fbclid',
-        'msclkid',
-        'ttclid',
-        'wbraid',
-        'gbraid',
-        'fbc',
-        'fbp',
-    ]);
-
-    const extras: Record<string, string> = {};
-
-    for (const [key, value] of Object.entries(source)) {
-        if (knownKeys.has(key)) continue;
-        if (typeof value !== 'string') continue;
-
-        const normalized = value.trim();
-        if (!normalized) continue;
-
-        extras[key] = normalized;
-    }
-
-    return {
-        utm_source: toNullable(source.utm_source),
-        utm_medium: toNullable(source.utm_medium),
-        utm_campaign: toNullable(source.utm_campaign),
-        utm_term: toNullable(source.utm_term),
-        utm_content: toNullable(source.utm_content),
-        cid: toNullable(source.cid),
-        sid: toNullable(source.sid),
-        gclid: toNullable(source.gclid),
-        fbclid: toNullable(source.fbclid),
-        msclkid: toNullable(source.msclkid),
-        ttclid: toNullable(source.ttclid),
-        wbraid: toNullable(source.wbraid),
-        gbraid: toNullable(source.gbraid),
-        fbc: toNullable(source.fbc),
-        fbp: toNullable(source.fbp),
-        extras: Object.keys(extras).length > 0 ? extras : undefined,
-    };
+    return normalizeLeadTracking(getTrackingDataObject());
 }
 
 function referralFromTracking(tracking?: LeadTracking | null): string {

--- a/hooks/useQuizCapture.ts
+++ b/hooks/useQuizCapture.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useAntiBot } from './useAntiBot';
 import { getTrackingDataObject } from '../utils/whatsapp';
+import { extractUtms, normalizeLeadTracking } from '../lib/tracking-normalization';
 import type { LeadTracking, LeadUtms } from '../types/leadCapture';
 import type { SubmitQuizRequest, SubmitQuizResponse } from '../types/quiz';
 
@@ -8,52 +9,9 @@ export type SubmitQuizResult =
     | { ok: true; requestId: string; warning?: string }
     | { ok: false; requestId?: string; error: string; code: string; status?: number };
 
-function toNullable(value: unknown): string | null {
-    if (typeof value !== 'string') return null;
-    const normalized = value.trim();
-    return normalized.length > 0 ? normalized : null;
-}
-
 function captureTrackingState(): { tracking: LeadTracking; utms: LeadUtms } {
-    const source = getTrackingDataObject() || {};
-    const extras: Record<string, string> = {};
-    const knownKeys = new Set([
-        'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content',
-        'cid', 'sid', 'gclid', 'fbclid', 'msclkid', 'ttclid', 'wbraid', 'gbraid', 'fbc', 'fbp',
-    ]);
-
-    for (const [key, value] of Object.entries(source)) {
-        if (knownKeys.has(key) || typeof value !== 'string') continue;
-        const normalized = value.trim();
-        if (!normalized) continue;
-        extras[key] = normalized;
-    }
-
-    const utms: LeadUtms = {
-        utm_source: toNullable(source.utm_source),
-        utm_medium: toNullable(source.utm_medium),
-        utm_campaign: toNullable(source.utm_campaign),
-        utm_term: toNullable(source.utm_term),
-        utm_content: toNullable(source.utm_content),
-    };
-
-    return {
-        utms,
-        tracking: {
-            ...utms,
-            cid: toNullable(source.cid),
-            sid: toNullable(source.sid),
-            gclid: toNullable(source.gclid),
-            fbclid: toNullable(source.fbclid),
-            msclkid: toNullable(source.msclkid),
-            ttclid: toNullable(source.ttclid),
-            wbraid: toNullable(source.wbraid),
-            gbraid: toNullable(source.gbraid),
-            fbc: toNullable(source.fbc),
-            fbp: toNullable(source.fbp),
-            extras: Object.keys(extras).length > 0 ? extras : undefined,
-        },
-    };
+    const tracking = normalizeLeadTracking(getTrackingDataObject());
+    return { tracking, utms: extractUtms(tracking) };
 }
 
 function pushQuizDataLayerEvent(payload: SubmitQuizRequest): void {

--- a/hooks/useWaitlistCapture.ts
+++ b/hooks/useWaitlistCapture.ts
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback } from 'react';
 import { useAntiBot } from './useAntiBot';
 import { cleanString } from '../lib/lead-logic';
 import { getTrackingDataObject } from '../utils/whatsapp';
+import { extractUtms, normalizeLeadTracking } from '../lib/tracking-normalization';
 import type { LeadTracking, LeadUtms } from '../types/leadCapture';
 import type { SubmitWaitlistRequest, SubmitWaitlistResponse } from '../types/waitlist';
 
@@ -22,65 +23,9 @@ type SubmitWaitlistResult =
 
 type SubmitWaitlistFailure = Extract<SubmitWaitlistResult, { ok: false }>;
 
-function toNullable(value: unknown): string | null {
-    if (typeof value !== 'string') return null;
-    const normalized = value.trim();
-    return normalized.length > 0 ? normalized : null;
-}
-
 function captureTrackingState(): { tracking: LeadTracking; utms: LeadUtms } {
-    const source = getTrackingDataObject() || {};
-    const extras: Record<string, string> = {};
-    const knownKeys = new Set([
-        'utm_source',
-        'utm_medium',
-        'utm_campaign',
-        'utm_term',
-        'utm_content',
-        'cid',
-        'sid',
-        'gclid',
-        'fbclid',
-        'msclkid',
-        'ttclid',
-        'wbraid',
-        'gbraid',
-        'fbc',
-        'fbp',
-    ]);
-
-    for (const [key, value] of Object.entries(source)) {
-        if (knownKeys.has(key) || typeof value !== 'string') continue;
-        const normalized = value.trim();
-        if (!normalized) continue;
-        extras[key] = normalized;
-    }
-
-    const utms: LeadUtms = {
-        utm_source: toNullable(source.utm_source),
-        utm_medium: toNullable(source.utm_medium),
-        utm_campaign: toNullable(source.utm_campaign),
-        utm_term: toNullable(source.utm_term),
-        utm_content: toNullable(source.utm_content),
-    };
-
-    return {
-        utms,
-        tracking: {
-            ...utms,
-            cid: toNullable(source.cid),
-            sid: toNullable(source.sid),
-            gclid: toNullable(source.gclid),
-            fbclid: toNullable(source.fbclid),
-            msclkid: toNullable(source.msclkid),
-            ttclid: toNullable(source.ttclid),
-            wbraid: toNullable(source.wbraid),
-            gbraid: toNullable(source.gbraid),
-            fbc: toNullable(source.fbc),
-            fbp: toNullable(source.fbp),
-            extras: Object.keys(extras).length > 0 ? extras : undefined,
-        },
-    };
+    const tracking = normalizeLeadTracking(getTrackingDataObject());
+    return { tracking, utms: extractUtms(tracking) };
 }
 
 function buildSubmitWaitlistError(

--- a/lib/tracking-normalization.ts
+++ b/lib/tracking-normalization.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared attribution-normalization contract for the four client-side capture
+ * hooks (lead, contact, quiz, waitlist). Each hook used to carry its own copy
+ * of this logic (issue #1148) — they had drifted: `useContactForm` sanitized
+ * values through `cleanString` (XSS-escaping `<`/`>`, bounding length),
+ * while `useLeadCapture`/`useQuizCapture`/`useWaitlistCapture` only trimmed.
+ * This module is the one source of truth; every hook now sanitizes the same
+ * way, since these values eventually reach CRM notes and logs.
+ */
+import { cleanString } from './lead-logic';
+import type { LeadTracking, LeadUtms } from '../types/leadCapture';
+
+const KNOWN_TRACKING_KEYS = new Set([
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+    'cid',
+    'sid',
+    'gclid',
+    'fbclid',
+    'msclkid',
+    'ttclid',
+    'wbraid',
+    'gbraid',
+    'fbc',
+    'fbp',
+]);
+
+function toNullable(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const normalized = cleanString(value);
+    return normalized.length > 0 ? normalized : null;
+}
+
+/**
+ * Shapes the raw tracking dictionary captured by `utils/whatsapp.ts`'s
+ * `getTrackingDataObject()` into the `LeadTracking` contract every submit
+ * payload sends: the 5 UTM fields, supported click identifiers (Google,
+ * Meta, Microsoft, TikTok), GA4 client/session identifiers, and any
+ * unrecognized key (e.g. `ref`, dynamic `hsa_*` Microsoft Ads params)
+ * bucketed into `extras`.
+ */
+export function normalizeLeadTracking(source: Record<string, string> | null | undefined): LeadTracking {
+    const raw = source ?? {};
+    const extras: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(raw)) {
+        if (KNOWN_TRACKING_KEYS.has(key)) continue;
+        const normalized = toNullable(value);
+        if (normalized) extras[key] = normalized;
+    }
+
+    return {
+        utm_source: toNullable(raw.utm_source),
+        utm_medium: toNullable(raw.utm_medium),
+        utm_campaign: toNullable(raw.utm_campaign),
+        utm_term: toNullable(raw.utm_term),
+        utm_content: toNullable(raw.utm_content),
+        cid: toNullable(raw.cid),
+        sid: toNullable(raw.sid),
+        gclid: toNullable(raw.gclid),
+        fbclid: toNullable(raw.fbclid),
+        msclkid: toNullable(raw.msclkid),
+        ttclid: toNullable(raw.ttclid),
+        wbraid: toNullable(raw.wbraid),
+        gbraid: toNullable(raw.gbraid),
+        fbc: toNullable(raw.fbc),
+        fbp: toNullable(raw.fbp),
+        extras: Object.keys(extras).length > 0 ? extras : undefined,
+    };
+}
+
+/** Projects the 5 UTM fields out of an already-normalized `LeadTracking`. */
+export function extractUtms(tracking: LeadTracking): LeadUtms {
+    return {
+        utm_source: tracking.utm_source ?? null,
+        utm_medium: tracking.utm_medium ?? null,
+        utm_campaign: tracking.utm_campaign ?? null,
+        utm_term: tracking.utm_term ?? null,
+        utm_content: tracking.utm_content ?? null,
+    };
+}

--- a/tests/hooks-useLeadCapture.test.ts
+++ b/tests/hooks-useLeadCapture.test.ts
@@ -2,13 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
     isPreparedSubmitLeadRequest,
-    extractUtms,
     buildSubmitLeadPayload,
     buildLeadWhatsAppMessage,
     createLeadEventId,
     pushGenerateLeadDataLayerEvent,
     type LeadDraft,
 } from '../hooks/useLeadCapture.ts';
+import { extractUtms } from '../lib/tracking-normalization.ts';
 import type { LeadTracking, SubmitLeadRequest } from '../types/leadCapture.ts';
 
 function validPayload(overrides?: Partial<SubmitLeadRequest>): SubmitLeadRequest {

--- a/tests/tracking-normalization.test.ts
+++ b/tests/tracking-normalization.test.ts
@@ -1,0 +1,133 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { extractUtms, normalizeLeadTracking } from '../lib/tracking-normalization.ts';
+
+// Regression coverage for issue #1148: lead/contact/quiz/waitlist capture hooks
+// each carried their own copy of this attribution-shaping logic and had
+// drifted (useContactForm sanitized via cleanString; the other three only
+// trimmed). This is the one shared, pure contract all four now consume —
+// table-driven so every supported identifier and edge case is explicit.
+
+test('normalizeLeadTracking projects every known key into the LeadTracking shape', () => {
+    const tracking = normalizeLeadTracking({
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        utm_campaign: 'summer',
+        utm_term: 'praia',
+        utm_content: 'ad-1',
+        cid: 'ga-cid-1',
+        sid: 'ga-sid-1',
+        gclid: 'g-click-1',
+        fbclid: 'fb-click-1',
+        msclkid: 'ms-click-1',
+        ttclid: 'tt-click-1',
+        wbraid: 'wb-1',
+        gbraid: 'gb-1',
+        fbc: 'fb.1.111.aaa',
+        fbp: 'fb.1.222.bbb',
+    });
+
+    assert.deepEqual(tracking, {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        utm_campaign: 'summer',
+        utm_term: 'praia',
+        utm_content: 'ad-1',
+        cid: 'ga-cid-1',
+        sid: 'ga-sid-1',
+        gclid: 'g-click-1',
+        fbclid: 'fb-click-1',
+        msclkid: 'ms-click-1',
+        ttclid: 'tt-click-1',
+        wbraid: 'wb-1',
+        gbraid: 'gb-1',
+        fbc: 'fb.1.111.aaa',
+        fbp: 'fb.1.222.bbb',
+        extras: undefined,
+    });
+});
+
+test('normalizeLeadTracking treats null/undefined/empty source as all-absent', () => {
+    for (const source of [null, undefined, {}]) {
+        const tracking = normalizeLeadTracking(source);
+        assert.equal(tracking.utm_source, null);
+        assert.equal(tracking.gclid, null);
+        assert.equal(tracking.extras, undefined);
+    }
+});
+
+test('normalizeLeadTracking trims whitespace and treats whitespace-only values as absent', () => {
+    const tracking = normalizeLeadTracking({
+        utm_source: '  instagram  ',
+        utm_medium: '   ',
+        gclid: '\t\n',
+    });
+
+    assert.equal(tracking.utm_source, 'instagram');
+    assert.equal(tracking.utm_medium, null, 'whitespace-only value normalizes to null');
+    assert.equal(tracking.gclid, null);
+});
+
+test('normalizeLeadTracking bucket unknown keys into extras, dropping blank ones', () => {
+    const tracking = normalizeLeadTracking({
+        ref: 'Maria Silva',
+        hsa_acc: '12345',
+        hsa_cam: '67890',
+        empty_extra: '   ',
+    });
+
+    assert.deepEqual(tracking.extras, {
+        ref: 'Maria Silva',
+        hsa_acc: '12345',
+        hsa_cam: '67890',
+    });
+});
+
+test('normalizeLeadTracking omits extras entirely when there are no unknown keys', () => {
+    const tracking = normalizeLeadTracking({ utm_source: 'google' });
+    assert.equal(tracking.extras, undefined);
+});
+
+test('normalizeLeadTracking escapes < and > (XSS-adjacent characters) in any field, known or extra', () => {
+    const tracking = normalizeLeadTracking({
+        utm_source: '<script>alert(1)</script>',
+        ref: '<b>bold</b>',
+    });
+
+    assert.equal(tracking.utm_source, '&lt;script&gt;alert(1)&lt;/script&gt;');
+    assert.equal(tracking.extras?.ref, '&lt;b&gt;bold&lt;/b&gt;');
+});
+
+test('normalizeLeadTracking bounds abusively long values to 10000 chars (shared with lib/lead-logic cleanString)', () => {
+    const longValue = 'a'.repeat(20000);
+    const tracking = normalizeLeadTracking({ utm_campaign: longValue, weird_extra_key: longValue });
+
+    assert.equal(tracking.utm_campaign?.length, 10000);
+    assert.equal(tracking.extras?.weird_extra_key.length, 10000);
+});
+
+test('normalizeLeadTracking ignores non-string values on both known and unknown keys', () => {
+    const tracking = normalizeLeadTracking({
+        utm_source: 42 as unknown as string,
+        gclid: null as unknown as string,
+        weird: { nested: true } as unknown as string,
+    });
+
+    assert.equal(tracking.utm_source, null);
+    assert.equal(tracking.gclid, null);
+    assert.equal(tracking.extras, undefined);
+});
+
+test('extractUtms projects only the 5 UTM fields, preserving null', () => {
+    const tracking = normalizeLeadTracking({ utm_source: 'google', cid: 'ga-1' });
+    const utms = extractUtms(tracking);
+
+    assert.deepEqual(utms, {
+        utm_source: 'google',
+        utm_medium: null,
+        utm_campaign: null,
+        utm_term: null,
+        utm_content: null,
+    });
+    assert.equal('cid' in utms, false, 'extractUtms must not leak non-UTM fields');
+});


### PR DESCRIPTION
## Summary
`useLeadCapture`, `useContactForm`, `useQuizCapture`, and `useWaitlistCapture` each carried their own copy of the raw-tracking-to-`LeadTracking` shaping logic (known attribution keys, UTM projection, click identifiers, GA identifiers, unknown extras) — duplicated 4 ways and quietly drifted: `useContactForm` sanitized every value through `cleanString` (XSS-escaping `<`/`>`, bounding length to 10000 chars) while the other three only trimmed. `useContactForm` also cross-imported `extractUtms` from `useLeadCapture`.

- Added `lib/tracking-normalization.ts` as the one shared, pure contract: `normalizeLeadTracking(source)` + `extractUtms(tracking)`.
- Migrated all four hooks to call it, removing every local implementation and the cross-hook import (`useContactForm` now imports `extractUtms`/`normalizeLeadTracking` from `lib/`, keeping only its unrelated `createLeadEventId` import from `useLeadCapture`).

**⚠️ Intentional behavior change, flagging for review:** lead/quiz/waitlist tracking values now sanitize the same way contact form values already did (XSS-escaping `<`/`>`, 10000-char bound via the existing `cleanString` helper) — since these values eventually reach CRM notes and logs, and `docs/standards/security.md` says to sanitize at the boundary and reuse `cleanString` rather than ad hoc filters. **Normal UTM/click-id values are completely unaffected** — this only changes output for adversarial input containing `<`/`>` or exceeding 10000 characters, which no existing test asserted raw (unescaped) values for. If this divergence was actually intentional rather than drift, let me know and I'll parameterize instead.

## Test plan
- [x] New `tests/tracking-normalization.test.ts`: table-driven coverage — every known identifier, whitespace/absent-value handling, unknown-key extras bucketing (including dynamic `hsa_*` keys and `ref`), the XSS-escaping/length-bound behavior, and non-string input (27/27 incl. existing `extractUtms` tests).
- [x] `pnpm test:regression` — 865/865 passed.
- [x] Targeted e2e: contact modal + inline CTA, destructive-contact (XSS/duplicate/API-failure), chatbot lead handoff, quiz double-submit/whatsapp, Lollapalooza waitlist — 22/22 passed.
- [x] `pnpm typecheck` passes.

Closes #1148.