### PR TITLE
refactor(design): migra ContactModal.tsx para o namespace anhanga-* (P3 do critique)

### DIFF
--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -6,7 +6,7 @@ import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
 import { FormField } from './forms/FormField';
 
 const FIELD_CLASSNAME =
-    'w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-brand-cyan focus-visible:ring-2 focus-visible:ring-brand-cyan';
+    'w-full rounded-xl border-2 border-zinc-200 px-3 py-2.5 text-sm font-medium text-zinc-800 outline-none transition-colors placeholder-zinc-400 focus:border-anhanga-action focus-visible:ring-2 focus-visible:ring-anhanga-action';
 
 const ContactModal: React.FC = () => {
     const [isOpen, setIsOpen] = useState(false);
@@ -95,17 +95,17 @@ const ContactModal: React.FC = () => {
             {isOpen && <div className="relative z-10 w-full overflow-hidden rounded-2xl bg-white shadow-[0_24px_60px_rgba(0,0,0,0.3)]">
                 <div className="flex items-start justify-between p-6 pb-4">
                     <div>
-                        <p className="mb-1 text-xs font-black uppercase tracking-widest text-brand-vibrant">
+                        <p className="mb-1 text-xs font-black uppercase tracking-widest text-anhanga-action">
                             Anhangá Viagens
                         </p>
-                        <h2 id={titleId} className="text-lg font-black text-brand-dark">
+                        <h2 id={titleId} className="text-lg font-black text-anhanga-dark">
                             Fale com um especialista
                         </h2>
                     </div>
                     <button
                         type="button"
                         onClick={close}
-                        className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan"
+                        className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-anhanga-action"
                         aria-label="Fechar"
                     >
                         <X className="size-5" weight="bold" />
@@ -130,7 +130,7 @@ const ContactModal: React.FC = () => {
                             ref={closeButtonRef}
                             type="button"
                             onClick={close}
-                            className="w-full rounded-xl bg-brand-dark py-3 font-bold text-white transition-colors hover:bg-brand-vibrant focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark focus-visible:ring-offset-2"
+                            className="w-full rounded-xl bg-anhanga-dark py-3 font-bold text-white transition-colors hover:bg-anhanga-action focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-anhanga-dark focus-visible:ring-offset-2"
                         >
                             Fechar
                         </button>
@@ -190,7 +190,7 @@ const ContactModal: React.FC = () => {
                                 type="checkbox"
                                 checked={fields.emailOptIn}
                                 onChange={(event) => setField('emailOptIn', event.target.checked)}
-                                className="mt-0.5 size-4 flex-shrink-0 cursor-pointer rounded border-2 border-brand-vibrant accent-brand-vibrant"
+                                className="mt-0.5 size-4 flex-shrink-0 cursor-pointer rounded border-2 border-anhanga-action accent-anhanga-action"
                             />
                             <label htmlFor="contact-optIn" className="cursor-pointer text-xs leading-relaxed text-blue-700">
                                 Quero receber novidades, ofertas e dicas de viagem da Anhangá Viagens.

--- a/tests/tailwind-brand-namespace-guard.test.ts
+++ b/tests/tailwind-brand-namespace-guard.test.ts
@@ -50,7 +50,10 @@ function collectRootFiles(): string[] {
 // para anhanga-*, ABAIXE este número para travar o ganho.
 // 2026-07-07: 594 → 592 (CookieConsentBanner migrado na auditoria LGPD).
 // 2026-07-07: 592 → 587 (BackToTop migrado no follow-up de review da PR #1107).
-const BRAND_NAMESPACE_BASELINE = 587;
+// 2026-07-16: 587 → 562 (ContactModal.tsx migrado — P3 do critique de
+// /consultoria-de-viagem, débito registrado na PR #1203; baseline reajustado
+// para a contagem real após a migração, não apenas os 9 usos removidos aqui).
+const BRAND_NAMESPACE_BASELINE = 562;
 
 test('legacy brand-* namespace does not grow (ratchet)', () => {
   const files = [...SCAN_DIRS.flatMap(collectTailwindFiles), ...collectRootFiles()];


### PR DESCRIPTION
## Summary

Quarto e último item do critique de \`/consultoria-de-viagem\` — P0 (banner de cookies), P1 (contraste do nav) e P2 (segunda foto) já resolvidos nas PRs #1205 e #1213. Este é o P3: \`ContactModal.tsx\` — o mesmo arquivo que ganhou o padrão canônico \`focus-visible:outline-anhanga-action\` nos botões de ação (PR #1203) — ainda usava o namespace Tailwind legado (\`brand-vibrant\`, \`brand-cyan\`, \`brand-dark\`) nos demais elementos.

## Mudanças

- **\`components/ContactModal.tsx\`**: 9 usos de \`brand-*\` migrados 1:1 por valor de cor real (conferido em \`tailwind.config.mjs\`): \`brand-cyan\`/\`brand-vibrant\` → \`anhanga-action\` (mesmo hex \`#0ea5e9\`), \`brand-dark\` → \`anhanga-dark\` (mesmo hex \`#0f172a\`). Nenhuma cor mudou — é troca de token, não de design. Padrão de interação de cada elemento preservado (inputs/checkbox continuam com \`ring\` no foco, botão "Fechar" continua com \`ring\` + \`outline-none\`) — sem mexer em comportamento, só no nome do token.
- **\`tests/tailwind-brand-namespace-guard.test.ts\`**: baseline do guard ratchet abaixado de 587 para 562 (contagem real pós-migração), travando o ganho conforme convenção documentada no próprio teste.

## Verificação

- Conferido visualmente no browser: modal aberto, formulário preenchido, checkbox marcado, botão "Abrir WhatsApp agora" habilitado — nenhuma diferença visual (esperado, mesmos hex).
- [x] \`pnpm typecheck\` limpo.
- [x] \`eslint\` limpo nos arquivos tocados.
- [x] \`pnpm test:regression\` — 964/964 passando (inclui o guard test atualizado).
- [x] \`contact-form.spec.ts\` + \`contact-form-attribution.spec.ts\` + \`chat-lead-form-a11y.spec.ts\` — 75/75 passando em todos os browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)