### PR TITLE
feat(design): segunda foto real na landing de consultoria (P2 do critique)

### DIFF
--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -342,32 +342,58 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
 
         {/* Sobre a Anhangá */}
         <section className="py-20 bg-anhanga-light">
-          <m.div
-            variants={fadeUp}
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
-            custom={0}
-            className="max-w-4xl mx-auto px-6 text-center"
-          >
-            <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6">
-              Sobre a Anhangá Viagens
-            </h2>
-            <p className="text-lg text-zinc-600 leading-relaxed max-w-2xl mx-auto">
-              Agência de viagens em São Paulo, especializada em viagens personalizadas desde 2018. Atendimento humano, nota 5.0 no Google e consultor fixo do início ao fim da sua viagem.
-            </p>
-            <div className="mt-10 flex flex-wrap justify-center gap-3">
-              {CREDENTIALS.map(item => (
-                <span
-                  key={item}
-                  className="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-bold text-anhanga-dark shadow-float"
-                >
-                  <CheckCircle className="size-4 text-anhanga-blue" aria-hidden="true" />
-                  {item}
-                </span>
-              ))}
+          <div className="max-w-5xl mx-auto px-6">
+            <div className="md:grid md:grid-cols-2 md:gap-16 items-center">
+              <m.div
+                variants={fadeUp}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
+                custom={0}
+                className="overflow-hidden rounded-3xl shadow-float"
+              >
+                {/*
+                  Segunda foto real da página (a primeira é o depoimento de
+                  Lisboa) — "Sobre" era só tipografia antes, contrariando
+                  "lugares reais, não categorias" para um brief sobre viagens.
+                  Ver critique de /consultoria-de-viagem (P2).
+                */}
+                <LazyImage
+                  src={getDestinationImage('Rio de Janeiro')}
+                  alt="Rio de Janeiro — um dos destinos planejados pela Anhangá Viagens"
+                  width={640}
+                  height={480}
+                  className="h-64 md:h-80 w-full"
+                />
+              </m.div>
+              <m.div
+                variants={fadeUp}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
+                custom={1}
+                className="mt-10 md:mt-0 text-center md:text-left"
+              >
+                <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6">
+                  Sobre a Anhangá Viagens
+                </h2>
+                <p className="text-lg text-zinc-600 leading-relaxed">
+                  Agência de viagens em São Paulo, especializada em viagens personalizadas desde 2018. Atendimento humano, nota 5.0 no Google e consultor fixo do início ao fim da sua viagem.
+                </p>
+                <div className="mt-10 flex flex-wrap justify-center md:justify-start gap-3">
+                  {CREDENTIALS.map(item => (
+                    <span
+                      key={item}
+                      className="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-bold text-anhanga-dark shadow-float"
+                    >
+                      <CheckCircle className="size-4 text-anhanga-blue" aria-hidden="true" />
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </m.div>
             </div>
-          </m.div>
+          </div>
         </section>
 
         {/* CTA Final */}

--- a/tests/e2e/landing-consultoria-content.spec.ts
+++ b/tests/e2e/landing-consultoria-content.spec.ts
@@ -50,6 +50,19 @@ test('landing de consultoria mostra uma foto real do destino junto ao depoimento
     .toBeGreaterThan(0);
 });
 
+test('landing de consultoria mostra uma foto real do Rio de Janeiro na seção "Sobre"', async ({ page }) => {
+  await page.goto('/consultoria-de-viagem');
+
+  await page.getByRole('heading', { name: 'Sobre a Anhangá Viagens' }).scrollIntoViewIfNeeded();
+
+  const photo = page.getByRole('img', { name: /rio de janeiro/i });
+  await expect(photo).toBeVisible();
+  await expect(photo).toHaveAttribute('src', /rio-de-janeiro/);
+  await expect
+    .poll(async () => photo.evaluate((img: HTMLImageElement) => img.naturalWidth))
+    .toBeGreaterThan(0);
+});
+
 test('links de "Outros serviços" recebem foco visível ao navegar por teclado', async ({ page }) => {
   await page.goto('/consultoria-de-viagem');
 


### PR DESCRIPTION
## Summary

Terceiro round de fixes do critique de `/consultoria-de-viagem` (score 33/40 após PR #1205, que já resolveu P0/P1). Ataca o P2: de ~10 seções da página, só 1 usava fotografia real (Lisboa, no depoimento) — insuficiente para descaracterizar a sensação de "card genérico" e contrariar o princípio "lugares reais, não categorias" (PRODUCT.md) para um brief que é literalmente sobre viagens.

P3 (namespace legado `brand-*` em `ContactModal.tsx`) segue como débito registrado no critique, fora de escopo desta PR.

## Mudanças

- **`pages/landings/ConsultoriaDeViagemLanding.tsx`**: a seção "Sobre a Anhangá Viagens" (antes só tipografia centralizada) ganha uma foto real do Rio de Janeiro, pareada em grid com o texto — mesmo padrão já validado no depoimento/Lisboa (`LazyImage` + `getDestinationImage`, `viewport` com margem de antecedência contra ghosting em scroll rápido). Ordem invertida (foto → texto, vs. texto → foto no depoimento) para variar o ritmo visual da página.

## Verificação

- Conferido visualmente no browser (imagem carrega, layout responde bem em mobile/desktop, sem quebra de ritmo).
- Reconfirmado que o P0 (banner de cookies x CTA do hero) continua com folga positiva — a mudança não toca o hero.
- [x] `pnpm typecheck` limpo.
- [x] `eslint` limpo no arquivo tocado.
- [x] `pnpm test:regression` — 964/964 passando.
- [x] `landing-consultoria-content.spec.ts` + `landing-no-aichat.spec.ts` — passando em todos os browsers exceto as 2 falhas pré-existentes de WebKit/tab-order (não relacionadas, já confirmadas antes da PR #1205).

🤖 Generated with [Claude Code](https://claude.com/claude-code)