### PR TITLE
fix(design): banner de cookies cobrindo CTA + contraste do nav (P0/P1)

### DIFF
--- a/.impeccable/critique/2026-07-16T04-53-15Z__pages-landings-consultoriadeviagemlanding-tsx.md
+++ b/.impeccable/critique/2026-07-16T04-53-15Z__pages-landings-consultoriadeviagemlanding-tsx.md
@@ -1,0 +1,91 @@
+---
+target: "/consultoria-de-viagem (re-crítica pós PR #1203)"
+total_score: 33
+p0_count: 1
+p1_count: 2
+timestamp: 2026-07-16T04-53-15Z
+slug: pages-landings-consultoriadeviagemlanding-tsx
+---
+Method: dual-agent (A: general-purpose · B: general-purpose) — re-crítica pós-merge da PR #1203
+
+## Design Health Score
+
+| # | Heurística | Nota | Ponto-chave |
+|---|---|---|---|
+| 1 | Visibilidade do status do sistema | 3/4 | Estado "Enviando…" e confirmação com `aria-live` corretos; ghosting residual em scroll extremo pode ler como quebrado por instantes |
+| 2 | Correspondência sistema/mundo real | 4/4 | Copy em segunda pessoa, natural, tom consistente |
+| 3 | Controle e liberdade do usuário | 4/4 | Modal fecha por X, ESC, clique fora |
+| 4 | Consistência e padrões | 3/4 | `ContactModal.tsx` mistura `anhanga-action` (novo) com `brand-cyan`/`brand-dark`/`brand-vibrant` (legado) no mesmo arquivo |
+| 5 | Prevenção de erros | 3/4 | Campos obrigatórios desabilitam submit; honeypot anti-spam |
+| 6 | Reconhecimento vs. recordação | 4/4 | Página única, sem necessidade de reter contexto |
+| 7 | Flexibilidade e eficiência de uso | 2/4 | Banner de cookies bloqueia clique no CTA principal do hero em mobile no primeiro paint (P0 novo, não relacionado à PR #1203) |
+| 8 | Design estético e minimalista | 4/4 | Whitespace generoso, hierarquia limpa, tokens de marca respeitados |
+| 9 | Ajudar a reconhecer/recuperar de erros | 3/4 | `role="alert"` no erro de submit |
+| 10 | Ajuda e documentação | 3/4 | FAQ antecipa dúvidas comuns |
+| **Total** | | **33/40** | **Bom — subiu de 26/40 na rodada anterior** |
+
+## Anti-Patterns Verdict
+
+**LLM assessment (A):** não parece feito por IA à primeira vista — nenhum banimento absoluto presente (sem side-stripe, gradient text, hero-metric, grid de cards idênticos, eyebrow repetido, overflow de texto). O "01/02/03" de "Como funciona" é sequência real, não scaffolding. Ressalva: de ~10 seções, só 1 usa fotografia real (Lisboa) — melhoria real vs. zero fotos antes, mas ainda insuficiente para descaracterizar a sensação de "card SaaS genérico" em "Por que consultoria?" e "Como funciona".
+
+**Deterministic scan:** `detect.mjs` no arquivo-alvo + `LandingNav`/`LandingFooter`/`ContactModal` retornou **limpo (0 achados)**, confirmado sem supressões (`--no-config` idêntico, sem `impeccable-disable`, sem config local). O overlay ao vivo no DOM renderizado completo encontrou 14-18 instâncias, incluindo um achado **novo e acionável**: `low-contrast` no botão "Falar no WhatsApp" do nav — texto branco sobre `bg-anhanga-action` (#0ea5e9) mede **2.8:1**, abaixo do mínimo de 4.5:1 do WCAG AA. Demais achados do overlay (FAQ accordion: `cramped-padding`, `nested-cards`, `layout-transition`) pertencem a `LandingFAQ.tsx`, fora do escopo do arquivo-alvo pedido no scan estático.
+
+**Onde A e B convergem:** ambos confirmam de forma independente, com evidência concreta, que as 5 correções alegadas pela PR #1203 estão realmente no código (não é só o comentário sobrevivendo como no bug do último ciclo de review).
+
+## Overall Impression
+
+A nota subiu de 26 para 33/40 — ganho real e verificado, não maquiagem: foco de teclado funciona de verdade (testado com Tab real, não `.focus()` sintético), a Regra do Âmbar se sustenta em todo scroll/breakpoint, e o ghosting sob scroll humano ágil realista está genuinamente resolvido. A rodada também revelou dois problemas **não relacionados à PR #1203** que só apareceram porque a inspeção desta vez foi mais rigorosa (scroll real, viewport real, Tab real): um banner de cookies bloqueando o único CTA do hero em mobile (P0) e um contraste insuficiente no botão do nav (P1). Nenhum dos dois é regressão da PR — são achados novos de um exame mais profundo.
+
+## What's Working
+
+1. **Foco de teclado real e verificado** — outline visível nas cores corretas nos dois botões do modal, confirmado com Tab de verdade em vez de `.focus()` programático (que dá falso positivo, como o próprio processo desta sessão descobriu duas vezes).
+2. **Regra do Âmbar sólida em todo o scroll e breakpoints** — nav nunca compete com o CTA da página.
+3. **Ghosting por scroll rápido resolvido para o cenário real** — scroll contínuo a ritmo humano ágil (~2100px/s) não produziu nenhuma seção semitransparente.
+
+## Priority Issues
+
+**[P0] Banner de cookies bloqueia o CTA principal do hero em mobile**
+- **Why it matters**: em 375×812, `elementFromPoint()` no centro do botão "Falar com um consultor" retorna o banner de cookies, não o botão. O único CTA da dobra inicial fica fisicamente inacessível ao toque antes de qualquer interação com o banner — o pior lugar possível para esse tipo de bloqueio (antes do primeiro engajamento).
+- **Fix**: usar o mesmo mecanismo (`--cookie-banner-h`) que já protege elementos flutuantes (AIChat) para também deslocar/considerar CTAs em fluxo normal no hero em viewports compactos, ou reduzir a prioridade de empilhamento do banner nessa faixa.
+- **Suggested command**: `/impeccable harden`
+
+**[P1] Contraste insuficiente no botão "Falar no WhatsApp" do nav**
+- **Why it matters**: texto branco sobre `bg-anhanga-action` mede 2.8:1, abaixo do piso de 4.5:1 do WCAG AA que o PRODUCT.md exige. Achado determinístico (overlay), não uma leitura subjetiva.
+- **Fix**: escurecer o fundo (ex. usar `anhanga-actionDark` como base em vez de hover) ou usar texto com peso/cor que atinja 4.5:1 mantendo a variante `action`.
+- **Suggested command**: `/impeccable polish`
+
+**[P1] Ghosting residual em scroll instantâneo/teleporte (limitação estrutural, não regressão)**
+- **Why it matters**: a margem de 1 viewport só ajuda quando o usuário rola progressivamente pela zona de antecedência. Um jump direto (arrastar thumb da scrollbar, âncora, `scrollTo` programático) ainda pousa em conteúdo semitransparente por até ~550ms. Sob scroll humano contínuo (o caso majoritário) já está resolvido.
+- **Fix**: avaliar custo/benefício de reduzir a duração da animação para itens tardios no stagger, ou aceitar como limitação conhecida do mecanismo.
+- **Suggested command**: `/impeccable animate` (opcional — ver pergunta provocativa 3)
+
+**[P2] Imagery ainda majoritariamente ícone-only**
+- **Why it matters**: 1 foto real em ~10 seções não é suficiente para descaracterizar o padrão de card genérico em "Por que consultoria?" e "Como funciona" — contraria o princípio "lugares reais, não categorias" para um brief que é literalmente sobre viagens.
+- **Fix**: considerar uma segunda foto real, por exemplo pareada com "Sobre a Anhangá Viagens".
+- **Suggested command**: `/impeccable colorize` ou `/impeccable shape`
+
+**[P3] Namespace legado `brand-*` ainda presente em `ContactModal.tsx`**
+- **Why it matters**: o mesmo arquivo que acabou de ganhar `focus-visible:outline-anhanga-action` nos botões de ação ainda usa `text-brand-vibrant`/`text-brand-dark`/`ring-brand-cyan` em outros elementos — já que o arquivo foi tocado por esta mesma PR, vale registrar como débito de follow-up.
+- **Fix**: migrar os elementos restantes para `anhanga-*` numa passada de limpeza.
+- **Suggested command**: `/impeccable polish`
+
+## Persona Red Flags
+
+**Jordan (primeira vez, mobile):** pousa na página, tenta tocar no botão amarelo do hero e toca no banner de cookies por baixo — sem entender por que nada aconteceu.
+
+**Riley (testador de estresse):** arrasta a scrollbar direto para o final — vê CTA Final e "Sobre a Anhangá" quase invisíveis por ~550ms. Com campos vazios no modal, o Tab pula os dois botões (comportamento HTML correto de `disabled`, mas sem pista visual/aria).
+
+**Casey (mobile distraído):** exatamente o perfil mais atingido pelo P0 — scroll rápido, toque rápido no que parece ser o CTA, e o toque cai no banner de cookies.
+
+## Minor Observations
+
+- Lista "Para quem é" tem 5 itens (viola levemente o teto de chunking ≤4).
+- Cards de "Por que consultoria?" ficam apertados em tablet (768px) — texto ainda cabe, mas é o breakpoint mais espremido.
+- Nav sticky com `backdrop-blur-md` produz "texto fantasma" quando um H2 rola por trás dele — funcional, não decorativo, mas vale um gut-check visual.
+- FAQ acordeão não usa `whileInView` — decisão implícita acertada, evita mais um ponto de ghosting.
+
+## Questions to Consider
+
+- Se o objetivo é "conversa não transação", por que o WhatsApp ainda é campo obrigatório de texto livre em vez de vir pré-preenchido no fluxo "Abrir WhatsApp agora"?
+- O banner de cookies já protege elementos flutuantes via `--cookie-banner-h` — por que esse cuidado não se estende a CTAs em fluxo normal no hero? Sugere que o padrão nunca foi testado em mobile real com o banner ativo.
+- Vale a pena investir na correção estrutural do ghosting por jump instantâneo, ou o custo/benefício não compensa dado que o scroll progressivo (caso majoritário) já está resolvido?

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -65,12 +65,12 @@ components:
     padding: "14px 28px"
   button-action:
     backgroundColor: "{colors.action}"
-    textColor: "#f8fafc"
+    textColor: "{colors.dark}"
     rounded: "{rounded.full}"
     padding: "10px 20px"
   button-action-hover:
-    backgroundColor: "{colors.action-dark}"
-    textColor: "#f8fafc"
+    backgroundColor: "{colors.action}"
+    textColor: "{colors.dark}"
     rounded: "{rounded.full}"
     padding: "10px 20px"
   button-cta:
@@ -195,7 +195,7 @@ O `shadow-glow` (brilho ciano) é reservado para highlights de estado ativo em e
 
 - **Shape:** Varia por variante. Primary: arredondado médio (12px / `rounded-xl`). Action: pílula completa (9999px / `rounded-full`). CTA: arredondado generoso (16px / `rounded-2xl`). Ghost: arredondado suave (8px / `rounded-lg`).
 - **Primary** (Ardósia Profunda, texto branco, `shadow-hard-yellow`): Para ações importantes em contexto light. Press-down com Âmbar Vivo. Tamanhos: `sm` (text-xs, px-4 py-2), `md` (text-sm, px-5 py-2.5), `lg` (text-base, px-7 py-3.5).
-- **Action** (Céu Vivo, texto Ardósia, pílula): Ações de fluxo, navegação, CTAs em contexto dark. `hover:bg-action-dark`. Sem hard shadow — a pílula já comunica interatividade. Texto Ardósia (não branco): branco sobre Céu Vivo mede 2.8:1, abaixo do piso de 4.5:1 do WCAG AA.
+- **Action** (Céu Vivo, texto Ardósia, pílula): Ações de fluxo, navegação, CTAs em contexto dark. `hover:brightness-105` (sem escurecer o fundo — `bg-action-dark` no hover derruba o par para 4.36:1, abaixo do piso). Sem hard shadow — a pílula já comunica interatividade. Texto Ardósia (não branco): branco sobre Céu Vivo mede 2.8:1, abaixo do piso de 4.5:1 do WCAG AA.
 - **CTA** (Âmbar Vivo, texto Ardósia, `shadow-hard`): O botão de conversão máxima. Reservado para o principal call-to-action de cada tela — nunca dois CTAs na mesma tela.
 - **Ghost** (transparente, texto Cinza): Ações terciárias e navegação discreta. `hover:text-action`. Sem sombra, sem borda.
 - **Estados:** `disabled:opacity-50 disabled:cursor-not-allowed`. Foco: `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action` em todas as variantes. Loading: ícone spin `CircleNotch` do `@phosphor-icons/react`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -195,7 +195,7 @@ O `shadow-glow` (brilho ciano) é reservado para highlights de estado ativo em e
 
 - **Shape:** Varia por variante. Primary: arredondado médio (12px / `rounded-xl`). Action: pílula completa (9999px / `rounded-full`). CTA: arredondado generoso (16px / `rounded-2xl`). Ghost: arredondado suave (8px / `rounded-lg`).
 - **Primary** (Ardósia Profunda, texto branco, `shadow-hard-yellow`): Para ações importantes em contexto light. Press-down com Âmbar Vivo. Tamanhos: `sm` (text-xs, px-4 py-2), `md` (text-sm, px-5 py-2.5), `lg` (text-base, px-7 py-3.5).
-- **Action** (Céu Vivo, texto branco, pílula): Ações de fluxo, navegação, CTAs em contexto dark. `hover:bg-action-dark`. Sem hard shadow — a pílula já comunica interatividade.
+- **Action** (Céu Vivo, texto Ardósia, pílula): Ações de fluxo, navegação, CTAs em contexto dark. `hover:bg-action-dark`. Sem hard shadow — a pílula já comunica interatividade. Texto Ardósia (não branco): branco sobre Céu Vivo mede 2.8:1, abaixo do piso de 4.5:1 do WCAG AA.
 - **CTA** (Âmbar Vivo, texto Ardósia, `shadow-hard`): O botão de conversão máxima. Reservado para o principal call-to-action de cada tela — nunca dois CTAs na mesma tela.
 - **Ghost** (transparente, texto Cinza): Ações terciárias e navegação discreta. `hover:text-action`. Sem sombra, sem borda.
 - **Estados:** `disabled:opacity-50 disabled:cursor-not-allowed`. Foco: `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action` em todas as variantes. Loading: ícone spin `CircleNotch` do `@phosphor-icons/react`.

--- a/components/CookieConsentBanner.tsx
+++ b/components/CookieConsentBanner.tsx
@@ -49,8 +49,8 @@ const CookieConsentBanner: React.FC = () => {
       aria-label="Preferências de cookies"
       className="fixed bottom-0 left-0 right-0 z-[10000] m-0 w-full max-w-none border-0 p-0 bg-anhanga-dark border-t border-white/10 shadow-lg"
     >
-      <div className="container mx-auto px-6 py-4 flex flex-col sm:flex-row items-center justify-between gap-4">
-        <p className="text-sm text-zinc-300 leading-relaxed max-w-2xl">
+      <div className="container mx-auto px-4 py-2.5 sm:px-6 sm:py-4 flex flex-col sm:flex-row items-center justify-between gap-2 sm:gap-4">
+        <p className="text-xs sm:text-sm text-zinc-300 leading-snug sm:leading-relaxed max-w-2xl">
           Usamos cookies de marketing para te mostrar ofertas de viagem mais relevantes.
           Analytics continua ativo por interesse legítimo {'—'}{' '}
           <a
@@ -61,18 +61,18 @@ const CookieConsentBanner: React.FC = () => {
           </a>
           .
         </p>
-        <div className="flex gap-3 shrink-0">
+        <div className="flex gap-2 sm:gap-3 shrink-0">
           <button
             type="button"
             onClick={handleDecline}
-            className="px-4 py-2 text-sm font-medium text-zinc-300 border border-white/20 rounded-lg hover:border-white/40 hover:text-white transition-colors"
+            className="px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-zinc-300 border border-white/20 rounded-lg hover:border-white/40 hover:text-white transition-colors"
           >
             Recusar
           </button>
           <button
             type="button"
             onClick={handleAccept}
-            className="px-4 py-2 text-sm font-medium text-zinc-300 border border-white/20 rounded-lg hover:border-white/40 hover:text-white transition-colors"
+            className="px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-zinc-300 border border-white/20 rounded-lg hover:border-white/40 hover:text-white transition-colors"
           >
             Aceitar
           </button>

--- a/components/CookieConsentBanner.tsx
+++ b/components/CookieConsentBanner.tsx
@@ -65,14 +65,14 @@ const CookieConsentBanner: React.FC = () => {
           <button
             type="button"
             onClick={handleDecline}
-            className="px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-zinc-300 border border-white/20 rounded-lg hover:border-white/40 hover:text-white transition-colors"
+            className="px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-zinc-300 border border-white/20 rounded-lg hover:border-white/40 hover:text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
           >
             Recusar
           </button>
           <button
             type="button"
             onClick={handleAccept}
-            className="px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-zinc-300 border border-white/20 rounded-lg hover:border-white/40 hover:text-white transition-colors"
+            className="px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-zinc-300 border border-white/20 rounded-lg hover:border-white/40 hover:text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
           >
             Aceitar
           </button>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -19,8 +19,10 @@ const variantClasses: Record<ButtonVariant, string> = {
     // texto Ardósia, não branco: branco sobre bg-anhanga-action mede 2.8:1
     // (abaixo do piso de 4.5:1 do WCAG AA) — mesma lógica de par acessível já
     // usada no variant `cta` (bg saturado + texto escuro). Ver critique de
-    // /consultoria-de-viagem.
-    action:  'bg-anhanga-action text-anhanga-dark rounded-full hover:bg-anhanga-actionDark',
+    // /consultoria-de-viagem. hover:bg-anhanga-actionDark foi removido: esse
+    // par media 4.36:1 com o texto Ardósia, abaixo do piso — brightness-105
+    // dá feedback de hover sem escurecer o fundo (só melhora o contraste).
+    action:  'bg-anhanga-action text-anhanga-dark rounded-full hover:brightness-105',
     cta:     'bg-anhanga-yellow text-anhanga-dark rounded-2xl shadow-hard hover:shadow-[2px_2px_0px_0px_rgba(15,23,42,1)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none',
     ghost:   'bg-transparent text-zinc-500 rounded-lg hover:text-anhanga-action',
 };

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -16,7 +16,11 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variantClasses: Record<ButtonVariant, string> = {
     primary: 'bg-anhanga-dark text-white rounded-xl shadow-hard-yellow hover:shadow-[2px_2px_0px_0px_#FFD600] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none',
-    action:  'bg-anhanga-action text-white rounded-full hover:bg-anhanga-actionDark',
+    // texto Ardósia, não branco: branco sobre bg-anhanga-action mede 2.8:1
+    // (abaixo do piso de 4.5:1 do WCAG AA) — mesma lógica de par acessível já
+    // usada no variant `cta` (bg saturado + texto escuro). Ver critique de
+    // /consultoria-de-viagem.
+    action:  'bg-anhanga-action text-anhanga-dark rounded-full hover:bg-anhanga-actionDark',
     cta:     'bg-anhanga-yellow text-anhanga-dark rounded-2xl shadow-hard hover:shadow-[2px_2px_0px_0px_rgba(15,23,42,1)] hover:translate-x-[2px] hover:translate-y-[2px] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none',
     ghost:   'bg-transparent text-zinc-500 rounded-lg hover:text-anhanga-action',
 };

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -130,14 +130,22 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
         <LandingNav source="consultoria-viagem" />
 
         {/* Hero */}
-        <section className="pt-16 pb-20 px-6">
+        {/*
+          Espaçamento e tamanho do texto reduzidos em mobile (md: restaura os
+          valores originais): em telas curtas (~360-812px de altura) o CTA e o
+          disclaimer "Sem taxa..." caem perto do fim do viewport inicial, e o
+          banner de cookies (fixed bottom-0) os cobre antes de qualquer scroll
+          — combinado com CookieConsentBanner.tsx, que também foi compactado
+          no mobile. Ver critique de /consultoria-de-viagem.
+        */}
+        <section className="pt-3 md:pt-16 pb-20 px-6">
           <div className="max-w-3xl mx-auto">
             <m.div
               variants={fadeUp}
               initial="hidden"
               animate="visible"
               custom={0}
-              className="inline-flex items-center gap-2 rounded-full border border-anhanga-blue/20 bg-anhanga-blue/5 px-3 py-1 mb-5 text-xs font-black uppercase tracking-widest text-anhanga-blue"
+              className="inline-flex items-center gap-2 rounded-full border border-anhanga-blue/20 bg-anhanga-blue/5 px-3 py-0.5 md:py-1 mb-2 md:mb-5 text-[11px] md:text-xs font-black uppercase tracking-widest text-anhanga-blue"
             >
               <Compass className="size-3.5" aria-hidden="true" />
               Consultoria de viagem · São Paulo
@@ -147,7 +155,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               initial="hidden"
               animate="visible"
               custom={1}
-              className="text-balance text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1]"
+              className="text-balance text-4xl md:text-6xl font-black text-anhanga-dark mb-2 md:mb-6 leading-[1.1]"
             >
               Planeje uma viagem sob medida sem depender de pacote pronto
             </m.h1>
@@ -156,7 +164,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               initial="hidden"
               animate="visible"
               custom={2}
-              className="text-xl text-zinc-600 mb-10 leading-relaxed max-w-2xl"
+              className="text-base md:text-xl text-zinc-600 mb-3 md:mb-10 leading-relaxed max-w-2xl"
             >
               Um consultor da Anhangá entende seu perfil, destino, orçamento e restrições para desenhar o melhor caminho antes de você fechar.
             </m.p>
@@ -171,7 +179,7 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
               >
                 Falar com um consultor
               </Button>
-              <p className="mt-4 text-sm text-zinc-600">Sem taxa de consultoria. Gratuito.</p>
+              <p className="mt-1 md:mt-4 text-sm text-zinc-600">Sem taxa de consultoria. Gratuito.</p>
             </m.div>
           </div>
         </section>

--- a/tests/e2e/landing-consultoria-content.spec.ts
+++ b/tests/e2e/landing-consultoria-content.spec.ts
@@ -1,5 +1,39 @@
 import { test, expect } from '@playwright/test';
 
+test.describe('CTA do hero não fica coberto pelo banner de cookies em mobile curto', () => {
+  test.use({ viewport: { width: 375, height: 667 } }); // iPhone SE — o mobile mais curto testado no critique
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem('anhanga_cookie_consent');
+      localStorage.removeItem('anhanga_cookie_consent_meta');
+    });
+  });
+
+  test('CTA "Falar com um consultor" e o disclaimer ficam acima do banner', async ({ page }) => {
+    await page.goto('/consultoria-de-viagem');
+
+    const banner = page.getByRole('dialog', { name: 'Preferências de cookies' });
+    await expect(banner).toBeVisible();
+
+    const cta = page.locator('[data-tracking="hero-consultoria-viagem"]');
+    const disclaimer = page.getByText('Sem taxa de consultoria. Gratuito.');
+
+    const bannerBox = await banner.boundingBox();
+    const ctaBox = await cta.boundingBox();
+    const disclaimerBox = await disclaimer.boundingBox();
+    expect(bannerBox).not.toBeNull();
+    expect(ctaBox).not.toBeNull();
+    expect(disclaimerBox).not.toBeNull();
+
+    // Ambos precisam terminar acima do topo do banner (fixed bottom-0) — ver
+    // critique de /consultoria-de-viagem: em telas curtas o disclaimer ficava
+    // coberto mesmo com o CTA já visível.
+    expect(ctaBox!.y + ctaBox!.height).toBeLessThanOrEqual(bannerBox!.y);
+    expect(disclaimerBox!.y + disclaimerBox!.height).toBeLessThanOrEqual(bannerBox!.y);
+  });
+});
+
 test('landing de consultoria mostra uma foto real do destino junto ao depoimento', async ({ page }) => {
   await page.goto('/consultoria-de-viagem');
 


### PR DESCRIPTION
## Summary

Segundo round de fixes do critique de `/consultoria-de-viagem` (score 26→33/40 após PR #1203). Ataca os 2 achados não causados pela PR anterior:

- **P0**: banner de cookies (`fixed bottom-0`) cobrindo o CTA/disclaimer do hero em viewports mobile curtos (confirmado via `elementFromPoint`/`boundingBox`).
- **P1**: contraste insuficiente do botão "Falar no WhatsApp" no nav (branco sobre `bg-anhanga-action` media 2,8:1, abaixo do piso 4,5:1 do WCAG AA).

P2 (segunda foto real de destino) foi explicitamente deixado de fora desta rodada.

## Mudanças

- **`components/ui/Button.tsx`**: variant `action` de texto branco → ardósia (6,44:1). Único call-site no repo, blast radius contido.
- **`components/CookieConsentBanner.tsx`**: layout mobile compactado (padding, gap, tipografia) — 200,75px → 125px de altura. Fix sitewide (aparece em todo o site), texto legal LGPD preservado intacto — só CSS/layout.
- **`pages/landings/ConsultoriaDeViagemLanding.tsx`**: trim leve e responsivo no hero mobile (`md:` preserva os valores originais em desktop), combinado com o banner compacto.
- **`DESIGN.md`**: atualizado para o novo par de cores do variant `action`.
- Tentativa inicial (só `padding-bottom` no hero) foi descartada por não mover o CTA de fato — revertida antes do commit final.

## Verificação

Medido empiricamente via Playwright (não estimado) em 5 viewports mobile — clearance do CTA e do disclaimer acima do banner:

| Viewport | CTA clearance | Disclaimer clearance |
|---|---|---|
| 375×667 (iPhone SE) | +39.6px | +15.6px |
| 360×800 | +172.5px | +148.5px |
| 375×812 | +184.0px | +160.0px |
| 390×844 | +216.9px | +192.9px |
| 412×915 | +288.2px | +264.2px |

Contraste do nav conferido também visualmente (não só pela matemática).

## Test plan

- [x] Novo teste e2e (`landing-consultoria-content.spec.ts`) fixando viewport 375×667 e afirmando CTA/disclaimer acima do banner — passa em todos os browsers.
- [x] `pnpm test:regression` — 963/963 passando.
- [x] `pnpm test:e2e` — 867 passando; 7 falhas pré-existentes em Firefox/WebKit não relacionadas a este diff (confirmado via `git stash` contra `main`).
- [x] `pnpm typecheck` limpo.
- [x] `eslint` limpo nos arquivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)