### PR TITLE
fix(security): cap parts array in AI chat request schema (DoS hardening)

### DIFF
--- a/lib/schemas/generate.ts
+++ b/lib/schemas/generate.ts
@@ -2,6 +2,12 @@ import { z } from 'zod';
 
 const MAX_TEXT_LENGTH = 5000;
 const MAX_CONTENTS_ENTRIES = 50;
+// Cap the parts array so a single message can't force unbounded validation work.
+// The chat client always sends exactly one text part per message, so a small cap
+// is generous for real traffic while closing a DoS vector: without it, a lone
+// message could carry a huge `parts` array that Zod iterates in full before the
+// downstream total-size guard (hasOversizedPayload) ever runs.
+const MAX_PARTS_PER_MESSAGE = 20;
 
 const GeneratePartSchema = z.object({
     text: z.string().max(MAX_TEXT_LENGTH),
@@ -9,7 +15,7 @@ const GeneratePartSchema = z.object({
 
 const GenerateMessageSchema = z.object({
     role: z.enum(['user', 'model']),
-    parts: z.array(GeneratePartSchema).min(1),
+    parts: z.array(GeneratePartSchema).min(1).max(MAX_PARTS_PER_MESSAGE),
 });
 
 export const GenerateRequestSchema = z.object({

--- a/lib/schemas/generate.ts
+++ b/lib/schemas/generate.ts
@@ -15,7 +15,18 @@ const GeneratePartSchema = z.object({
 
 const GenerateMessageSchema = z.object({
     role: z.enum(['user', 'model']),
-    parts: z.array(GeneratePartSchema).min(1).max(MAX_PARTS_PER_MESSAGE),
+    // Guard the array length BEFORE validating elements. z.array().max() parses
+    // every element against GeneratePartSchema first and only then enforces the
+    // cap, so a huge `parts` array would still be iterated in full (CPU-exhaustion
+    // DoS) before being rejected. Pre-checking the length via refine short-circuits
+    // that iteration, so an oversized array is rejected in O(1).
+    parts: z
+        .unknown()
+        .refine(
+            (value): value is unknown[] => Array.isArray(value) && value.length <= MAX_PARTS_PER_MESSAGE,
+            { message: `parts deve ter no máximo ${MAX_PARTS_PER_MESSAGE} itens` },
+        )
+        .pipe(z.array(GeneratePartSchema).min(1)),
 });
 
 export const GenerateRequestSchema = z.object({

--- a/tests/generate-schema.test.ts
+++ b/tests/generate-schema.test.ts
@@ -57,6 +57,18 @@ test('rejeita parts vazio', () => {
     assert.equal(result.success, false);
 });
 
+test('aceita até 20 parts por mensagem', () => {
+    const parts = Array.from({ length: 20 }, () => ({ text: 'Olá' }));
+    const result = GenerateRequestSchema.safeParse({ contents: [{ role: 'user', parts }] });
+    assert.equal(result.success, true);
+});
+
+test('rejeita mais de 20 parts por mensagem (DoS guard)', () => {
+    const parts = Array.from({ length: 21 }, () => ({ text: 'Olá' }));
+    const result = GenerateRequestSchema.safeParse({ contents: [{ role: 'user', parts }] });
+    assert.equal(result.success, false);
+});
+
 test('rejeita text com mais de 5000 chars', () => {
     const result = GenerateRequestSchema.safeParse({
         contents: [{ role: 'user', parts: [{ text: 'a'.repeat(5001) }] }],


### PR DESCRIPTION
## Resumo

- **O que muda:** Adiciona um limite máximo (`MAX_PARTS_PER_MESSAGE = 20`) ao array `parts` de cada mensagem em `GenerateRequestSchema` (`lib/schemas/generate.ts`).
- **Por quê:** O schema já limitava `contents` a 50 entradas e o `text` de cada part a 5000 chars, mas o array `parts` dentro de cada mensagem era **ilimitado**. O Zod valida o array inteiro *antes* do guard de tamanho total downstream (`hasOversizedPayload`), então uma única mensagem com um `parts` gigante forçava trabalho de validação ilimitado — uma brecha de DoS (defense-in-depth).
- **Impacto para o usuário:** Nenhum. O chat sempre envia exatamente um text part por mensagem; o cap de 20 é generoso para tráfego real e apenas fecha o vetor abusivo.
- **Nível de risco:** baixo

## Issue relacionada

Sem issue — hardening proativo de segurança (rodada Sentinel). Fecha uma lacuna de validação encontrada durante varredura das bordas de API.

## Tipo de mudança

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] ♻️ Refatoração (sem mudança de comportamento)
- [ ] ⚙️ Infra / CI
- [ ] 📚 Documentação
- [ ] 🔍 SEO / GEO
- [ ] ⚡ Performance

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only)
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível)

Dois casos de regressão adicionados em `tests/generate-schema.test.ts`: aceita até 20 parts; rejeita 21+ (guard de DoS), espelhando o padrão existente do cap de `contents`.

Comandos executados:

```text
npx tsx --test tests/generate-schema.test.ts        # 15/15 pass
npx tsx --test tests/generate-message-size.test.ts tests/api-generate.test.ts  # 24/24 pass
pnpm typecheck                                       # exit 0
pnpm lint:changed                                    # sem erros nos 2 arquivos alterados
```

## API & Segurança

- [x] Inputs validados/sanitizados na borda, antes de side effects ou chamadas a providers
- [x] Respostas e códigos de erro permanecem estruturados; helpers compartilhados (`lib/network`, `lib/rate-limit`, `lib/schemas`) reutilizados
- [x] Sem secrets ou PII bruta em logs
- [x] `dangerouslySetInnerHTML` não foi introduzido sem fonte controlada e justificativa

O cap fecha um vetor de trabalho de validação ilimitado no endpoint público `api/generate.ts`, que já é rate-limited (10 req/min/IP). A defesa é ordenada corretamente: o Zod rejeita o array excessivo na borda, antes de qualquer chamada ao provider Gemini.

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`fix:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

Nenhum desvio. O valor do cap (20) é arbitrariamente generoso — o cliente de chat sempre envia um único text part por mensagem, então o limite real observável em produção é 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m6QK5JjRweVgFfXJNaNGg

---
_Generated by [Claude Code](https://claude.ai/code/session_014m6QK5JjRweVgFfXJNaNGg)_