### PR TITLE
fix(design): polish da landing de consultoria + foco visível sitewide

### DIFF
--- a/.impeccable/critique/2026-07-16T01-43-13Z__pages-landings-consultoriadeviagemlanding-tsx.md
+++ b/.impeccable/critique/2026-07-16T01-43-13Z__pages-landings-consultoriadeviagemlanding-tsx.md
@@ -1,0 +1,93 @@
+---
+target: página de consultoria
+total_score: 26
+p0_count: 0
+p1_count: 3
+timestamp: 2026-07-16T01-43-13Z
+slug: pages-landings-consultoriadeviagemlanding-tsx
+---
+Method: dual-agent (A: general-purpose · B: general-purpose)
+
+## Design Health Score
+
+| # | Heurística | Nota | Ponto-chave |
+|---|-----------|-------|-----|
+| 1 | Visibilidade do status do sistema | 2/4 | Conteúdo em `whileInView` some/reaparece sem placeholder — lê como quebrado durante rolagem rápida |
+| 2 | Correspondência sistema/mundo real | 3/4 | Linguagem natural PT-BR; relação do bubble "ROTEIRO IA" com o CTA principal não é explicada |
+| 3 | Controle e liberdade do usuário | 3/4 | Modal fecha por X, ESC e backdrop — bem implementado |
+| 4 | Consistência e padrões | 2/4 | Regra do Âmbar do próprio DESIGN.md violada; CTA do nav desaparece no mobile sem razão de conteúdo |
+| 5 | Prevenção de erros | 3/4 | Campos obrigatórios, tipos de input corretos, honeypot, submit desabilitado até validar |
+| 6 | Reconhecimento vs. recordação | 3/4 | FAQ accordion, steps com título+descrição |
+| 7 | Flexibilidade e eficiência de uso | 2/4 | Sem atalho; WhatsApp obrigatório sem caminho alternativo real por e-mail |
+| 8 | Design estético e minimalista | 2/4 | Três affordances de CTA competindo no hero; Âmbar duplicado |
+| 9 | Ajudar a reconhecer/diagnosticar/recuperar erros | 3/4 | `role="alert"`, mensagens de campo — estrutura correta |
+| 10 | Ajuda e documentação | 3/4 | FAQ funciona como ajuda embutida; política de privacidade linkada no momento certo |
+| **Total** | | **26/40** | **Aceitável — melhorias significativas antes que usuários fiquem satisfeitos** |
+
+## Anti-Patterns Verdict
+
+**LLM assessment (Assessment A):** Não é slop grosseiro à primeira vista — paleta restrita, sem gradiente, sem grid de cards idênticos, testemunho único em vez de grade genérica. Mas carrega 3 digitais de scaffolding de IA: (1) numeração `01/02/03` em "Como funciona", o padrão explicitamente banido pelo sistema Impeccable; (2) pilares 100% ícone-only (`MessageSquare`, `Users`, `Headphones`) sem nenhuma fotografia real de destino/viajante — contradiz o princípio de produto #4 "lugares reais, não categorias"; (3) todo o conteúdo gated por `whileInView` fade-up sem exceção, confirmado visualmente escondendo seções inteiras (inclusive dentro do viewport) durante rolagem instrumentada.
+
+**Deterministic scan:** `detect.mjs` no arquivo-alvo + `components/landings/shared/*` (LandingNav, LandingFooter, constants) retornou **limpo (0 achados)**. A injeção ao vivo via overlay (`detect.js` no DOM renderizado completo) encontrou **13-17 instâncias** de achados, mas a maioria pertence a `components/LandingFAQ.tsx` — fora do escopo do arquivo-alvo pedido, então não é uma falha da página em si, é cobertura mais ampla do overlay: `all-caps-body`/`hero-eyebrow-chip` no chip do hero, `cramped-padding`+`nested-cards` no item de FAQ, `layout-transition` (max-height) 5x no accordion, `line-length` 5x nas respostas do FAQ, `single-font` e `bounce-easing` no body.
+
+**Falsos positivos identificados por B:** `single-font` é esperado — CLAUDE.md reserva Merriweather só para prosa de blog, landing usar só Poppins é conforme o design system. `layout-transition: max-height` no accordion é a técnica padrão para animar altura em CSS (não é bug). `nested-cards` no FAQ é um accordion dentro de painel — pode ser heurística capturando um padrão de lista comum, não um erro real.
+
+**Overlaps entre A e B:** Nenhum dos achados do detector aponta diretamente para os 3 P1s que A levantou (Regra do Âmbar, 3 CTAs competindo, twin-button no modal) — são problemas de julgamento holístico que só uma revisão visual pega, confirmando o valor de rodar os dois assessments. Onde os dois se cruzam é no acordeão do FAQ: B sinaliza `layout-transition`/`cramped-padding` ali; A não citou o FAQ diretamente, mas ambos concordam que animação de conteúdo é um ponto de atenção recorrente da página (A no `whileInView` das seções principais, B no accordion).
+
+## Overall Impression
+
+A página está tecnicamente sólida (reduced-motion tratado, contraste de cor validado, honeypot anti-spam, foco visível na maior parte) e evita os clichês óbvios de "SaaS genérico". O problema real é que ela **quebra as próprias regras que o DESIGN.md e o PRODUCT.md da marca escreveram**: a Regra do Âmbar (máximo 1 por tela) é violada por um botão de nav sticky visível o tempo todo; o princípio "um CTA dominante por tela" perde para três affordances de conversão competindo simultaneamente no hero; e o princípio "lugares reais, não categorias de produto" perde para uma página 100% ícone-only sem nenhuma imagem de destino. A maior oportunidade não é remover slop de IA — é fazer a página seguir o próprio sistema de design que a Anhangá já documentou.
+
+## What's Working
+
+1. **`MotionConfig reducedMotion="user"` + fallback sem JS** (`ConsultoriaDeViagemLanding.tsx:102-105`) — tratamento cuidadoso de acessibilidade de movimento, raro de ver bem-feito.
+2. **Testemunho único e crível** em vez de grade de depoimentos genéricos, com atribuição só de iniciais (LGPD-consciente) — coerente com "curadoria sobre catálogo".
+3. **Contraste de cor validado em todo o sistema de tokens** — combinações âmbar/ardósia e azul/branco passam AA com folga.
+
+## Priority Issues
+
+**[P1] Regra do Âmbar violada em tablet/desktop**
+- **Why it matters**: O DESIGN.md é explícito: "Colocado em dois lugares ao mesmo tempo, perde todo o efeito." O botão do nav sticky (`shadow-hard-yellow`) fica visível ao lado do CTA do hero (`bg-anhanga-yellow`) na primeira tela em tablet/desktop, confirmado visualmente — dilui o sinal de "isso é a ação principal" que a marca deliberadamente reserva para 1 elemento.
+- **Fix**: Trocar o botão do nav para a variante `action` (Céu Vivo, pílula, sem hard shadow) ou `ghost`, deixando o Âmbar exclusivo ao CTA hero/CTA final.
+- **Suggested command**: `/impeccable polish`
+
+**[P1] Três affordances de conversão competindo no hero**
+- **Why it matters**: Nav WhatsApp + CTA hero + bubble flutuante do AIChat aparecem juntos na primeira dobra. `App.tsx` comenta que landing pages evitam overlays flutuantes, mas `STANDALONE_ROUTES` só exclui `/links` — o AIChat aparece normalmente em `/consultoria-de-viagem`, contradizendo "um CTA dominante por tela" do PRODUCT.md.
+- **Fix**: Adicionar `/consultoria-de-viagem` (e possivelmente as demais landings de conversão) a `STANDALONE_ROUTES`, ou decidir deliberadamente qual dos três é o caminho primário e rebaixar os outros dois visualmente.
+- **Suggested command**: `/impeccable polish`
+
+**[P1] Twin-button no modal de conversão**
+- **Why it matters**: "Chamar no WhatsApp" e "Me chamem no WhatsApp" (`ContactModal.tsx:219-233`) têm peso visual quase idêntico no momento de maior risco do funil (entrega de dados pessoais) — a diferença semântica (você inicia vs. eles ligam) não é óbvia à primeira leitura, gerando hesitação exatamente onde a conversão mais importa.
+- **Fix**: Diferenciar hierarquia visual (um primário, um secundário/ghost) e/ou rotular com a ação mais explícita ("Chamar agora no WhatsApp" vs. "Prefiro que vocês me liguem").
+- **Suggested command**: `/impeccable clarify`
+
+**[P2] Conteúdo gated por animação sem fallback de progresso**
+- **Why it matters**: Elementos dentro do viewport (não só fora dele) renderizam semitransparentes por período perceptível durante rolagem — confirmado em captura instrumentada. Para a persona "Casey" (mobile, rolagem rápida), isso lê como página quebrada, não como transição intencional.
+- **Fix**: Reduzir o threshold/delay do `whileInView`, ou remover o gate de opacidade em seções que já estão predominantemente no viewport ao carregar.
+- **Suggested command**: `/impeccable animate`
+
+**[P2] Página 100% ícone-only, nenhuma imagem de lugar real**
+- **Why it matters**: Contraria diretamente o princípio de produto #4 ("lugares reais, não categorias de produto") e a Regra do Diário de Bordo. Pilares usam `MessageSquare`/`Users`/`Headphones` — o mesmo inventário de ícone que qualquer SaaS B2B usaria para vender suporte técnico.
+- **Fix**: Substituir ao menos 1-2 blocos de ícone por imagem/foto de destino real ou momento de viagem, mantendo a curadoria (não virar grade de fotos genéricas).
+- **Suggested command**: `/impeccable colorize` (ou `/impeccable shape` se a mudança exigir redesenho de seção)
+
+## Persona Red Flags
+
+**Jordan (primeira vez, decidindo se confia):** Vê 3 formas diferentes de "falar com alguém" no hero sem hierarquia clara. Ao clicar no CTA principal, chega num modal pedindo WhatsApp real, mas o único reasseguramento de confiança (nota 5.0, fundada em 2018) vive numa seção "Sobre" que só aparece *depois* do modal na ordem da página — risco real de abandono por falta de prova social próxima ao ponto de decisão.
+
+**Casey (mobile distraído, rolagem rápida):** CTA do nav é `hidden` no mobile — depois do hero, não há nenhum CTA persistente até a seção final, 4 seções de distância. Se parar no meio da rolagem, corre risco real de ver conteúdo semitransparente e concluir que a página travou. O banner de cookies também cobre parcialmente o CTA do hero na primeira dobra em mobile, tornando "Sem taxa de consultoria. Gratuito." praticamente inacessível até lidar com o banner.
+
+**Riley (testador de stress):** Se preenche e-mail mas deixa WhatsApp em branco (por preferir esse canal), o submit continua bloqueado porque WhatsApp é obrigatório — decisão de produto válida, mas a copy não avisa isso antes da tentativa de envio.
+
+## Minor Observations
+
+- `ContactModal.tsx` e `LandingFAQ.tsx` ainda usam o namespace legado `brand-*` em vez de `anhanga-*` — sem divergência visual (mesmos hex), mas fora do padrão atual; componente compartilhado, fora do escopo desta landing especificamente.
+- Bubble do AIChat e botão `BackToTop` colidem levemente no canto inferior direito durante a rolagem — dois FABs empilhados muito próximos.
+- Seção "Outros serviços", logo antes da FAQ e do fechamento, oferece 3 links de saída no momento em que a página deveria reforçar conversão, não abrir rotas de escape.
+- 3 `<Link>` de "Outros serviços" (`ConsultoriaDeViagemLanding.tsx:375-407`) não têm `focus-visible` explícito, diferente do resto da página que usa o padrão consistentemente.
+
+## Questions to Consider
+
+- Por que uma agência "boutique" e "curadora" vende consultoria inteiramente com ícones de mensagem/pessoas/headset — o mesmo inventário que qualquer SaaS B2B usaria? Onde estão os lugares reais que o PRODUCT.md diz que a marca deve mostrar?
+- Se a Regra do Âmbar existe para que a cor grite raramente, por que o botão de nav — presente em toda tela, todo scroll — recebeu a mesma cor reservada para "a ação máxima"?
+- O AIChat aparece em toda landing exceto `/links`. Foi decisão deliberada de que toda landing deve competir consigo mesma por atenção, ou efeito colateral de uma lista de exclusão desatualizada?

--- a/App.tsx
+++ b/App.tsx
@@ -42,6 +42,23 @@ const LandingRouteFallback: React.FC = () => <div className="min-h-screen bg-whi
 // ContactModal, nem BackToTop. Esses FABs cobririam o conteúdo curado e os selos de confiança.
 const STANDALONE_ROUTES = ['/links'];
 
+// Landing pages de campanha (ver "Routing" no CLAUDE.md — mesma lista das rotas registradas
+// abaixo em AppLayout): já não renderizam Header/Footer, e o AIChat também fica de fora aqui.
+// Cada uma tem seu próprio CTA de conversão; um segundo overlay flutuante de contato
+// competindo com ele dilui "um CTA dominante por tela" (PRODUCT.md). ContactModal continua
+// montado — os CTAs dessas landings disparam openContactModal() e dependem dele.
+const LANDING_PAGE_ROUTES = [
+  '/beto-carrero',
+  '/lollapalooza',
+  '/orlando',
+  '/melhor-idade',
+  '/corporativo',
+  '/consultoria-de-viagem',
+  '/curadoria-cruzeiros-brasil',
+  '/nps',
+  '/quiz',
+];
+
 const ClientFeatures: React.FC = () => {
   const { pathname } = useLocation();
   // Normaliza trailing slash e caixa antes de comparar: o React Router casa a rota com ou sem
@@ -49,9 +66,10 @@ const ClientFeatures: React.FC = () => {
   // preserva ambos — sem normalizar, os overlays vazariam em /links/ ou /LINKS.
   const normalizedPath = (pathname === '/' ? '/' : pathname.replace(/\/$/, '')).toLowerCase();
   if (STANDALONE_ROUTES.includes(normalizedPath)) return null;
+  const hideAIChat = LANDING_PAGE_ROUTES.includes(normalizedPath);
   return (
     <ClientOnly>
-      <AIChat />
+      {hideAIChat ? null : <AIChat />}
       <ContactModal />
       <BackToTop />
     </ClientOnly>

--- a/components/AIChatPanel.tsx
+++ b/components/AIChatPanel.tsx
@@ -362,7 +362,7 @@ const AIChatPanel: React.FC<AIChatPanelProps> = memo(({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      submitMessage(input);
+      void submitMessage(input);
     }
   };
 
@@ -372,7 +372,7 @@ const AIChatPanel: React.FC<AIChatPanelProps> = memo(({
     if (!initialAutoSendMessage) return;
 
     const timer = setTimeout(() => {
-      submitMessageRef.current(initialAutoSendMessage, false);
+      void submitMessageRef.current(initialAutoSendMessage, false);
       onConsumePending();
     }, initialAutoSendDelayMs ?? 500);
 
@@ -514,7 +514,7 @@ const AIChatPanel: React.FC<AIChatPanelProps> = memo(({
                     <button
                       type="button"
                       key={chip.id}
-                      onClick={() => submitMessage(chip.label)}
+                      onClick={() => void submitMessage(chip.label)}
                       className="text-[13px] font-semibold text-zinc-600 bg-white border border-zinc-200 px-4 py-3 min-h-12 rounded-xl shadow-sm hover:shadow hover:border-brand-vibrant/30 hover:text-brand-vibrant hover:-translate-y-0.5 transition text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant/50"
                     >
                       {chip.label}
@@ -556,9 +556,9 @@ const AIChatPanel: React.FC<AIChatPanelProps> = memo(({
           />
           <button
             type="button"
-            onClick={() => submitMessage(input)}
+            onClick={() => void submitMessage(input)}
             disabled={isLoading || !input.trim()}
-            className="absolute right-2 bottom-1 min-h-12 min-w-12 flex items-center justify-center bg-brand-vibrant text-white rounded-[10px] shadow-sm hover:bg-brand-blue hover:shadow-md transition disabled:opacity-0 disabled:scale-75 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-vibrant/50"
+            className="absolute right-2 bottom-1 min-h-12 min-w-12 flex items-center justify-center bg-brand-vibrant text-white rounded-[10px] shadow-sm hover:bg-brand-blue hover:shadow-md transition disabled:opacity-0 disabled:scale-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-vibrant/50"
             aria-label="Enviar mensagem"
           >
             <PaperPlaneTilt className="size-5 ml-0.5" weight="fill" />

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -215,21 +215,30 @@ const ContactModal: React.FC = () => {
                             </p>
                         ) : null}
 
+                        {/*
+                          As duas ações usam raízes de verbo distintas ("Abrir" vs. "chamem")
+                          e pesos visuais diferentes de propósito: a primária (preenchida,
+                          verde WhatsApp) é quem age agora; a secundária (borda, sem
+                          preenchimento) é quem prefere que a equipe chame depois. Antes as
+                          duas liam como opções gêmeas de mesmo peso ("Chamar no WhatsApp" /
+                          "Me chamem no WhatsApp"), causando hesitação no ponto de maior risco
+                          do funil — ver critique de /consultoria-de-viagem.
+                        */}
                         <div className="flex flex-col gap-2 pt-1">
                             <button
                                 type="submit"
                                 disabled={!canAttemptSubmit || isSubmitting}
                                 className="w-full rounded-xl bg-[#25D366] py-3 text-sm font-black text-white transition-colors hover:bg-[#1fba59] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#25D366] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
                             >
-                                {isSubmitting ? 'Enviando…' : 'Chamar no WhatsApp'}
+                                {isSubmitting ? 'Enviando…' : 'Abrir WhatsApp agora'}
                             </button>
                             <button
                                 type="button"
                                 onClick={() => void submit('callback')}
                                 disabled={!canAttemptSubmit || isSubmitting}
-                                className="w-full rounded-xl bg-brand-dark py-3 text-sm font-black text-white transition-colors hover:bg-brand-vibrant focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
+                                className="w-full rounded-xl border-2 border-zinc-200 bg-white py-3 text-sm font-bold text-zinc-600 transition-colors hover:border-anhanga-action hover:text-anhanga-action focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-anhanga-action focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
                             >
-                                {isSubmitting ? 'Enviando…' : 'Me chamem no WhatsApp'}
+                                {isSubmitting ? 'Enviando…' : 'Prefiro que me chamem'}
                             </button>
                         </div>
                     </form>

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -228,7 +228,7 @@ const ContactModal: React.FC = () => {
                             <button
                                 type="submit"
                                 disabled={!canAttemptSubmit || isSubmitting}
-                                className="w-full rounded-xl bg-[#25D366] py-3 text-sm font-black text-white transition-colors hover:bg-[#1fba59] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#25D366] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
+                                className="w-full rounded-xl bg-[#25D366] py-3 text-sm font-black text-white transition-colors hover:bg-[#1fba59] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#25D366] disabled:cursor-not-allowed disabled:opacity-40"
                             >
                                 {isSubmitting ? 'Enviando…' : 'Abrir WhatsApp agora'}
                             </button>
@@ -236,7 +236,7 @@ const ContactModal: React.FC = () => {
                                 type="button"
                                 onClick={() => void submit('callback')}
                                 disabled={!canAttemptSubmit || isSubmitting}
-                                className="w-full rounded-xl border-2 border-zinc-200 bg-white py-3 text-sm font-bold text-zinc-600 transition-colors hover:border-anhanga-action hover:text-anhanga-action focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-anhanga-action focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
+                                className="w-full rounded-xl border-2 border-zinc-200 bg-white py-3 text-sm font-bold text-zinc-600 transition-colors hover:border-anhanga-action hover:text-anhanga-action focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action disabled:cursor-not-allowed disabled:opacity-40"
                             >
                                 {isSubmitting ? 'Enviando…' : 'Prefiro que me chamem'}
                             </button>

--- a/components/Header/HeaderNavigation.tsx
+++ b/components/Header/HeaderNavigation.tsx
@@ -42,7 +42,7 @@ export const DesktopNavigation = React.memo(function DesktopNavigation({
         <div key={link.name} className="relative group">
           {link.subLinks ? (
             <>
-              <button type="button" className={`flex items-center gap-1 cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-yellow focus-visible:outline-offset-2 rounded ${navTextClass}`}>
+              <button type="button" className={`flex items-center gap-1 cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-yellow focus-visible:outline-offset-2 rounded ${navTextClass}`}>
                 {link.name}
                 <CaretDown className="size-4 transition-transform duration-300 group-hover:rotate-180" weight="bold" />
               </button>
@@ -80,7 +80,7 @@ export const DesktopNavigation = React.memo(function DesktopNavigation({
                   onNavClick(event, link.href!);
                 }
               }}
-              className={`cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-yellow focus-visible:outline-offset-2 rounded ${navTextClass}`}
+              className={`cursor-pointer font-medium text-sm transition-colors duration-500 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-yellow focus-visible:outline-offset-2 rounded ${navTextClass}`}
             >
               {link.name}
             </a>
@@ -90,7 +90,7 @@ export const DesktopNavigation = React.memo(function DesktopNavigation({
 
       <a
         href={getBlogHomeUrl()}
-        className={`font-medium text-sm transition-colors duration-500 hover:opacity-80 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-yellow focus-visible:outline-offset-2 rounded ${navTextClass}`}
+        className={`font-medium text-sm transition-colors duration-500 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-yellow focus-visible:outline-offset-2 rounded ${navTextClass}`}
       >
         Blog de Viagens
       </a>
@@ -125,7 +125,7 @@ export const MobileNavigationMenu = React.memo(function MobileNavigationMenu({
               <a
                 key={subLink.name}
                 href={href}
-                className="text-zinc-700 font-medium py-3 border-b border-zinc-50 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-vibrant focus-visible:outline-offset-1 rounded"
+                className="text-zinc-700 font-medium py-3 border-b border-zinc-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-vibrant focus-visible:outline-offset-1 rounded"
                 onClick={(event) => {
                   if (!isPageLink(subLink.href) && isHome) {
                     onNavClick(event, subLink.href);
@@ -144,7 +144,7 @@ export const MobileNavigationMenu = React.memo(function MobileNavigationMenu({
           <a
             key={link.name}
             href={buildSectionHref(link.href!, isHome)}
-            className="text-zinc-700 font-medium py-3 border-b border-zinc-50 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-vibrant focus-visible:outline-offset-1 rounded"
+            className="text-zinc-700 font-medium py-3 border-b border-zinc-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-vibrant focus-visible:outline-offset-1 rounded"
             onClick={(event) => {
               if (isHome) {
                 onNavClick(event, link.href!);
@@ -160,7 +160,7 @@ export const MobileNavigationMenu = React.memo(function MobileNavigationMenu({
 
       <a
         href={getBlogHomeUrl()}
-        className="text-zinc-700 font-medium py-3 border-b border-zinc-50 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-vibrant focus-visible:outline-offset-1 rounded"
+        className="text-zinc-700 font-medium py-3 border-b border-zinc-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-vibrant focus-visible:outline-offset-1 rounded"
         onClick={onCloseMenu}
       >
         Blog de Viagens

--- a/components/landings/corporativo/CorpContactForm.tsx
+++ b/components/landings/corporativo/CorpContactForm.tsx
@@ -160,7 +160,7 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
             {state.phase === 'success' ? (
                 <CorpSuccessState whatsappUrl={whatsappUrl} />
             ) : (
-                <form onSubmit={handleSubmit} noValidate>
+                <form onSubmit={(e) => void handleSubmit(e)} noValidate>
                     {/* Honeypot: hidden from humans, blind form-fillers populate it. */}
                     <input {...honeypotProps} />
                     <div className="flex justify-between items-center px-6 sm:px-8 py-5 border-b-2 border-dashed border-zinc-100 gap-4">
@@ -193,7 +193,7 @@ export function CorpContactForm({ whatsappUrl }: CorpContactFormProps) {
                         <button
                             type="submit"
                             disabled={busy}
-                            className="w-full flex items-center justify-center gap-3 bg-brand-dark text-white py-4 rounded-xl font-bold text-base shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition disabled:opacity-60 disabled:pointer-events-none focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+                            className="w-full flex items-center justify-center gap-3 bg-brand-dark text-white py-4 rounded-xl font-bold text-base shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition disabled:opacity-60 disabled:pointer-events-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
                             data-tracking="submit-form-corporativo"
                         >
                             {busy ? (

--- a/components/landings/corporativo/CorpContactInfo.tsx
+++ b/components/landings/corporativo/CorpContactInfo.tsx
@@ -44,7 +44,7 @@ export function CorpContactInfo({ whatsappUrl }: CorpContactInfoProps) {
                             <Icon className="size-5 text-blue-600" weight="fill" />
                         </div>
                         {href ? (
-                            <a href={href} className="font-semibold text-zinc-700 hover:text-brand-cyan transition-colors duration-150 pt-1.5 rounded focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
+                            <a href={href} className="font-semibold text-zinc-700 hover:text-brand-cyan transition-colors duration-150 pt-1.5 rounded focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
                                 {label}
                             </a>
                         ) : (
@@ -69,7 +69,7 @@ export function CorpContactInfo({ whatsappUrl }: CorpContactInfoProps) {
                             href={href}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="size-11 rounded-xl bg-white border-2 border-zinc-200 flex items-center justify-center text-zinc-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-hard-yellow hover:-translate-y-1 transition duration-200 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+                            className="size-11 rounded-xl bg-white border-2 border-zinc-200 flex items-center justify-center text-zinc-500 hover:border-brand-cyan hover:text-brand-cyan shadow-[2px_2px_0px_rgba(0,0,0,0.05)] hover:shadow-hard-yellow hover:-translate-y-1 transition duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
                             aria-label={label}
                             {...(contact ? { 'data-contact-intent': true, 'data-tracking': 'social-whatsapp-corporativo' } : {})}
                         >

--- a/components/landings/corporativo/CorpHero.tsx
+++ b/components/landings/corporativo/CorpHero.tsx
@@ -101,7 +101,7 @@ export function CorpHero() {
                         <button
                             type="button"
                             onClick={() => openContactModal({ source: 'corporativo' })}
-                            className="btn-whatsapp btn-specialist flex items-center justify-center gap-3 bg-brand-yellow text-brand-dark px-8 py-4 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(0,0,0,0.2)] hover:shadow-[2px_2px_0px_rgba(0,0,0,0.2)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+                            className="btn-whatsapp btn-specialist flex items-center justify-center gap-3 bg-brand-yellow text-brand-dark px-8 py-4 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(0,0,0,0.2)] hover:shadow-[2px_2px_0px_rgba(0,0,0,0.2)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
                             data-contact-intent
                             data-tracking="hero-corporativo"
                         >
@@ -110,7 +110,7 @@ export function CorpHero() {
                         </button>
                         <a
                             href="#contato"
-                            className="btn-specialist flex items-center justify-center gap-2 border-2 border-white/40 text-white px-8 py-4 rounded-2xl font-bold text-lg hover:border-white hover:bg-white/10 transition duration-200 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+                            className="btn-specialist flex items-center justify-center gap-2 border-2 border-white/40 text-white px-8 py-4 rounded-2xl font-bold text-lg hover:border-white hover:bg-white/10 transition duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
                         >
                             Prefiro ser contatado
                             <ArrowRight className="size-5" />

--- a/components/landings/corporativo/CorpSuccessState.tsx
+++ b/components/landings/corporativo/CorpSuccessState.tsx
@@ -25,7 +25,7 @@ export function CorpSuccessState({ whatsappUrl }: CorpSuccessStateProps) {
                 href={whatsappUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+                className="btn-whatsapp btn-specialist flex items-center gap-2 bg-brand-dark text-white px-6 py-3 rounded-xl font-bold text-sm shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
                 data-contact-intent
                 data-tracking="success-corporativo"
             >

--- a/components/landings/shared/LandingNav.tsx
+++ b/components/landings/shared/LandingNav.tsx
@@ -2,6 +2,7 @@ import { WhatsappLogo } from '@phosphor-icons/react';
 import { Link } from 'react-router-dom';
 import { BRAND_LOGO_BLUE_URL } from '@/lib/media-assets';
 import { openContactModal } from '@/utils/contactForm';
+import { Button } from '@/components/ui/Button';
 
 interface LandingNavProps {
     source: string;
@@ -11,7 +12,7 @@ export function LandingNav({ source }: LandingNavProps) {
     return (
         <nav className="bg-white/90 backdrop-blur-md border-b border-zinc-100 sticky top-0 z-50 px-6 py-2">
             <div className="container mx-auto flex items-center justify-between">
-                <Link to="/" aria-label="Voltar para o site principal" className="inline-block rounded-lg focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
+                <Link to="/" aria-label="Voltar para o site principal" className="inline-block rounded-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
                     <img
                         src={BRAND_LOGO_BLUE_URL}
                         alt="Anhangá Viagens"
@@ -20,16 +21,25 @@ export function LandingNav({ source }: LandingNavProps) {
                         className="h-12 w-auto object-contain"
                     />
                 </Link>
-                <button
-                    type="button"
-                    onClick={() => openContactModal({ source })}
-                    className="btn-whatsapp btn-specialist hidden sm:flex items-center gap-2 bg-brand-dark text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-hard-yellow hover:shadow-[2px_2px_0px_theme(colors.brand.yellow)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
-                    data-contact-intent
-                    data-tracking={`header-${source}`}
-                >
-                    <WhatsappLogo className="size-4" weight="fill" />
-                    Falar no WhatsApp
-                </button>
+                {/*
+                  Variante `action` (pílula Céu Vivo), não `cta` (âmbar): a Regra do
+                  Âmbar do DESIGN.md reserva o Âmbar Vivo a 1 elemento por tela, já
+                  ocupado pelo CTA principal da página. O nav em estado "scrolled/
+                  internal" usa exatamente `bg-action hover:bg-action-dark` por
+                  especificação do componente Navigation do DESIGN.md.
+                */}
+                <div className="hidden sm:block">
+                    <Button
+                        variant="action"
+                        onClick={() => openContactModal({ source })}
+                        className="btn-whatsapp btn-specialist"
+                        leftIcon={<WhatsappLogo className="size-4" weight="fill" aria-hidden="true" />}
+                        data-contact-intent
+                        data-tracking={`header-${source}`}
+                    >
+                        Falar no WhatsApp
+                    </Button>
+                </div>
             </div>
         </nav>
     );

--- a/components/landings/shared/LandingWhatsAppBand.tsx
+++ b/components/landings/shared/LandingWhatsAppBand.tsx
@@ -39,7 +39,7 @@ export function LandingWhatsAppBand({ source, subtitle, headline }: LandingWhats
                     <button
                         type="button"
                         onClick={() => openContactModal({ source })}
-                        className="btn-whatsapp btn-specialist shrink-0 flex items-center gap-3 bg-brand-yellow text-brand-dark px-10 py-5 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(255,255,255,0.15)] hover:shadow-[2px_2px_0px_rgba(255,255,255,0.15)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition whitespace-nowrap focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                        className="btn-whatsapp btn-specialist shrink-0 flex items-center gap-3 bg-brand-yellow text-brand-dark px-10 py-5 rounded-2xl font-bold text-lg shadow-[4px_4px_0px_rgba(255,255,255,0.15)] hover:shadow-[2px_2px_0px_rgba(255,255,255,0.15)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition whitespace-nowrap focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
                         data-contact-intent
                         data-tracking={`whatsapp-band-${source}`}
                     >

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -27,7 +27,13 @@ const sizeClasses: Record<ButtonSize, string> = {
     lg: 'text-base px-7 py-3.5',
 };
 
-const baseClasses = 'inline-flex items-center justify-center gap-2 font-bold transition duration-150 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none';
+// Sem `focus:outline-none`: no Tailwind v4, essa classe zera a custom property
+// --tw-outline-style para "none", e como todo elemento com foco de teclado
+// casa com :focus E :focus-visible ao mesmo tempo, esse valor "vaza" para a
+// regra focus-visible (que lê a mesma variável) e o anel nunca pinta —
+// mesmo com outline-width/color corretos. Só as classes focus-visible:*
+// já evitam o anel em foco de mouse nos navegadores modernos.
+const baseClasses = 'inline-flex items-center justify-center gap-2 font-bold transition duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none';
 
 export const Button: React.FC<ButtonProps> = ({
     children,

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -190,7 +190,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               variants={fadeUp}
               initial="hidden"
               whileInView="visible"
-              viewport={{ once: true, amount: 0.2 }}
+              viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
               custom={0}
               className="mb-12"
             >
@@ -208,7 +208,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                   variants={fadeUp}
                   initial="hidden"
                   whileInView="visible"
-                  viewport={{ once: true, amount: 0.2 }}
+                  viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
                   custom={idx + 1}
                   className={`p-8 rounded-2xl transition duration-300 ${
                     variant === 'filled'
@@ -246,7 +246,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                 variants={fadeUp}
                 initial="hidden"
                 whileInView="visible"
-                viewport={{ once: true, amount: 0.2 }}
+                viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
                 custom={0}
               >
                 <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-8">
@@ -265,7 +265,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                 variants={fadeUp}
                 initial="hidden"
                 whileInView="visible"
-                viewport={{ once: true, amount: 0.2 }}
+                viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
                 custom={1}
                 className="mt-12 md:mt-0 overflow-hidden rounded-3xl bg-white shadow-float"
               >
@@ -302,7 +302,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               variants={fadeUp}
               initial="hidden"
               whileInView="visible"
-              viewport={{ once: true, amount: 0.2 }}
+              viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
               custom={0}
               className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12"
             >
@@ -315,7 +315,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                   variants={fadeUp}
                   initial="hidden"
                   whileInView="visible"
-                  viewport={{ once: true, amount: 0.3 }}
+                  viewport={{ once: true, amount: 0.3, margin: '0px 0px 100% 0px' }}
                   custom={idx + 1}
                   className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-zinc-100' : ''}`}
                 >
@@ -338,7 +338,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             variants={fadeUp}
             initial="hidden"
             whileInView="visible"
-            viewport={{ once: true, amount: 0.2 }}
+            viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
             custom={0}
             className="max-w-4xl mx-auto px-6 text-center"
           >
@@ -368,7 +368,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
             variants={fadeUp}
             initial="hidden"
             whileInView="visible"
-            viewport={{ once: true, amount: 0.3 }}
+            viewport={{ once: true, amount: 0.3, margin: '0px 0px 100% 0px' }}
             custom={0}
             className="max-w-3xl mx-auto px-6 text-center"
           >

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -180,10 +180,10 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
         <section className="py-20 bg-white">
           <div className="max-w-5xl mx-auto px-6">
             {/*
-              margin '200px' abaixo do viewport (mesma convenção em todas as
-              seções seguintes): dispara a revelação antes da seção entrar na
-              tela, não quando já está visível. Sem isso, rolagem rápida
-              mostrava conteúdo semitransparente mesmo já dentro do viewport
+              margin de um viewport de altura (100%) abaixo do viewport (mesma
+              convenção em todas as seções seguintes): dispara a revelação antes da
+              seção entrar na tela, não quando já está visível. Sem isso, rolagem
+              rápida mostrava conteúdo semitransparente mesmo já dentro do viewport
               — lia como página quebrada. Ver critique de /consultoria-de-viagem.
             */}
             <m.div

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -7,10 +7,12 @@ import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
 import { ServiceSchema } from '@/components/schemas/ServiceSchema';
 import { Button } from '@/components/ui/Button';
+import { LazyImage } from '@/components/ui/LazyImage';
 import { LandingNav } from '@/components/landings/shared/LandingNav';
 import { LandingFooter } from '@/components/landings/shared/LandingFooter';
 import { fadeUp } from '@/components/landings/shared/constants';
 import { openContactModal } from '@/utils/contactForm';
+import { getDestinationImage } from '@/data/mediaConfig';
 import { ArrowRight, CheckCircle, MessageSquare, Users, Headphones, Compass } from 'lucide-react';
 
 const FAQ_ITEMS = [
@@ -177,6 +179,13 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
         {/* Por que consultoria? */}
         <section className="py-20 bg-white">
           <div className="max-w-5xl mx-auto px-6">
+            {/*
+              margin '200px' abaixo do viewport (mesma convenção em todas as
+              seções seguintes): dispara a revelação antes da seção entrar na
+              tela, não quando já está visível. Sem isso, rolagem rápida
+              mostrava conteúdo semitransparente mesmo já dentro do viewport
+              — lia como página quebrada. Ver critique de /consultoria-de-viagem.
+            */}
             <m.div
               variants={fadeUp}
               initial="hidden"
@@ -258,14 +267,29 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
                 whileInView="visible"
                 viewport={{ once: true, amount: 0.2 }}
                 custom={1}
-                className="mt-12 md:mt-0 bg-white rounded-3xl p-8 shadow-float"
+                className="mt-12 md:mt-0 overflow-hidden rounded-3xl bg-white shadow-float"
               >
-                <blockquote className="text-xl text-anhanga-dark font-semibold leading-relaxed">
-                  "A Anhangá cuidou de cada detalhe. Só precisei aparecer no aeroporto."
-                </blockquote>
-                <p className="mt-4 text-zinc-600 text-sm">
-                  R.M. · São Paulo · Viagem para Portugal, 2025
-                </p>
+                {/*
+                  Depoimento pareado com o lugar real da viagem (não um ícone
+                  genérico): reforça "lugares reais, não categorias de
+                  produto" — a página inteira era só tipografia + ícones antes
+                  desta correção. Ver critique de /consultoria-de-viagem.
+                */}
+                <LazyImage
+                  src={getDestinationImage('Lisboa')}
+                  alt="Lisboa, Portugal — destino da viagem relatada no depoimento"
+                  width={640}
+                  height={280}
+                  className="h-48 w-full"
+                />
+                <div className="p-8">
+                  <blockquote className="text-xl text-anhanga-dark font-semibold leading-relaxed">
+                    "A Anhangá cuidou de cada detalhe. Só precisei aparecer no aeroporto."
+                  </blockquote>
+                  <p className="mt-4 text-zinc-600 text-sm">
+                    R.M. · São Paulo · Viagem para Portugal, 2025
+                  </p>
+                </div>
               </m.div>
             </div>
           </div>

--- a/pages/landings/CorporativoLanding.tsx
+++ b/pages/landings/CorporativoLanding.tsx
@@ -57,13 +57,13 @@ const CorporativoLanding: React.FC = () => {
                     <div className="container mx-auto px-6 text-center">
                         <p className="text-sm text-zinc-500 font-medium mb-4">Conheça também</p>
                         <div className="flex flex-wrap justify-center gap-3">
-                            <Link to="/consultoria-de-viagem/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
+                            <Link to="/consultoria-de-viagem/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
                                 Consultoria de Viagem
                             </Link>
-                            <Link to="/melhor-idade/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
+                            <Link to="/melhor-idade/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
                                 Viagens Melhor Idade
                             </Link>
-                            <Link to="/curadoria-cruzeiros-brasil/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
+                            <Link to="/curadoria-cruzeiros-brasil/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
                                 Cruzeiros pelo Brasil
                             </Link>
                         </div>

--- a/tests/e2e/contact-form-attribution.spec.ts
+++ b/tests/e2e/contact-form-attribution.spec.ts
@@ -29,7 +29,7 @@ async function stubWindowOpen(page: Page) {
 
 function captureSubmitContact(page: Page): Promise<Record<string, unknown>> {
   return new Promise((resolve) => {
-    page.route('**/api/submit-contact', async (route: Route) => {
+    void page.route('**/api/submit-contact', async (route: Route) => {
       const payload = route.request().postDataJSON();
       await route.fulfill({
         status: 200,
@@ -57,7 +57,7 @@ test.describe('Contact form attribution payload', () => {
     await page.locator('#contact-whatsapp').fill('11987654321');
     await page.locator('#contact-email').fill('maria@example.com');
     await page.locator('#contact-optIn').check();
-    await page.getByRole('button', { name: /^me chamem no whatsapp$/i }).click();
+    await page.getByRole('button', { name: /^prefiro que me chamem$/i }).click();
 
     const payload = await payloadPromise;
 
@@ -95,7 +95,7 @@ test.describe('Contact form attribution payload', () => {
 
     await page.locator('#contact-firstName').fill('João Souza');
     await page.locator('#contact-whatsapp').fill('11988887777');
-    await page.getByRole('button', { name: /^me chamem no whatsapp$/i }).click();
+    await page.getByRole('button', { name: /^prefiro que me chamem$/i }).click();
 
     const payload = await payloadPromise;
 
@@ -145,7 +145,7 @@ test.describe('Contact form attribution payload', () => {
 
     await page.locator('#contact-firstName').fill('Carla Mendes');
     await page.locator('#contact-whatsapp').fill('11977776666');
-    await page.getByRole('button', { name: /^chamar no whatsapp$/i }).click();
+    await page.getByRole('button', { name: /^abrir whatsapp agora$/i }).click();
 
     // The WhatsApp tab opens regardless of whether the background CRM tracking call
     // succeeds — the visitor's path to a human must never depend on Odoo being up.

--- a/tests/e2e/contact-form.spec.ts
+++ b/tests/e2e/contact-form.spec.ts
@@ -45,8 +45,8 @@ test.describe('Contact form modal', () => {
   test('mantém botões desabilitados com campos vazios', async ({ page, isMobile }) => {
     await openHeaderContactModal(page, isMobile);
 
-    await expect(page.getByRole('button', { name: /^chamar no whatsapp$/i })).toBeDisabled();
-    await expect(page.getByRole('button', { name: /^me chamem no whatsapp$/i })).toBeDisabled();
+    await expect(page.getByRole('button', { name: /^abrir whatsapp agora$/i })).toBeDisabled();
+    await expect(page.getByRole('button', { name: /^prefiro que me chamem$/i })).toBeDisabled();
   });
 
   test('habilita botões após preencher nome e WhatsApp', async ({ page, isMobile }) => {
@@ -55,8 +55,8 @@ test.describe('Contact form modal', () => {
     await page.locator('#contact-firstName').fill('Maria');
     await page.locator('#contact-whatsapp').fill('11987654321');
 
-    await expect(page.getByRole('button', { name: /^chamar no whatsapp$/i })).toBeEnabled();
-    await expect(page.getByRole('button', { name: /^me chamem no whatsapp$/i })).toBeEnabled();
+    await expect(page.getByRole('button', { name: /^abrir whatsapp agora$/i })).toBeEnabled();
+    await expect(page.getByRole('button', { name: /^prefiro que me chamem$/i })).toBeEnabled();
   });
 
   test('bloqueia envio com e-mail inválido após clique e mantém dados editáveis', async ({ page, isMobile }) => {
@@ -66,7 +66,7 @@ test.describe('Contact form modal', () => {
     await page.locator('#contact-whatsapp').fill('11987654321');
     await page.locator('#contact-email').fill('maria@');
 
-    const callbackButton = page.getByRole('button', { name: /^me chamem no whatsapp$/i });
+    const callbackButton = page.getByRole('button', { name: /^prefiro que me chamem$/i });
     await expect(callbackButton).toBeEnabled();
     await callbackButton.click();
 
@@ -80,7 +80,7 @@ test.describe('Contact form modal', () => {
 
     await page.locator('#contact-firstName').fill('Maria');
     await page.locator('#contact-whatsapp').fill('11987654321');
-    await page.getByRole('button', { name: /^me chamem no whatsapp$/i }).click();
+    await page.getByRole('button', { name: /^prefiro que me chamem$/i }).click();
 
     await expect(page.getByText(/recebemos seu contato/i)).toBeVisible();
     await expect(page.getByText('Nossa equipe chama você em breve pelo WhatsApp.')).toBeVisible();

--- a/tests/e2e/landing-consultoria-content.spec.ts
+++ b/tests/e2e/landing-consultoria-content.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test('landing de consultoria mostra uma foto real do destino junto ao depoimento', async ({ page }) => {
+  await page.goto('/consultoria-de-viagem');
+
+  // LazyImage só renderiza a tag <img> quando o IntersectionObserver marca o
+  // container como visível — precisa rolar até a seção (via o heading, que
+  // renderiza imediatamente) antes de procurar a imagem pela role.
+  await page.getByRole('heading', { name: 'Para quem é' }).scrollIntoViewIfNeeded();
+
+  const photo = page.getByRole('img', { name: /lisboa, portugal/i });
+  await expect(photo).toBeVisible();
+  await expect(photo).toHaveAttribute('src', /lisboa/);
+  await expect
+    .poll(async () => photo.evaluate((img: HTMLImageElement) => img.naturalWidth))
+    .toBeGreaterThan(0);
+});
+
+test('links de "Outros serviços" recebem foco visível ao navegar por teclado', async ({ page }) => {
+  await page.goto('/consultoria-de-viagem');
+
+  const firstLink = page.getByRole('link', { name: /viagens para executivos/i });
+  const ctaFinal = page.locator('[data-tracking="footer-consultoria-viagem"]');
+  // Foca programaticamente o elemento tabável imediatamente anterior (o CTA
+  // final) e avança com um Tab real — só o Tab (não .focus() programático)
+  // aciona o heurístico de :focus-visible do Chromium no destino.
+  await ctaFinal.scrollIntoViewIfNeeded();
+  await ctaFinal.focus();
+  await page.keyboard.press('Tab');
+  await expect(firstLink).toBeFocused();
+
+  const outlineStyle = await firstLink.evaluate((el) => getComputedStyle(el).outlineStyle);
+  expect(outlineStyle).not.toBe('none');
+});

--- a/tests/e2e/landing-no-aichat.spec.ts
+++ b/tests/e2e/landing-no-aichat.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+// CLAUDE.md documenta as landing pages de campanha como "no Header/Footer/AIChat" —
+// cada uma tem seu próprio CTA de conversão, e um segundo overlay flutuante de contato
+// dilui "um CTA dominante por tela" (PRODUCT.md). Ver LANDING_PAGE_ROUTES em App.tsx.
+test.describe('Landing pages de campanha não renderizam o AIChat flutuante', () => {
+  test('AIChat ausente em /consultoria-de-viagem, mas o CTA de contato continua funcional', async ({ page }) => {
+    await page.goto('/consultoria-de-viagem');
+
+    await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Falar com um consultor' }).first().click();
+    await expect(page.getByRole('heading', { name: 'Fale com um especialista' })).toBeVisible();
+  });
+
+  test('AIChat ausente em /corporativo', async ({ page }) => {
+    await page.goto('/corporativo');
+    await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toHaveCount(0);
+  });
+
+  test('AIChat continua presente no site principal', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toBeVisible();
+  });
+});

--- a/tests/e2e/pages/ContactModal.ts
+++ b/tests/e2e/pages/ContactModal.ts
@@ -18,8 +18,8 @@ export class ContactModal {
     this.whatsappInput = page.locator('#contact-whatsapp');
     this.emailInput = page.locator('#contact-email');
     this.optInCheckbox = page.locator('#contact-optIn');
-    this.whatsappSubmitBtn = page.getByRole('button', { name: 'Chamar no WhatsApp' });
-    this.callbackSubmitBtn = page.getByRole('button', { name: 'Me chamem no WhatsApp' });
+    this.whatsappSubmitBtn = page.getByRole('button', { name: 'Abrir WhatsApp agora' });
+    this.callbackSubmitBtn = page.getByRole('button', { name: 'Prefiro que me chamem' });
     this.successMessage = page.getByText('Recebemos seu contato!');
   }
 


### PR DESCRIPTION
## Summary

Ações derivadas do `/impeccable critique` em `/consultoria-de-viagem`, rodadas uma de cada vez com verificação (typecheck/lint/e2e) entre cada uma:

- **Hierarquia de CTA** — o botão do nav sticky duplicava a variante `primary` (âmbar) manualmente; trocado pelo componente `Button` compartilhado com `variant="action"` (pílula Céu Vivo), restaurando a Regra do Âmbar do DESIGN.md (1 elemento por tela). O `AIChat` flutuante deixa de aparecer nas 9 landing pages de campanha, alinhando `App.tsx` ao que o próprio CLAUDE.md já documentava ("no Header/Footer/AIChat").
- **Twin-button do `ContactModal`** — "Chamar no WhatsApp" / "Me chamem no WhatsApp" liam como opções gêmeas de mesmo peso. Renomeadas para "Abrir WhatsApp agora" / "Prefiro que me chamem" (raízes de verbo distintas) e diferenciadas visualmente (preenchida vs. bordada).
- **Imagem real de destino** — a página inteira era só tipografia + ícones. Adicionada foto de Lisboa (via `getDestinationImage()`, já existente) ao card de depoimento, que cita "Viagem para Portugal, 2025".
- **Animação de scroll** — seções reveladas por `whileInView` agora pré-disparam com `margin` de um viewport de antecedência, evitando conteúdo semitransparente durante rolagem rápida.
- **Bug sitewide de foco visível (Tailwind v4)** — `focus:outline-none` zera a custom property `--tw-outline-style`, que "vaza" para `focus-visible:outline-*` no mesmo elemento (todo foco de teclado casa com `:focus` e `:focus-visible` simultaneamente ), apagando o anel de foco mesmo com outline-width/color corretos. Descoberto ao tentar adicionar foco visível a 3 links; a correção original teria sido uma regressão (esses links dependiam do anel padrão do navegador, que funcionava). Escopo ampliado com aprovação explícita para cobrir `Button.tsx`, `HeaderNavigation.tsx` (nav principal do site) e os componentes de landing com o mesmo padrão quebrado — 10 arquivos ao todo. Corrigido removendo `focus:outline-none` e mantendo só as classes `focus-visible:*`; verificado visualmente via screenshot com foco real de teclado.

## Test plan

- [x] `pnpm typecheck` limpo
- [x] `eslint` limpo em todos os arquivos tocados
- [x] `pnpm test:regression` — 963/963 passando
- [x] `pnpm test:e2e` (exclui `@visual`, que precisa da baseline do CI) — 175/175 passando, incluindo 2 specs novos (`landing-no-aichat.spec.ts`, `landing-consultoria-content.spec.ts`)
- [x] Verificação visual manual (screenshots com foco de teclado real) confirmando o anel de foco pintando no header principal, nav das landings e CTA hero
- [x] `git stash` comparativo confirmando que o único teste que falha na suíte completa (`visual.spec.ts` @visual) já falha identicamente no `main` sem nenhuma das mudanças desta PR — diferença de plataforma macOS/Linux documentada no próprio arquivo, não uma regressão

🤖 Generated with [Claude Code](https://claude.com/claude-code)