### PR TITLE
docs(plans): planos 019-021 da rodada 4 de direção (/improve next)

### DIFF
--- a/plans/019-odoo-ads-conversion-loop.md
+++ b/plans/019-odoo-ads-conversion-loop.md
@@ -1,0 +1,432 @@
+# Plan 019: Fechar o loop de conversão Odoo → Google/Meta (parte executável no repo)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat f5e4324..HEAD -- api/purchase-dispatch.ts lib/odoo-lead-mapping.ts lib/odoo-submit-handler.ts lib/conversions/ tests/purchase-dispatch.test.ts tests/odoo-lead-mapping.test.ts .env.example docs/product/odoo-ads-conversion-decision.md`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED (toca o caminho de criação de lead no Odoo — mitigado por flag default-off)
+- **Depends on**: none (mas tem **gates externos** que bloqueiam a *ativação*, não a implementação — ver "Gates externos")
+- **Category**: direction
+- **Planned at**: commit `f5e4324`, 2026-07-12
+
+## Why this matters
+
+Quando uma oportunidade vira "Ganho" no Odoo, nada hoje reenvia essa conversão
+para o Google e para a Meta — o algoritmo de lance otimiza por quem preenche
+formulário, não por quem vira receita. A infraestrutura de dispatch já existe e
+funciona (`api/purchase-dispatch.ts` + `lib/conversions/{google,meta}.ts`), mas
+ficou **órfã** após o cut-over do CRM para o Odoo (jun/2026): nenhum gatilho a
+aciona. A arquitetura completa já foi decidida e documentada em
+`docs/product/odoo-ads-conversion-decision.md` — este plano implementa **apenas
+a parte que vive no repo** (Fases 1 [lado repo], 3a e o ajuste de payload da
+Fase 2), preservando todos os gates externos e de compliance daquele documento.
+
+**Este plano NÃO ativa nenhum disparo real.** Ele deixa o código pronto atrás
+de flags default-off, para que a ativação aconteça só depois dos gates externos
+(campos no Odoo, revisão DPO/RIPD, fase de sombra).
+
+## Current state
+
+Arquivos relevantes:
+
+- `docs/product/odoo-ads-conversion-decision.md` — a decisão de arquitetura. **Leia o documento inteiro antes do Step 1.** Este plano implementa as "Fatias de implementação" 1 (lado repo), 2 (ajuste de payload) e 3a dele.
+- `api/purchase-dispatch.ts` — endpoint que recebe eventos de conversão (autentica por `X-Webhook-Secret` contra `N8N_WEBHOOK_SECRET`), dispara GA4 MP + Meta CAPI em paralelo, retorna `mode: full/partial/failed`. Hoje **não tem kill switch**.
+- `lib/conversions/google.ts` — GA4 Measurement Protocol (envs `GA4_MEASUREMENT_ID`, `GA4_API_SECRET`). Não mudar.
+- `lib/conversions/meta.ts` — Meta CAPI (envs `META_PIXEL_ID`, `META_ACCESS_TOKEN`, `META_TEST_EVENT_CODE` para fase de sombra). Já usa `deduplicationId` como `event_id` do payload. Não mudar.
+- `lib/odoo-lead-mapping.ts` — mapeamento puro form → `res.partner`/`crm.lead`. Hoje os click IDs vão **só como texto** dentro do HTML de `description` (`buildDescriptionHtml`), inacessíveis para automações do Odoo.
+- `lib/odoo-submit-handler.ts` — orquestra `openOdooSession` → `upsertPartner` → `createLead`; é onde `buildLeadFields` é chamado (linhas 87–88) e onde uma leitura de env fica no boundary certo.
+- `tests/purchase-dispatch.test.ts` — padrão de teste do handler (salva/restaura `process.env`, mocka `global.fetch`, monta `Request` com header de secret). Modelar os novos testes nele.
+- `tests/odoo-lead-mapping.test.ts` — testes do mapeamento puro.
+
+### Excerto 1 — fluxo do handler (`api/purchase-dispatch.ts:411-447`)
+
+```ts
+export default async function handler(request: Request): Promise<Response> {
+  const requestId = createRequestId();
+  const methodError = validateRequestMethod(request, requestId);
+  if (methodError) {
+    return methodError;
+  }
+
+  const authError = validateAuthorization(request, requestId);
+  if (authError) {
+    return authError;
+  }
+  // ... rate limit → parse → dispatchConversion(payload, requestId)
+```
+
+### Excerto 2 — deduplicationId hoje (`api/purchase-dispatch.ts:187-198`)
+
+```ts
+  let deduplicationId: string;
+
+  if (eventType === 'lead_qualificado') {
+    if (!attributionKey) {
+      return { error: 'Missing attributionKey' };
+    }
+    deduplicationId = attributionKey;
+  } else if (!dealId) {
+    return { error: 'Missing dealId' };
+  } else {
+    deduplicationId = dealId;
+  }
+```
+
+Para `purchase`, o id de dedup é o `dealId` cru. A decisão (§4 do doc) exige o
+identificador determinístico **`purchase_{dealId}`** para idempotência do
+disparo no Meta.
+
+### Excerto 3 — buildLeadFields hoje (`lib/odoo-lead-mapping.ts:195-222`)
+
+```ts
+export function buildLeadFields(input: OdooLeadInput, partnerId: number, idempotencyKey?: string): Record<string, unknown> {
+    // ...
+    if (input.email) fields.email_from = input.email;
+    if (input.phone) fields.phone = input.phone;
+    if (input.referred) fields.referred = input.referred;
+    if (input.empresa) fields.partner_name = input.empresa;
+    if (input.cargo) fields.function = input.cargo;
+    if (input.destination) fields.x_destino = input.destination;
+
+    const description = buildDescriptionHtml(input, idempotencyKey);
+    if (description) fields.description = description;
+
+    return fields;
+}
+```
+
+`x_destino` é o exemplar do padrão a seguir (campo Studio custom já criado no
+Odoo, escrito condicionalmente). O tracking (`input.tracking`: `gclid`,
+`fbclid`, `fbp`, `fbc`, `cid`, `sid`) hoje só aparece em `buildDescriptionHtml`.
+
+### Excerto 4 — call site do mapeamento (`lib/odoo-submit-handler.ts:87-88`)
+
+```ts
+        const idempotencyKey = await resolveIdempotencyKey(input);
+        const leadFields = buildLeadFields(input, partnerId, idempotencyKey);
+```
+
+### Convenções do repo que se aplicam
+
+- Handlers seguem a ordem method gate → CORS → config → parse → validação →
+  rate limit → orquestração → resposta estruturada (`docs/standards/api-conventions.md`).
+  O kill switch é um "configuration check" e entra **depois** da autenticação
+  (não vazar o estado da flag para chamadores não autenticados).
+- Leitura de `process.env` fica perto do boundary de configuração — seguir o
+  padrão de `getExpectedSecret()` em `api/purchase-dispatch.ts:138-143`.
+- `lib/odoo-lead-mapping.ts` é **puro** (sem env, sem I/O) — a flag de env é
+  lida no `lib/odoo-submit-handler.ts` e passada como opção.
+- Testes: `node:test` + `assert/strict`, mock de `global.fetch`, salvar e
+  restaurar env (ver `tests/purchase-dispatch.test.ts:5-36`).
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Install | `pnpm install` | exit 0 |
+| Typecheck | `pnpm typecheck` | exit 0 |
+| Testes do handler | `tsx --test tests/purchase-dispatch.test.ts` | all pass |
+| Testes do mapeamento | `tsx --test tests/odoo-lead-mapping.test.ts` | all pass |
+| Regressão completa | `pnpm test:regression` | all pass |
+| Lint (ratchet CI) | `pnpm lint:changed` | exit 0 |
+
+## Scope
+
+**In scope** (únicos arquivos a modificar/criar):
+- `api/purchase-dispatch.ts`
+- `lib/odoo-lead-mapping.ts`
+- `lib/odoo-submit-handler.ts`
+- `tests/purchase-dispatch.test.ts`
+- `tests/odoo-lead-mapping.test.ts`
+- `.env.example`
+- `docs/ops/conversion-dispatch-runbook.md` (criar)
+- `docs/product/odoo-ads-conversion-decision.md` (só a linha de Status no topo)
+- `plans/README.md` (linha de status)
+
+**Out of scope** (NÃO tocar, mesmo parecendo relacionado):
+- `lib/conversions/google.ts` e `lib/conversions/meta.ts` — já suportam tudo
+  que este plano precisa (`deduplicationId`, `META_TEST_EVENT_CODE`).
+- A Automated Action / Server Action no Odoo — é configuração externa (Fase 2
+  do doc), não vive no repo.
+- Migração para Offline Conversion Import nativo do Google (Fase 3b) — condicional,
+  só após reconciliação provar necessidade.
+- `msclkid`/`ttclid`/`wbraid`/`gbraid` (Fase 4) — condicional a confirmação de
+  campanha ativa; não mapear.
+- O esquema de autenticação do endpoint (`X-Webhook-Secret`) — decidido no doc.
+- Qualquer verificação de consentimento no repo: o gate de `x_lgpd_consent`
+  (§7 do doc) atravessa `partner_id` e vive na automação do Odoo, não aqui.
+
+## Git workflow
+
+- Branch: `feature/019-odoo-ads-conversion-loop`
+- Conventional commits (ex.: `feat(conversions): add PURCHASE_DISPATCH_ENABLED kill switch`)
+- Abrir PR draft ao final; **merge é sempre humano** (squash). CI `build-and-test` precisa passar.
+
+## Steps
+
+### Step 1: Kill switch `PURCHASE_DISPATCH_ENABLED` no handler (Fase 3a)
+
+Em `api/purchase-dispatch.ts`:
+
+1. Adicionar um helper no padrão de `getExpectedSecret()`:
+
+   ```ts
+   function isDispatchEnabled(): boolean {
+     const raw = typeof process.env.PURCHASE_DISPATCH_ENABLED === 'string'
+       ? process.env.PURCHASE_DISPATCH_ENABLED.trim().toLowerCase()
+       : '';
+     // Default true: ausência da env não desliga o endpoint (decisão §6 do doc).
+     return raw !== 'false' && raw !== '0';
+   }
+   ```
+
+2. No `handler`, **depois** de `validateAuthorization` e **antes** de
+   `enforceRateLimit`, retornar 503 quando desligado:
+
+   ```ts
+   if (!isDispatchEnabled()) {
+     emitConversionLog('warn', requestId, 'dispatch_disabled');
+     return buildJsonResponse(
+       { ok: false, requestId, code: 'DISPATCH_DISABLED', error: 'Conversion dispatch disabled' },
+       503,
+     );
+   }
+   ```
+
+   Racional da posição: chamador não autenticado não descobre o estado da flag;
+   e a automação do Odoo recebe erro ≥500, grava `failed` e o job de
+   reconciliação reprocessa depois (comportamento de rollback do §8 do doc).
+
+**Verify**: `tsx --test tests/purchase-dispatch.test.ts` → all pass (os testes
+existentes não setam a env, e o default é ligado).
+
+### Step 2: Identificador determinístico `purchase_{dealId}` (§4 do doc)
+
+Em `normalizePayload` (`api/purchase-dispatch.ts`), no ramo em que
+`eventType === 'purchase'`, derivar o id de dedup com o prefixo determinístico
+em vez do `dealId` cru:
+
+```ts
+  } else {
+    deduplicationId = eventType === 'purchase' ? `purchase_${dealId}` : dealId;
+  }
+```
+
+Isso garante a decisão do §4 (idempotência de reexecuções no Meta) **no código
+que controlamos**, independente de como a automação do Odoo montar o payload —
+ela só precisa mandar `dealId`. `close_convert_lead` mantém o comportamento
+atual. O mesmo valor vira `transaction_id` no GA4 (via `transactionId`), o que
+também é desejável para dedup lá.
+
+**Verify**: `tsx --test tests/purchase-dispatch.test.ts` → all pass **após** o
+Step 5 adicionar/ajustar as asserções (se algum teste existente assertar o
+`deduplicationId` de purchase como `dealId` cru, ajustá-lo faz parte deste
+passo — é mudança de contrato intencional num endpoint hoje órfão, sem
+chamadores em produção).
+
+### Step 3: Campos estruturados de tracking no `crm.lead`, atrás de flag default-off (Fase 1, lado repo)
+
+**Contexto crítico**: escrever um campo inexistente num `create` do Odoo faz o
+JSON-RPC falhar — e derrubaria os formulários de lead/contato em produção. Os
+campos `x_gclid` etc. **ainda não existem** no Odoo (gate externo). Por isso a
+escrita fica atrás de `ODOO_CONVERSION_FIELDS_ENABLED` (default **off**).
+
+1. Em `lib/odoo-lead-mapping.ts`, estender a assinatura de `buildLeadFields`
+   com um parâmetro opcional (mantendo o módulo puro):
+
+   ```ts
+   export interface BuildLeadFieldsOptions {
+     /**
+      * Escreve os campos estruturados de tracking (x_gclid, x_fbclid, x_fbc,
+      * x_fbp, x_ga_client_id, x_ga_session_id) exigidos pela automação de
+      * conversão Odoo→Ads (docs/product/odoo-ads-conversion-decision.md §1).
+      * Default false: os campos custom precisam existir na instância Odoo
+      * antes — escrever campo inexistente derruba o create via JSON-RPC.
+      */
+     includeConversionFields?: boolean;
+   }
+
+   export function buildLeadFields(
+     input: OdooLeadInput,
+     partnerId: number,
+     idempotencyKey?: string,
+     options: BuildLeadFieldsOptions = {},
+   ): Record<string, unknown> {
+   ```
+
+2. Dentro da função, após o bloco de `x_destino`, adicionar (mesmo padrão
+   condicional dos campos existentes):
+
+   ```ts
+   if (options.includeConversionFields) {
+       const t = input.tracking;
+       if (t?.gclid) fields.x_gclid = t.gclid;
+       if (t?.fbclid) fields.x_fbclid = t.fbclid;
+       if (t?.fbc) fields.x_fbc = t.fbc;
+       if (t?.fbp) fields.x_fbp = t.fbp;
+       if (t?.cid) fields.x_ga_client_id = t.cid;
+       if (t?.sid) fields.x_ga_session_id = t.sid;
+   }
+   ```
+
+   **Não** escrever `x_event_id`, `x_conversion_dispatch_status` nem
+   `x_conversion_dispatch_attempts`: pelo §4 do doc, esses são gravados pela
+   automação do Odoo no primeiro disparo, não pelo site na entrada do lead.
+   As linhas correspondentes em `buildDescriptionHtml` **permanecem** (a
+   descrição continua sendo o registro legível por humanos).
+
+3. Em `lib/odoo-submit-handler.ts`, ler a env uma vez perto do call site e
+   passar a opção (padrão: env access no boundary de configuração):
+
+   ```ts
+   const includeConversionFields = process.env.ODOO_CONVERSION_FIELDS_ENABLED === 'true';
+   const leadFields = buildLeadFields(input, partnerId, idempotencyKey, { includeConversionFields });
+   ```
+
+**Verify**: `tsx --test tests/odoo-lead-mapping.test.ts` → all pass (testes
+existentes chamam sem `options` e nada muda no output default).
+
+### Step 4: `.env.example` + runbook de reconciliação (Fase 3a)
+
+1. Em `.env.example`, no bloco de conversões/n8n, adicionar com comentários:
+
+   ```bash
+   # Conversões offline (Odoo → Google/Meta) — ver docs/product/odoo-ads-conversion-decision.md
+   PURCHASE_DISPATCH_ENABLED=     # 'false' desliga /api/purchase-dispatch (kill switch; default: ligado)
+   ODOO_CONVERSION_FIELDS_ENABLED=  # 'true' só depois dos campos x_gclid/x_fbclid/... existirem no Odoo
+   ```
+
+2. Criar `docs/ops/conversion-dispatch-runbook.md` com, no mínimo, estas
+   seções (conteúdo vem das §§5–6 e 8 do doc de decisão — transcrever as
+   regras, não inventar novas):
+   - `## Reconciliação semanal` — comparar contagem/valor de `crm.lead` Ganho
+     vs. eventos Purchase no Meta Events Manager e conversões GA4; variância
+     aceitável ≤5%; acima disso, investigar `x_conversion_dispatch_status = 'failed'`.
+   - `## Retry` — reprocessar `status = 'failed' AND attempts < 5` com backoff
+     (1h, 4h, 12h, 24h); `attempts >= 5` → investigação manual (reenvio direto
+     ao endpoint com o `dealId`).
+   - `## Kill switch / rollback` — `PURCHASE_DISPATCH_ENABLED=false` no
+     dashboard do Cloudflare Pages; automação do Odoo continua gravando
+     `failed`; ao religar, a reconciliação reprocessa o backlog.
+   - `## Fase de sombra` — `META_TEST_EVENT_CODE` + GA4 DebugView; critério de
+     saída: 10 oportunidades Ganhas consecutivas com `mode: full`.
+   - `## Checklist de ativação (gates externos)` — a lista da seção "Gates
+     externos" deste plano, como checkboxes.
+
+3. Em `docs/product/odoo-ads-conversion-decision.md`, atualizar só a linha de
+   Status do topo para: `**Status:** decisão de arquitetura tomada; parte
+   repo implementada (plans/019) atrás de flags — ativação pendente dos gates
+   externos.`
+
+**Verify**: `ls docs/ops/conversion-dispatch-runbook.md` → existe;
+`grep -c "PURCHASE_DISPATCH_ENABLED" .env.example` → `1`.
+
+### Step 5: Testes
+
+Ver "Test plan" abaixo. Escrever os testes e rodar a suíte completa.
+
+**Verify**: `pnpm test:regression` → all pass; `pnpm typecheck` → exit 0;
+`pnpm lint:changed` → exit 0.
+
+## Test plan
+
+Em `tests/purchase-dispatch.test.ts` (modelar nos testes existentes do arquivo
+— mesmo save/restore de env e mock de fetch):
+
+1. **Kill switch desligado**: com `PURCHASE_DISPATCH_ENABLED='false'` e secret
+   válido → 503, body com `code: 'DISPATCH_DISABLED'`, e `global.fetch` de
+   provedores **não** chamado.
+2. **Kill switch não vaza para não autenticado**: `PURCHASE_DISPATCH_ENABLED='false'`
+   + secret errado → 401 (não 503).
+3. **Default ligado**: env ausente → comportamento atual preservado (200/`mode: full`
+   no caminho feliz já testado).
+4. **Id determinístico**: payload `eventType: 'purchase', dealId: '123'` →
+   o payload enviado ao Meta (capturado no mock de fetch) tem
+   `event_id: 'purchase_123'` e o do GA4 tem `transaction_id: 'purchase_123'`;
+   `eventType: 'close_convert_lead', dealId: '123'` mantém `'123'`.
+
+Em `tests/odoo-lead-mapping.test.ts` (modelar nos testes existentes do arquivo):
+
+5. **Flag off (default)**: `buildLeadFields(input, 1, 'k')` com tracking
+   completo → resultado **não** contém nenhuma chave `x_gclid`/`x_fbclid`/
+   `x_fbc`/`x_fbp`/`x_ga_client_id`/`x_ga_session_id`.
+6. **Flag on**: `{ includeConversionFields: true }` com tracking completo →
+   as seis chaves presentes com os valores do tracking; campos de tracking
+   ausentes/vazios não geram chave.
+7. **Descrição intacta**: com flag on, `description` continua contendo as
+   linhas `gclid:`/`fbclid:` de `buildDescriptionHtml` (sem regressão).
+
+Verification: `pnpm test:regression` → all pass, incluindo os 7 novos casos.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `pnpm typecheck` exit 0
+- [ ] `pnpm test:regression` exit 0, incluindo os novos testes dos Steps 1–3
+- [ ] `pnpm lint:changed` exit 0
+- [ ] `grep -n "PURCHASE_DISPATCH_ENABLED" api/purchase-dispatch.ts` → ≥1 match
+- [ ] `grep -n "purchase_" api/purchase-dispatch.ts` → contém a derivação `purchase_${dealId}`
+- [ ] `grep -n "includeConversionFields" lib/odoo-lead-mapping.ts lib/odoo-submit-handler.ts` → match nos dois arquivos
+- [ ] `grep -c "x_event_id" lib/odoo-lead-mapping.ts` → `0` (não é escrito pelo site)
+- [ ] `docs/ops/conversion-dispatch-runbook.md` existe com as 5 seções do Step 4
+- [ ] `git status` não mostra arquivos modificados fora do escopo
+- [ ] Linha do plano 019 atualizada em `plans/README.md`
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- Os excertos de "Current state" não batem com o código (drift desde `f5e4324`).
+- Algum teste existente de `tests/purchase-dispatch.test.ts` falhar por motivo
+  **diferente** do id determinístico do Step 2 após duas tentativas de ajuste.
+- Você se sentir tentado a ligar `ODOO_CONVERSION_FIELDS_ENABLED` ou
+  configurar secrets/dashboard — isso é ativação, e ativação é bloqueada
+  pelos gates externos abaixo. Este plano termina com tudo default-off.
+- Descobrir que `buildLeadFields` ganhou outro call site além de
+  `lib/odoo-submit-handler.ts` (verificar com `grep -rn "buildLeadFields(" --include="*.ts" | grep -v test`).
+
+## Gates externos (bloqueiam a ATIVAÇÃO, não este plano)
+
+Transcritos do doc de decisão — ficam como checklist no runbook (Step 4):
+
+1. **Campos custom no Odoo** (`x_gclid`, `x_fbclid`, `x_fbc`, `x_fbp`,
+   `x_ga_client_id`, `x_ga_session_id`, `x_event_id`,
+   `x_conversion_dispatch_status`, `x_conversion_dispatch_attempts`) — acesso
+   Studio/admin. Só então `ODOO_CONVERSION_FIELDS_ENABLED=true`.
+2. **RIPD atualizado + confirmação do DPO** sobre a base legal do reenvio de
+   PII hasheada e identificadores de clique (§7 do doc) — **nenhum disparo
+   real antes disso**.
+3. **Automated Action no Odoo validada** (Server Action com HTTP custom, ou
+   "Send Webhook Notification" nativo; fallback: polling n8n) — §2 do doc.
+4. **Fase de sombra concluída** (`META_TEST_EVENT_CODE` + DebugView, 10
+   Ganhos consecutivos `mode: full`) — §8 do doc.
+5. Confirmar campo de valor monetário da oportunidade Ganha, e link GA4↔Ads
+   ativo com evento marcado como conversão — §§3 e 5 do doc.
+
+## Maintenance notes
+
+- O contrato do payload da automação Odoo → `/api/purchase-dispatch` é:
+  `{ eventType: 'purchase', dealId, value, currency, email?, phone?, firstName?, lastName?, gclid?, fbclid?, fbc?, fbp?, gaClientId?, gaSessionId? }`
+  com header `X-Webhook-Secret`. O handler deriva o `event_id` determinístico;
+  a automação não precisa (nem deve) gerar ids aleatórios.
+- Quando `ODOO_CONVERSION_FIELDS_ENABLED` estiver ligada há tempo suficiente e
+  estável, considerar remover a flag e tornar a escrita incondicional (issue
+  própria, não rider).
+- Revisor deve escrutinar: posição do kill switch (depois do auth), e que
+  nenhum campo `x_*` novo é escrito com a flag off.
+- Follow-ups explicitamente fora deste plano: Fase 3b (Offline Conversion
+  Import nativo do Google — condicional à reconciliação) e Fase 4
+  (Microsoft/TikTok — condicional a campanha ativa confirmada).

--- a/plans/020-funil-canonico-spec.md
+++ b/plans/020-funil-canonico-spec.md
@@ -1,0 +1,262 @@
+# Plan 020: SPIKE — especificar o funil canônico de medição (visitante → receita no CRM)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat f5e4324..HEAD -- utils/formAnalytics.ts hooks/useLeadCapture.ts hooks/useQuizCapture.ts components/AIChatPanel.tsx components/ChatLeadForm.tsx lib/odoo-submit-handler.ts lib/odoo-lead-mapping.ts docs/product/`
+> If any in-scope-for-reading file changed since this plan was written, compare
+> the "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW (entregável é um documento; zero mudança de código)
+- **Depends on**: none. Sinergia com `plans/019-odoo-ads-conversion-loop.md`: os campos estruturados de tracking no Odoo (019, Step 3) são o mecanismo natural de correlação do estágio `won` — a spec deve referenciá-los, não redesenhá-los.
+- **Category**: direction
+- **Planned at**: commit `f5e4324`, 2026-07-12
+
+## Why this matters
+
+O site roda funis distintos (chatbot BANT, quiz, formulários de contato,
+waitlists) que emitem eventos de analytics **assimétricos** — cada funil mede
+etapas diferentes com nomes diferentes, e nenhum evento cobre o trecho do meio
+("handoff criado") nem o final ("virou receita no CRM"). A consequência
+concreta já está registrada: `docs/product/quiz-to-chatbot-funnel-spike.md`
+recomendou um A/B test quiz→chat e o declarou **bloqueado** por falta de
+medição downstream simétrica ("Sem um evento de 'chegou no orçamento'... a
+comparação ficaria limitada a cliques no CTA — insuficiente para decidir").
+Este spike define **um** ciclo de vida canônico, a fonte de verdade de cada
+estágio, as propriedades privacy-safe e a chave de correlação estável — a spec
+que qualquer instrumentação futura (e os experimentos hoje bloqueados)
+implementa. Definir antes de implementar; este plano não instrumenta nada.
+
+## Current state
+
+Inventário verificado no commit `f5e4324` (o executor deve re-verificar cada
+item — é a matéria-prima da spec):
+
+### Eventos browser-side existentes
+
+- `utils/formAnalytics.ts` — vocabulário compartilhado de formulários, 8
+  eventos: `form_view`, `form_start`, `field_complete`, `field_error`,
+  `submit_attempt`, `submit_success`, `submit_failure`, `whatsapp_opened`.
+  Payload passa por allowlist (`SAFE_FIELD_NAMES`) e redação de PII na URL
+  (`currentPageLocation`, linhas 45–64) — **este é o padrão privacy-safe do
+  repo; a spec deve adotá-lo como regra**. Usado por `ChatLeadForm.tsx`,
+  `ContactModal.tsx`, `SearchForm.tsx`, `MobileHeroForm.tsx`,
+  `CorpContactForm.tsx`, entre outros.
+- `hooks/useLeadCapture.ts:204-232` — `pushGenerateLeadDataLayerEvent`: no
+  sucesso do `/api/submit-lead` empurra `generate_lead` (com `event_id`,
+  `destination`, UTMs, `ga_client_id`/`ga_session_id`) + `form_submission`
+  (`form_type`: `ai_chatbot_lead` | `event_lead` | `corporate_lead`,
+  `form_id` = `event_id`).
+- `hooks/useQuizCapture.ts:17-38` — `pushQuizDataLayerEvent`: no sucesso do
+  `/api/submit-quiz` empurra `quiz_lead` (com `quiz_profile`, UTMs,
+  `ga_client_id`/`ga_session_id`) + `form_submission` (`form_type:
+  'quiz_lead'`, `form_id: 'quiz_anhanga'` — **fixo**, não é um event_id).
+  Nota de drift: a versão citada no spike do quiz chamava
+  `sendLeadToSalesforce`; isso **não existe mais** (cut-over Odoo).
+- `components/ChatLeadForm.tsx` — usa `pushFormAnalyticsEvent` com
+  `formType: 'ai_chatbot_lead'` e `'ai_chatbot_direct_whatsapp'`.
+
+### O gap central verificado
+
+`components/AIChatPanel.tsx:320-340` — quando o Gemini retorna
+`response.budgetLink` (BANT completo → cartão "Orçamento Pronto"), o código
+seta o draft e injeta o cartão de ação, **sem nenhum push ao dataLayer**:
+
+```ts
+    if (response.budgetLink) {
+      setLeadDraft({
+        bantSummary: response.budgetLink.bantSummary,
+        // ...
+      });
+      nextMessages.push({
+        id: generateMessageId(),
+        role: 'model',
+        text: 'Orçamento Pronto',
+        isAction: true,
+        // ...
+      });
+    }
+```
+
+Ou seja: o momento "qualificado/handoff criado" do funil do chatbot — o
+equivalente ao `quiz_lead` do quiz — é invisível hoje. É exatamente a
+assimetria que bloqueou o A/B test.
+
+### Correlação client ↔ CRM existente
+
+- O chatbot gera `event_id` no formato `lead_{uuid}`
+  (`hooks/useLeadCapture.ts:145-151`, `createLeadEventId`), envia ao
+  `/api/submit-lead` (schema aceita `event_id` até 128 chars,
+  `lib/schemas/submit-lead.ts:43`).
+- `lib/odoo-submit-handler.ts:65-66` usa esse `eventId` como **chave de
+  idempotência** do `crm.lead`, gravada como linha `idempotency_key: ...` no
+  HTML de `description` (`lib/odoo-lead-mapping.ts`,
+  `IDEMPOTENCY_KEY_LABEL`). Portanto o `event_id` do browser **já chega ao
+  Odoo hoje**, mas só como texto de descrição (consultável via domain `like`,
+  não como campo estruturado).
+- `ga_client_id`/`ga_session_id` são capturados no cliente
+  (`utils/whatsapp.ts`) e viajam no `tracking` de todos os hooks de captura.
+- Estágios do CRM: `crm.lead` nasce com `stage_id = 1` (Novo,
+  `lib/odoo-lead-mapping.ts:37`); transições de estágio (aceito, qualificado
+  pelo vendedor, Ganho/Perdido) **não emitem nada** — a infraestrutura para o
+  estágio `won` é o objeto do plano 019.
+
+### Intenção de produto a honrar
+
+`PRODUCT.md` (princípio "conversa não transação") e o spike do quiz: o funil
+canônico deve **descrever** os caminhos existentes (chat, quiz, formulários,
+WhatsApp direto), não forçá-los a um só fluxo. Funis distintos, ciclo de vida
+de medição único. Preferência registrada do mantenedor: não achatar funis
+distintos.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Typecheck (sanidade, nada deve mudar) | `pnpm typecheck` | exit 0 |
+| Confirmar zero mudança de código | `git status --porcelain -- . ':!docs' ':!plans'` | vazio |
+
+## Scope
+
+**In scope** (únicos arquivos a criar/modificar):
+- `docs/product/funil-canonico-de-medicao.md` (criar — o entregável)
+- `plans/README.md` (linha de status)
+
+**Out of scope** (NÃO tocar):
+- **Qualquer arquivo de código.** Este plano é docs-only por definição
+  ("definir antes de implementar"). Nada de adicionar eventos, mesmo o
+  `handoff_created` óbvio — ele entra na spec como "instrumentação proposta",
+  para um plano/PR futuro.
+- `docs/product/quiz-to-chatbot-funnel-spike.md` e
+  `docs/product/chatbot-tool-expansion-spike.md` — referenciar, não editar.
+- GTM/GA4/dashboards — configuração externa; a spec só nomeia o que deve
+  existir lá.
+
+## Git workflow
+
+- Branch: `docs/020-funil-canonico`
+- Conventional commit (ex.: `docs(product): spec do funil canônico de medição`)
+- PR draft ao final; merge é sempre humano (squash).
+
+## Steps
+
+### Step 1: Re-verificar o inventário
+
+Confirmar, com `grep`/leitura, cada afirmação da seção "Current state" (os 8
+eventos de `formAnalytics`, os pushes de `useLeadCapture`/`useQuizCapture`, a
+ausência de push em `AIChatPanel.tsx` no ramo `response.budgetLink`, o fluxo do
+`event_id` até a `description` do Odoo). Qualquer divergência → STOP.
+
+**Verify**: `grep -c "dataLayer" components/AIChatPanel.tsx` → `0`.
+
+### Step 2: Escrever `docs/product/funil-canonico-de-medicao.md`
+
+Cabeçalho no padrão dos spikes existentes (ver
+`docs/product/quiz-to-chatbot-funnel-spike.md`): data, tipo ("Spec de medição —
+não há mudança de comportamento neste documento"), commit de verificação.
+
+Seções obrigatórias (títulos exatos, são o done-criteria):
+
+1. `## Ciclo de vida canônico` — os estágios
+   `intent_started → qualified → handoff_created → lead_accepted → sales_qualified → won/lost`,
+   cada um com definição de uma frase e o critério observável que o dispara.
+2. `## Mapeamento por funil` — tabela: estágio canônico × funil (chatbot,
+   quiz, contato/formulários, WhatsApp direto) × evento/sinal existente hoje ×
+   lacuna. Usar o inventário do "Current state". Exemplos do mapeamento
+   esperado (o executor valida e completa, não copia cegamente):
+   - `intent_started`: chat = primeira mensagem do usuário (sem evento hoje);
+     quiz = início do quiz; formulários = `form_start`.
+   - `qualified`/`handoff_created`: chat = `response.budgetLink` chega
+     (**lacuna — o gap central**); quiz = `quiz_lead`.
+   - `lead_accepted`: `submit_success`/`generate_lead` (lead criado no Odoo).
+   - `sales_qualified`, `won/lost`: transições de estágio do `crm.lead`
+     (**lacuna — só medível via infraestrutura do plano 019**).
+   Regra dura: funis distintos mapeiam para o MESMO vocabulário de estágios;
+   nenhum funil é removido ou fundido por causa da medição.
+3. `## Fonte de verdade por estágio` — decidir e justificar: browser/dataLayer
+   (GA4) para estágios pré-lead; Odoo para `lead_accepted` em diante. Nomear o
+   sistema que desempata quando os dois discordam (recomendação: Odoo para
+   contagem de leads e receita; GA4 para comportamento pré-lead).
+4. `## Chave de correlação` — especificar a chave estável ponta a ponta:
+   `event_id` (`lead_{uuid}`) como id primário do lead do chat +
+   `ga_client_id`/`ga_session_id` como join secundário; documentar que o
+   `event_id` já chega ao Odoo como `idempotency_key` na description e que a
+   versão estruturada (campo consultável) depende dos campos do plano 019.
+   O quiz não tem event_id por submissão hoje (`form_id: 'quiz_anhanga'` fixo)
+   — registrar como lacuna com proposta (gerar `quiz_{uuid}` no submit).
+5. `## Propriedades privacy-safe` — a allowlist de propriedades permitidas por
+   evento, herdando as regras de `utils/formAnalytics.ts` (allowlist de
+   nomes de campo, redação de e-mail/telefone em URLs, nunca PII crua no
+   dataLayer). Registrar explicitamente: `x_lgpd_consent` no Odoo é opt-in de
+   **e-mail marketing**, não consentimento de analytics — se algum estágio
+   exigir base legal própria, sinalizar para o DPO (mesmo processo do §7 de
+   `docs/product/odoo-ads-conversion-decision.md`).
+6. `## Lacunas de instrumentação propostas` — lista priorizada do que um plano
+   futuro implementa (no mínimo: evento `handoff_created` no ramo
+   `response.budgetLink` de `AIChatPanel.tsx`; `intent_started` no chat;
+   event_id por submissão do quiz; eventos de estágio CRM via plano 019).
+   Cada item com: onde no código, payload proposto (conforme seção 5), e o que
+   desbloqueia (ex.: o A/B test do spike do quiz).
+7. `## O que esta spec NÃO decide` — escolha de ferramenta de dashboard,
+   mudanças de UX nos funis, e qualquer implementação.
+
+**Verify**:
+`grep -c "^## " docs/product/funil-canonico-de-medicao.md` → ≥ 7.
+
+### Step 3: Sanidade docs-only
+
+**Verify**: `git status --porcelain` mostra somente
+`docs/product/funil-canonico-de-medicao.md` e `plans/README.md`;
+`pnpm typecheck` → exit 0.
+
+## Test plan
+
+Docs-only — isento de testes de runtime pela regra do repo
+(`.claude/rules/testing.md`, "Documentation-only changes do not require
+runtime tests"). A verificação é estrutural (seções obrigatórias presentes) e
+factual (Step 1).
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `docs/product/funil-canonico-de-medicao.md` existe
+- [ ] `grep -c "^## " docs/product/funil-canonico-de-medicao.md` → ≥ 7, com os 7 títulos do Step 2 presentes literalmente
+- [ ] `grep -n "handoff_created" docs/product/funil-canonico-de-medicao.md` → ≥ 1 match
+- [ ] `grep -n "AIChatPanel" docs/product/funil-canonico-de-medicao.md` → ≥ 1 match (o gap central está documentado com file path)
+- [ ] `git status --porcelain` limpo fora de `docs/product/` e `plans/`
+- [ ] `pnpm typecheck` exit 0
+- [ ] Linha do plano 020 atualizada em `plans/README.md`
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- Alguma afirmação do "Current state" não confere no Step 1 (ex.:
+  `AIChatPanel.tsx` já ganhou um push de dataLayer no ramo do `budgetLink` —
+  nesse caso parte da spec já foi implementada por outra via e o plano precisa
+  ser re-baselined).
+- Você se pegar editando um `.ts`/`.tsx` — este plano não instrumenta nada.
+- Já existir um doc equivalente em `docs/product/` (procurar por
+  `funil`/`funnel` antes de criar) — reconciliar em vez de duplicar.
+
+## Maintenance notes
+
+- Quando a instrumentação da seção 6 da spec for implementada (plano futuro),
+  cada evento novo deve nascer com teste em `tests/` no padrão de
+  `tests/form-analytics.test.ts`.
+- O plano 019, ao ser executado, cria os campos de correlação no Odoo — a spec
+  deve ser atualizada (uma linha) quando `x_ga_client_id`/`x_gclid` saírem de
+  "proposto" para "existente".
+- O A/B test quiz→chat (`docs/product/quiz-to-chatbot-funnel-spike.md`)
+  permanece bloqueado até a lacuna `handoff_created` ser implementada — a spec
+  é o pré-requisito, não a resolução.

--- a/plans/021-prova-social-por-destino.md
+++ b/plans/021-prova-social-por-destino.md
@@ -197,8 +197,11 @@ export function findReviewsForDestination(
   city: string,
   country: string,
 ): DisplayReview[] {
-  // normalizar: lowercase + remoção de acentos (NFD + strip ̀-ͯ)
-  // match: review.destination normalizado === city normalizado OU === country normalizado
+  // normalizar: lowercase + remoção de acentos via NFD + .replace(/[\u0300-\u036f]/g, "")
+  //   (usar o escape Unicode explícito, nunca caracteres combinantes literais na regex)
+  // match: review.destination existe (é opcional em DisplayReview — guard antes de
+  //   normalizar, senão TypeError) && (destination normalizado === city normalizado
+  //   OU === country normalizado)
 }
 ```
 

--- a/plans/021-prova-social-por-destino.md
+++ b/plans/021-prova-social-por-destino.md
@@ -1,0 +1,337 @@
+# Plan 021: Protótipo de prova social casada ao destino no ponto de decisão
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat f5e4324..HEAD -- components/Destinations.tsx data/reviewsAdapter.ts data/reviewAnnotations.json data/googleReviews.json data/testimonialsData.ts types/reviews.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW–MED (UI nova em componente de alto tráfego; risco maior é quebrar snapshot visual de e2e)
+- **Depends on**: none
+- **Category**: direction
+- **Planned at**: commit `f5e4324`, 2026-07-12
+
+## Why this matters
+
+No modal de destino (`components/Destinations.tsx`), o visitante chega ao CTA
+"Solicitar Orçamento" sem nenhuma prova social — enquanto os depoimentos (que
+até carregam `destination`) vivem numa seção separada da Home, desconectados do
+ponto de decisão. Colocar a prova certa no momento da decisão é a alavanca
+clássica de conversão; a versão honesta disso exige duas coisas que este plano
+entrega: (a) uma auditoria real de cobertura de tags destino×review (hoje a
+cobertura é quase nula — ver abaixo), e (b) um cartão compacto com **fallback
+honesto** (nota agregada real do Google) quando não houver review daquele
+destino — nunca prova fabricada. É um protótipo: pequeno, mensurável via
+`data-tracking`, e reversível.
+
+## Current state
+
+Arquivos relevantes:
+
+- `components/Destinations.tsx` — seção do mapa + modal de destino. O modal
+  (linhas 382–473) mostra foto, detalhes, atrações, share e os CTAs. **Não
+  importa nada de reviews hoje.** Atenção: o arquivo usa classes `brand-*`
+  legadas — congeladas por `tests/tailwind-brand-namespace-guard.test.ts`;
+  **código novo deve usar tokens `anhanga-*`** (`lib/design-tokens.ts`).
+- `data/reviewsAdapter.ts` — adapter puro google/manual → `DisplayReview`.
+  `getDisplayReviews` é **tudo-ou-nada**: se há reviews do Google (há 3 hoje),
+  os depoimentos manuais (`TESTIMONIALS`) nem entram na lista exibida.
+- `data/googleReviews.json` — 3 reviews reais (nota média 5.0, `totalReviews: 3`),
+  **nenhuma com campo `destination`** e nenhum texto menciona destino.
+- `data/reviewAnnotations.json` — `{}` (vazio). É o mecanismo existente para
+  anotar destino em review do Google: `scripts/fetch-google-reviews.ts:254-256`
+  faz merge de `ReviewAnnotations` (`types/reviews.ts:30-34`, shape
+  `{ [reviewId]: { destination?: string } }`) sobre os reviews baixados.
+- `data/testimonialsData.ts` — 3 depoimentos manuais com `destination`
+  (`'Finlândia'`, `'Paraty'`, `'Alemanha'`).
+- `data/mapDestinations.ts` — `DESTINATIONS: Destination[]` com `city` (ex.
+  `"Orlando"`, `"Punta Cana"`, `"Cancún"`) e `country` (ex. `"EUA"`,
+  `"México"`). O match do protótipo compara `DisplayReview.destination` contra
+  `city` **e** `country`.
+- `components/ReviewSummaryBar.tsx` — exemplar visual de "nota agregada"
+  (média + total), 43 linhas; referência para o fallback.
+- `tests/destination-region.test.ts` — exemplar estrutural de teste
+  `node:test` de helper puro sobre nomes de destino.
+
+### Excerto 1 — o CTA sem prova (`components/Destinations.tsx:444-469`)
+
+```tsx
+        <div className="flex flex-col gap-3">
+            {selectedDestination.landingPage && (
+                <Link to={selectedDestination.landingPage} ... >
+                    Ver detalhes do pacote <ArrowRight className="size-5" />
+                </Link>
+            )}
+            <button
+                type="button"
+                onClick={(e) => {
+                    e.preventDefault();
+                    openContactModal({
+                        source: 'destinations-modal',
+                        destination: selectedDestination.city,
+                    });
+                    closeModal();
+                }}
+                ...
+                data-tracking={`modal-destinations-${selectedDestination.city.toLowerCase()}`}
+            >
+                Solicitar Orçamento
+            </button>
+        </div>
+```
+
+O cartão de prova entra imediatamente **antes** deste bloco `flex flex-col gap-3`.
+
+### Excerto 2 — fallback tudo-ou-nada do adapter (`data/reviewsAdapter.ts:31-36`)
+
+```ts
+export function getDisplayReviews(googleData: GoogleReviewsData): DisplayReview[] {
+  if (googleData.reviews.length > 0) {
+    return googleToDisplayReviews(googleData.reviews);
+  }
+  return manualToDisplayReviews(TESTIMONIALS);
+}
+```
+
+Para o **matching por destino** (não para o carrossel), o pool deve ser a
+união google+manual — um depoimento manual verdadeiro de Paraty continua sendo
+prova legítima mesmo com reviews do Google presentes. Não alterar
+`getDisplayReviews` (o carrossel da Home depende dele); criar uma função nova.
+
+### Design system a honrar (DESIGN.md, "O Diário de Bordo")
+
+- Cards informativos: `shadow-float` por padrão; **nunca** `shadow-hard` em
+  card informativo (hard shadow é só para o CTA principal) — DESIGN.md, seção
+  de cards ("Shadow Strategy") e Don'ts ("Don't colocar hard shadow em
+  elementos passivos").
+- Padding de card compacto mobile: `p-4`.
+- Não usar `border-left` colorido como acento; preferir fundo tonalizado.
+- Tokens: usar `anhanga-*` (ex. `text-anhanga-dark`, `bg-anhanga-light`) —
+  `brand-*` está congelado pelo guard test.
+- PRODUCT.md: "curadoria sobre catálogo", "lugares reais não categorias" — o
+  cartão cita uma pessoa real e um destino real, ou mostra a nota agregada
+  real; nunca texto genérico fabricado.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Install | `pnpm install` | exit 0 |
+| Typecheck | `pnpm typecheck` | exit 0 |
+| Teste novo (matcher) | `tsx --test tests/destination-proof.test.ts` | all pass |
+| Guard de namespace | `tsx --test tests/tailwind-brand-namespace-guard.test.ts` | all pass |
+| Regressão completa | `pnpm test:regression` | all pass |
+| Lint (ratchet CI) | `pnpm lint:changed` | exit 0 |
+| E2E (fluxos críticos + visual) | `pnpm test:e2e` | all pass (ver STOP sobre snapshots) |
+
+## Scope
+
+**In scope** (únicos arquivos a modificar/criar):
+- `data/reviewsAdapter.ts` (adicionar o matcher; não alterar funções existentes)
+- `components/ui/DestinationProofCard.tsx` (criar)
+- `components/Destinations.tsx` (renderizar o cartão no modal)
+- `data/reviewAnnotations.json` (só se o Step 1 encontrar evidência — ver regra)
+- `tests/destination-proof.test.ts` (criar)
+- `plans/README.md` (linha de status)
+
+**Out of scope** (NÃO tocar, mesmo parecendo relacionado):
+- `components/Testimonials.tsx` e `getDisplayReviews` — o carrossel da Home
+  não muda.
+- `scripts/fetch-google-reviews.ts` — o mecanismo de annotations já existe e
+  funciona; nada a mudar.
+- `data/googleReviews.json` — arquivo gerado pelo workflow agendado; editar à
+  mão dessincroniza o próximo fetch.
+- `pages/landings/*` — o protótipo é só no modal de Destinations; expandir
+  para landings é follow-up condicionado a sinal de conversão.
+- Schema JSON-LD do modal — o carrossel já emite `schema.org/Review`; duplicar
+  markup de review no modal arrisca rich-result spam.
+
+## Git workflow
+
+- Branch: `feature/021-prova-social-destino`
+- Conventional commits (ex.: `feat(destinations): proof card por destino no modal`)
+- PR draft ao final; merge é sempre humano (squash).
+
+## Steps
+
+### Step 1: Auditoria de cobertura de tags
+
+1. Enumerar os pools: reviews do Google (3, sem `destination`), depoimentos
+   manuais (3, com `destination`) e a lista de `city`/`country` de
+   `data/mapDestinations.ts`.
+2. Regra de anotação **honesta**: só preencher `data/reviewAnnotations.json`
+   para um review do Google se o **próprio texto do review** nomear um destino
+   inequívoco. No snapshot atual, nenhum dos 3 textos nomeia destino →
+   esperado: o arquivo permanece `{}`. Não inventar destino a partir de
+   conhecimento de negócio — isso é decisão do mantenedor, não do executor.
+3. Registrar o resultado da auditoria numa tabela no corpo da PR (review ×
+   destino × fonte × match com algum `city`/`country` do mapa). Com os dados
+   atuais o esperado é: cobertura de match ≈ 0 e fallback agregado dominando —
+   esse é o estado honesto e o cartão foi desenhado para ele.
+
+**Verify**: `node -e "const a=require('./data/reviewAnnotations.json'); console.log(Object.keys(a).length)"`
+→ número igual ao de reviews cujo TEXTO nomeia destino (esperado hoje: `0`).
+
+### Step 2: Matcher puro em `data/reviewsAdapter.ts`
+
+Adicionar (exports nomeados, módulo permanece puro):
+
+```ts
+/** União google+manual para matching por destino (o carrossel continua tudo-ou-nada). */
+export function getAllDisplayReviews(googleData: GoogleReviewsData): DisplayReview[] {
+  return [...googleToDisplayReviews(googleData.reviews), ...manualToDisplayReviews(TESTIMONIALS)];
+}
+
+export function findReviewsForDestination(
+  reviews: DisplayReview[],
+  city: string,
+  country: string,
+): DisplayReview[] {
+  // normalizar: lowercase + remoção de acentos (NFD + strip ̀-ͯ)
+  // match: review.destination normalizado === city normalizado OU === country normalizado
+}
+```
+
+Regras: retorno ordenado com reviews de maior `rating` primeiro e, em empate,
+mais recente primeiro; reviews sem `destination` nunca casam; match é por
+igualdade de string normalizada (sem substring — "Paraty" não pode casar
+"Paraty Mirim" por acidente de includes).
+
+**Verify**: `pnpm typecheck` → exit 0.
+
+### Step 3: `components/ui/DestinationProofCard.tsx`
+
+Componente de apresentação puro (props, sem fetch, sem estado):
+
+```ts
+interface DestinationProofCardProps {
+  city: string;
+  country: string;
+}
+```
+
+Comportamento (dados importados no módulo, como `Testimonials.tsx:10-14` faz
+com `googleReviewsRaw`):
+
+- Calcula `findReviewsForDestination(getAllDisplayReviews(googleReviewsData), city, country)`.
+- **Com match** (1º da lista): citação curta (truncar texto em ~140 chars no
+  limite de palavra + "…"), nome do autor, estrelas, e a linha "Viajou para
+  {destination}" (mesmo padrão textual de `Testimonials.tsx:164-168`); badge
+  "Google" só quando `source === 'google'`.
+- **Sem match** (fallback honesto): nota agregada real — "★ 5.0 no Google ·
+  3 avaliações" — lendo `averageRating`/`totalReviews` de
+  `googleReviewsData` via `getReviewSummary` (nunca hardcode dos números). Se
+  `getReviewSummary` retornar `null`, o componente retorna `null` (nenhum
+  cartão em vez de cartão vazio).
+- Visual: card informativo compacto seguindo DESIGN.md — `p-4`, `shadow-float`
+  (nunca hard shadow: não é CTA), fundo tonalizado (ex. `bg-anhanga-light`),
+  tokens `anhanga-*` apenas. Sem animação de entrada própria (o modal já anima).
+- Acessibilidade: estrelas com `aria-label` (padrão de
+  `Testimonials.tsx:147`), texto real no DOM (não só ícones).
+- Atributo raiz: `data-tracking="destination-proof-card"` e
+  `data-proof-variant="matched" | "aggregate"` — é o gancho de medição do
+  protótipo (GTM consegue distinguir as variantes sem código novo).
+
+**Verify**: `pnpm typecheck` → exit 0; `pnpm lint:changed` → exit 0.
+
+### Step 4: Renderizar no modal de `Destinations.tsx`
+
+Importar o componente e inserir imediatamente antes do bloco
+`<div className="flex flex-col gap-3">` (Excerto 1):
+
+```tsx
+<DestinationProofCard
+  city={selectedDestination.city}
+  country={selectedDestination.country}
+/>
+```
+
+Não tocar em mais nada do arquivo (nem migrar os `brand-*` existentes — o
+guard congela o estado atual e a migração é oportunística fora deste plano).
+
+**Verify**: `tsx --test tests/tailwind-brand-namespace-guard.test.ts` → pass
+(nenhuma classe `brand-*` nova foi introduzida).
+
+### Step 5: Testes + verificação manual
+
+Escrever `tests/destination-proof.test.ts` (ver Test plan) e verificar no
+browser: `pnpm dev` → Home → seção Destinos → abrir um destino → o cartão
+aparece antes dos CTAs com a variante `aggregate` (estado atual dos dados).
+
+**Verify**: `pnpm test:regression` → all pass; `pnpm test:e2e` → all pass.
+
+## Test plan
+
+`tests/destination-proof.test.ts`, `node:test` + `assert/strict`, modelado em
+`tests/destination-region.test.ts` (helper puro, casos nomeados):
+
+1. `findReviewsForDestination` casa por `city` com normalização de acento/caixa
+   (`'cancún'` vs `'Cancun'`).
+2. Casa por `country` quando o `destination` do review é um país (`'Alemanha'`).
+3. Não casa por substring (`'Paraty'` não casa review `'Paraty Mirim'` e vice-versa).
+4. Reviews sem `destination` são ignorados.
+5. Ordenação: rating desc, depois data desc.
+6. `getAllDisplayReviews` retorna google+manual mesmo com reviews do Google
+   presentes (tamanho = google.length + TESTIMONIALS.length).
+7. Fixture do estado real: com `data/googleReviews.json` e annotations `{}`,
+   `findReviewsForDestination(..., 'Orlando', 'EUA')` → `[]` (garante que o
+   fallback agregado é o caminho vivo hoje).
+
+Verification: `tsx --test tests/destination-proof.test.ts` → 7 pass.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `pnpm typecheck` exit 0
+- [ ] `pnpm test:regression` exit 0, incluindo `tests/destination-proof.test.ts` (7 casos)
+- [ ] `pnpm lint:changed` exit 0
+- [ ] `pnpm test:e2e` exit 0 (ou snapshots atualizados intencionalmente e mencionados na PR)
+- [ ] `grep -n "DestinationProofCard" components/Destinations.tsx` → 2 matches (import + render)
+- [ ] `grep -n "data-proof-variant" components/ui/DestinationProofCard.tsx` → ≥1 match
+- [ ] `grep -rn "brand-" components/ui/DestinationProofCard.tsx` → 0 matches (só tokens `anhanga-*`)
+- [ ] `getDisplayReviews` em `data/reviewsAdapter.ts` está byte-idêntico ao excerto 2 (carrossel intocado)
+- [ ] `git status` sem arquivos fora do escopo
+- [ ] Linha do plano 021 atualizada em `plans/README.md`
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- Os excertos de "Current state" não batem com o código (drift desde `f5e4324`).
+- `pnpm test:e2e` falhar em snapshot **visual** após inserir o cartão: se a
+  única diferença for o cartão novo no modal, rodar
+  `pnpm test:update-snapshots`, tratar como mudança intencional e destacar na
+  PR (regra de `.claude/rules/testing.md`); se a diferença for em outra
+  página/estado, STOP — algo fora do escopo mudou.
+- Você se sentir tentado a anotar um destino em `reviewAnnotations.json` sem
+  que o texto do review o nomeie — isso vira pergunta ao mantenedor, não
+  decisão do executor.
+- O bundle guard (`pnpm test:size`) falhar por causa do JSON importado no
+  chunk das Destinations — reportar em vez de reestruturar imports por conta
+  própria.
+
+## Maintenance notes
+
+- **Medição do protótipo**: `data-proof-variant` permite comparar, no GTM/GA4,
+  cliques em "Solicitar Orçamento" com cartão `matched` vs `aggregate` vs
+  período pré-cartão (o CTA já tem `data-tracking`). Decidir expandir (landings,
+  seção de destinos) só com esse sinal — é o espírito de protótipo do achado.
+- Quando novos reviews do Google mencionarem destinos, preencher
+  `data/reviewAnnotations.json` (mecanismo já pronto) aumenta a cobertura
+  `matched` sem nenhuma mudança de código.
+- Se um futuro plano migrar `Destinations.tsx` de `brand-*` para `anhanga-*`,
+  o guard test precisa ser re-baselined — não fazer aqui.
+- Revisor deve escrutinar: fallback honesto (números vindos de
+  `getReviewSummary`, nunca literais), truncamento da citação, e a ausência de
+  JSON-LD novo no modal.

--- a/plans/README.md
+++ b/plans/README.md
@@ -26,6 +26,9 @@ começar, honre as STOP conditions e atualize sua linha ao terminar.
 | 016 | SPIKE: rotear resultado do quiz para o chatbot (design doc) | P3 | M | — | DONE |
 | 017 | Mover folder do design system → `docs/design/brand-system/` + ajustar teste | P3 | S | — | DONE |
 | 018 | Guard do workflow de reviews ignora mudança só de `lastFetched` | P3 | S | 014 | DONE |
+| 019 | Fechar o loop de conversão Odoo → Google/Meta (parte repo, flags off) | P1 | M | — (gates externos p/ ativação) | TODO |
+| 020 | SPIKE: spec do funil canônico de medição (visitante → receita CRM) | P2 | M | — | TODO |
+| 021 | Protótipo de prova social casada ao destino no modal de Destinations | P2 | M | — | TODO |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (com motivo) | REJECTED (com justificativa)
 
@@ -41,6 +44,14 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (com motivo) | REJECTED (com 
 > (freeze do namespace de cor — versão segura S/LOW, não o big-bang). Direção
 > auditada via `/improve next` — sugestões grounded apresentadas ao mantenedor.
 
+> **Rodada 4** (commit `f5e4324`, 2026-07-12): planos de direção derivados do
+> `/improve next` desta rodada, escopo confirmado pelo mantenedor (achados 1–3).
+> 019 implementa a parte repo de `docs/product/odoo-ads-conversion-decision.md`
+> atrás de flags default-off — a **ativação** segue bloqueada pelos gates
+> externos (campos no Odoo, RIPD/DPO, fase de sombra); não declarar completo
+> sem validação viva. 020 é spec/docs-only (define antes de implementar).
+> 021 é protótipo mensurável com fallback honesto.
+
 ## Dependency notes
 
 - 001–005: sem dependências rígidas (todos DONE).
@@ -48,6 +59,12 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (com motivo) | REJECTED (com 
 - 008 não depende rigidamente de 007, mas recomenda-se executá-lo **depois** —
   os testes dos builders (007) dão rede de segurança extra ao refatorar os
   handlers de lead.
+- 019, 020, 021: independentes entre si (executáveis em qualquer ordem).
+  Sinergia sem dependência rígida: os campos estruturados do 019 (x_gclid,
+  x_ga_client_id etc.) são o mecanismo de correlação do estágio `won` que a
+  spec do 020 referencia; e a instrumentação que o 020 especifica (ex.
+  `handoff_created`) é pré-requisito do A/B test quiz→chat do plano 016 —
+  a spec vem antes de qualquer implementação de eventos.
 
 ## Findings considered and rejected
 
@@ -131,6 +148,29 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (com motivo) | REJECTED (com 
 - **D4 → plano 016 (spike)**: rotear resultado do quiz p/ o chatbot. Assimetria
   real (quiz → WhatsApp, ignora o chatbot apesar de já ter perfil + bantSummary),
   mas o caminho atual converte lead morno — medir antes de mudar.
+
+### Direção (`/improve next`) — rodada 4 (commit `f5e4324`, 2026-07-12)
+
+Achados 1–3 viraram os planos 019–021 (escopo confirmado pelo mantenedor).
+Opções de menor prioridade, **estudadas e não planejadas** — exigem nova
+evidência antes de reabrir:
+
+- **Retomada de conversa mobile (consentida, expirável)** em
+  `components/AIChatPanel.tsx`/`components/AIChat.tsx` — não planejar sem um
+  design de privacidade prévio (não persistir histórico sensível sem base
+  clara); demanda também sinal de que abandono de conversa é problema real.
+- **Estados explícitos de campanha evergreen** (`pages/landings/LollapaloozaLanding.tsx`
+  + `App.tsx`) — não generalizar máquina de estados até uma **segunda**
+  campanha recorrente provar o padrão.
+- **Clusters editoriais / GEO** (`docs/seo/orlando-content-cluster.md`,
+  `docs/seo/geo-citation-monitoring-pilot.md`, `docs/seo/geo-content-strategy-2026-07.md`)
+  — gated em evidência: o primeiro baseline de citação GEO ainda não rodou;
+  rodar o piloto antes de investir em produção de conteúdo.
+- **Expansão de tools do chatbot** — segue deferida
+  (`docs/product/chatbot-tool-expansion-spike.md`, plano 015).
+- **Quiz → chatbot** — segue como A/B test instrumentado
+  (`docs/product/quiz-to-chatbot-funnel-spike.md`, plano 016), bloqueado pela
+  lacuna de medição que o plano 020 especifica.
 
 ## Audit gaps
 


### PR DESCRIPTION
## O que é

Três planos de implementação autocontidos derivados da auditoria de direção (`/improve next`), com escopo confirmado pelo mantenedor. **Docs-only** — nenhum código de produção foi tocado; os planos são para execução posterior por executor separado.

| Plano | Título | Prioridade |
|---|---|---|
| 019 | Fechar o loop de conversão Odoo → Google/Meta (parte repo, flags default-off) | P1 |
| 020 | SPIKE: spec do funil canônico de medição (visitante → receita CRM) | P2 |
| 021 | Protótipo de prova social casada ao destino no modal de Destinations | P2 |

## Pontos de atenção

- **019** transforma as fases de `docs/product/odoo-ads-conversion-decision.md` em plano executável **sem duplicar a decisão**: preserva revisão DPO/RIPD, idempotência determinística (`purchase_{dealId}`), shadow rollout via `META_TEST_EVENT_CODE`, reconciliação e kill switch. A escrita dos campos `x_gclid`/etc. fica atrás de `ODOO_CONVERSION_FIELDS_ENABLED` (default off) porque escrever campo inexistente derrubaria o create do lead — a ativação real segue bloqueada pelos gates externos listados no plano.
- **020** define o ciclo `intent_started → qualified → handoff_created → lead_accepted → sales_qualified → won/lost`, fonte de verdade, propriedades privacy-safe e correlação estável — **antes** de instrumentar. Gap central verificado: `AIChatPanel.tsx` não emite nada quando o `budgetLink` chega, exatamente a lacuna que bloqueou o A/B quiz→chat do plano 016.
- **021** começa pela auditoria de cobertura de tags (hoje: 3 reviews Google sem destino, `reviewAnnotations.json` vazio) e um proof card compacto com **fallback honesto** (nota agregada real via `getReviewSummary`), mensurável por `data-proof-variant`.
- `plans/README.md` reconciliado: 001–018 seguem DONE, numeração monotônica, rodada 4 registrada com os achados de direção estudados e não planejados.

Todos os excertos de código nos planos foram verificados em primeira mão contra o commit `f5e4324`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgzxBYC95k4dMmjcRwBvrD