### PR TITLE
docs(bolt): note react-doctor CI check is a false-red tool bug

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
+## 2026-07-14 - ⚡ Bolt: react-doctor CI check is a false-red (tool bug)
+**Learning:** The `react-doctor` CI check fails on *every* PR with "Scan could not complete / react-doctor exited with status 0 before producing a JSON report" — the job log shows `ERROR_COUNT: 0`, `WARNING_COUNT: 0` and `SCAN_EXIT: 1`. This is a bug in the react-doctor 0.7.1 action (bumped in #1180), not a finding on the diff, and it does NOT block human merge (PR #1190 merged red on react-doctor). Re-running the failed job reproduces it identically.
+**Action:** When a Bolt PR shows red on `react-doctor`, don't investigate it as a code problem or try to fix it — confirm `ERROR_COUNT`/`WARNING_COUNT` are 0 in the job log, flag it once to the user as a known tool bug needing a CI/deps decision, and leave workflows/deps untouched (out of scope for a perf PR).
+
 ## 2027-01-20 - ⚡ Bolt: Header Scroll Stabilization
 **Learning:** Global components like the `Header` that listen to scroll events are high-frequency targets for optimization. Without stable function references and memoized sub-navigation components, every scroll tick triggers a full reconciliation of the entire navigation tree. Stabilizing the style object with `useMemo` and callbacks with `useCallback` ensures that the main thread remains free for smooth scrolling and interaction.
 **Action:** Always memoize sub-components and stabilize callback references in global UI elements that react to high-frequency events like scrolling or window resizing.


### PR DESCRIPTION
## Resumo

- **O que muda:** adiciona uma entrada ao journal interno do agente Bolt (`.jules/bolt.md`) registrando que o check de CI `react-doctor` está persistentemente quebrado.
- **Por quê:** durante a PR #1190, o check `react-doctor` falhou em todos os commits com "Scan could not complete / react-doctor exited with status 0 before producing a JSON report", enquanto o log do job mostra `ERROR_COUNT: 0` e `WARNING_COUNT: 0`. É um bug na action `react-doctor` 0.7.1 (bump em #1180), não um achado sobre o diff — e não bloqueou o merge humano. Registrar isso evita que execuções futuras do Bolt gastem ciclos re-investigando o mesmo vermelho.
- **Impacto para o usuário:** nenhum em runtime — é documentação interna do agente.
- **Nível de risco:** baixo (docs-only)

## Issue relacionada

Sem issue — follow-up de bookkeeping após o merge da #1190.

## Tipo de mudança

- [x] 📚 Documentação

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only)

Mudança docs-only: `docs/standards/testing.md` isenta alterações somente de documentação de testes de runtime.

## API & Segurança

- [x] Não se aplica

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`docs:`)

## Exceções / observações para o revisor

Nota: o próprio check `react-doctor` provavelmente aparecerá vermelho nesta PR pelo mesmo motivo documentado aqui — é o bug da action, não um problema do conteúdo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01822unanWhYBAX9sqCYsYkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01822unanWhYBAX9sqCYsYkH)_