### PR TITLE
feat(cruzeiros): redesign com ofertas selecionadas de fornecedores

### DIFF
--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -101,6 +101,14 @@ const ContactModal: React.FC = () => {
                         <h2 id={titleId} className="text-lg font-black text-anhanga-dark">
                             Fale com um especialista
                         </h2>
+                        {/* Confirma ao visitante que o clique carregou o contexto certo
+                            (ex.: a oferta de cruzeiro escolhida). Aditivo: só aparece
+                            quando o CTA passa `destination`. */}
+                        {options.destination ? (
+                            <p className="mt-1.5 text-sm font-semibold text-zinc-500">
+                                Sobre: <span className="text-brand-dark">{options.destination}</span>
+                            </p>
+                        ) : null}
                     </div>
                     <button
                         type="button"

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -106,7 +106,7 @@ const ContactModal: React.FC = () => {
                             quando o CTA passa `destination`. */}
                         {options.destination ? (
                             <p className="mt-1.5 text-sm font-semibold text-zinc-500">
-                                Sobre: <span className="text-brand-dark">{options.destination}</span>
+                                Sobre: <span className="text-anhanga-dark">{options.destination}</span>
                             </p>
                         ) : null}
                     </div>

--- a/data/cruiseOffers.ts
+++ b/data/cruiseOffers.ts
@@ -1,0 +1,128 @@
+// Ofertas de cruzeiro exibidas na landing /cruzeiros.
+//
+// Curadoria sobre catálogo (PRODUCT.md): poucas ofertas escolhidas a dedo, com
+// uma nota autoral por que ELA foi selecionada — não uma grade de tudo que os
+// fornecedores oferecem. Mantenha entre ~4 e 8; acima disso a página comunica
+// commodity, não curadoria.
+//
+// Expiração: `expiraEm` (YYYY-MM-DD, fuso de São Paulo) é o último dia em que a
+// oferta aparece. O rebuild diário do Cloudflare Pages remove as vencidas sem
+// PR — ver lib/cruise-offers-schedule.js. Não precisa ser a data de saída:
+// normalmente pare de anunciar alguns dias antes de o navio zarpar.
+//
+// Imagens: `imagem` é um path relativo servido pelo R2 (media.anhanga.tur.br),
+// otimizado em runtime pelo LazyImage. As imagens abaixo são PLACEHOLDERS de
+// destino (reaproveitadas do blog) para o layout já renderizar — troque pelas
+// fotos reais do navio/roteiro que o fornecedor licenciar, subindo-as em
+// images/cruzeiros/ no R2 e atualizando o path aqui.
+
+export interface CruiseOffer {
+  /** Slug estável — vira React key, data-tracking e não muda ao editar o mix. */
+  id: string;
+  companhia: string;
+  navio: string;
+  /** Porto de embarque. Brasil (Santos, Rio) ou internacional (Barcelona…). */
+  portoEmbarque: string;
+  /** Escalas na ordem do roteiro, embarque incluso. */
+  roteiro: string[];
+  /** Rótulo de saída legível ("Fevereiro 2027", "Temporada 2026/27"). */
+  saida: string;
+  noites: number;
+  /** Path relativo no R2 (sem host); otimizado pelo LazyImage. */
+  imagem: string;
+  imagemAlt: string;
+  /** 1–2 linhas autorais: por que ESTA oferta foi escolhida. O diferencial. */
+  notaCuratorial: string;
+  /** Perfis a que a oferta atende — vira badge no card. */
+  perfis: string[];
+  /** Região, usada para um selo discreto ("Brasil" vs destino internacional). */
+  regiao: string;
+  /** No máximo uma oferta em destaque por vez (ver layout da landing). */
+  featured?: boolean;
+  /** Último dia visível (YYYY-MM-DD, São Paulo). */
+  expiraEm: string;
+}
+
+export const CRUISE_OFFERS: readonly CruiseOffer[] = [
+  {
+    id: 'msc-seaside-costa-brasileira-fev-2027',
+    companhia: 'MSC Cruzeiros',
+    navio: 'MSC Seaside',
+    portoEmbarque: 'Santos',
+    roteiro: ['Santos', 'Búzios', 'Ilhéus', 'Santos'],
+    saida: 'Fevereiro 2027',
+    noites: 7,
+    imagem: 'images/blog/blog-viagem-solo-feminina.png',
+    imagemAlt: 'Navio de cruzeiro navegando ao pôr do sol na costa brasileira',
+    notaCuratorial:
+      'Escolhemos este porque o Seaside tem a melhor estrutura de bordo da temporada em Santos — e Ilhéus em fevereiro é a parada mais bonita da costa.',
+    perfis: ['Primeira vez', 'Casal', 'Família'],
+    regiao: 'Brasil',
+    featured: true,
+    expiraEm: '2027-01-25',
+  },
+  {
+    id: 'costa-diadema-ilha-grande-jan-2027',
+    companhia: 'Costa Cruzeiros',
+    navio: 'Costa Diadema',
+    portoEmbarque: 'Santos',
+    roteiro: ['Santos', 'Ilha Grande', 'Porto Belo', 'Santos'],
+    saida: 'Janeiro 2027',
+    noites: 5,
+    imagem: 'images/blog/cancun-punta-cana-aruba-lua-de-mel.jpg',
+    imagemAlt: 'Praia de águas claras vista de um cruzeiro',
+    notaCuratorial:
+      'Roteiro curto e sem voo: ideal para quem quer experimentar um cruzeiro pela primeira vez sem tirar a semana inteira de folga.',
+    perfis: ['Primeira vez', 'Casal'],
+    regiao: 'Brasil',
+    expiraEm: '2026-12-28',
+  },
+  {
+    id: 'msc-grandiosa-mediterraneo-mai-2027',
+    companhia: 'MSC Cruzeiros',
+    navio: 'MSC Grandiosa',
+    portoEmbarque: 'Barcelona',
+    roteiro: ['Barcelona', 'Marselha', 'Gênova', 'Nápoles', 'Barcelona'],
+    saida: 'Maio 2027',
+    noites: 7,
+    imagem: 'images/destinations/lisboa.jpg',
+    imagemAlt: 'Cidade mediterrânea à beira-mar ao entardecer',
+    notaCuratorial:
+      'O Mediterrâneo em maio pega o clima antes da alta temporada europeia — menos multidão nas escalas e preço melhor que julho.',
+    perfis: ['Casal', 'Quem já foi'],
+    regiao: 'Mediterrâneo',
+    expiraEm: '2027-04-10',
+  },
+  {
+    id: 'royal-caribbean-caribe-abr-2027',
+    companhia: 'Royal Caribbean',
+    navio: 'Wonder of the Seas',
+    portoEmbarque: 'Miami',
+    roteiro: ['Miami', 'Nassau', 'Ilha CocoCay', 'Miami'],
+    saida: 'Abril 2027',
+    noites: 7,
+    imagem: 'images/destinations/cartagena.jpg',
+    imagemAlt: 'Litoral caribenho de águas turquesa',
+    notaCuratorial:
+      'Um dos maiores navios do mundo, com estrutura de parque temático a bordo — a aposta certa para família com adolescente que se entedia fácil.',
+    perfis: ['Família', 'Quem já foi'],
+    regiao: 'Caribe',
+    expiraEm: '2027-03-15',
+  },
+  {
+    id: 'norwegian-nordeste-mar-2027',
+    companhia: 'Norwegian Cruise Line',
+    navio: 'Norwegian Getaway',
+    portoEmbarque: 'Santos',
+    roteiro: ['Santos', 'Salvador', 'Maceió', 'Santos'],
+    saida: 'Março 2027',
+    noites: 8,
+    imagem: 'images/blog/caribe-destinos-para-brasileiros.jpg',
+    imagemAlt: 'Vista do mar a partir do deck de um navio de cruzeiro',
+    notaCuratorial:
+      'A Norwegian é a mais flexível em horários de jantar — combina com quem viaja em grupo e não quer se prender a mesa marcada.',
+    perfis: ['Grupos', 'Casal'],
+    regiao: 'Brasil',
+    expiraEm: '2027-02-20',
+  },
+];

--- a/lib/cruise-offers-schedule.js
+++ b/lib/cruise-offers-schedule.js
@@ -1,0 +1,45 @@
+// Expiração das ofertas de cruzeiro da landing /cruzeiros.
+//
+// Cada oferta em data/cruiseOffers.ts tem um `expiraEm` (YYYY-MM-DD, fuso de
+// São Paulo). A oferta é visível ATÉ e incluindo esse dia; a partir do dia
+// seguinte ela some. O rebuild diário do Cloudflare Pages
+// (.github/workflows/scheduled-publish.yml, ~06:15 America/Sao_Paulo)
+// re-renderiza a landing estática e materializa a remoção sem PR nenhum.
+//
+// Arquivo .js (não .ts) de propósito: reusa todayInSaoPaulo() de
+// blog-schedule.js e é importado pelo componente da landing (runtime) e pelos
+// testes. Prerender e cliente rodam ESTE MESMO código, então concordam sobre
+// quais ofertas mostrar — a única divergência possível é a data-base entre o
+// build e o load. Como o rebuild é diário e a granularidade de `expiraEm` é o
+// dia, o HTML servido em qualquer dia D contém as ofertas ativas em D e o
+// cliente que carrega em D filtra idêntico. A janela de divergência é apenas
+// 00:00–06:15 SP (antes do rebuild do novo dia), afetando só uma oferta que
+// expirou na virada; o efeito é ela sumir suavemente após a hidratação, sem
+// quebrar o layout (keys estáveis por `id`).
+
+import { todayInSaoPaulo } from './blog-schedule.js';
+
+export { todayInSaoPaulo };
+
+/**
+ * Uma oferta está expirada quando hoje já passou do seu `expiraEm`.
+ * Datas ISO (YYYY-MM-DD) comparam corretamente como string.
+ * @param {string | undefined} expiraEm
+ * @param {string} [today]
+ * @returns {boolean}
+ */
+export function isOfferExpired(expiraEm, today = todayInSaoPaulo()) {
+  if (!expiraEm) return false;
+  return today > expiraEm;
+}
+
+/**
+ * Filtra a lista mantendo só as ofertas ainda válidas, preservando a ordem.
+ * @template {{ expiraEm?: string }} T
+ * @param {readonly T[]} offers
+ * @param {string} [today]
+ * @returns {T[]}
+ */
+export function getActiveOffers(offers, today = todayInSaoPaulo()) {
+  return offers.filter((offer) => !isOfferExpired(offer.expiraEm, today));
+}

--- a/pages/landings/CruzeirosLanding.tsx
+++ b/pages/landings/CruzeirosLanding.tsx
@@ -5,67 +5,60 @@ import { LandingFAQ } from '@/components/LandingFAQ';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
 import { ServiceSchema } from '@/components/schemas/ServiceSchema';
+import { LazyImage } from '@/components/ui/LazyImage';
 import { openContactModal } from '@/utils/contactForm';
-import { ArrowLeft, ArrowRight, Compass, LayoutGrid, CalendarCheck, CheckCircle } from 'lucide-react';
+import { CRUISE_OFFERS, type CruiseOffer } from '@/data/cruiseOffers';
+import { getActiveOffers } from '@/lib/cruise-offers-schedule.js';
+import { ArrowLeft, ArrowRight, Compass, Ship, MapPin, CalendarCheck, Moon } from 'lucide-react';
+
+// Filtra as ofertas vencidas no topo do módulo (import-time), não no render:
+// o prerender (build) e o cliente rodam este mesmo caminho e concordam sobre a
+// lista. Ver lib/cruise-offers-schedule.js para a janela de divergência.
+const ACTIVE_OFFERS = getActiveOffers(CRUISE_OFFERS);
+const FEATURED_OFFER = ACTIVE_OFFERS.find((o) => o.featured);
+const SECONDARY_OFFERS = ACTIVE_OFFERS.filter((o) => o !== FEATURED_OFFER);
+
+// Rótulo enviado ao CRM (campo `destination` → x_destino no Odoo) e mostrado no
+// ContactModal. A palavra "cruzeiro" auto-classifica o lead com a tag Cruzeiros
+// (lib/destination-region.ts). Também é o texto que o especialista vê primeiro.
+function offerCrmLabel(o: CruiseOffer): string {
+  return `Cruzeiro ${o.navio} · ${o.portoEmbarque} · ${o.saida}`;
+}
+
+// Mensagem natural pré-preenchida no WhatsApp quando o lead abre a conversa.
+function offerWhatsappMessage(o: CruiseOffer): string {
+  return `Olá! Tenho interesse no cruzeiro do ${o.navio} saindo de ${o.portoEmbarque} em ${o.saida}. Podem me ajudar?`;
+}
+
+function openOfferConversation(o: CruiseOffer): void {
+  openContactModal({
+    source: 'cruzeiros-oferta',
+    destination: offerCrmLabel(o),
+    message: offerWhatsappMessage(o),
+  });
+}
 
 const FAQ_ITEMS = [
   {
-    question: 'Qual o melhor cruzeiro para primeira vez?',
-    answer: 'Depende do seu perfil — casal, família, solo, orçamento, preferência de roteiro. É exatamente isso que a curadoria resolve: encontrar o navio e a cabine certos para você antes de fechar.'
+    question: 'Qual o melhor cruzeiro para a primeira vez?',
+    answer: 'Depende do seu perfil — casal, família, solo, orçamento, preferência de roteiro. É exatamente isso que a curadoria resolve: encontrar o navio, a cabine e a saída certos para você antes de fechar.'
+  },
+  {
+    question: 'Vocês trabalham só com saídas do Brasil?',
+    answer: 'Não. Temos cruzeiros saindo de Santos e do Rio de Janeiro na temporada brasileira, e também roteiros internacionais — Mediterrâneo, Caribe e outros. A seleção acima muda conforme a temporada e a disponibilidade dos armadores.'
   },
   {
     question: 'Cabine interna ou com varanda?',
-    answer: 'Para a primeira vez, a cabine com varanda vale muito pelo conforto e pela experiência visual durante o roteiro. Mas depende do orçamento e do navio. Explicamos tudo na conversa.'
-  },
-  {
-    question: 'Quais saídas de porto vocês trabalham?',
-    answer: 'Principalmente Santos, que é o maior porto de cruzeiros do Brasil. Também trabalhamos com saídas do Rio de Janeiro e outros portos conforme disponibilidade.'
+    answer: 'Para a primeira vez, a cabine com varanda costuma valer pelo conforto e pela experiência visual durante o roteiro. Mas depende do orçamento e do navio. Explicamos as diferenças na conversa.'
   },
   {
     question: 'Tem cruzeiro bom para família com criança pequena?',
     answer: 'Sim. Alguns navios têm estrutura kids excelente com monitores, piscinas infantis e programação específica. Indicamos o certo para a faixa etária dos seus filhos.'
   },
   {
-    question: 'Como é cobrado o serviço?',
-    answer: 'Sem taxa de curadoria no momento. Você fala com um especialista gratuitamente e decide se quer fechar seu cruzeiro com a Anhangá.'
+    question: 'As ofertas do site têm preço fechado?',
+    answer: 'As ofertas mostram navio, roteiro, porto de saída e período — o valor depende de cabine, número de passageiros e extras, e a gente fecha isso na conversa, sem taxa de curadoria.'
   }
-];
-
-const FOR_WHO = [
-  { title: 'Primeiro cruzeiro', desc: 'Quer entender o que esperar antes de comprar a passagem.' },
-  { title: 'Casal', desc: 'Busca a combinação certa de navio, cabine e roteiro para uma viagem especial.' },
-  { title: 'Família com crianças', desc: 'Precisa de um navio com boa estrutura kids e cabine que caiba todo mundo.' },
-  { title: 'Quem já foi', desc: 'Quer melhorar a experiência, subir de categoria ou experimentar outro roteiro.' },
-];
-
-const WHAT_WE_ANALYZE = [
-  'Navio e companhia (MSC, Costa, Carnival, Royal Caribbean)',
-  'Tipo de cabine: interna, oceanview, varanda ou suíte',
-  'Roteiro: Santos, Búzios, Ilhéus, Salvador, Ilha Grande',
-  'Datas e temporada (alto vs. baixo)',
-  'Perfil da viagem: romântica, familiar, solo, grupos',
-  'Orçamento total incluindo pacotes e extras a bordo',
-];
-
-const PILLARS = [
-  {
-    icon: Compass,
-    title: 'Navio certo para seu perfil',
-    desc: 'Cada companhia tem um DNA diferente. Indicamos o que combina com o que você quer viver a bordo.',
-    variant: 'light' as const,
-  },
-  {
-    icon: LayoutGrid,
-    title: 'Cabine sem arrependimento',
-    desc: 'Interna, oceanview, varanda ou suíte: explicamos o que cada categoria entrega e o que vale para o seu caso.',
-    variant: 'filled' as const,
-  },
-  {
-    icon: CalendarCheck,
-    title: 'Roteiro e datas ideais',
-    desc: 'Temporada, roteiro e disponibilidade fazem diferença no preço e na experiência. Analisamos tudo junto.',
-    variant: 'light' as const,
-  },
 ];
 
 const HOW_IT_WORKS = [
@@ -77,42 +70,176 @@ const HOW_IT_WORKS = [
   {
     step: '02',
     title: 'Curadoria personalizada',
-    desc: 'Com base no seu perfil, indicamos o navio, a cabine e o roteiro que mais fazem sentido para você.'
+    desc: 'Com base no seu perfil, indicamos o navio, a cabine e o roteiro que mais fazem sentido para você — inclusive fora da seleção do site.'
   },
   {
     step: '03',
     title: 'Reserva e suporte',
-    desc: 'Quando decidir, cuidamos da reserva e estamos disponíveis até você embarcar.'
+    desc: 'Quando decidir, cuidamos da reserva e ficamos disponíveis até você embarcar.'
   },
 ];
 
+const WHY_CURATION = [
+  {
+    icon: Compass,
+    title: 'Navio certo para seu perfil',
+    desc: 'Cada companhia tem um DNA diferente. Indicamos o que combina com o que você quer viver a bordo.',
+  },
+  {
+    icon: MapPin,
+    title: 'Roteiro que vale a viagem',
+    desc: 'Saída do Brasil ou internacional, escalas e temporada mudam o preço e a experiência. Analisamos tudo junto.',
+  },
+  {
+    icon: CalendarCheck,
+    title: 'Cabine sem arrependimento',
+    desc: 'Interna, varanda ou suíte: explicamos o que cada categoria entrega e o que vale para o seu caso.',
+  },
+];
+
+const OfferMeta: React.FC<{ offer: CruiseOffer; className?: string }> = ({ offer, className }) => (
+  <dl className={`flex flex-wrap gap-x-6 gap-y-2 text-sm ${className ?? ''}`}>
+    <div className="flex items-center gap-1.5">
+      <Ship className="size-4 text-anhanga-action flex-shrink-0" aria-hidden="true" />
+      <dt className="sr-only">Navio</dt>
+      <dd className="font-semibold text-anhanga-dark">{offer.companhia}</dd>
+    </div>
+    <div className="flex items-center gap-1.5">
+      <MapPin className="size-4 text-anhanga-action flex-shrink-0" aria-hidden="true" />
+      <dt className="sr-only">Roteiro</dt>
+      <dd className="text-zinc-600">{offer.roteiro.join(' · ')}</dd>
+    </div>
+    <div className="flex items-center gap-1.5">
+      <Moon className="size-4 text-anhanga-action flex-shrink-0" aria-hidden="true" />
+      <dt className="sr-only">Duração</dt>
+      <dd className="text-zinc-600">{offer.noites} noites</dd>
+    </div>
+  </dl>
+);
+
+const ProfileTags: React.FC<{ perfis: string[] }> = ({ perfis }) => (
+  <ul className="flex flex-wrap gap-2" aria-label="Perfis indicados">
+    {perfis.map((p) => (
+      <li key={p} className="text-xs font-semibold text-anhanga-blue bg-anhanga-blue/10 rounded-full px-3 py-1">
+        {p}
+      </li>
+    ))}
+  </ul>
+);
+
+const RegionBadge: React.FC<{ regiao: string; saida: string }> = ({ regiao, saida }) => (
+  <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-anhanga-action">
+    <span>{regiao}</span>
+    <span className="text-zinc-300" aria-hidden="true">·</span>
+    <span className="text-zinc-500">{saida}</span>
+  </div>
+);
+
+const FeaturedOffer: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
+  <article className="grid md:grid-cols-2 gap-0 rounded-3xl overflow-hidden bg-white shadow-float border border-anhanga-blue/10">
+    <LazyImage
+      src={offer.imagem}
+      alt={offer.imagemAlt}
+      width={800}
+      height={600}
+      sizes="(min-width: 768px) 50vw, 100vw"
+      className="h-64 md:h-full"
+    />
+    <div className="p-8 md:p-10 flex flex-col">
+      <RegionBadge regiao={offer.regiao} saida={offer.saida} />
+      <h3 className="mt-3 text-2xl md:text-3xl font-black text-anhanga-dark leading-tight">
+        {offer.navio}
+      </h3>
+      <OfferMeta offer={offer} className="mt-4" />
+      <div className="mt-5 rounded-xl bg-anhanga-blue/[0.04] p-4">
+        <p className="text-xs font-black uppercase tracking-wide text-anhanga-blue mb-1.5">
+          Por que escolhemos
+        </p>
+        <p className="text-zinc-700 leading-relaxed">{offer.notaCuratorial}</p>
+      </div>
+      <div className="mt-6">
+        <ProfileTags perfis={offer.perfis} />
+      </div>
+      <button
+        type="button"
+        onClick={() => openOfferConversation(offer)}
+        className="btn-whatsapp btn-specialist mt-8 inline-flex items-center justify-center gap-2 bg-anhanga-blue text-white font-bold px-7 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors shadow-lg self-start"
+        aria-label={`Falar com um especialista sobre o cruzeiro ${offer.navio}`}
+        data-tracking={`oferta-featured-${offer.id}`}
+      >
+        Quero saber mais
+        <ArrowRight className="size-5" />
+      </button>
+    </div>
+  </article>
+);
+
+const OfferCard: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
+  <article className="flex flex-col rounded-2xl overflow-hidden bg-white border border-anhanga-blue/10 hover:border-anhanga-blue/30 transition-colors">
+    <LazyImage
+      src={offer.imagem}
+      alt={offer.imagemAlt}
+      width={480}
+      height={300}
+      sizes="(min-width: 768px) 33vw, 100vw"
+      className="h-48"
+    />
+    <div className="p-6 flex flex-col flex-1">
+      <RegionBadge regiao={offer.regiao} saida={offer.saida} />
+      <h3 className="mt-2 text-xl font-black text-anhanga-dark leading-tight">{offer.navio}</h3>
+      <OfferMeta offer={offer} className="mt-3" />
+      <div className="mt-4 rounded-lg bg-anhanga-blue/[0.04] p-3 flex-1">
+        <p className="text-[0.65rem] font-black uppercase tracking-wide text-anhanga-blue mb-1">
+          Por que escolhemos
+        </p>
+        <p className="text-sm text-zinc-600 leading-relaxed">{offer.notaCuratorial}</p>
+      </div>
+      <div className="mt-4">
+        <ProfileTags perfis={offer.perfis} />
+      </div>
+      <button
+        type="button"
+        onClick={() => openOfferConversation(offer)}
+        className="btn-whatsapp btn-specialist mt-5 inline-flex items-center justify-center gap-2 w-full bg-white border-2 border-anhanga-blue/15 text-anhanga-blue font-bold px-5 py-3 rounded-xl hover:bg-anhanga-blue hover:text-white hover:border-anhanga-blue transition-colors"
+        aria-label={`Falar com um especialista sobre o cruzeiro ${offer.navio}`}
+        data-tracking={`oferta-${offer.id}`}
+      >
+        Falar sobre este
+        <ArrowRight className="size-4" />
+      </button>
+    </div>
+  </article>
+);
+
 const CruzeirosLanding: React.FC = () => {
+  const hasOffers = ACTIVE_OFFERS.length > 0;
+
   return (
     <div className="bg-anhanga-light min-h-screen font-sans">
       <Seo
-        title="Curadoria de Cruzeiros no Brasil — Anhangá Viagens"
-        description="Escolha navio, cabine e roteiro certos para o seu perfil. Curadoria consultiva para quem quer fazer o cruzeiro certo na primeira vez."
+        title="Cruzeiros — Ofertas e Curadoria | Anhangá Viagens"
+        description="Ofertas selecionadas de cruzeiros no Brasil e internacionais, com curadoria consultiva para escolher navio, cabine e roteiro certos antes de fechar."
         canonical="https://www.anhanga.tur.br/cruzeiros/"
         noHreflang
       />
       <ServiceSchema
-        name="Curadoria de Cruzeiros no Brasil"
-        description="Ajuda especializada para escolher navio, cabine, roteiro e datas ideais para seu cruzeiro no Brasil. Atendimento consultivo para casais, famílias e primeira viagem."
+        name="Cruzeiros — Ofertas e Curadoria"
+        description="Seleção de cruzeiros no Brasil e internacionais com atendimento consultivo para escolher navio, cabine, roteiro e datas ideais. Para casais, famílias e primeira viagem."
         serviceUrl="https://www.anhanga.tur.br/cruzeiros/"
-        serviceType="Curadoria de Cruzeiros"
+        serviceType="Cruzeiros"
         areaServed="Brasil"
       />
       <BreadcrumbSchema
         items={[
           { name: 'Home', item: 'https://www.anhanga.tur.br/' },
-          { name: 'Curadoria de Cruzeiros', item: 'https://www.anhanga.tur.br/cruzeiros/' }
+          { name: 'Cruzeiros', item: 'https://www.anhanga.tur.br/cruzeiros/' }
         ]}
       />
       <FAQPageSchema items={FAQ_ITEMS} />
 
       {/* Mini Header */}
       <header className="bg-white/90 backdrop-blur-sm border-b border-anhanga-blue/10 sticky top-0 z-50 py-3">
-        <div className="max-w-5xl mx-auto px-6 flex items-center justify-between">
+        <div className="max-w-6xl mx-auto px-6 flex items-center justify-between">
           <Link
             to="/"
             className="inline-flex items-center gap-2 group"
@@ -128,9 +255,9 @@ const CruzeirosLanding: React.FC = () => {
           </Link>
           <button
             type="button"
-            onClick={() => openContactModal({ source: 'cruzeiros-brasil' })}
+            onClick={() => openContactModal({ source: 'cruzeiros' })}
             className="btn-whatsapp btn-specialist text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap"
-            data-tracking="header-cruzeiros-brasil"
+            data-tracking="header-cruzeiros"
           >
             Falar com especialista
           </button>
@@ -141,20 +268,20 @@ const CruzeirosLanding: React.FC = () => {
       <section className="pt-16 pb-20 px-6 bg-anhanga-light">
         <div className="max-w-3xl mx-auto">
           <p className="text-sm font-semibold text-anhanga-blue mb-4 tracking-wide uppercase">
-            Cruzeiros no Brasil · Curadoria consultiva
+            Cruzeiros · Brasil e internacionais
           </p>
           <h1 className="text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1] font-serif">
-            Escolha o cruzeiro certo no Brasil antes de fechar
+            Os cruzeiros que a gente escolheria
           </h1>
           <p className="text-xl text-zinc-600 mb-10 leading-relaxed max-w-2xl">
-            Entenda navio, cabine, roteiro, datas e perfil da viagem com uma curadoria consultiva da Anhangá.
+            Uma seleção enxuta de saídas que valem a pena — no Brasil e pelo mundo — com um especialista para acertar navio, cabine e roteiro antes de você fechar.
           </p>
           <button
             type="button"
-            onClick={() => openContactModal({ source: 'cruzeiros-brasil' })}
+            onClick={() => openContactModal({ source: 'cruzeiros' })}
             className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-blue text-white font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors text-lg shadow-lg"
             aria-label="Falar com um especialista em cruzeiros"
-            data-tracking="hero-cruzeiros-brasil"
+            data-tracking="hero-cruzeiros"
           >
             Falar com um especialista
             <ArrowRight className="size-5" />
@@ -163,82 +290,47 @@ const CruzeirosLanding: React.FC = () => {
         </div>
       </section>
 
-      {/* O que analisamos juntos — posição 2: informação mais diferenciadora */}
-      <section className="py-20 bg-white">
-        <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-4 font-serif">
-            O que analisamos juntos
-          </h2>
-          <p className="text-zinc-600 text-lg mb-10">
-            Na curadoria, passamos por todos esses pontos antes de você decidir.
-          </p>
-          <div className="grid sm:grid-cols-2 gap-4">
-            {WHAT_WE_ANALYZE.map(item => (
-              <div key={item} className="flex items-start gap-3 p-4 rounded-xl bg-anhanga-light">
-                <CheckCircle className="size-5 text-anhanga-blue flex-shrink-0 mt-0.5" aria-hidden="true" />
-                <span className="text-zinc-700">{item}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      {/* Ofertas — protagonista. Some quando não há oferta válida (a curadoria
+          abaixo sustenta a página nesse estado). */}
+      {hasOffers ? (
+        <section className="py-20 bg-white" aria-labelledby="ofertas-titulo">
+          <div className="max-w-6xl mx-auto px-6">
+            <h2 id="ofertas-titulo" className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
+              Seleção da temporada
+            </h2>
+            <p className="text-zinc-600 text-lg mb-10 max-w-2xl">
+              Poucas saídas, escolhidas a dedo. Cada uma vem com o porquê de estar aqui — e um especialista para fechar a sua.
+            </p>
 
-      {/* Por que curadoria? */}
-      <section className="py-20 bg-anhanga-light">
-        <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
-            Por que curadoria?
-          </h2>
-          <p className="text-zinc-600 text-lg mb-12">
-            Porque escolher um cruzeiro envolve mais variáveis do que parece.
-          </p>
-          <div className="grid md:grid-cols-3 gap-6">
-            {PILLARS.map(({ icon: Icon, title, desc, variant }) => (
-              <div
-                key={title}
-                className={`p-8 rounded-2xl ${
-                  variant === 'filled'
-                    ? 'bg-anhanga-blue text-white'
-                    : 'bg-white'
-                }`}
+            {FEATURED_OFFER ? (
+              <div className="mb-6">
+                <FeaturedOffer offer={FEATURED_OFFER} />
+              </div>
+            ) : null}
+
+            {SECONDARY_OFFERS.length > 0 ? (
+              <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {SECONDARY_OFFERS.map((offer) => (
+                  <OfferCard key={offer.id} offer={offer} />
+                ))}
+              </div>
+            ) : null}
+
+            <p className="mt-10 text-zinc-600">
+              Não achou a saída ideal?{' '}
+              <button
+                type="button"
+                onClick={() => openContactModal({ source: 'cruzeiros' })}
+                className="font-bold text-anhanga-blue underline underline-offset-2 hover:text-anhanga-darkBlue transition-colors"
+                data-tracking="ofertas-fallback-cruzeiros"
               >
-                <div
-                  className={`size-11 rounded-xl flex items-center justify-center mb-5 ${
-                    variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
-                  }`}
-                >
-                  <Icon
-                    className={`size-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`}
-                  />
-                </div>
-                <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
-                  {title}
-                </h3>
-                <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-zinc-600 leading-relaxed'}>
-                  {desc}
-                </p>
-              </div>
-            ))}
+                Conte o que procura
+              </button>{' '}
+              — a gente busca fora da lista também.
+            </p>
           </div>
-        </div>
-      </section>
-
-      {/* Para quem é */}
-      <section className="py-20 bg-white">
-        <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
-            Para quem é
-          </h2>
-          <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-5">
-            {FOR_WHO.map(({ title, desc }) => (
-              <div key={title} className="bg-anhanga-light rounded-2xl p-6">
-                <h3 className="font-black text-anhanga-dark mb-2">{title}</h3>
-                <p className="text-zinc-600 text-sm leading-relaxed">{desc}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+        </section>
+      ) : null}
 
       {/* Como funciona */}
       <section className="py-20 bg-anhanga-light">
@@ -265,14 +357,37 @@ const CruzeirosLanding: React.FC = () => {
         </div>
       </section>
 
-      {/* Sobre a Anhangá */}
+      {/* Por que curadoria */}
       <section className="py-20 bg-white">
+        <div className="max-w-5xl mx-auto px-6">
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
+            Por que curadoria?
+          </h2>
+          <p className="text-zinc-600 text-lg mb-12">
+            Porque escolher um cruzeiro envolve mais variáveis do que parece.
+          </p>
+          <div className="grid md:grid-cols-3 gap-6">
+            {WHY_CURATION.map(({ icon: Icon, title, desc }) => (
+              <div key={title} className="p-8 rounded-2xl bg-anhanga-light">
+                <div className="size-11 rounded-xl flex items-center justify-center mb-5 bg-anhanga-blue/10">
+                  <Icon className="size-5 text-anhanga-blue" />
+                </div>
+                <h3 className="text-xl font-black mb-3 text-anhanga-dark">{title}</h3>
+                <p className="text-zinc-600 leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Sobre a Anhangá */}
+      <section className="py-20 bg-anhanga-light">
         <div className="max-w-4xl mx-auto px-6 text-center">
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
             Sobre a Anhangá Viagens
           </h2>
           <p className="text-lg text-zinc-600 leading-relaxed max-w-2xl mx-auto">
-            Agência de viagens em São Paulo desde 2018, com especialistas em cruzeiros no Brasil e roteiros personalizados. Nota 5.0 no Google e atendimento humano do início ao fim.
+            Agência de viagens em São Paulo desde 2018, com especialistas em cruzeiros e roteiros personalizados. Nota 5.0 no Google e atendimento humano do início ao fim.
           </p>
           <div className="mt-12 flex flex-wrap justify-center gap-12">
             {[
@@ -293,17 +408,17 @@ const CruzeirosLanding: React.FC = () => {
       <section className="py-20 bg-anhanga-blue">
         <div className="max-w-3xl mx-auto px-6 text-center">
           <h2 className="text-3xl md:text-5xl font-black text-white mb-6 font-serif">
-            Descubra o cruzeiro certo para você.
+            Vamos achar o seu cruzeiro?
           </h2>
           <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
             Fale com um especialista e resolva a escolha em uma conversa. Sem taxa, sem compromisso.
           </p>
           <button
             type="button"
-            onClick={() => openContactModal({ source: 'cruzeiros-brasil' })}
+            onClick={() => openContactModal({ source: 'cruzeiros' })}
             className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-black px-10 py-5 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-xl shadow-lg"
             aria-label="Falar com um especialista em cruzeiros"
-            data-tracking="footer-cruzeiros-brasil"
+            data-tracking="footer-cruzeiros"
           >
             Falar com um especialista
             <ArrowRight className="size-6" />
@@ -356,14 +471,13 @@ const CruzeirosLanding: React.FC = () => {
       {/* FAQ */}
       <LandingFAQ
         items={FAQ_ITEMS}
-        title="Dúvidas sobre cruzeiros no Brasil"
+        title="Dúvidas sobre cruzeiros"
         subtitle="Tire suas dúvidas antes de escolher seu cruzeiro."
       />
 
       {/* Footer */}
       <footer className="py-8 bg-anhanga-light border-t border-anhanga-blue/10 text-center text-sm text-zinc-600">
         <p>Anhangá Viagens · Agência de viagens em São Paulo</p>
-        <p className="mt-1">Atualizado em abril de 2026</p>
       </footer>
     </div>
   );

--- a/pages/landings/CruzeirosLanding.tsx
+++ b/pages/landings/CruzeirosLanding.tsx
@@ -137,13 +137,16 @@ const RegionBadge: React.FC<{ regiao: string; saida: string }> = ({ regiao, said
 
 const FeaturedOffer: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
   <article className="grid md:grid-cols-2 gap-0 rounded-3xl overflow-hidden bg-white shadow-float border border-anhanga-blue/10">
+    {/* w-full é obrigatório: o LazyImage aplica `aspect-ratio` inline a partir de
+        width/height, e sem uma largura explícita o container deriva a largura da
+        altura (h-full) e estoura a coluna do grid. */}
     <LazyImage
       src={offer.imagem}
       alt={offer.imagemAlt}
       width={800}
       height={600}
       sizes="(min-width: 768px) 50vw, 100vw"
-      className="h-64 md:h-full"
+      className="w-full h-64 md:h-full"
     />
     <div className="p-8 md:p-10 flex flex-col">
       <RegionBadge regiao={offer.regiao} saida={offer.saida} />
@@ -182,7 +185,7 @@ const OfferCard: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
       width={480}
       height={300}
       sizes="(min-width: 768px) 33vw, 100vw"
-      className="h-48"
+      className="w-full h-48"
     />
     <div className="p-6 flex flex-col flex-1">
       <RegionBadge regiao={offer.regiao} saida={offer.saida} />

--- a/pages/landings/CruzeirosLanding.tsx
+++ b/pages/landings/CruzeirosLanding.tsx
@@ -79,21 +79,28 @@ const HOW_IT_WORKS = [
   },
 ];
 
+// `variant` não é decoração: DESIGN.md:261 proíbe cards idênticos em grade
+// repetida. O card preenchido quebra a repetição e ancora a leitura no meio —
+// mesma razão pela qual a seção de ofertas destaca uma saída em vez de listar
+// tudo com o mesmo peso.
 const WHY_CURATION = [
   {
     icon: Compass,
     title: 'Navio certo para seu perfil',
     desc: 'Cada companhia tem um DNA diferente. Indicamos o que combina com o que você quer viver a bordo.',
+    variant: 'light' as const,
   },
   {
     icon: MapPin,
     title: 'Roteiro que vale a viagem',
     desc: 'Saída do Brasil ou internacional, escalas e temporada mudam o preço e a experiência. Analisamos tudo junto.',
+    variant: 'filled' as const,
   },
   {
     icon: CalendarCheck,
     title: 'Cabine sem arrependimento',
     desc: 'Interna, varanda ou suíte: explicamos o que cada categoria entrega e o que vale para o seu caso.',
+    variant: 'light' as const,
   },
 ];
 
@@ -370,13 +377,24 @@ const CruzeirosLanding: React.FC = () => {
             Porque escolher um cruzeiro envolve mais variáveis do que parece.
           </p>
           <div className="grid md:grid-cols-3 gap-6">
-            {WHY_CURATION.map(({ icon: Icon, title, desc }) => (
-              <div key={title} className="p-8 rounded-2xl bg-anhanga-light">
-                <div className="size-11 rounded-xl flex items-center justify-center mb-5 bg-anhanga-blue/10">
-                  <Icon className="size-5 text-anhanga-blue" />
+            {WHY_CURATION.map(({ icon: Icon, title, desc, variant }) => (
+              <div
+                key={title}
+                className={`p-8 rounded-2xl ${variant === 'filled' ? 'bg-anhanga-blue' : 'bg-anhanga-light'}`}
+              >
+                <div
+                  className={`size-11 rounded-xl flex items-center justify-center mb-5 ${
+                    variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
+                  }`}
+                >
+                  <Icon className={`size-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`} />
                 </div>
-                <h3 className="text-xl font-black mb-3 text-anhanga-dark">{title}</h3>
-                <p className="text-zinc-600 leading-relaxed">{desc}</p>
+                <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
+                  {title}
+                </h3>
+                <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-zinc-600 leading-relaxed'}>
+                  {desc}
+                </p>
               </div>
             ))}
           </div>

--- a/pages/landings/CruzeirosLanding.tsx
+++ b/pages/landings/CruzeirosLanding.tsx
@@ -166,7 +166,7 @@ const FeaturedOffer: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
       <button
         type="button"
         onClick={() => openOfferConversation(offer)}
-        className="btn-whatsapp btn-specialist mt-8 inline-flex items-center justify-center gap-2 bg-anhanga-blue text-white font-bold px-7 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors shadow-lg self-start"
+        className="btn-whatsapp btn-specialist mt-8 inline-flex items-center justify-center gap-2 bg-anhanga-blue text-white font-bold px-7 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors shadow-lg self-start focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
         aria-label={`Falar com um especialista sobre o cruzeiro ${offer.navio}`}
         data-tracking={`oferta-featured-${offer.id}`}
       >
@@ -203,7 +203,7 @@ const OfferCard: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
       <button
         type="button"
         onClick={() => openOfferConversation(offer)}
-        className="btn-whatsapp btn-specialist mt-5 inline-flex items-center justify-center gap-2 w-full bg-white border-2 border-anhanga-blue/15 text-anhanga-blue font-bold px-5 py-3 rounded-xl hover:bg-anhanga-blue hover:text-white hover:border-anhanga-blue transition-colors"
+        className="btn-whatsapp btn-specialist mt-5 inline-flex items-center justify-center gap-2 w-full bg-white border-2 border-anhanga-blue/15 text-anhanga-blue font-bold px-5 py-3 rounded-xl hover:bg-anhanga-blue hover:text-white hover:border-anhanga-blue transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
         aria-label={`Falar com um especialista sobre o cruzeiro ${offer.navio}`}
         data-tracking={`oferta-${offer.id}`}
       >
@@ -259,7 +259,7 @@ const CruzeirosLanding: React.FC = () => {
           <button
             type="button"
             onClick={() => openContactModal({ source: 'cruzeiros' })}
-            className="btn-whatsapp btn-specialist text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap"
+            className="btn-whatsapp btn-specialist text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
             data-tracking="header-cruzeiros"
           >
             Falar com especialista
@@ -282,7 +282,7 @@ const CruzeirosLanding: React.FC = () => {
           <button
             type="button"
             onClick={() => openContactModal({ source: 'cruzeiros' })}
-            className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-blue text-white font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors text-lg shadow-lg"
+            className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-blue text-white font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors text-lg shadow-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
             aria-label="Falar com um especialista em cruzeiros"
             data-tracking="hero-cruzeiros"
           >
@@ -324,7 +324,7 @@ const CruzeirosLanding: React.FC = () => {
               <button
                 type="button"
                 onClick={() => openContactModal({ source: 'cruzeiros' })}
-                className="font-bold text-anhanga-blue underline underline-offset-2 hover:text-anhanga-darkBlue transition-colors"
+                className="font-bold text-anhanga-blue underline underline-offset-2 hover:text-anhanga-darkBlue transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action rounded"
                 data-tracking="ofertas-fallback-cruzeiros"
               >
                 Conte o que procura
@@ -419,7 +419,10 @@ const CruzeirosLanding: React.FC = () => {
           <button
             type="button"
             onClick={() => openContactModal({ source: 'cruzeiros' })}
-            className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-black px-10 py-5 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-xl shadow-lg"
+            /* outline branco (não o anhanga-action canônico): este CTA fica sobre
+               bg-anhanga-blue, onde o ciano do foco não teria contraste. Mesmo
+               padrão de components/landings/shared/LandingWhatsAppBand.tsx. */
+            className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-black px-10 py-5 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-xl shadow-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
             aria-label="Falar com um especialista em cruzeiros"
             data-tracking="footer-cruzeiros"
           >

--- a/tests/cruise-offers-schedule.test.ts
+++ b/tests/cruise-offers-schedule.test.ts
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isOfferExpired, getActiveOffers } from '../lib/cruise-offers-schedule.js';
+import { CRUISE_OFFERS } from '../data/cruiseOffers.ts';
+
+// Data fixa em vez do relógio: o filtro é determinístico e os testes não podem
+// depender de quando rodam nem de process.env — mesmo princípio de
+// tests/blog-schedule.test.ts.
+const HOJE = '2027-01-15';
+
+test('isOfferExpired: expira só a partir do dia seguinte a expiraEm', () => {
+  // Válida no próprio dia de expiraEm.
+  assert.equal(isOfferExpired('2027-01-15', HOJE), false);
+  // Válida antes.
+  assert.equal(isOfferExpired('2027-02-01', HOJE), false);
+  // Expirada no dia seguinte.
+  assert.equal(isOfferExpired('2027-01-14', HOJE), true);
+});
+
+test('isOfferExpired: sem expiraEm nunca expira', () => {
+  assert.equal(isOfferExpired(undefined, HOJE), false);
+});
+
+test('getActiveOffers: remove só as vencidas e preserva a ordem', () => {
+  const offers = [
+    { id: 'a', expiraEm: '2027-02-01' },
+    { id: 'b', expiraEm: '2027-01-10' }, // vencida
+    { id: 'c', expiraEm: '2027-01-15' }, // último dia — ainda válida
+    { id: 'd', expiraEm: '2026-12-31' }, // vencida
+  ];
+  const ativos = getActiveOffers(offers, HOJE);
+  assert.deepEqual(
+    ativos.map((o) => o.id),
+    ['a', 'c'],
+  );
+});
+
+test('getActiveOffers: lista vazia quando tudo expirou', () => {
+  const offers = [
+    { id: 'a', expiraEm: '2020-01-01' },
+    { id: 'b', expiraEm: '2019-06-30' },
+  ];
+  assert.deepEqual(getActiveOffers(offers, HOJE), []);
+});
+
+test('CRUISE_OFFERS: dados-semente são bem formados', () => {
+  assert.ok(CRUISE_OFFERS.length >= 4 && CRUISE_OFFERS.length <= 8, 'entre 4 e 8 ofertas');
+  // No máximo uma featured (o layout destaca uma só).
+  const featured = CRUISE_OFFERS.filter((o) => o.featured);
+  assert.ok(featured.length <= 1, 'no máximo uma oferta featured');
+  // ids únicos (viram React key / data-tracking).
+  const ids = new Set(CRUISE_OFFERS.map((o) => o.id));
+  assert.equal(ids.size, CRUISE_OFFERS.length, 'ids únicos');
+  for (const o of CRUISE_OFFERS) {
+    assert.ok(/^\d{4}-\d{2}-\d{2}$/.test(o.expiraEm), `expiraEm ISO em ${o.id}`);
+    assert.ok(o.roteiro.length >= 2, `roteiro com escalas em ${o.id}`);
+    assert.ok(o.notaCuratorial.length > 0, `nota curatorial em ${o.id}`);
+  }
+});

--- a/tests/e2e/cruzeiros-ofertas.spec.ts
+++ b/tests/e2e/cruzeiros-ofertas.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+// A landing /cruzeiros mostra ofertas selecionadas; o CTA de cada oferta abre o
+// ContactModal já carregado com o contexto da oferta (linha "Sobre:"), que
+// também viaja ao CRM via `destination`. Ver pages/landings/CruzeirosLanding.tsx
+// e a decisão registrada no grilling desta feature.
+test.describe('Landing de cruzeiros — ofertas', () => {
+  test('renderiza a seção de ofertas com a seleção da temporada', async ({ page }) => {
+    await page.goto('/cruzeiros');
+    await expect(page.getByRole('heading', { name: 'Os cruzeiros que a gente escolheria' })).toBeVisible();
+    await expect(page.getByRole('region', { name: 'Seleção da temporada' })).toBeVisible();
+    // O featured card expõe seu CTA com aria-label específico da oferta.
+    await expect(
+      page.getByRole('button', { name: /Falar com um especialista sobre o cruzeiro/ }).first(),
+    ).toBeVisible();
+  });
+
+  test('o CTA de uma oferta abre o modal com o contexto da oferta', async ({ page }) => {
+    await page.goto('/cruzeiros');
+
+    await page
+      .getByRole('button', { name: /Falar com um especialista sobre o cruzeiro MSC Seaside/ })
+      .click();
+
+    const modal = page.getByRole('dialog', { name: 'Fale com um especialista' });
+    await expect(modal).toBeVisible();
+    // A linha de contexto confirma ao visitante qual oferta foi carregada.
+    await expect(modal.getByText(/^Sobre:/)).toContainText('MSC Seaside');
+  });
+
+  test('não renderiza o AIChat flutuante (é landing de campanha)', async ({ page }) => {
+    await page.goto('/cruzeiros');
+    await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toHaveCount(0);
+  });
+});

--- a/tests/e2e/cruzeiros-ofertas.spec.ts
+++ b/tests/e2e/cruzeiros-ofertas.spec.ts
@@ -2,30 +2,43 @@ import { test, expect } from '@playwright/test';
 
 // A landing /cruzeiros mostra ofertas selecionadas; o CTA de cada oferta abre o
 // ContactModal já carregado com o contexto da oferta (linha "Sobre:"), que
-// também viaja ao CRM via `destination`. Ver pages/landings/CruzeirosLanding.tsx
-// e a decisão registrada no grilling desta feature.
+// também viaja ao CRM via `destination`. Ver pages/landings/CruzeirosLanding.tsx.
+//
+// ACOPLAMENTO AO CALENDÁRIO (intencional): o filtro de expiração
+// (lib/cruise-offers-schedule.js) usa o relógio real, então estes specs dependem
+// de haver ao menos uma oferta válida em data/cruiseOffers.ts. Quando TODAS
+// vencerem, eles falham — e isso é o sinal desejado: a página caiu no estado
+// vazio porque ninguém repôs o mix. Se o CI ficar vermelho aqui sem nenhuma
+// mudança de código, cheque os `expiraEm` antes de procurar regressão (o mais
+// longevo do seed atual é 2027-03-15).
+//
+// As asserções não fixam um navio específico — leem o nome do próprio card — para
+// sobreviverem à troca do mix a cada ciclo.
 test.describe('Landing de cruzeiros — ofertas', () => {
+  const CTA_OFERTA = /Falar com um especialista sobre o cruzeiro/;
+
   test('renderiza a seção de ofertas com a seleção da temporada', async ({ page }) => {
     await page.goto('/cruzeiros');
     await expect(page.getByRole('heading', { name: 'Os cruzeiros que a gente escolheria' })).toBeVisible();
     await expect(page.getByRole('region', { name: 'Seleção da temporada' })).toBeVisible();
-    // O featured card expõe seu CTA com aria-label específico da oferta.
-    await expect(
-      page.getByRole('button', { name: /Falar com um especialista sobre o cruzeiro/ }).first(),
-    ).toBeVisible();
+    await expect(page.getByRole('button', { name: CTA_OFERTA }).first()).toBeVisible();
   });
 
-  test('o CTA de uma oferta abre o modal com o contexto da oferta', async ({ page }) => {
+  test('o CTA de uma oferta abre o modal com o contexto daquela oferta', async ({ page }) => {
     await page.goto('/cruzeiros');
 
-    await page
-      .getByRole('button', { name: /Falar com um especialista sobre o cruzeiro MSC Seaside/ })
-      .click();
+    const cta = page.getByRole('button', { name: CTA_OFERTA }).first();
+    const label = (await cta.getAttribute('aria-label')) ?? '';
+    const navio = label.replace('Falar com um especialista sobre o cruzeiro ', '').trim();
+    expect(navio).not.toBe('');
+
+    await cta.click();
 
     const modal = page.getByRole('dialog', { name: 'Fale com um especialista' });
     await expect(modal).toBeVisible();
-    // A linha de contexto confirma ao visitante qual oferta foi carregada.
-    await expect(modal.getByText(/^Sobre:/)).toContainText('MSC Seaside');
+    // A linha de contexto confirma ao visitante qual oferta foi carregada — e é o
+    // mesmo texto que vai ao CRM em `destination`.
+    await expect(modal.getByText(/^Sobre:/)).toContainText(navio);
   });
 
   test('não renderiza o AIChat flutuante (é landing de campanha)', async ({ page }) => {


### PR DESCRIPTION
## O quê

Redesenha a `/cruzeiros` (renomeada na #1206) para mostrar uma **seleção enxuta de ofertas de cruzeiro** — Brasil e internacionais — mantendo a conversa como fechamento. Não vira catálogo/OTA: cada oferta traz uma nota autoral de *por que foi escolhida*, que é o diferencial contra um comparador de preço.

> **Empilhada sobre a #1206** (base = `claude/cruise-landing-page-ba85d4`). Este diff mostra só os commits da PR 2. Mergear a #1206 primeiro; o GitHub reaponta a base para `main` automaticamente.

## Decisões (via /grilling + follow-ups)

| Área | Decisão |
|---|---|
| Papel | Ofertas no palco, conversa fecha — sem filtro, sem grade de comparação |
| Preço | **Sem preço** (some risco de CDC; gancho = imagem + roteiro + nota curatorial) |
| Fonte | `data/cruiseOffers.ts` tipado; troca do mix via PR |
| Expiração | Some sozinha no rebuild diário (helper espelha `blog-schedule.js`) |
| Estado vazio | Seção some, curadoria sustenta a página |
| CRM | Rótulo da oferta em `destination` → `x_destino` + tag Cruzeiros automática |
| Layout | Featured + menores (nunca grade uniforme — DESIGN.md:261) |

## Estrutura

- **`data/cruiseOffers.ts`** — `CruiseOffer` tipado com `notaCuratorial`, `perfis`, `regiao`, `featured`, `expiraEm`. Imagens-semente são placeholders do R2, a trocar pelas fotos reais dos fornecedores.
- **`lib/cruise-offers-schedule.js`** — filtro de expiração reusando `todayInSaoPaulo()`. Prerender e cliente rodam o mesmo código; janela de divergência documentada no arquivo.
- **`CruzeirosLanding.tsx`** — reescrita: hero → ofertas (featured + cards) → como funciona → por que curadoria → sobre → CTA → FAQ. Nota do curador em bloco tonalizado (sem border-left decorativo, sem consumir o âmbar — reservado ao CTA final).
- **`ContactModal.tsx`** — ganha a linha "Sobre: {oferta}" (aditivo; Orlando/Destinations também se beneficiam). O hook **não** foi tocado — menor raio de alcance.

## Verificação

- `pnpm test:regression` — **968/968** (5 novos: helper de expiração, data fixa)
- e2e `cruzeiros-ofertas.spec.ts` — ofertas renderizam · CTA leva contexto ao modal · sem AIChat — **3/3**
- `pnpm typecheck` limpo · `pnpm lint:changed` exit 0
- **Prerender (`pnpm build`)** — as 5 ofertas estão no HTML estático de `/cruzeiros` (`MSC Seaside`, `Wonder of the Seas`, 5× "Por que escolhemos", 5 CTAs), **não** o fallback vazio; o helper `.js` não quebra o prerenderer; canonical + `areaServed` corretos
- No browser: imagens do R2 carregam, modal mostra "Sobre: Cruzeiro MSC Seaside · Santos · Fevereiro 2027", sem hydration mismatch

## Para você manter (a cada ciclo)

Cada oferta exige **1 nota curatorial autoral + 1 foto licenciada** do fornecedor. Sem isso, as ofertas expiram e a página volta ao modo curadoria — silenciosamente. Suba as fotos reais em `images/cruzeiros/` no R2 e troque os paths placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)