### PR TITLE
fix(lint): give Node globals to .mjs/.js/.cjs files in eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,6 +63,17 @@ export default tseslint.config(
     },
   },
   {
+    // Root-level config files and build scripts (postcss.config.mjs,
+    // scripts/*.mjs) run under Node outside the TS project service, so they
+    // don't pick up the globals set on the `**/*.{ts,tsx}` block above —
+    // without this, `console`/`process` are flagged as no-undef false
+    // positives.
+    files: ['**/*.{js,mjs,cjs}'],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+  {
     // Regression/e2e tests run under node:test / Playwright, not a browser —
     // node globals apply, and test files legitimately use `any` more freely
     // for mock/fixture shaping.


### PR DESCRIPTION
## Summary

Follow-up to #1166. The `globals` block in `eslint.config.js` only applied to `**/*.{ts,tsx}`, so build scripts (`scripts/*.mjs`, `postcss.config.mjs`, `tailwind.config.mjs`) had no `console`/`process` in scope. This surfaced as 11 `no-undef` false positives once CodeFactor ran the unscoped `pnpm lint` against the whole repo (`scripts/install-hooks.mjs`, `scripts/prerender.mjs`, `scripts/update-post-dates.mjs`).

Fix: a new config block matching `**/*.{js,mjs,cjs}` that gives those files `globals.node`.

Not touched here: the 68 CodeFactor findings' other categories (16 real `react-hooks/purity`/`refs`/`set-state-in-effect` correctness bugs in pre-existing code — tracked in #1173; cosmetic `no-useless-escape`/`no-unused-vars`/`no-empty` left to the lint ratchet's normal adoption path per `docs/standards/linting.md`).

## Test plan
- [x] `npx eslint scripts/install-hooks.mjs scripts/prerender.mjs scripts/update-post-dates.mjs postcss.config.mjs tailwind.config.mjs` — exits 0, no more no-undef errors.
- [x] `pnpm typecheck` passes.
- [x] `pnpm test:regression` — 942/942 passed.

Note: `pnpm lint` (unscoped, informational-only per this file's own comment) still crashes with a pre-existing, unrelated `TypeError` in `eslint-plugin-jsx-a11y`'s `label-has-associated-control` rule (minimatch version mismatch) — confirmed this reproduces identically on `main` before this change, so it's out of scope here.