### PR TITLE
fix(blog): rebuild diário incondicional no Scheduled Blog Publish

### DIFF
--- a/.github/workflows/scheduled-publish.yml
+++ b/.github/workflows/scheduled-publish.yml
@@ -1,12 +1,16 @@
 # Publica posts agendados: o build de produção do Cloudflare Pages oculta
-# posts com `date` futura (ver lib/blog-schedule.js). Este workflow roda todo
-# dia de manhã e, quando existe um post vencido (date <= hoje) que ainda não
-# aparece no sitemap de produção, dispara o Deploy Hook do Pages — o rebuild
-# materializa o post no site, no sitemap, no feed RSS e no llms.txt.
+# posts com `date` futura (ver lib/blog-schedule.js). Este workflow dispara o
+# Deploy Hook do Pages todo dia de manhã — o rebuild materializa qualquer
+# post vencido no site, no sitemap, no feed RSS e no llms.txt.
 #
-# Comparar com o sitemap (em vez de "date == hoje") dá catch-up automático:
-# se o cron falhar ou atrasar no dia do post (schedule é best-effort no
-# GitHub Actions), a execução seguinte ainda enxerga o post pendente.
+# O rebuild é INCONDICIONAL de propósito. As duas variantes condicionais
+# foram testadas e descartadas (sondas em 14/07/2026):
+#   - conferir o sitemap de produção → 403: o WAF do Cloudflare bloqueia
+#     IPs de runner do GitHub para o site, com qualquer user-agent;
+#   - conferir o último deploy via API do Pages → 401: o CLOUDFLARE_API_TOKEN
+#     do repo não tem escopo de leitura do Pages.
+# Um build diário (~30/mês) é irrelevante perto da cota e elimina qualquer
+# cenário de post preso: o catch-up é inerente.
 #
 # Setup (uma vez): criar um Deploy Hook no dashboard do Cloudflare Pages
 # (av-site → Settings → Builds & deployments → Deploy hooks, branch main) e
@@ -23,7 +27,7 @@ permissions:
 
 jobs:
   trigger-rebuild:
-    name: Rebuild produção se há post vencido fora do ar
+    name: Rebuild diário de produção (publica posts vencidos)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,41 +35,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Verifica se há post vencido fora do ar
-        id: due
+      # Informativo apenas — não condiciona o disparo.
+      - name: Lista posts que vencem hoje
         run: |
           TODAY="$(TZ=America/Sao_Paulo date +%F)"
           echo "Hoje (São Paulo): $TODAY"
+          grep -rlE "^date: *[\"']?${TODAY}" content/blog --include='*.mdx' \
+            | sed 's|.*/|• publica hoje: |; s|\.mdx$||' || echo "Nenhum post vence hoje."
 
-          SITEMAP="$(curl -fsS --max-time 30 https://www.anhanga.tur.br/sitemap.xml)" || {
-            echo "::error::Não consegui ler o sitemap de produção — sem ele não dá para saber o que já está publicado."
-            exit 1
-          }
-
-          publish=false
-          for file in content/blog/*.mdx; do
-            slug="$(basename "$file" .mdx)"
-            case "$slug" in _*) continue ;; esac
-            date="$(sed -nE "s/^date: *[\"']?([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/p" "$file" | head -1)"
-            [ -z "$date" ] && continue
-            [ "$date" \> "$TODAY" ] && continue
-            # O sitemap usa URLs com barra final; o -F exato evita casar
-            # slugs que são prefixo de outros.
-            if ! printf '%s' "$SITEMAP" | grep -qF "/blog/$slug/"; then
-              echo "Post vencido ausente de produção: $slug (date: $date)"
-              publish=true
-            fi
-          done
-
-          if [ "$publish" = false ]; then
-            echo "Todos os posts vencidos já estão publicados — nada a fazer."
-          fi
-          echo "publish=$publish" >> "$GITHUB_OUTPUT"
-
-      # workflow_dispatch sempre dispara o rebuild, para permitir publicação
-      # manual fora do horário do cron.
       - name: Dispara Deploy Hook do Cloudflare Pages
-        if: steps.due.outputs.publish == 'true' || github.event_name == 'workflow_dispatch'
         env:
           DEPLOY_HOOK_URL: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK_URL }}
         run: |

--- a/content/blog/README.md
+++ b/content/blog/README.md
@@ -4,7 +4,7 @@ Posts do blog em formato MDX com frontmatter YAML.
 
 ## Agendamento de publicação
 
-O campo `date` do frontmatter agenda a publicação: **no build de produção** (Cloudflare Pages, branch `main`), posts com `date` futura ficam fora do manifest, do prerender, do `sitemap.xml`, do `feed.xml` e do `llms.txt`. Um workflow diário (`.github/workflows/scheduled-publish.yml`, 06:15 de São Paulo) verifica se algum post vencido (data <= hoje) ainda está fora do sitemap de produção e, se sim, dispara o Deploy Hook do Pages — o rebuild coloca o post no ar. A comparação com o sitemap dá catch-up automático: se o cron falhar no dia do post, a execução seguinte publica o atrasado.
+O campo `date` do frontmatter agenda a publicação: **no build de produção** (Cloudflare Pages, branch `main`), posts com `date` futura ficam fora do manifest, do prerender, do `sitemap.xml`, do `feed.xml` e do `llms.txt`. Um workflow diário (`.github/workflows/scheduled-publish.yml`, 06:15 de São Paulo) dispara o Deploy Hook do Pages incondicionalmente — o rebuild materializa qualquer post vencido, e um cron perdido é coberto pelo dia seguinte (catch-up inerente). O porquê de não haver verificação condicional está documentado no cabeçalho do próprio workflow.
 
 Na prática: pode mergear a PR do post quando o conteúdo estiver pronto; ele só publica na data do frontmatter.
 


### PR DESCRIPTION
## Contexto

O primeiro `workflow_dispatch` do **Scheduled Blog Publish** (pós-merge da #1186) falhou: o passo que conferia o sitemap de produção tomou **403** — o WAF do Cloudflare bloqueia IPs de runner do GitHub para o site inteiro.

## Investigação (sondas em branch descartável, sem gastar merges)

| Variante testada | Resultado |
|---|---|
| `curl` sitemap, UA padrão | 403 |
| `curl` sitemap, UA de navegador (+ headers Accept/Language) | 403 |
| `curl` sitemap, host sem www | 403 |
| API de deployments do Pages com `CLOUDFLARE_API_TOKEN` do repo | 401 (token sem escopo de leitura do Pages) |

## Solução

Rebuild **incondicional** diário (06:15 SP): dispara o Deploy Hook sem gate. Racional documentado no cabeçalho do workflow:

- ~30 builds/mês é irrelevante perto da cota (500/mês);
- catch-up vira inerente — impossível um post ficar preso por cron perdido;
- única dependência externa é o Deploy Hook, já validado E2E (POST retornou `success: true`, build criado).

O passo que lista os posts que vencem no dia foi mantido como log informativo. `workflow_dispatch` segue disponível para publicação manual.

## Pós-merge

Vou disparar o `workflow_dispatch` para o teste E2E completo (era o objetivo original antes do 403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)