### PR TITLE
fix(cruzeiros): alinha landing de cruzeiros ao design system

### DIFF
--- a/pages/landings/CruzeirosLanding.tsx
+++ b/pages/landings/CruzeirosLanding.tsx
@@ -565,7 +565,7 @@ const CruzeirosLanding: React.FC = () => {
             <div className="grid md:grid-cols-3 gap-4">
               <Link
                 to="/consultoria-de-viagem/"
-                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
+                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
               >
                 <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                   Consultoria de Viagem
@@ -576,7 +576,7 @@ const CruzeirosLanding: React.FC = () => {
               </Link>
               <Link
                 to="/corporativo/"
-                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
+                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
               >
                 <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                   Viagens para Executivos
@@ -587,7 +587,7 @@ const CruzeirosLanding: React.FC = () => {
               </Link>
               <Link
                 to="/"
-                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
+                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
               >
                 <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
                   Site principal

--- a/pages/landings/CruzeirosLanding.tsx
+++ b/pages/landings/CruzeirosLanding.tsx
@@ -548,7 +548,7 @@ const CruzeirosLanding: React.FC = () => {
               variant="cta"
               size="lg"
               onClick={() => openContactModal({ source: 'cruzeiros' })}
-              className="btn-whatsapp btn-specialist font-black"
+              className="btn-whatsapp btn-specialist font-black focus-visible:outline-white"
               rightIcon={<ArrowRight className="size-6" aria-hidden="true" />}
               aria-label="Falar com um especialista em cruzeiros"
               data-tracking="footer-cruzeiros"

--- a/pages/landings/CruzeirosLanding.tsx
+++ b/pages/landings/CruzeirosLanding.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { m, MotionConfig } from 'framer-motion';
 import { Seo } from '@/components/Seo';
 import { LandingFAQ } from '@/components/LandingFAQ';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
 import { ServiceSchema } from '@/components/schemas/ServiceSchema';
+import { Button } from '@/components/ui/Button';
 import { LazyImage } from '@/components/ui/LazyImage';
+import { fadeUp } from '@/components/landings/shared/constants';
 import { openContactModal } from '@/utils/contactForm';
 import { CRUISE_OFFERS, type CruiseOffer } from '@/data/cruiseOffers';
 import { getActiveOffers } from '@/lib/cruise-offers-schedule.js';
@@ -17,6 +20,8 @@ import { ArrowLeft, ArrowRight, Compass, Ship, MapPin, CalendarCheck, Moon } fro
 const ACTIVE_OFFERS = getActiveOffers(CRUISE_OFFERS);
 const FEATURED_OFFER = ACTIVE_OFFERS.find((o) => o.featured);
 const SECONDARY_OFFERS = ACTIVE_OFFERS.filter((o) => o !== FEATURED_OFFER);
+
+const VIEWPORT_REVEAL = { once: true, amount: 0.2, margin: '0px 0px 100% 0px' } as const;
 
 // Rótulo enviado ao CRM (campo `destination` → x_destino no Odoo) e mostrado no
 // ContactModal. A palavra "cruzeiro" auto-classifica o lead com a tag Cruzeiros
@@ -142,8 +147,13 @@ const RegionBadge: React.FC<{ regiao: string; saida: string }> = ({ regiao, said
   </div>
 );
 
+// shadow-float (não border): DESIGN.md §5 reserva border a inputs — cards
+// separam por sombra ou fundo tonalizado. Sem lift no hover: o card em si não
+// é clicável, só o botão dentro dele; sombra que cresce ao passar o mouse no
+// card inteiro seria affordance de clique sem clique (mesmo raciocínio do
+// PILLARS de /consultoria-de-viagem).
 const FeaturedOffer: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
-  <article className="grid md:grid-cols-2 gap-0 rounded-3xl overflow-hidden bg-white shadow-float border border-anhanga-blue/10">
+  <article className="grid md:grid-cols-2 gap-0 rounded-3xl overflow-hidden bg-white shadow-float">
     {/* w-full é obrigatório: o LazyImage aplica `aspect-ratio` inline a partir de
         width/height, e sem uma largura explícita o container deriva a largura da
         altura (h-full) e estoura a coluna do grid. */}
@@ -170,22 +180,23 @@ const FeaturedOffer: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
       <div className="mt-6">
         <ProfileTags perfis={offer.perfis} />
       </div>
-      <button
-        type="button"
+      <Button
+        variant="primary"
+        size="lg"
         onClick={() => openOfferConversation(offer)}
-        className="btn-whatsapp btn-specialist mt-8 inline-flex items-center justify-center gap-2 bg-anhanga-blue text-white font-bold px-7 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors shadow-lg self-start focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+        className="btn-whatsapp btn-specialist mt-8 self-start"
+        rightIcon={<ArrowRight className="size-5" aria-hidden="true" />}
         aria-label={`Falar com um especialista sobre o cruzeiro ${offer.navio}`}
         data-tracking={`oferta-featured-${offer.id}`}
       >
         Quero saber mais
-        <ArrowRight className="size-5" />
-      </button>
+      </Button>
     </div>
   </article>
 );
 
 const OfferCard: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
-  <article className="flex flex-col rounded-2xl overflow-hidden bg-white border border-anhanga-blue/10 hover:border-anhanga-blue/30 transition-colors">
+  <article className="flex flex-col rounded-2xl overflow-hidden bg-white shadow-float">
     <LazyImage
       src={offer.imagem}
       alt={offer.imagemAlt}
@@ -207,16 +218,16 @@ const OfferCard: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
       <div className="mt-4">
         <ProfileTags perfis={offer.perfis} />
       </div>
-      <button
-        type="button"
+      <Button
+        variant="primary"
         onClick={() => openOfferConversation(offer)}
-        className="btn-whatsapp btn-specialist mt-5 inline-flex items-center justify-center gap-2 w-full bg-white border-2 border-anhanga-blue/15 text-anhanga-blue font-bold px-5 py-3 rounded-xl hover:bg-anhanga-blue hover:text-white hover:border-anhanga-blue transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+        className="btn-whatsapp btn-specialist mt-5 w-full"
+        rightIcon={<ArrowRight className="size-4" aria-hidden="true" />}
         aria-label={`Falar com um especialista sobre o cruzeiro ${offer.navio}`}
         data-tracking={`oferta-${offer.id}`}
       >
         Falar sobre este
-        <ArrowRight className="size-4" />
-      </button>
+      </Button>
     </div>
   </article>
 );
@@ -225,285 +236,384 @@ const CruzeirosLanding: React.FC = () => {
   const hasOffers = ACTIVE_OFFERS.length > 0;
 
   return (
-    <div className="bg-anhanga-light min-h-screen font-sans">
-      <Seo
-        title="Cruzeiros — Ofertas e Curadoria | Anhangá Viagens"
-        description="Ofertas selecionadas de cruzeiros no Brasil e internacionais, com curadoria consultiva para escolher navio, cabine e roteiro certos antes de fechar."
-        canonical="https://www.anhanga.tur.br/cruzeiros/"
-        noHreflang
-      />
-      <ServiceSchema
-        name="Cruzeiros — Ofertas e Curadoria"
-        description="Seleção de cruzeiros no Brasil e internacionais com atendimento consultivo para escolher navio, cabine, roteiro e datas ideais. Para casais, famílias e primeira viagem."
-        serviceUrl="https://www.anhanga.tur.br/cruzeiros/"
-        serviceType="Cruzeiros"
-        areaServed="Brasil"
-      />
-      <BreadcrumbSchema
-        items={[
-          { name: 'Home', item: 'https://www.anhanga.tur.br/' },
-          { name: 'Cruzeiros', item: 'https://www.anhanga.tur.br/cruzeiros/' }
-        ]}
-      />
-      <FAQPageSchema items={FAQ_ITEMS} />
+    <>
+      {/*
+        No-JS / pre-hydration fallback: framer-motion serializa os estilos
+        `initial` (opacity:0) no HTML pré-renderizado. Sem JS a revelação
+        nunca dispara e as seções ficariam em branco. Isso força visibilidade
+        quando scripts estão desabilitados; com JS o seletor fica inerte e as
+        entradas animam normalmente. Mesmo padrão de /consultoria-de-viagem.
+      */}
+      <noscript>
+        <style>{`[data-cruzeiros-landing] [style*="opacity"]{opacity:1!important}`}</style>
+      </noscript>
+      <MotionConfig reducedMotion="user">
+      <div data-cruzeiros-landing className="bg-anhanga-light min-h-screen font-sans">
+        <Seo
+          title="Cruzeiros — Ofertas e Curadoria | Anhangá Viagens"
+          description="Ofertas selecionadas de cruzeiros no Brasil e internacionais, com curadoria consultiva para escolher navio, cabine e roteiro certos antes de fechar."
+          canonical="https://www.anhanga.tur.br/cruzeiros/"
+          noHreflang
+        />
+        <ServiceSchema
+          name="Cruzeiros — Ofertas e Curadoria"
+          description="Seleção de cruzeiros no Brasil e internacionais com atendimento consultivo para escolher navio, cabine, roteiro e datas ideais. Para casais, famílias e primeira viagem."
+          serviceUrl="https://www.anhanga.tur.br/cruzeiros/"
+          serviceType="Cruzeiros"
+          areaServed="Brasil"
+        />
+        <BreadcrumbSchema
+          items={[
+            { name: 'Home', item: 'https://www.anhanga.tur.br/' },
+            { name: 'Cruzeiros', item: 'https://www.anhanga.tur.br/cruzeiros/' }
+          ]}
+        />
+        <FAQPageSchema items={FAQ_ITEMS} />
 
-      {/* Mini Header */}
-      <header className="bg-white/90 backdrop-blur-sm border-b border-anhanga-blue/10 sticky top-0 z-50 py-3">
-        <div className="max-w-6xl mx-auto px-6 flex items-center justify-between">
-          <Link
-            to="/"
-            className="inline-flex items-center gap-2 group"
-            aria-label="Voltar para o site principal da Anhangá Viagens"
-          >
-            <ArrowLeft className="size-4 text-zinc-400 group-hover:text-anhanga-blue transition-colors" />
-            <span className="size-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
-              <img src="/favicon.svg" alt="" aria-hidden="true" className="size-4" />
-            </span>
-            <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
-              Anhangá Viagens
-            </span>
-          </Link>
-          <button
-            type="button"
-            onClick={() => openContactModal({ source: 'cruzeiros' })}
-            className="btn-whatsapp btn-specialist text-xs font-bold bg-anhanga-blue text-white px-4 py-2 rounded-xl hover:bg-anhanga-darkBlue transition-colors whitespace-nowrap focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
-            data-tracking="header-cruzeiros"
-          >
-            Falar com especialista
-          </button>
-        </div>
-      </header>
-
-      {/* Hero */}
-      <section className="pt-16 pb-20 px-6 bg-anhanga-light">
-        <div className="max-w-3xl mx-auto">
-          <p className="text-sm font-semibold text-anhanga-blue mb-4 tracking-wide uppercase">
-            Cruzeiros · Brasil e internacionais
-          </p>
-          <h1 className="text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1] font-serif">
-            Os cruzeiros que a gente escolheria
-          </h1>
-          <p className="text-xl text-zinc-600 mb-10 leading-relaxed max-w-2xl">
-            Uma seleção enxuta de saídas que valem a pena — no Brasil e pelo mundo — com um especialista para acertar navio, cabine e roteiro antes de você fechar.
-          </p>
-          <button
-            type="button"
-            onClick={() => openContactModal({ source: 'cruzeiros' })}
-            className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-blue text-white font-bold px-8 py-4 rounded-2xl hover:bg-anhanga-darkBlue transition-colors text-lg shadow-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
-            aria-label="Falar com um especialista em cruzeiros"
-            data-tracking="hero-cruzeiros"
-          >
-            Falar com um especialista
-            <ArrowRight className="size-5" />
-          </button>
-          <p className="mt-4 text-sm text-zinc-600">Sem taxa de curadoria. Gratuito.</p>
-        </div>
-      </section>
-
-      {/* Ofertas — protagonista. Some quando não há oferta válida (a curadoria
-          abaixo sustenta a página nesse estado). */}
-      {hasOffers ? (
-        <section className="py-20 bg-white" aria-labelledby="ofertas-titulo">
-          <div className="max-w-6xl mx-auto px-6">
-            <h2 id="ofertas-titulo" className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
-              Seleção da temporada
-            </h2>
-            <p className="text-zinc-600 text-lg mb-10 max-w-2xl">
-              Poucas saídas, escolhidas a dedo. Cada uma vem com o porquê de estar aqui — e um especialista para fechar a sua.
-            </p>
-
-            {FEATURED_OFFER ? (
-              <div className="mb-6">
-                <FeaturedOffer offer={FEATURED_OFFER} />
-              </div>
-            ) : null}
-
-            {SECONDARY_OFFERS.length > 0 ? (
-              <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {SECONDARY_OFFERS.map((offer) => (
-                  <OfferCard key={offer.id} offer={offer} />
-                ))}
-              </div>
-            ) : null}
-
-            <p className="mt-10 text-zinc-600">
-              Não achou a saída ideal?{' '}
-              <button
-                type="button"
-                onClick={() => openContactModal({ source: 'cruzeiros' })}
-                className="font-bold text-anhanga-blue underline underline-offset-2 hover:text-anhanga-darkBlue transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action rounded"
-                data-tracking="ofertas-fallback-cruzeiros"
-              >
-                Conte o que procura
-              </button>{' '}
-              — a gente busca fora da lista também.
-            </p>
-          </div>
-        </section>
-      ) : null}
-
-      {/* Como funciona */}
-      <section className="py-20 bg-anhanga-light">
-        <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12 font-serif">
-            Como funciona
-          </h2>
-          <div className="space-y-0">
-            {HOW_IT_WORKS.map(({ step, title, desc }, idx) => (
-              <div
-                key={step}
-                className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-anhanga-blue/10' : ''}`}
-              >
-                <div className="flex-shrink-0 size-12 rounded-full bg-white flex items-center justify-center shadow-sm">
-                  <span className="text-sm font-black text-anhanga-blue">{step}</span>
-                </div>
-                <div>
-                  <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
-                  <p className="text-zinc-600 leading-relaxed max-w-xl">{desc}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Por que curadoria */}
-      <section className="py-20 bg-white">
-        <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3 font-serif">
-            Por que curadoria?
-          </h2>
-          <p className="text-zinc-600 text-lg mb-12">
-            Porque escolher um cruzeiro envolve mais variáveis do que parece.
-          </p>
-          <div className="grid md:grid-cols-3 gap-6">
-            {WHY_CURATION.map(({ icon: Icon, title, desc, variant }) => (
-              <div
-                key={title}
-                className={`p-8 rounded-2xl ${variant === 'filled' ? 'bg-anhanga-blue' : 'bg-anhanga-light'}`}
-              >
-                <div
-                  className={`size-11 rounded-xl flex items-center justify-center mb-5 ${
-                    variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
-                  }`}
-                >
-                  <Icon className={`size-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`} />
-                </div>
-                <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
-                  {title}
-                </h3>
-                <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-zinc-600 leading-relaxed'}>
-                  {desc}
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Sobre a Anhangá */}
-      <section className="py-20 bg-anhanga-light">
-        <div className="max-w-4xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6 font-serif">
-            Sobre a Anhangá Viagens
-          </h2>
-          <p className="text-lg text-zinc-600 leading-relaxed max-w-2xl mx-auto">
-            Agência de viagens em São Paulo desde 2018, com especialistas em cruzeiros e roteiros personalizados. Nota 5.0 no Google e atendimento humano do início ao fim.
-          </p>
-          <div className="mt-12 flex flex-wrap justify-center gap-12">
-            {[
-              { label: 'Fundada em', value: '2018' },
-              { label: 'Nota Google', value: '5.0' },
-              { label: 'Especialistas', value: 'Em cruzeiros' },
-            ].map(({ label, value }) => (
-              <div key={label}>
-                <div className="text-4xl font-black text-anhanga-blue">{value}</div>
-                <div className="text-sm text-zinc-600 mt-1">{label}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* CTA Final */}
-      <section className="py-20 bg-anhanga-blue">
-        <div className="max-w-3xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-5xl font-black text-white mb-6 font-serif">
-            Vamos achar o seu cruzeiro?
-          </h2>
-          <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
-            Fale com um consultor e resolva a escolha em uma conversa. Sem taxa, sem compromisso.
-          </p>
-          <button
-            type="button"
-            onClick={() => openContactModal({ source: 'cruzeiros' })}
-            /* outline branco (não o anhanga-action canônico): este CTA fica sobre
-               bg-anhanga-blue, onde o ciano do foco não teria contraste. Mesmo
-               padrão de components/landings/shared/LandingWhatsAppBand.tsx. */
-            className="btn-whatsapp btn-specialist inline-flex items-center gap-3 bg-anhanga-yellow text-anhanga-dark font-black px-10 py-5 rounded-2xl hover:bg-anhanga-yellowHover transition-colors text-xl shadow-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-            aria-label="Falar com um especialista em cruzeiros"
-            data-tracking="footer-cruzeiros"
-          >
-            Falar com um especialista
-            <ArrowRight className="size-6" />
-          </button>
-        </div>
-      </section>
-
-      {/* Outros serviços */}
-      <section className="py-16 bg-anhanga-light">
-        <div className="max-w-5xl mx-auto px-6">
-          <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
-          <div className="grid md:grid-cols-3 gap-4">
-            <Link
-              to="/consultoria-de-viagem/"
-              className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
-            >
-              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
-                Consultoria de Viagem
-              </div>
-              <div className="text-sm text-zinc-600 mt-1">
-                Roteiro sob medida com consultor humano
-              </div>
-            </Link>
-            <Link
-              to="/corporativo/"
-              className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
-            >
-              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
-                Viagens para Executivos
-              </div>
-              <div className="text-sm text-zinc-600 mt-1">
-                Planejamento com precisão para profissionais
-              </div>
-            </Link>
+        {/* Mini Header */}
+        <header className="bg-white/90 backdrop-blur-sm border-b border-anhanga-blue/10 sticky top-0 z-50 py-3">
+          <div className="max-w-6xl mx-auto px-6 flex items-center justify-between">
             <Link
               to="/"
-              className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
+              className="inline-flex items-center gap-2 group"
+              aria-label="Voltar para o site principal da Anhangá Viagens"
             >
-              <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
-                Site principal
-              </div>
-              <div className="text-sm text-zinc-600 mt-1">
-                Conheça todos os serviços da Anhangá
-              </div>
+              <ArrowLeft className="size-4 text-zinc-400 group-hover:text-anhanga-blue transition-colors" />
+              <span className="size-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
+                <img src="/favicon.svg" alt="" aria-hidden="true" className="size-4" />
+              </span>
+              <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                Anhangá Viagens
+              </span>
             </Link>
+            <Button
+              variant="action"
+              size="sm"
+              onClick={() => openContactModal({ source: 'cruzeiros' })}
+              className="btn-whatsapp btn-specialist whitespace-nowrap"
+              data-tracking="header-cruzeiros"
+            >
+              Falar com especialista
+            </Button>
           </div>
-        </div>
-      </section>
+        </header>
 
-      {/* FAQ */}
-      <LandingFAQ
-        items={FAQ_ITEMS}
-        title="Dúvidas sobre cruzeiros"
-        subtitle="Tire suas dúvidas antes de escolher seu cruzeiro."
-      />
+        {/* Hero */}
+        <section className="pt-16 pb-20 px-6 bg-anhanga-light">
+          <div className="max-w-3xl mx-auto">
+            <m.p
+              variants={fadeUp}
+              initial="hidden"
+              animate="visible"
+              custom={0}
+              className="text-sm font-semibold text-anhanga-blue mb-4 tracking-wide uppercase"
+            >
+              Cruzeiros · Brasil e internacionais
+            </m.p>
+            <m.h1
+              variants={fadeUp}
+              initial="hidden"
+              animate="visible"
+              custom={1}
+              className="text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1]"
+            >
+              Os cruzeiros que a gente escolheria
+            </m.h1>
+            <m.p
+              variants={fadeUp}
+              initial="hidden"
+              animate="visible"
+              custom={2}
+              className="text-xl text-zinc-600 mb-10 leading-relaxed max-w-2xl"
+            >
+              Uma seleção enxuta de saídas que valem a pena — no Brasil e pelo mundo — com um especialista para acertar navio, cabine e roteiro antes de você fechar.
+            </m.p>
+            <m.div variants={fadeUp} initial="hidden" animate="visible" custom={3}>
+              <Button
+                variant="cta"
+                size="lg"
+                onClick={() => openContactModal({ source: 'cruzeiros' })}
+                className="btn-whatsapp btn-specialist font-black"
+                rightIcon={<ArrowRight className="size-5" aria-hidden="true" />}
+                aria-label="Falar com um especialista em cruzeiros"
+                data-tracking="hero-cruzeiros"
+              >
+                Falar com um especialista
+              </Button>
+              <p className="mt-4 text-sm text-zinc-600">Sem taxa de curadoria. Gratuito.</p>
+            </m.div>
+          </div>
+        </section>
 
-      {/* Footer */}
-      <footer className="py-8 bg-anhanga-light border-t border-anhanga-blue/10 text-center text-sm text-zinc-600">
-        <p>Anhangá Viagens · Agência de viagens em São Paulo</p>
-      </footer>
-    </div>
+        {/* Ofertas — protagonista. Some quando não há oferta válida (a curadoria
+            abaixo sustenta a página nesse estado). */}
+        {hasOffers ? (
+          <section className="py-20 bg-white" aria-labelledby="ofertas-titulo">
+            <div className="max-w-6xl mx-auto px-6">
+              <m.div
+                variants={fadeUp}
+                initial="hidden"
+                whileInView="visible"
+                viewport={VIEWPORT_REVEAL}
+                custom={0}
+                className="mb-10"
+              >
+                <h2 id="ofertas-titulo" className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3">
+                  Seleção da temporada
+                </h2>
+                <p className="text-zinc-600 text-lg max-w-2xl">
+                  Poucas saídas, escolhidas a dedo. Cada uma vem com o porquê de estar aqui — e um especialista para fechar a sua.
+                </p>
+              </m.div>
+
+              {FEATURED_OFFER ? (
+                <m.div
+                  variants={fadeUp}
+                  initial="hidden"
+                  whileInView="visible"
+                  viewport={VIEWPORT_REVEAL}
+                  custom={1}
+                  className="mb-6"
+                >
+                  <FeaturedOffer offer={FEATURED_OFFER} />
+                </m.div>
+              ) : null}
+
+              {SECONDARY_OFFERS.length > 0 ? (
+                <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {SECONDARY_OFFERS.map((offer, idx) => (
+                    <m.div
+                      key={offer.id}
+                      variants={fadeUp}
+                      initial="hidden"
+                      whileInView="visible"
+                      viewport={VIEWPORT_REVEAL}
+                      custom={idx + 2}
+                    >
+                      <OfferCard offer={offer} />
+                    </m.div>
+                  ))}
+                </div>
+              ) : null}
+
+              <p className="mt-10 text-zinc-600">
+                Não achou a saída ideal?{' '}
+                <button
+                  type="button"
+                  onClick={() => openContactModal({ source: 'cruzeiros' })}
+                  className="font-bold text-anhanga-blue underline underline-offset-2 hover:text-anhanga-darkBlue transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action rounded"
+                  data-tracking="ofertas-fallback-cruzeiros"
+                >
+                  Conte o que procura
+                </button>{' '}
+                — a gente busca fora da lista também.
+              </p>
+            </div>
+          </section>
+        ) : null}
+
+        {/* Como funciona */}
+        <section className="py-20 bg-anhanga-light">
+          <div className="max-w-5xl mx-auto px-6">
+            <m.h2
+              variants={fadeUp}
+              initial="hidden"
+              whileInView="visible"
+              viewport={VIEWPORT_REVEAL}
+              custom={0}
+              className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12"
+            >
+              Como funciona
+            </m.h2>
+            <div className="space-y-0">
+              {HOW_IT_WORKS.map(({ step, title, desc }, idx) => (
+                <m.div
+                  key={step}
+                  variants={fadeUp}
+                  initial="hidden"
+                  whileInView="visible"
+                  viewport={VIEWPORT_REVEAL}
+                  custom={idx + 1}
+                  className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-anhanga-blue/10' : ''}`}
+                >
+                  <div className="flex-shrink-0 size-12 rounded-full bg-white flex items-center justify-center shadow-sm">
+                    <span className="text-sm font-black text-anhanga-blue">{step}</span>
+                  </div>
+                  <div>
+                    <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
+                    <p className="text-zinc-600 leading-relaxed max-w-xl">{desc}</p>
+                  </div>
+                </m.div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Por que curadoria */}
+        <section className="py-20 bg-white">
+          <div className="max-w-5xl mx-auto px-6">
+            <m.div
+              variants={fadeUp}
+              initial="hidden"
+              whileInView="visible"
+              viewport={VIEWPORT_REVEAL}
+              custom={0}
+              className="mb-12"
+            >
+              <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3">
+                Por que curadoria?
+              </h2>
+              <p className="text-zinc-600 text-lg">
+                Porque escolher um cruzeiro envolve mais variáveis do que parece.
+              </p>
+            </m.div>
+            <div className="grid md:grid-cols-3 gap-6">
+              {WHY_CURATION.map(({ icon: Icon, title, desc, variant }, idx) => (
+                <m.div
+                  key={title}
+                  variants={fadeUp}
+                  initial="hidden"
+                  whileInView="visible"
+                  viewport={VIEWPORT_REVEAL}
+                  custom={idx + 1}
+                  className={`p-8 rounded-2xl ${variant === 'filled' ? 'bg-anhanga-blue' : 'bg-anhanga-light shadow-float'}`}
+                >
+                  <div
+                    className={`size-11 rounded-xl flex items-center justify-center mb-5 ${
+                      variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
+                    }`}
+                  >
+                    <Icon className={`size-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`} />
+                  </div>
+                  <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
+                    {title}
+                  </h3>
+                  <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-zinc-600 leading-relaxed'}>
+                    {desc}
+                  </p>
+                </m.div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Sobre a Anhangá */}
+        <section className="py-20 bg-anhanga-light">
+          <m.div
+            variants={fadeUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={VIEWPORT_REVEAL}
+            custom={0}
+            className="max-w-4xl mx-auto px-6 text-center"
+          >
+            <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6">
+              Sobre a Anhangá Viagens
+            </h2>
+            <p className="text-lg text-zinc-600 leading-relaxed max-w-2xl mx-auto">
+              Agência de viagens em São Paulo desde 2018, com especialistas em cruzeiros e roteiros personalizados. Nota 5.0 no Google e atendimento humano do início ao fim.
+            </p>
+            <div className="mt-12 flex flex-wrap justify-center gap-12">
+              {[
+                { label: 'Fundada em', value: '2018' },
+                { label: 'Nota Google', value: '5.0' },
+                { label: 'Especialistas', value: 'Em cruzeiros' },
+              ].map(({ label, value }) => (
+                <div key={label}>
+                  <div className="text-4xl font-black text-anhanga-blue">{value}</div>
+                  <div className="text-sm text-zinc-600 mt-1">{label}</div>
+                </div>
+              ))}
+            </div>
+          </m.div>
+        </section>
+
+        {/* CTA Final */}
+        <section className="py-20 bg-anhanga-blue">
+          <m.div
+            variants={fadeUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={VIEWPORT_REVEAL}
+            custom={0}
+            className="max-w-3xl mx-auto px-6 text-center"
+          >
+            <h2 className="text-3xl md:text-5xl font-black text-white mb-6">
+              Vamos achar o seu cruzeiro?
+            </h2>
+            <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
+              Fale com um consultor e resolva a escolha em uma conversa. Sem taxa, sem compromisso.
+            </p>
+            <Button
+              variant="cta"
+              size="lg"
+              onClick={() => openContactModal({ source: 'cruzeiros' })}
+              className="btn-whatsapp btn-specialist font-black"
+              rightIcon={<ArrowRight className="size-6" aria-hidden="true" />}
+              aria-label="Falar com um especialista em cruzeiros"
+              data-tracking="footer-cruzeiros"
+            >
+              Falar com um especialista
+            </Button>
+          </m.div>
+        </section>
+
+        {/* Outros serviços */}
+        <section className="py-16 bg-anhanga-light">
+          <div className="max-w-5xl mx-auto px-6">
+            <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
+            <div className="grid md:grid-cols-3 gap-4">
+              <Link
+                to="/consultoria-de-viagem/"
+                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
+              >
+                <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                  Consultoria de Viagem
+                </div>
+                <div className="text-sm text-zinc-600 mt-1">
+                  Roteiro sob medida com consultor humano
+                </div>
+              </Link>
+              <Link
+                to="/corporativo/"
+                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
+              >
+                <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                  Viagens para Executivos
+                </div>
+                <div className="text-sm text-zinc-600 mt-1">
+                  Planejamento com precisão para profissionais
+                </div>
+              </Link>
+              <Link
+                to="/"
+                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group"
+              >
+                <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+                  Site principal
+                </div>
+                <div className="text-sm text-zinc-600 mt-1">
+                  Conheça todos os serviços da Anhangá
+                </div>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <LandingFAQ
+          items={FAQ_ITEMS}
+          title="Dúvidas sobre cruzeiros"
+          subtitle="Tire suas dúvidas antes de escolher seu cruzeiro."
+        />
+
+        {/* Footer */}
+        <footer className="py-8 bg-anhanga-light border-t border-anhanga-blue/10 text-center text-sm text-zinc-600">
+          <p>Anhangá Viagens · Agência de viagens em São Paulo</p>
+        </footer>
+      </div>
+      </MotionConfig>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

A landing `/cruzeiros` divergia do design system ("O Diário de Bordo", ver `DESIGN.md`) que as demais landings (`ConsultoriaDeViagemLanding`, `CorporativoLanding`) já seguem:

- **Fonte**: usava `font-serif` (Merriweather) em H1/H2 — essa fonte é documentada em `tailwind.config.mjs` como exclusiva do blog editorial. Trocado por `font-black` (Poppins), consistente com todas as outras landings.
- **Botões**: todos os CTAs eram hand-rolled com `shadow-lg`, sem usar o componente `<Button>` compartilhado (`components/ui/Button.tsx`) — perdendo a sombra hard neo-brutalista + sequência de press-down (rest → hover → active) que é a assinatura tátil documentada no `DESIGN.md`. Substituídos pelo `<Button>` com a variante adequada a cada papel (`cta` no hero/CTA final, `action` no header, `primary` nos cards de oferta, para não repetir o âmbar em vários cards simultâneos na tela).
- **Cards de oferta**: usavam `border` em vez de `shadow-float` — `DESIGN.md` reserva `border` a inputs, cards separam por sombra/fundo tonalizado.
- **Motion**: página era 100% estática, enquanto as landings irmãs animam a entrada do hero e das seções com `fadeUp` (framer-motion). Adicionado o mesmo padrão, com `MotionConfig reducedMotion="user"` e fallback `noscript` para pré-render.

Nenhuma mudança de conteúdo, copy, IA ou lógica de negócio — só conformidade visual/estrutural.

## Preservado (verificado)

- Todos os `data-tracking` (`header-cruzeiros`, `hero-cruzeiros`, `oferta-featured-*`, `oferta-*`, `footer-cruzeiros`) inalterados.
- Todos os `aria-label` inalterados.
- `source`/`destination` enviados ao CRM (Odoo) via `openContactModal` inalterados.

## Test plan

- [x] `pnpm exec tsc --noEmit` — sem erros
- [x] `pnpm exec eslint pages/landings/CruzeirosLanding.tsx` — sem erros
- [x] Verificado visualmente em browser: fonte Poppins, sombra hard + press-down nos CTAs, shadow-float nos cards, pílula action no header
- [x] `pnpm exec playwright test tests/e2e/cruzeiros-ofertas.spec.ts tests/e2e/cruzeiros-redirect.spec.ts` — 4/5 passam. A 1 falha restante ("abre o modal com o contexto da oferta") é **pré-existente**, confirmada via `git stash` no arquivo original antes desta mudança: o teste espera o texto "Fale com um especialista" no título do modal, mas `ContactModal.tsx` já usa "Fale com um consultor" desde uma unificação de terminologia anterior (não relacionado a este PR). Tarefa de correção do teste registrada separadamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)