### PR TITLE
fix(ci): fetch full history for React Doctor's PR diff

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -31,6 +31,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The action's own PR-diff step needs the base commit reachable to
+          # compute the changed-file set locally; a shallow checkout (the
+          # default) forces it onto a GitHub-API fallback path that has been
+          # producing "Scan could not complete" failures on this repo's PRs
+          # since 2026-07-12 (every PR, regardless of diff content).
+          fetch-depth: 0
 
       - uses: millionco/react-doctor@ced746f518f11e8283d488c4ff31c44e478bb0e5 # v2.2.6
         # Advisory by default: React Doctor reports findings on every PR — a

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -61,16 +61,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
           package-manager-cache: false
       - name: Run react-doctor directly and capture raw output
+        env:
+          REACT_DOCTOR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set +e
-          npx --yes react-doctor@0.7.7 . --json --json-compact --blocking none --project '*' > /tmp/raw-report.json 2> /tmp/raw-report.err
+          git diff --name-only --diff-filter=AMR "${REACT_DOCTOR_BASE_SHA}...HEAD" > /tmp/changed.txt
+          echo "--- changed files ---"
+          cat /tmp/changed.txt
+          wc -l < /tmp/changed.txt
+          npx --yes react-doctor@0.7.7 . --json --json-compact --blocking none --project '*' --scope changed --changed-files-from /tmp/changed.txt > /tmp/raw-report.json 2> /tmp/raw-report.err
           echo "EXIT_CODE=$?"
-          echo "--- stdout ---"
+          echo "--- stdout (len=$(wc -c < /tmp/raw-report.json)) ---"
           cat /tmp/raw-report.json
-          echo "--- stderr ---"
+          echo "--- stderr (len=$(wc -c < /tmp/raw-report.err)) ---"
           cat /tmp/raw-report.err
+          echo "--- END ---"

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -57,48 +57,17 @@ jobs:
         #   directory: apps/web      # Scan a sub-directory (default: ".")
         #   project: "web,admin"     # In a monorepo, scan specific workspace project(s)
 
-  debug-react-doctor-raw:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: "24"
-          package-manager-cache: false
-      - name: Run react-doctor directly and capture raw output
-        env:
-          REACT_DOCTOR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          RUNNER_TEMP: ${{ runner.temp }}
-          REACT_DOCTOR_CACHE_DIR: ${{ runner.temp }}/react-doctor-cache
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          REACT_DOCTOR_GITHUB_ACTION: ${{ github.action_ref || '1' }}
-          REACT_DOCTOR_ACTION_BLOCKING: none
-          REACT_DOCTOR_ACTION_COMMENT: true
-          REACT_DOCTOR_ACTION_REVIEW_COMMENTS: true
-          REACT_DOCTOR_ACTION_VERSION: latest
-          NO_COLOR: "1"
+      - name: DEBUG - inspect report file and re-run CLI in-situ
+        if: always()
         run: |
-          set +e
-          mkdir -p "$REACT_DOCTOR_CACHE_DIR"
-          git diff --name-only --diff-filter=AMR "${REACT_DOCTOR_BASE_SHA}...HEAD" > /tmp/changed.txt
-          echo "--- changed files ---"
-          cat /tmp/changed.txt
-          wc -l < /tmp/changed.txt
-
-          echo "--- installing exactly like the action (npm install --prefix) ---"
-          mkdir -p /tmp/toolchain
-          npm install --prefix /tmp/toolchain --no-save --no-audit --no-fund react-doctor@0.7.7
-          echo "npm install exit: $?"
-          /tmp/toolchain/node_modules/.bin/react-doctor --version
-          echo "--version exit: $?"
-
-          echo "--- running the installed bin with FULL action env (not npx) ---"
-          /tmp/toolchain/node_modules/.bin/react-doctor . --json --json-compact --blocking none --project '*' --scope changed --changed-files-from /tmp/changed.txt > /tmp/raw-report.json 2> /tmp/raw-report.err
-          echo "EXIT_CODE=$?"
-          echo "--- stdout (len=$(wc -c < /tmp/raw-report.json)) ---"
-          cat /tmp/raw-report.json
-          echo "--- stderr (len=$(wc -c < /tmp/raw-report.err)) ---"
-          cat /tmp/raw-report.err
-          echo "--- END ---"
+          echo "=== report file ==="
+          cat "${RUNNER_TEMP}/react-doctor-report-${GITHUB_RUN_ID}.json" 2>&1 || echo "(none / not found)"
+          echo "=== changed-files-from file ==="
+          cat "${RUNNER_TEMP}/react-doctor-changed-files.txt" 2>&1 || echo "(none / not found)"
+          echo "=== toolchain bin present? ==="
+          ls -la "${RUNNER_TEMP}/react-doctor-toolchain/node_modules/.bin/" 2>&1 || echo "(no toolchain dir)"
+          echo "=== re-run CLI in-situ, capture stderr ==="
+          "${RUNNER_TEMP}/react-doctor-toolchain/node_modules/.bin/react-doctor" . \
+            --json --json-compact --blocking none --project '*' \
+            --scope changed --changed-files-from "${RUNNER_TEMP}/react-doctor-changed-files.txt" 2>&1 | head -80
+          echo "in-situ exit: $?"

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -56,3 +56,20 @@ jobs:
         #   version: "0.4.0"         # Pin to a specific react-doctor version instead of "latest"
         #   directory: apps/web      # Scan a sub-directory (default: ".")
         #   project: "web,admin"     # In a monorepo, scan specific workspace project(s)
+
+  debug-react-doctor-raw:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "24"
+      - name: Run react-doctor directly and capture raw output
+        run: |
+          set +e
+          npx --yes react-doctor@0.7.7 . --json --json-compact --blocking none --project '*' > /tmp/raw-report.json 2> /tmp/raw-report.err
+          echo "EXIT_CODE=$?"
+          echo "--- stdout ---"
+          cat /tmp/raw-report.json
+          echo "--- stderr ---"
+          cat /tmp/raw-report.err

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -34,9 +34,11 @@ jobs:
         with:
           # The action's own PR-diff step needs the base commit reachable to
           # compute the changed-file set locally; a shallow checkout (the
-          # default) forces it onto a GitHub-API fallback path that has been
-          # producing "Scan could not complete" failures on this repo's PRs
-          # since 2026-07-12 (every PR, regardless of diff content).
+          # default) forces it onto a GitHub-API changed-files fallback.
+          # This doesn't fix the separate "Scan could not complete" failures
+          # (root-caused to an intermittent CLI stdout-truncation-on-exit race
+          # upstream, filed as millionco/react-doctor#1242), but it's a
+          # correctness improvement in its own right and worth keeping.
           fetch-depth: 0
 
       - uses: millionco/react-doctor@ced746f518f11e8283d488c4ff31c44e478bb0e5 # v2.2.6
@@ -56,18 +58,3 @@ jobs:
         #   version: "0.4.0"         # Pin to a specific react-doctor version instead of "latest"
         #   directory: apps/web      # Scan a sub-directory (default: ".")
         #   project: "web,admin"     # In a monorepo, scan specific workspace project(s)
-
-      - name: DEBUG - inspect report file and re-run CLI in-situ
-        if: always()
-        run: |
-          echo "=== report file ==="
-          cat "${RUNNER_TEMP}/react-doctor-report-${GITHUB_RUN_ID}.json" 2>&1 || echo "(none / not found)"
-          echo "=== changed-files-from file ==="
-          cat "${RUNNER_TEMP}/react-doctor-changed-files.txt" 2>&1 || echo "(none / not found)"
-          echo "=== toolchain bin present? ==="
-          ls -la "${RUNNER_TEMP}/react-doctor-toolchain/node_modules/.bin/" 2>&1 || echo "(no toolchain dir)"
-          echo "=== re-run CLI in-situ, capture stderr ==="
-          "${RUNNER_TEMP}/react-doctor-toolchain/node_modules/.bin/react-doctor" . \
-            --json --json-compact --blocking none --project '*' \
-            --scope changed --changed-files-from "${RUNNER_TEMP}/react-doctor-changed-files.txt" 2>&1 | head -80
-          echo "in-situ exit: $?"

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -64,6 +64,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
+          package-manager-cache: false
       - name: Run react-doctor directly and capture raw output
         run: |
           set +e

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -70,8 +70,18 @@ jobs:
       - name: Run react-doctor directly and capture raw output
         env:
           REACT_DOCTOR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          RUNNER_TEMP: ${{ runner.temp }}
+          REACT_DOCTOR_CACHE_DIR: ${{ runner.temp }}/react-doctor-cache
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          REACT_DOCTOR_GITHUB_ACTION: ${{ github.action_ref || '1' }}
+          REACT_DOCTOR_ACTION_BLOCKING: none
+          REACT_DOCTOR_ACTION_COMMENT: true
+          REACT_DOCTOR_ACTION_REVIEW_COMMENTS: true
+          REACT_DOCTOR_ACTION_VERSION: latest
+          NO_COLOR: "1"
         run: |
           set +e
+          mkdir -p "$REACT_DOCTOR_CACHE_DIR"
           git diff --name-only --diff-filter=AMR "${REACT_DOCTOR_BASE_SHA}...HEAD" > /tmp/changed.txt
           echo "--- changed files ---"
           cat /tmp/changed.txt
@@ -84,7 +94,7 @@ jobs:
           /tmp/toolchain/node_modules/.bin/react-doctor --version
           echo "--version exit: $?"
 
-          echo "--- running the installed bin (not npx) ---"
+          echo "--- running the installed bin with FULL action env (not npx) ---"
           /tmp/toolchain/node_modules/.bin/react-doctor . --json --json-compact --blocking none --project '*' --scope changed --changed-files-from /tmp/changed.txt > /tmp/raw-report.json 2> /tmp/raw-report.err
           echo "EXIT_CODE=$?"
           echo "--- stdout (len=$(wc -c < /tmp/raw-report.json)) ---"

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -76,7 +76,16 @@ jobs:
           echo "--- changed files ---"
           cat /tmp/changed.txt
           wc -l < /tmp/changed.txt
-          npx --yes react-doctor@0.7.7 . --json --json-compact --blocking none --project '*' --scope changed --changed-files-from /tmp/changed.txt > /tmp/raw-report.json 2> /tmp/raw-report.err
+
+          echo "--- installing exactly like the action (npm install --prefix) ---"
+          mkdir -p /tmp/toolchain
+          npm install --prefix /tmp/toolchain --no-save --no-audit --no-fund react-doctor@0.7.7
+          echo "npm install exit: $?"
+          /tmp/toolchain/node_modules/.bin/react-doctor --version
+          echo "--version exit: $?"
+
+          echo "--- running the installed bin (not npx) ---"
+          /tmp/toolchain/node_modules/.bin/react-doctor . --json --json-compact --blocking none --project '*' --scope changed --changed-files-from /tmp/changed.txt > /tmp/raw-report.json 2> /tmp/raw-report.err
           echo "EXIT_CODE=$?"
           echo "--- stdout (len=$(wc -c < /tmp/raw-report.json)) ---"
           cat /tmp/raw-report.json


### PR DESCRIPTION
## Summary

React Doctor has been failing "Scan could not complete" / "react-doctor exited with status 0 before producing a JSON report" on essentially every PR since 2026-07-12, regardless of diff content. It's not a required check so it hasn't blocked merges, but it's noise on every PR.

## Root cause

After extensive isolation (base-reachability, toolchain cache, scan-result cache, install method, full env-var parity, and finally an in-situ re-run of the exact same installed binary in the same job/VM immediately after a failure — which succeeded instantly), this is an **intermittent upstream CLI bug**: the report file shows the CLI's own recorded exit status as `0` (success), but no valid JSON ever reached the report file. That signature — clean exit, no output — combined with an identical immediate re-run succeeding, points to a timing-dependent stdout-flush race on process exit inside the CLI itself, not anything wrong in our workflow, cache, or repo. Filed upstream with full repro data: https://github.com/millionco/react-doctor/issues/1242

## What's included in this PR

- `fetch-depth: 0` on the checkout step. This fixes a real (but separate) issue: the action's own local git-diff path was falling back to the GitHub API because the PR base commit wasn't reachable in a shallow checkout. This is a correctness improvement on its own, but does **not** resolve the "Scan could not complete" failures — those are the upstream bug above.
- No workaround was possible from our side for the upstream race condition itself (the check is advisory-only already, `blocking: none`, so it doesn't block merges).

## Test plan

- [x] Confirmed the "base commit isn't reachable" warning is gone in later runs after `fetch-depth: 0`
- [x] Root-caused the remaining failures to an upstream bug, filed with reproducible evidence
- [ ] No further action needed here until upstream responds; the check remains advisory/non-blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)