### PR TITLE
fix: resolve top React Doctor diagnostics

### DIFF
--- a/components/AIChatPanel.tsx
+++ b/components/AIChatPanel.tsx
@@ -1,4 +1,12 @@
-import React, { useState, useRef, useEffect, memo, useMemo, useCallback } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   X,
   PaperPlaneTilt,
@@ -120,6 +128,7 @@ const AIChatPanel: React.FC<AIChatPanelProps> = memo(({
   initialInputPrefill,
   onConsumePending,
 }) => {
+  const onConsumePendingEvent = useEffectEvent(onConsumePending);
   const [messages, setMessages] = useState<Message[]>([
     { id: 'init', role: 'model', text: 'Olá! Sou seu guia Anhangá 🧭.\n\nPosso te ajudar com:\n- Roteiros exclusivos\n- Dúvidas sobre o destino\n- **Orçamento personalizado**\n\nVamos começar?\n\n_Ao conversar comigo, você concorda com nossa [Política de Privacidade](/politica-privacidade/)._' }
   ]);
@@ -373,18 +382,18 @@ const AIChatPanel: React.FC<AIChatPanelProps> = memo(({
 
     const timer = setTimeout(() => {
       void submitMessageRef.current(initialAutoSendMessage, false);
-      onConsumePending();
+      onConsumePendingEvent();
     }, initialAutoSendDelayMs ?? 500);
 
     return () => clearTimeout(timer);
-  }, [initialAutoSendMessage, initialAutoSendDelayMs, onConsumePending]);
+  }, [initialAutoSendMessage, initialAutoSendDelayMs]);
 
   // Applies a pending input pre-fill (`?chat=1&m=`/`message=`/`destino=`) once mounted.
   useEffect(() => {
     if (!initialInputPrefill) return;
     setInput(initialInputPrefill);
-    onConsumePending();
-  }, [initialInputPrefill, onConsumePending]);
+    onConsumePendingEvent();
+  }, [initialInputPrefill]);
 
   return (
     <dialog

--- a/components/AIChatPanel.tsx
+++ b/components/AIChatPanel.tsx
@@ -7,39 +7,12 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import {
-  X,
-  PaperPlaneTilt,
-  Sparkle,
-  CircleNotch,
-  Robot,
-  User,
-} from '@phosphor-icons/react';
-import ReactMarkdown from 'react-markdown';
 import { getTravelAdvice } from '../services/geminiService';
 import { useLeadCapture, type SubmitLeadHookResult } from '../hooks/useLeadCapture';
-import { PassportStamp } from './ui/PassportStamp';
-import { ChatLeadForm } from './ChatLeadForm';
 import type { LeadFinalizePayload, LeadFinalizeResult } from '../lib/chat-lead-form-logic';
 import type { SubmitLeadRequest } from '../types/leadCapture';
 import { triggerHaptic } from '../utils/haptics';
-import { sanitizeAiLinkUrl } from '../lib/ai/safe-link';
-
-interface Message {
-  id: string;
-  role: 'user' | 'model';
-  text: string;
-  chips?: Array<{
-    id: string;
-    label: string;
-  }>;
-  isAction?: boolean;
-  actionData?: {
-    destination: string;
-    bantSummary: string;
-    iataCode?: string;
-  };
-}
+import { AIChatPanelView, type ChatMessage } from './ai-chat/AIChatPanelView';
 
 /** crypto.randomUUID() is unavailable in older browsers and non-secure (HTTP) contexts. */
 function generateMessageId(): string {
@@ -67,47 +40,6 @@ export interface AIChatPanelProps {
 }
 
 /**
- * Optimized FormattedText component.
- *
- * PERFORMANCE WIN: Wrapped in React.memo to prevent redundant string processing
- * and re-renders of static message content during chat interactions.
- */
-const FormattedText = memo(({ text }: { text: string }) => {
-  const paragraphs = text.split('\n').filter(p => p.trim() !== '').map((paragraph, idx) => {
-    const isList = paragraph.trim().startsWith('-');
-    const cleanText = isList ? paragraph.replace('-', '').trim() : paragraph;
-    const parts = cleanText.split(/(\*\*.*?\*\*)/g).map((part, i) => ({ id: `${idx}-${i}`, part }));
-    return { id: `para-${idx}-${paragraph.slice(0, 20)}`, isList, parts };
-  });
-
-  return (
-    <div className="space-y-3 font-sans">
-      {paragraphs.map(({ id, isList, parts }) => {
-        const content = parts.map(({ id: partId, part }) => {
-          if (part.startsWith('**') && part.endsWith('**')) {
-            return <strong key={partId} className="font-bold text-zinc-900">{part.slice(2, -2)}</strong>;
-          }
-          return part;
-        });
-
-        if (isList) {
-          return (
-            <div key={id} className="flex items-start gap-2 ml-1">
-              <span className="shrink-0 mt-1.5 size-1.5 bg-brand-vibrant rounded-full opacity-70"></span>
-              <span className="leading-relaxed text-zinc-700">{content}</span>
-            </div>
-          );
-        }
-
-        return <p key={id} className="leading-relaxed text-zinc-700">{content}</p>;
-      })}
-    </div>
-  );
-});
-
-FormattedText.displayName = 'FormattedText';
-
-/**
  * AIChatPanel — the full chat drawer (messages, markdown rendering, lead capture).
  * Loaded on demand via `React.lazy` from `AIChat.tsx` once the visitor expresses
  * intent to chat, so its dependencies (react-markdown, geminiService, lead-capture
@@ -129,7 +61,7 @@ const AIChatPanel: React.FC<AIChatPanelProps> = memo(({
   onConsumePending,
 }) => {
   const onConsumePendingEvent = useEffectEvent(onConsumePending);
-  const [messages, setMessages] = useState<Message[]>([
+  const [messages, setMessages] = useState<ChatMessage[]>([
     { id: 'init', role: 'model', text: 'Olá! Sou seu guia Anhangá 🧭.\n\nPosso te ajudar com:\n- Roteiros exclusivos\n- Dúvidas sobre o destino\n- **Orçamento personalizado**\n\nVamos começar?\n\n_Ao conversar comigo, você concorda com nossa [Política de Privacidade](/politica-privacidade/)._' }
   ]);
   const [input, setInput] = useState('');
@@ -137,7 +69,7 @@ const AIChatPanel: React.FC<AIChatPanelProps> = memo(({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const messagesRef = useRef<Message[]>(messages);
+  const messagesRef = useRef<ChatMessage[]>(messages);
   const {
     getLeadWhatsAppUrl,
     prepareLeadSubmitPayload,
@@ -274,7 +206,7 @@ const AIChatPanel: React.FC<AIChatPanelProps> = memo(({
       void triggerHaptic('medium');
     }
 
-    const newHistory: Message[] = [...messagesRef.current, { id: generateMessageId(), role: 'user', text }];
+    const newHistory: ChatMessage[] = [...messagesRef.current, { id: generateMessageId(), role: 'user', text }];
     setMessages(newHistory);
     setInput('');
 
@@ -312,7 +244,7 @@ const AIChatPanel: React.FC<AIChatPanelProps> = memo(({
     }
     setIsLoading(false);
 
-    const nextMessages: Message[] = [];
+    const nextMessages: ChatMessage[] = [];
 
     if (response.text) {
       nextMessages.push({
@@ -396,188 +328,24 @@ const AIChatPanel: React.FC<AIChatPanelProps> = memo(({
   }, [initialInputPrefill]);
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="ai-chat-drawer fixed top-0 right-0 h-full w-full sm:w-[450px] z-[9999] m-0 ml-auto p-0 bg-white flex-col shadow-[-10px_0_40px_rgba(0,0,0,0.1)] sm:rounded-l-[2rem] overflow-hidden outline-none max-h-full max-w-full"
-      aria-labelledby="ai-chat-title"
-    >
-      {/* Header - Scrapbook Softness */}
-      <div className="bg-white/80 backdrop-blur-md px-6 py-5 border-b border-zinc-100 flex justify-between items-center shrink-0 z-10">
-        <div className="flex gap-4 items-center">
-          <div className="size-12 bg-zinc-50 rounded-[1.25rem] flex items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
-            <Sparkle className="size-6 text-brand-vibrant" weight="fill" />
-          </div>
-          <div>
-            <h2 id="ai-chat-title" className="font-extrabold text-lg text-brand-dark tracking-tight leading-none">
-              Hub Anhangá
-            </h2>
-            <div className="flex items-center gap-1.5 mt-1 opacity-80">
-              <span className="relative flex size-2">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
-                <span className="relative inline-flex rounded-full size-2 bg-green-400"></span>
-              </span>
-              <span className="text-xs font-bold text-zinc-500 uppercase tracking-widest">
-                Assistente Online
-              </span>
-            </div>
-          </div>
-        </div>
-        <button
-          type="button"
-          onClick={closeChatDrawer}
-          className="text-zinc-400 hover:text-zinc-700 bg-zinc-50 hover:bg-zinc-100 rounded-full p-3 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant"
-          aria-label="Fechar gaveta"
-        >
-          <X className="size-6" weight="bold" />
-        </button>
-      </div>
-
-      {/* Screen-reader announcer for new AI messages */}
-      <output aria-live="polite" aria-atomic="true" className="sr-only">
-        {liveAnnouncement}
-      </output>
-
-      {/* Messages Area - Scrapbook vibe */}
-      <div className="flex-1 overflow-y-auto p-6 space-y-6 scroll-smooth bg-white relative">
-        {/* Fundo suave */}
-        <div className="absolute inset-0 opacity-[0.03] pointer-events-none" style={{ backgroundImage: 'radial-gradient(circle at 1px 1px, black 1px, transparent 0)', backgroundSize: '32px 32px' }}></div>
-
-        {messages.map((msg, idx) => {
-          const isLastModelMsg = msg.role === 'model' && idx === lastModelIndex;
-
-          return (
-            <div key={msg.id} className={`relative flex flex-col gap-2 ${msg.role === 'user' ? 'items-end' : 'items-start'} z-10`}>
-              <div className={`flex items-end gap-3 max-w-[90%] ${msg.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}>
-                {/* Avatar */}
-                <div className={`size-9 flex items-center justify-center shrink-0 rounded-full shadow-sm ${msg.role === 'user'
-                  ? 'bg-brand-dark text-white'
-                  : 'bg-white text-brand-vibrant border border-zinc-100'
-                  }`}>
-                  {msg.role === 'user' ? <User className="size-4" weight="fill" /> : <Robot className="size-5" weight="fill" />}
-                </div>
-
-                {/* Bubble */}
-                {msg.isAction ? (
-                  <div className="w-full relative mt-3 pt-4">
-                    {/* Passport Stamp Overlay */}
-                    <PassportStamp
-                      destination={msg.actionData?.destination || 'Viagem'}
-                      iataCode={msg.actionData?.iataCode}
-                      className="absolute top-[-25px] right-[-10px] sm:right-[5px] pointer-events-none"
-                    />
-                    <ChatLeadForm
-                      destination={msg.actionData?.destination}
-                      defaultBantSummary={msg.actionData?.bantSummary}
-                      getWhatsAppUrl={getLeadWhatsAppUrl}
-                      prepareLeadSubmitPayload={handlePrepareLeadSubmitPayload}
-                      onFinalizeLead={handleFinalizeLead}
-                      isSubmittingLead={isSubmittingLead}
-                    />
-                  </div>
-                ) : (
-                  <div
-                    data-testid={msg.role === 'user' ? 'chat-user-message' : undefined}
-                    className={`p-4 text-sm shadow-sm ${msg.role === 'user'
-                    ? 'bg-brand-vibrant text-white rounded-2xl rounded-br-sm'
-                    : 'bg-white text-zinc-800 border border-zinc-100 rounded-2xl rounded-bl-sm'
-                    }`}>
-                    {msg.role === 'model' ? (
-                      <div className="prose prose-sm max-w-none prose-p:text-zinc-700 prose-p:leading-relaxed prose-strong:text-zinc-900 prose-strong:font-bold prose-ul:text-zinc-700">
-                        <ReactMarkdown
-                          urlTransform={sanitizeAiLinkUrl}
-                          components={{
-                            a: ({ href, children, ...props }) => {
-                              if (!href) return <span>{children}</span>;
-                              // Internal SPA links stay in-tab; external (allowlisted)
-                              // links open in a new tab to preserve chat state.
-                              const isInternal = href.startsWith('/') && !href.startsWith('//');
-                              return (
-                                <a
-                                  href={href}
-                                  rel="noopener noreferrer"
-                                  target={isInternal ? undefined : '_blank'}
-                                  {...props}
-                                >
-                                  {children}
-                                </a>
-                              );
-                            },
-                          }}
-                        >
-                          {msg.text}
-                        </ReactMarkdown>
-                      </div>
-                    ) : (
-                      <div className="text-white font-medium leading-relaxed max-w-[300px] break-words">
-                        <FormattedText text={msg.text} />
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {/* Action Chips */}
-              {isLastModelMsg && msg.chips && msg.chips.length > 0 && (
-                <div className="flex flex-wrap gap-2 pl-12 mt-1">
-                  {msg.chips.map((chip) => (
-                    <button
-                      type="button"
-                      key={chip.id}
-                      onClick={() => void submitMessage(chip.label)}
-                      className="text-[13px] font-semibold text-zinc-600 bg-white border border-zinc-200 px-4 py-3 min-h-12 rounded-xl shadow-sm hover:shadow hover:border-brand-vibrant/30 hover:text-brand-vibrant hover:-translate-y-0.5 transition text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant/50"
-                    >
-                      {chip.label}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          );
-        })}
-
-        {isLoading && (
-          <div data-testid="chat-typing-indicator" className="flex items-end gap-3 z-10 relative">
-            <div className="size-9 bg-white rounded-full border border-zinc-100 text-brand-vibrant flex items-center justify-center shadow-sm">
-              <Robot className="size-5" weight="fill" />
-            </div>
-            <div className="bg-white px-4 py-3 border border-zinc-100 rounded-2xl rounded-bl-sm shadow-sm flex items-center gap-2.5">
-              <CircleNotch className="size-4 animate-spin text-brand-vibrant" weight="bold" />
-              <span className="text-xs font-medium text-zinc-400">Anhangá digitando…</span>
-            </div>
-          </div>
-        )}
-        <div ref={messagesEndRef} className="h-2" />
-      </div>
-
-      {/* Input Area */}
-      <div className="p-4 sm:p-5 bg-white border-t border-zinc-100 shrink-0 z-10 shadow-[0_-4px_20px_rgba(0,0,0,0.02)]">
-        <div className="relative flex items-end bg-zinc-50 border border-zinc-200 rounded-2xl focus-within:border-brand-vibrant/40 focus-within:bg-white focus-within:ring-4 focus-within:ring-brand-vibrant/10 transition">
-          <label htmlFor="chat-textarea" className="sr-only">Sua mensagem</label>
-          <textarea
-            id="chat-textarea"
-            ref={inputRef}
-            value={input}
-            onChange={handleInput}
-            onKeyDown={handleKeyDown}
-            placeholder="Digite sua dúvida aqui..."
-            rows={1}
-            className="flex-1 max-h-[120px] pl-4 pr-[50px] py-4 bg-transparent outline-none text-sm text-zinc-700 font-medium placeholder-zinc-400 resize-none overflow-y-auto w-full leading-snug"
-          />
-          <button
-            type="button"
-            onClick={() => void submitMessage(input)}
-            disabled={isLoading || !input.trim()}
-            className="absolute right-2 bottom-1 min-h-12 min-w-12 flex items-center justify-center bg-brand-vibrant text-white rounded-[10px] shadow-sm hover:bg-brand-blue hover:shadow-md transition disabled:opacity-0 disabled:scale-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-vibrant/50"
-            aria-label="Enviar mensagem"
-          >
-            <PaperPlaneTilt className="size-5 ml-0.5" weight="fill" />
-          </button>
-        </div>
-        <p className="text-center text-[10px] text-zinc-400 mt-2">
-          Nossa IA pode cometer erros. Confirme os dados no WhatsApp.
-        </p>
-      </div>
-    </dialog>
+    <AIChatPanelView
+      dialogRef={dialogRef}
+      messagesEndRef={messagesEndRef}
+      inputRef={inputRef}
+      messages={messages}
+      lastModelIndex={lastModelIndex}
+      liveAnnouncement={liveAnnouncement}
+      input={input}
+      isLoading={isLoading}
+      isSubmittingLead={isSubmittingLead}
+      getLeadWhatsAppUrl={getLeadWhatsAppUrl}
+      prepareLeadSubmitPayload={handlePrepareLeadSubmitPayload}
+      finalizeLead={handleFinalizeLead}
+      onClose={closeChatDrawer}
+      onInput={handleInput}
+      onKeyDown={handleKeyDown}
+      onSubmitMessage={(text) => void submitMessage(text)}
+    />
   );
 });
 

--- a/components/Destinations.tsx
+++ b/components/Destinations.tsx
@@ -1,21 +1,7 @@
-import React, { useEffect, useRef, useState, useMemo, memo, useCallback } from 'react';
-import L from 'leaflet';
-import 'leaflet/dist/leaflet.css';
-import { MapPin, X, Calendar, ArrowRight, Star, Compass, MousePointerClick, Share2, Image as ImageIcon, Loader2, Plus, Minus, Share } from 'lucide-react';
-import { SocialShare } from './SocialShare';
-import { LazyImage } from './ui/LazyImage';
-import { openContactModal } from '../utils/contactForm';
-import { NOISE_TEXTURE_URL } from '../lib/static-assets';
-import { DESTINATIONS, FILTERS, CONTINENT_COLORS, type Destination } from '../data/mapDestinations';
-
-import { Link } from "react-router-dom";
-
-const noiseTextureStyle = {
-    backgroundImage: `url("${NOISE_TEXTURE_URL}")`,
-};
-
-// Componente LazyImage Otimizado - REFATORADO PARA COMPONENTE COMPARTILHADO
-// importado de ../components/ui/LazyImage
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { DESTINATIONS, type Destination } from '../data/mapDestinations';
+import { DestinationsView } from './destinations/DestinationsView';
+import { useDestinationMap } from './destinations/useDestinationMap';
 
 /**
  * Destinations Component - Optimized with React.memo
@@ -24,21 +10,18 @@ const noiseTextureStyle = {
  * This is particularly important because this component initializes a Leaflet map and
  * iterates over a large set of destination markers and cards.
  */
-const Destinations: React.FC = memo(() => {
-    const mapRef = useRef<HTMLDivElement>(null);
-    const mapInstance = useRef<L.Map | null>(null);
-    const markersLayerRef = useRef<L.FeatureGroup | null>(null);
+const Destinations = memo(() => {
     const destinationModalRef = useRef<HTMLDialogElement>(null);
-
     const [activeFilter, setActiveFilter] = useState('Todos');
     const [selectedDestination, setSelectedDestination] = useState<Destination | null>(null);
 
     const filteredDestinations = useMemo(() => {
         if (activeFilter === 'Todos') return DESTINATIONS;
-        return DESTINATIONS.filter(d => d.continent === activeFilter);
+        return DESTINATIONS.filter(destination => destination.continent === activeFilter);
     }, [activeFilter]);
 
     const closeModal = useCallback(() => setSelectedDestination(null), []);
+    const { mapRef, handleZoom } = useDestinationMap(filteredDestinations, setSelectedDestination);
 
     useEffect(() => {
         const dialog = destinationModalRef.current;
@@ -55,13 +38,13 @@ const Destinations: React.FC = memo(() => {
         const dialog = destinationModalRef.current;
         if (!dialog) return;
 
-        const handleCancel = (e: Event) => {
-            e.preventDefault();
+        const handleCancel = (event: Event) => {
+            event.preventDefault();
             closeModal();
         };
 
-        const handleClick = (e: MouseEvent) => {
-            if (e.target === dialog) closeModal();
+        const handleClick = (event: MouseEvent) => {
+            if (event.target === dialog) closeModal();
         };
 
         dialog.addEventListener('cancel', handleCancel);
@@ -72,406 +55,18 @@ const Destinations: React.FC = memo(() => {
         };
     }, [closeModal]);
 
-    // Map Init
-    useEffect(() => {
-        if (!mapRef.current || mapInstance.current) return;
-
-        // Check if mobile for config
-        const isMobile = window.innerWidth < 768;
-
-        // CSS Injection for markers, Map Tile Styling & Washi Tapes
-        const styleId = 'leaflet-marker-anim-styles';
-        if (!document.getElementById(styleId)) {
-            const style = document.createElement('style');
-            style.id = styleId;
-            style.innerHTML = `
-            @keyframes bounce-in { 0% { opacity: 0; transform: scale(0.3) translateY(-10px); } 50% { opacity: 1; transform: scale(1.1) translateY(5px); } 70% { transform: scale(0.95) translateY(-2px); } 100% { opacity: 1; transform: scale(1) translateY(0); } }
-            @keyframes pin-shadow-pulse { 0% { opacity: 0.3; transform: scale(0.8); } 100% { opacity: 0.5; transform: scale(1.1); } }
-            
-            /* CUSTOM STICKER MARKER */
-            .custom-marker-container { position: relative; display: flex; align-items: flex-end; justify-content: center; cursor: pointer; filter: drop-shadow(0px 4px 6px rgba(0,0,0,0.3)); }
-            
-            /* Pin Animation */
-            .pin-animated { animation: bounce-in 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards; transform-origin: bottom center; }
-
-            /* Pin Shadow on Map */
-            .pin-shadow { position: absolute; bottom: 0px; width: 60%; height: 15%; background: black; border-radius: 50%; opacity: 0.3; filter: blur(3px); z-index: -1; transform: translateY(2px); animation: pin-shadow-pulse 2s infinite alternate; }
-
-            .leaflet-div-icon { background: transparent; border: none; }
-            
-            /* Tooltip "Handwritten" Style - Updated for better Portuguese legibility */
-            .custom-dest-tooltip { 
-                background-color: #ffffff !important; 
-                color: #0f172a !important; 
-                font-family: 'Poppins', sans-serif !important; 
-                font-weight: 700 !important; 
-                font-size: 14px !important; 
-                border: 2px solid #fff !important; 
-                box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06) !important;
-                border-radius: 8px !important; 
-                padding: 6px 12px !important; 
-                white-space: nowrap; 
-                transform: rotate(-1deg); 
-            }
-            .leaflet-tooltip-top.custom-dest-tooltip::before { border-top-color: #ffffff !important; }
-            
-            /* MAP TILE STYLING - CartoDB Voyager (Clean, No strong borders) */
-            .leaflet-tile-pane { 
-                /* High saturation to keep it fun, contrast for clarity */
-                filter: contrast(1.05) saturate(1.2); 
-            }
-            /* Background matches Voyager water color */
-            .leaflet-container { background: #FAFAFA; font-family: 'Poppins', sans-serif; } 
-            
-            /* Hide Default Zoom Controls to replace with custom stickers */
-            .leaflet-control-zoom { display: none !important; }
-        `;
-            document.head.appendChild(style);
-        }
-
-        const map = L.map(mapRef.current, {
-            scrollWheelZoom: false,
-            zoomControl: false, // Hidden default, using custom
-            dragging: !isMobile,
-            touchZoom: true,
-            zoomSnap: 0.5,
-            zoomDelta: 0.5
-        }).setView([20, -40], 3);
-
-        mapInstance.current = map;
-        markersLayerRef.current = L.featureGroup().addTo(map);
-
-        // CartoDB Voyager - Clean, Modern, No Heavy Borders. Perfect for overlaying Portuguese labels.
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
-            maxZoom: 20
-        }).addTo(map);
-
-        return () => { map.remove(); mapInstance.current = null; };
-    }, []);
-
-    useEffect(() => {
-        if (!mapInstance.current || !markersLayerRef.current) return;
-
-        const markersLayer = markersLayerRef.current;
-        markersLayer.clearLayers();
-
-        const isMobile = window.innerWidth < 768;
-        // Tamanho do pin ajustado para o novo SVG (Lollipop Style)
-        const markerWidth = isMobile ? 32 : 36;
-        const markerHeight = isMobile ? 48 : 54;
-
-        filteredDestinations.forEach((dest, idx) => {
-            const baseColor = CONTINENT_COLORS[dest.continent] || '#0ea5e9';
-
-            // Creating a "Lollipop/Tack" style icon using SVG
-            const icon = L.divIcon({
-                className: 'bg-transparent border-none',
-                html: `
-                <div class="custom-marker-container" style="width: ${markerWidth}px; height: ${markerHeight}px;">
-                    <div class="pin-animated" style="animation-delay: ${idx * 50}ms; opacity: 0; width: 100%; height: 100%;">
-                         <svg viewBox="0 0 32 48" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 100%; height: 100%; filter: drop-shadow(0 2px 3px rgba(0,0,0,0.2));">
-                            <!-- Stick -->
-                            <path d="M16 30V48" stroke="#555" stroke-width="2" stroke-linecap="round"/>
-                            <!-- Head -->
-                            <circle cx="16" cy="16" r="15" fill="${baseColor}" stroke="white" stroke-width="3"/>
-                            <!-- Inner Shine/Dot -->
-                            <circle cx="16" cy="16" r="5" fill="white"/>
-                            <!-- Reflection -->
-                            <path d="M16 4 Q 24 4 26 8" stroke="white" stroke-width="2" opacity="0.4" fill="none" stroke-linecap="round"/>
-                         </svg>
-                    </div>
-                    <div class="pin-shadow" style="width: 40%; height: 8%; opacity: 0.2;"></div>
-                </div>
-            `,
-                iconSize: [markerWidth, markerHeight],
-                iconAnchor: [markerWidth / 2, markerHeight],
-                popupAnchor: [0, -markerHeight],
-            });
-
-            const marker = L.marker(dest.coords, {
-                icon,
-                riseOnHover: true,
-                zIndexOffset: 100
-            });
-
-            marker.bindTooltip(dest.city, {
-                direction: 'top',
-                offset: [0, -(markerHeight + 5)],
-                className: 'custom-dest-tooltip',
-                permanent: false
-            });
-
-            marker.on('click', (e) => {
-                L.DomEvent.stopPropagation(e);
-                setSelectedDestination(dest);
-            });
-
-            marker.addTo(markersLayer);
-        });
-
-        let flyTimer: ReturnType<typeof setTimeout> | undefined;
-        if (markersLayer.getLayers().length > 0 && mapInstance.current) {
-            flyTimer = setTimeout(() => {
-                const map = mapInstance.current;
-                if (map && markersLayer) {
-                    try {
-                        map.invalidateSize();
-                        const bounds = markersLayer.getBounds();
-                        if (bounds.isValid()) {
-                            map.flyToBounds(bounds, {
-                                padding: isMobile ? [40, 40] : [80, 80],
-                                duration: 1.5,
-                                maxZoom: 5
-                            });
-                        }
-                    } catch (e) { }
-                }
-            }, 100);
-        }
-        return () => {
-            clearTimeout(flyTimer);
-            markersLayer.clearLayers();
-        };
-    }, [filteredDestinations, activeFilter]);
-
-    // Custom Zoom Handlers
-    const handleZoom = (type: 'in' | 'out') => {
-        if (mapInstance.current) {
-            if (type === 'in') mapInstance.current.zoomIn();
-            else mapInstance.current.zoomOut();
-        }
-    };
-
     return (
-        <section id="destinos" className="py-24 bg-brand-surface relative overflow-hidden">
-
-            {/* Background Doodles */}
-            <div className="absolute top-0 right-0 w-full h-full opacity-[0.03] pointer-events-none z-0" style={{ backgroundImage: 'radial-gradient(circle at 1px 1px, black 1px, transparent 0)', backgroundSize: '40px 40px' }}></div>
-
-            <div className="container mx-auto px-6 relative z-10">
-
-                {/* Header */}
-                <div className="flex flex-col md:flex-row justify-between items-end mb-12">
-                    <div>
-                        <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-dashed border-brand-dark bg-yellow-100 text-brand-dark font-black text-xs uppercase tracking-widest shadow-sm transform -rotate-1 mb-4">
-                            <Compass className="size-4" /> Mapa Mundi
-                        </div>
-                        <h2 className="text-4xl font-black text-brand-dark">Escolha seu <span className="text-brand-cyan relative inline-block">Pin 📍<svg className="absolute w-full h-3 -bottom-1 left-0 text-brand-cyan opacity-40" viewBox="0 0 100 10" preserveAspectRatio="none"><path d="M0 5 Q 50 10 100 5" stroke="currentColor" strokeWidth="4" fill="none" /></svg></span></h2>
-                    </div>
-
-                    {/* Filter Pills - Sticker Style */}
-                    <div className="flex overflow-x-auto hide-scrollbar gap-3 pb-2 md:pb-0 w-full md:w-auto mt-6 md:mt-0 px-1">
-                        {FILTERS.map(filter => (
-                            <button
-                                key={filter}
-                                type="button"
-                                onClick={() => setActiveFilter(filter)}
-                                className={`px-5 py-2 rounded-lg text-sm font-bold border-2 transition whitespace-nowrap flex-shrink-0 shadow-[3px_3px_0px_rgba(0,0,0,0.1)] active:shadow-none active:translate-x-[2px] active:translate-y-[2px] ${activeFilter === filter
-                                    ? 'bg-brand-dark text-white border-brand-dark transform -rotate-1'
-                                    : 'bg-white text-zinc-600 border-zinc-100 hover:border-brand-vibrant hover:text-brand-vibrant'
-                                    }`}
-                            >
-                                {filter}
-                            </button>
-                        ))}
-                    </div>
-                </div>
-
-                {/* Map Container - The "Glued Photo" Look */}
-                <div className="relative mb-16 px-2">
-                    {/* The Map Frame */}
-                    <div className="relative w-full h-[500px] bg-white p-3 shadow-[0_20px_60px_-10px_rgba(0,0,0,0.2)] transform rotate-1 transition-transform duration-500 hover:rotate-0 group">
-
-                        {/* Washi Tapes */}
-                        <div className="absolute -top-3 -left-3 w-32 h-8 bg-red-400/80 rotate-[-45deg] z-30 backdrop-blur-sm shadow-sm opacity-90 border-l border-r border-white/30"></div>
-                        <div className="absolute -bottom-3 -right-3 w-32 h-8 bg-brand-cyan/80 rotate-[-45deg] z-30 backdrop-blur-sm shadow-sm opacity-90 border-l border-r border-white/30"></div>
-                        <div className="absolute -top-3 right-10 w-24 h-8 bg-yellow-400/80 rotate-[10deg] z-30 backdrop-blur-sm shadow-sm opacity-90 border-l border-r border-white/30"></div>
-
-                        {/* Map Inner Border & Content */}
-                        <div className="w-full h-full border-2 border-zinc-100 overflow-hidden relative bg-[#FAFAFA]">
-                            {/* Paper Texture Overlay */}
-                            <div className="absolute inset-0 z-[5] pointer-events-none opacity-[0.15] mix-blend-multiply" style={noiseTextureStyle}></div>
-
-                            {/* Inner Shadow for Depth */}
-                            <div className="absolute inset-0 z-[5] pointer-events-none shadow-[inset_0_0_40px_rgba(0,0,0,0.1)]"></div>
-
-                            <div ref={mapRef} className="w-full h-full z-0" />
-
-                            {/* Mobile Hint */}
-                            <div className="md:hidden absolute bottom-4 left-1/2 -translate-x-1/2 bg-white/90 backdrop-blur-sm px-4 py-2 rounded-full text-[10px] font-bold text-zinc-500 pointer-events-none z-[400] shadow-md border border-zinc-200">
-                                Use dois dedos para mover
-                            </div>
-                        </div>
-
-                        {/* Custom Controls (Stickers) */}
-                        <div className="absolute bottom-6 right-6 flex flex-col gap-2 z-[400]">
-                            <button
-                                type="button"
-                                onClick={() => handleZoom('in')}
-                                className="size-12 bg-white border-2 border-zinc-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition text-zinc-700 font-black"
-                                aria-label="Aumentar zoom no mapa"
-                            >
-                                <Plus className="size-5" />
-                            </button>
-                            <button
-                                type="button"
-                                onClick={() => handleZoom('out')}
-                                className="size-12 bg-white border-2 border-zinc-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition text-zinc-700 font-black"
-                                aria-label="Diminuir zoom no mapa"
-                            >
-                                <Minus className="size-5" />
-                            </button>
-                        </div>
-
-                        {/* "Note" Sticker */}
-                        <div className="hidden md:block absolute top-8 left-8 bg-yellow-100 p-4 rounded-sm shadow-md transform -rotate-3 z-[400] max-w-[150px] border border-yellow-200">
-                            <div className="size-3 rounded-full bg-red-400 mx-auto -mt-6 mb-2 shadow-sm border border-red-500"></div>
-                            <p className="font-serif italic text-zinc-700 text-sm leading-tight text-center">
-                                "O mundo é um livro e quem não viaja lê apenas uma página."
-                                <span className="block not-italic text-zinc-400 text-xs mt-1">(Santo Agostinho)</span>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-
-                {/* Destinations Grid - Luggage Tag Style */}
-                <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-                    {filteredDestinations.slice(0, 3).map((dest) => (
-                        <button
-                            type="button"
-                            key={`${dest.city}-${dest.country}`}
-                            aria-label={`Ver detalhes de ${dest.city}, ${dest.country}`}
-                            className="group bg-white rounded-[2rem] border-2 border-zinc-100 p-4 pb-0 shadow-[6px_6px_0px_rgba(0,0,0,0.05)] hover:shadow-[10px_10px_0px_rgba(0,0,0,0.08)] hover:-translate-y-2 transition cursor-pointer flex flex-col focus:outline-none focus-visible:ring-4 focus-visible:ring-brand-cyan w-full text-left"
-                            onClick={() => setSelectedDestination(dest)}
-                        >
-                            <div className="relative h-56 rounded-[1.5rem] overflow-hidden mb-4 border border-zinc-100">
-                                <LazyImage
-                                    src={dest.image}
-                                    alt={`${dest.city}, ${dest.country} — pacote de viagem personalizado Anhangá Viagens`}
-                                    width={600}
-                                    height={400}
-                                    className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
-                                />
-
-                                {/* Price Tag Sticker */}
-                                <div className="absolute top-4 right-4 bg-white text-brand-dark font-black px-3 py-1 rounded-md shadow-[3px_3px_0px_rgba(0,0,0,0.2)] text-sm rotate-3 group-hover:rotate-6 transition-transform border border-zinc-100">
-                                    A partir de {dest.price}
-                                </div>
-                            </div>
-
-                            <div className="px-2 pb-6">
-                                <div className="flex justify-between items-center mb-2">
-                                    <h3 className="text-2xl font-black text-zinc-800">{dest.city}</h3>
-                                    <div className="flex items-center gap-1 text-yellow-500 font-bold text-sm bg-yellow-50 px-2 py-1 rounded-full border border-yellow-100">
-                                        <Star className="size-3 fill-current" /> {dest.rating}
-                                    </div>
-                                </div>
-                                <p className="text-zinc-500 text-sm font-medium mb-4">{dest.description}</p>
-
-                                <div className="flex items-center gap-2 text-brand-cyan font-bold text-sm uppercase tracking-wide group-hover:gap-3 transition-[gap,color]">
-                                    Saiba Mais <ArrowRight className="size-4" />
-                                </div>
-                            </div>
-                        </button>
-                    ))}
-                </div>
-            </div>
-
-            {/* Modal - Scrapbook Page Style */}
-            <dialog
-                ref={destinationModalRef}
-                className="fixed inset-0 z-[9999] m-auto p-4 bg-transparent backdrop:bg-zinc-900/60 backdrop:backdrop-blur-sm max-w-4xl w-full"
-                aria-labelledby="dest-modal-title"
-            >
-                {selectedDestination && (
-                    <div
-                        className="bg-brand-surface w-full rounded-[2.5rem] shadow-2xl overflow-hidden relative flex flex-col md:flex-row max-h-[90vh] border-8 border-white transform rotate-1"
-                    >
-
-                        {/* Washi Tape Decor */}
-                        <div className="absolute -top-6 left-1/2 -translate-x-1/2 w-32 h-10 bg-red-400/80 rotate-1 backdrop-blur-sm z-20 shadow-sm border-l-2 border-r-2 border-white/40"></div>
-
-                        <button
-                            type="button"
-                            onClick={closeModal}
-                            className="absolute top-4 right-4 z-30 bg-white border-2 border-zinc-100 p-2 rounded-full shadow-md hover:scale-110 transition-transform text-zinc-800"
-                            aria-label="Fechar detalhes do destino"
-                        >
-                            <X className="size-5" />
-                        </button>
-
-                        <div className="w-full md:w-1/2 h-64 md:h-auto relative bg-zinc-100">
-                            <LazyImage
-                                src={selectedDestination.image}
-                                alt={selectedDestination.city}
-                                width={1200}
-                                height={800}
-                                className="w-full h-full object-cover"
-                            />
-                            <div className="absolute bottom-0 left-0 w-full h-32 bg-gradient-to-t from-black/60 to-transparent"></div>
-                            <div className="absolute bottom-6 left-6 text-white">
-                                <h2 id="dest-modal-title" className="text-4xl font-black mb-1 drop-shadow-md">{selectedDestination.city}</h2>
-                                <div className="flex items-center gap-2 font-medium opacity-90 drop-shadow-sm">
-                                    <MapPin className="size-4" /> {selectedDestination.country}
-                                </div>
-                            </div>
-                        </div>
-
-                        <div className="w-full md:w-1/2 p-8 md:p-10 overflow-y-auto" style={noiseTextureStyle}>
-                            <p className="text-zinc-600 mb-8 text-lg leading-relaxed font-medium font-serif italic">"{selectedDestination.details}"</p>
-
-                            <h4 className="font-black text-zinc-900 mb-4 flex items-center gap-2">
-                                <Star className="size-5 text-yellow-400 fill-current" /> Atrações Imperdíveis
-                            </h4>
-                            <div className="flex flex-wrap gap-3 mb-8">
-                                {selectedDestination.activities.map((act) => (
-                                    <span key={act} className="bg-white border-2 border-zinc-100 px-4 py-2 rounded-xl text-sm text-zinc-700 font-bold shadow-sm transform hover:-rotate-1 transition-transform cursor-default">
-                                        {act}
-                                    </span>
-                                ))}
-                            </div>
-
-                            <div className="mb-8 p-4 bg-white/50 rounded-2xl border border-zinc-100">
-                                <p className="text-sm font-bold text-zinc-400 uppercase tracking-widest mb-3">Compartilhar destino</p>
-                                <SocialShare
-                                    url={`https://www.anhanga.tur.br/#destinos`}
-                                    title={`Confira esse destino na Anhangá Viagens: ${selectedDestination.city}`}
-                                    excerpt={selectedDestination.details}
-                                />
-                            </div>
-
-                            <div className="flex flex-col gap-3">
-                                {selectedDestination.landingPage && (
-                                    <Link
-                                        to={selectedDestination.landingPage}
-                                        onClick={closeModal}
-                                        className="w-full bg-white border-2 border-brand-dark text-brand-dark py-4 rounded-xl font-black text-lg hover:bg-zinc-50 transition shadow-[4px_4px_0px_#0f172a] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2"
-                                    >
-                                        Ver detalhes do pacote <ArrowRight className="size-5" />
-                                    </Link>
-                                )}
-                                <button
-                                    type="button"
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        openContactModal({
-                                            source: 'destinations-modal',
-                                            destination: selectedDestination.city,
-                                        });
-                                        closeModal();
-                                    }}
-                                    className={`btn-whatsapp btn-specialist w-full bg-brand-dark text-white py-4 rounded-xl font-black text-lg hover:bg-brand-vibrant transition shadow-[4px_4px_0px_#94a3b8] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2`}
-                                    data-tracking={`modal-destinations-${selectedDestination.city.toLowerCase()}`}
-                                >
-                                    Solicitar Orçamento
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                )}
-            </dialog>
-        </section>
+        <DestinationsView
+            activeFilter={activeFilter}
+            filteredDestinations={filteredDestinations}
+            selectedDestination={selectedDestination}
+            mapRef={mapRef}
+            destinationModalRef={destinationModalRef}
+            onFilterChange={setActiveFilter}
+            onDestinationSelect={setSelectedDestination}
+            onCloseModal={closeModal}
+            onZoom={handleZoom}
+        />
     );
 });
 

--- a/components/SearchForm.tsx
+++ b/components/SearchForm.tsx
@@ -1,350 +1,67 @@
-import { useEffect, useMemo, useRef, useState, memo, useCallback } from 'react';
-import {
-  normalizeStr,
-  PRE_NORMALIZED_DB,
-  TRIP_OPTIONS,
-  BUDGET_TIERS,
-  getDaysInMonth
-} from '../data/destinations';
-import { openAiChat } from '../utils/aiChat';
-import DestinationField from './search/DestinationField';
-import DateField from './search/DateField';
-import GuestsField from './search/GuestsField';
-import TripTypeField from './search/TripTypeField';
+import { memo } from 'react';
 import BudgetField from './search/BudgetField';
+import DateField from './search/DateField';
+import DestinationField from './search/DestinationField';
+import GuestsField from './search/GuestsField';
 import SearchButton from './search/SearchButton';
-import { buildSearchMessage, getGuestSummary, isDateInPast } from './search/helpers';
-import { useSearchFormDismiss, type PanelRegistryEntry } from './search/useSearchFormDismiss';
-import type { DestinationOption, OpenPanel } from './search/types';
-import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
-
-type ActivePanel = Exclude<OpenPanel, null>;
+import TripTypeField from './search/TripTypeField';
+import { useSearchFormController } from './search/useSearchFormController';
 
 interface SearchFormProps {
   onDestinationMatch: (city: string | null) => void;
 }
 
 const SearchForm = memo(({ onDestinationMatch }: SearchFormProps) => {
-  const [inputValue, setInputValue] = useState('');
-  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
-  const [openPanel, setOpenPanel] = useState<OpenPanel>(null);
-  const [startDate, setStartDate] = useState<Date | null>(null);
-  const [endDate, setEndDate] = useState<Date | null>(null);
-  const [currentMonth, setCurrentMonth] = useState(new Date());
-  const [adults, setAdults] = useState(2);
-  const [children, setChildren] = useState(0);
-  const [childAges, setChildAges] = useState<string[]>([]);
-  const [tripType, setTripType] = useState('');
-  const [budget, setBudget] = useState('');
-  const [showTripType, setShowTripType] = useState(false);
-  const [isSearchLoading, setIsSearchLoading] = useState(false);
-  const [validationError, setValidationError] = useState<string | null>(null);
-  const errorTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const startedRef = useRef(false);
-  const completedFields = useRef<Set<'destination' | 'date' | 'budget'> | null>(null);
-
-  useEffect(() => {
-    pushFormAnalyticsEvent({
-      event: 'form_view',
-      formType: 'home_search',
-      formId: 'hero-search',
-    });
-  }, []);
-
-  const markStarted = useCallback((fieldName: 'destination' | 'date' | 'budget') => {
-    if (!startedRef.current) {
-      startedRef.current = true;
-      pushFormAnalyticsEvent({
-        event: 'form_start',
-        formType: 'home_search',
-        formId: 'hero-search',
-      });
-    }
-    const trackedFields = completedFields.current ?? (completedFields.current = new Set());
-    if (!trackedFields.has(fieldName)) {
-      trackedFields.add(fieldName);
-      pushFormAnalyticsEvent({
-        event: 'field_complete',
-        formType: 'home_search',
-        formId: 'hero-search',
-        fieldName,
-      });
-    }
-  }, []);
-
-  // Cleanup timeout on unmount
-  useEffect(() => {
-    const timerRef = errorTimeoutRef;
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, []);
-
-  const guestDropdownRef = useRef<HTMLDivElement>(null);
-  const destRef = useRef<HTMLDivElement>(null);
-  const destinationInputRef = useRef<HTMLInputElement>(null);
-  const calendarRef = useRef<HTMLDivElement>(null);
-  const tripTypeRef = useRef<HTMLDivElement>(null);
-  const budgetRef = useRef<HTMLDivElement>(null);
-
-  // Move o foco pro botão do TripTypeField assim que ele é revelado —
-  // o próximo passo natural do usuário é abrir o dropdown de opções.
-  useEffect(() => {
-    if (showTripType) {
-      tripTypeRef.current?.querySelector<HTMLButtonElement>('[data-testid="trip-type-filter-btn"]')?.focus();
-    }
-  }, [showTripType]);
-
-  const closePanel = useCallback((panel: ActivePanel) => {
-    setOpenPanel((prev) => (prev === panel ? null : prev));
-  }, []);
-
-  const closeAllPanels = useCallback(() => setOpenPanel(null), []);
-
-  const togglePanel = useCallback((panel: ActivePanel) => {
-    setOpenPanel((prev) => (prev === panel ? null : panel));
-    import('../utils/haptics').then(m => m.triggerHaptic('light'));
-  }, []);
-
-  const panelRegistry = useMemo<PanelRegistryEntry[]>(() => ([
-    { panel: 'dest', ref: destRef },
-    { panel: 'calendar', ref: calendarRef },
-    { panel: 'guests', ref: guestDropdownRef },
-    { panel: 'trip', ref: tripTypeRef },
-    { panel: 'budget', ref: budgetRef },
-  ]), []);
-
-  useSearchFormDismiss(panelRegistry, openPanel, closePanel, closeAllPanels);
-
-  const calendarDays = useMemo(() => getDaysInMonth(currentMonth), [currentMonth]);
-
-  const filteredDestinations = useMemo(() => {
-    if (!inputValue) return [];
-    const search = normalizeStr(inputValue);
-    return PRE_NORMALIZED_DB.filter((destination) => destination.nLabel.includes(search)).slice(0, 8);
-  }, [inputValue]);
-
-  const guestSummary = useMemo(() => getGuestSummary(adults, children), [adults, children]);
-  const selectedTripObj = useMemo(() => TRIP_OPTIONS.find((option) => option.label === tripType), [tripType]);
-  const selectedBudgetObj = useMemo(() => BUDGET_TIERS.find((tier) => tier.label === budget), [budget]);
-
-  const handleDestinationChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-    setInputValue(value);
-    if (value.trim()) markStarted('destination');
-    setOpenPanel('dest');
-    setActiveSuggestionIndex(-1);
-
-    const search = normalizeStr(value);
-    const exactMatch = PRE_NORMALIZED_DB.find((destination) => (
-      destination.nLabel === search || destination.nCity === search
-    ));
-
-    onDestinationMatch(exactMatch ? exactMatch.city : null);
-  }, [onDestinationMatch, markStarted]);
-
-  const handleDestinationSelect = useCallback((destination: DestinationOption) => {
-    setInputValue(destination.label);
-    onDestinationMatch(destination.city);
-    closePanel('dest');
-    setActiveSuggestionIndex(-1);
-  }, [onDestinationMatch, closePanel]);
-
-  const handleDestinationKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (openPanel !== 'dest' || filteredDestinations.length === 0) return;
-
-    if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      setActiveSuggestionIndex((prev) => (prev < filteredDestinations.length - 1 ? prev + 1 : 0));
-      import('../utils/haptics').then(m => m.triggerHaptic('light'));
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      setActiveSuggestionIndex((prev) => (prev > 0 ? prev - 1 : filteredDestinations.length - 1));
-      import('../utils/haptics').then(m => m.triggerHaptic('light'));
-    } else if (event.key === 'Enter') {
-      if (activeSuggestionIndex >= 0) {
-        event.preventDefault();
-        handleDestinationSelect(filteredDestinations[activeSuggestionIndex]);
-      }
-    } else if (event.key === 'Escape') {
-      closePanel('dest');
-      setActiveSuggestionIndex(-1);
-    }
-  }, [openPanel, filteredDestinations, activeSuggestionIndex, handleDestinationSelect, closePanel]);
-
-  const handleClearDestination = useCallback(() => {
-    setInputValue('');
-    onDestinationMatch(null);
-    closePanel('dest');
-    setActiveSuggestionIndex(-1);
-    if (destinationInputRef.current) {
-      destinationInputRef.current.focus();
-    }
-    import('../utils/haptics').then(m => m.triggerHaptic('light'));
-  }, [onDestinationMatch, closePanel]);
-
-  const handleAdultsChange = useCallback((nextValue: number) => {
-    setAdults(nextValue);
-    import('../utils/haptics').then(m => m.triggerHaptic('light'));
-  }, []);
-
-  const handleChildCountChange = useCallback((operation: 'add' | 'remove') => {
-    import('../utils/haptics').then(m => m.triggerHaptic('light'));
-    if (operation === 'add') {
-      setChildren((previous) => previous + 1);
-      setChildAges((previous) => [...previous, '']);
-      return;
-    }
-
-    setChildren((previous) => (previous > 0 ? previous - 1 : 0));
-    setChildAges((previous) => (previous.length > 0 ? previous.slice(0, -1) : []));
-  }, []);
-
-  const handleChildAgeChange = useCallback((index: number, value: string) => {
-    setChildAges((previous) => {
-      const nextAges = [...previous];
-      nextAges[index] = value;
-      return nextAges;
-    });
-    import('../utils/haptics').then(m => m.triggerHaptic('light'));
-  }, []);
-
-  const handleDateClick = useCallback((date: Date) => {
-    if (isDateInPast(date)) return;
-
-    if (!startDate || endDate) {
-      setStartDate(date);
-      setEndDate(null);
-      markStarted('date');
-      return;
-    }
-
-    if (date < startDate) {
-      setStartDate(date);
-      setEndDate(startDate);
-      return;
-    }
-
-    setEndDate(date);
-    closePanel('calendar');
-  }, [startDate, endDate, closePanel, markStarted]);
-
-  const isDateSelected = useCallback((date: Date) => {
-    if (!startDate) return false;
-    if (startDate.toDateString() === date.toDateString()) return true;
-    return !!endDate && endDate.toDateString() === date.toDateString();
-  }, [startDate, endDate]);
-
-  const isDateInRange = useCallback((date: Date) => {
-    if (!startDate || !endDate) return false;
-    return date > startDate && date < endDate;
-  }, [startDate, endDate]);
-
-  const handleMonthChange = useCallback((offset: number) => {
-    setCurrentMonth((prevMonth) => {
-        const nextMonth = new Date(prevMonth);
-        nextMonth.setMonth(nextMonth.getMonth() + offset);
-
-        const today = new Date();
-        const nextYear = nextMonth.getFullYear();
-        const nextMonthIndex = nextMonth.getMonth();
-        const currentYear = today.getFullYear();
-        const currentMonthIndex = today.getMonth();
-
-        if (nextYear < currentYear || (nextYear === currentYear && nextMonthIndex < currentMonthIndex)) {
-            return prevMonth;
-        }
-
-        return nextMonth;
-    });
-  }, []);
-
-  const canGoToPreviousMonth = useMemo(() => {
-    const today = new Date();
-    return currentMonth.getFullYear() > today.getFullYear()
-      || (currentMonth.getFullYear() === today.getFullYear() && currentMonth.getMonth() > today.getMonth());
-  }, [currentMonth]);
-
-  const handleTripTypeSelect = useCallback((label: string) => {
-    setTripType(label);
-    closePanel('trip');
-  }, [closePanel]);
-
-  const revealTripType = useCallback(() => {
-    setShowTripType(true);
-  }, []);
-
-  const handleBudgetSelect = useCallback((label: string) => {
-    setBudget(label);
-    markStarted('budget');
-    closePanel('budget');
-  }, [closePanel, markStarted]);
-
-  const handleSearch = useCallback(() => {
-    if (!inputValue.trim()) {
-      if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current);
-      setValidationError("Por favor, informe o destino.");
-      pushFormAnalyticsEvent({
-        event: 'field_error',
-        formType: 'home_search',
-        formId: 'hero-search',
-        fieldName: 'destination',
-        errorType: 'required',
-      });
-      import('../utils/haptics').then(m => m.triggerHaptic('medium'));
-      errorTimeoutRef.current = setTimeout(() => setValidationError(null), 4000);
-      return;
-    }
-
-    setIsSearchLoading(true);
-    setValidationError(null);
-    pushFormAnalyticsEvent({
-      event: 'submit_attempt',
-      formType: 'home_search',
-      formId: 'hero-search',
-      destination: inputValue,
-    });
-
-    openAiChat({
-      haptic: 'medium',
-      message: buildSearchMessage({
-        inputValue,
-        startDate,
-        endDate,
-        adults,
-        children,
-        childAges,
-        tripType,
-        budget,
-      }),
-    });
-    pushFormAnalyticsEvent({
-      event: 'submit_success',
-      formType: 'home_search',
-      formId: 'hero-search',
-      destination: inputValue,
-    });
-
-    setTimeout(() => {
-      setIsSearchLoading(false);
-    }, 1000);
-  }, [inputValue, startDate, endDate, adults, children, childAges, tripType, budget]);
-
-  // This form is intentionally client-only: it opens the AI chat drawer (SPA action, no server endpoint).
-  const handleSubmit = useCallback((event: React.FormEvent) => {
-    event.preventDefault();
-    handleSearch();
-  }, [handleSearch]);
-
-  const toggleCalendar = useCallback(() => togglePanel('calendar'), [togglePanel]);
-  const toggleGuestDropdown = useCallback(() => togglePanel('guests'), [togglePanel]);
-  const closeGuestDropdown = useCallback(() => closePanel('guests'), [closePanel]);
-  const toggleTripTypeDropdown = useCallback(() => togglePanel('trip'), [togglePanel]);
-  const toggleBudgetDropdown = useCallback(() => togglePanel('budget'), [togglePanel]);
-  const onDestinationFocus = useCallback(() => {
-    setOpenPanel('dest');
-    setActiveSuggestionIndex(-1);
-  }, []);
+  const controller = useSearchFormController(onDestinationMatch);
+  const {
+    inputValue,
+    activeSuggestionIndex,
+    openPanel,
+    startDate,
+    endDate,
+    currentMonth,
+    adults,
+    children,
+    childAges,
+    tripType,
+    budget,
+    showTripType,
+    filteredDestinations,
+    calendarDays,
+    guestSummary,
+    selectedTripObj,
+    selectedBudgetObj,
+    canGoToPreviousMonth,
+    isSearchLoading,
+    validationError,
+    guestDropdownRef,
+    destRef,
+    destinationInputRef,
+    calendarRef,
+    tripTypeRef,
+    budgetRef,
+    handleSubmit,
+    handleDestinationChange,
+    handleDestinationSelect,
+    handleDestinationKeyDown,
+    handleClearDestination,
+    handleAdultsChange,
+    handleChildCountChange,
+    handleChildAgeChange,
+    handleDateClick,
+    isDateSelected,
+    isDateInRange,
+    handleMonthChange,
+    handleTripTypeSelect,
+    revealTripType,
+    handleBudgetSelect,
+    toggleCalendar,
+    toggleGuestDropdown,
+    closeGuestDropdown,
+    toggleTripTypeDropdown,
+    toggleBudgetDropdown,
+    onDestinationFocus,
+  } = controller;
 
   return (
     <form

--- a/components/ai-chat/AIChatPanelView.tsx
+++ b/components/ai-chat/AIChatPanelView.tsx
@@ -1,0 +1,367 @@
+import React, { memo } from 'react';
+import {
+  CircleNotch,
+  PaperPlaneTilt,
+  Robot,
+  Sparkle,
+  User,
+  X,
+} from '@phosphor-icons/react';
+import ReactMarkdown from 'react-markdown';
+import { ChatLeadForm } from '../ChatLeadForm';
+import { PassportStamp } from '../ui/PassportStamp';
+import type { useLeadCapture } from '../../hooks/useLeadCapture';
+import type { LeadFinalizePayload, LeadFinalizeResult } from '../../lib/chat-lead-form-logic';
+import { sanitizeAiLinkUrl } from '../../lib/ai/safe-link';
+import type { SubmitLeadRequest } from '../../types/leadCapture';
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'model';
+  text: string;
+  chips?: Array<{ id: string; label: string }>;
+  isAction?: boolean;
+  actionData?: {
+    destination: string;
+    bantSummary: string;
+    iataCode?: string;
+  };
+}
+
+interface AIChatPanelViewProps {
+  dialogRef: React.RefObject<HTMLDialogElement | null>;
+  messagesEndRef: React.RefObject<HTMLDivElement | null>;
+  inputRef: React.RefObject<HTMLTextAreaElement | null>;
+  messages: ChatMessage[];
+  lastModelIndex: number;
+  liveAnnouncement: string;
+  input: string;
+  isLoading: boolean;
+  isSubmittingLead: boolean;
+  getLeadWhatsAppUrl: ReturnType<typeof useLeadCapture>['getLeadWhatsAppUrl'];
+  prepareLeadSubmitPayload: (payload: LeadFinalizePayload, eventId: string) => SubmitLeadRequest;
+  finalizeLead: (payload: SubmitLeadRequest) => Promise<LeadFinalizeResult>;
+  onClose: () => void;
+  onInput: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onSubmitMessage: (text: string) => void;
+}
+
+/**
+ * Optimized FormattedText component.
+ *
+ * PERFORMANCE WIN: Wrapped in React.memo to prevent redundant string processing
+ * and re-renders of static message content during chat interactions.
+ */
+const FormattedText = memo(({ text }: { text: string }) => {
+  const paragraphs = text.split('\n').filter(p => p.trim() !== '').map((paragraph, idx) => {
+    const isList = paragraph.trim().startsWith('-');
+    const cleanText = isList ? paragraph.replace('-', '').trim() : paragraph;
+    const parts = cleanText.split(/(\*\*.*?\*\*)/g).map((part, i) => ({ id: `${idx}-${i}`, part }));
+    return { id: `para-${idx}-${paragraph.slice(0, 20)}`, isList, parts };
+  });
+
+  return (
+    <div className="space-y-3 font-sans">
+      {paragraphs.map(({ id, isList, parts }) => {
+        const content = parts.map(({ id: partId, part }) => {
+          if (part.startsWith('**') && part.endsWith('**')) {
+            return <strong key={partId} className="font-bold text-zinc-900">{part.slice(2, -2)}</strong>;
+          }
+          return part;
+        });
+
+        if (isList) {
+          return (
+            <div key={id} className="flex items-start gap-2 ml-1">
+              <span className="shrink-0 mt-1.5 size-1.5 bg-brand-vibrant rounded-full opacity-70"></span>
+              <span className="leading-relaxed text-zinc-700">{content}</span>
+            </div>
+          );
+        }
+
+        return <p key={id} className="leading-relaxed text-zinc-700">{content}</p>;
+      })}
+    </div>
+  );
+});
+
+FormattedText.displayName = 'FormattedText';
+
+function ChatPanelHeader({ onClose }: Pick<AIChatPanelViewProps, 'onClose'>) {
+  return (
+    <div className="bg-white/80 backdrop-blur-md px-6 py-5 border-b border-zinc-100 flex justify-between items-center shrink-0 z-10">
+      <div className="flex gap-4 items-center">
+        <div className="size-12 bg-zinc-50 rounded-[1.25rem] flex items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+          <Sparkle className="size-6 text-brand-vibrant" weight="fill" />
+        </div>
+        <div>
+          <h2 id="ai-chat-title" className="font-extrabold text-lg text-brand-dark tracking-tight leading-none">
+            Hub Anhangá
+          </h2>
+          <div className="flex items-center gap-1.5 mt-1 opacity-80">
+            <span className="relative flex size-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full size-2 bg-green-400"></span>
+            </span>
+            <span className="text-xs font-bold text-zinc-500 uppercase tracking-widest">
+              Assistente Online
+            </span>
+          </div>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="text-zinc-400 hover:text-zinc-700 bg-zinc-50 hover:bg-zinc-100 rounded-full p-3 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant"
+        aria-label="Fechar gaveta"
+      >
+        <X className="size-6" weight="bold" />
+      </button>
+    </div>
+  );
+}
+
+type ChatMessageListProps = Pick<AIChatPanelViewProps,
+  | 'messagesEndRef'
+  | 'messages'
+  | 'lastModelIndex'
+  | 'liveAnnouncement'
+  | 'isLoading'
+  | 'isSubmittingLead'
+  | 'getLeadWhatsAppUrl'
+  | 'prepareLeadSubmitPayload'
+  | 'finalizeLead'
+  | 'onSubmitMessage'
+>;
+
+function ChatMessageList({
+  messagesEndRef,
+  messages,
+  lastModelIndex,
+  liveAnnouncement,
+  isLoading,
+  isSubmittingLead,
+  getLeadWhatsAppUrl,
+  prepareLeadSubmitPayload,
+  finalizeLead,
+  onSubmitMessage,
+}: ChatMessageListProps) {
+  return (
+    <>
+      {/* Screen-reader announcer for new AI messages */}
+      <output aria-live="polite" aria-atomic="true" className="sr-only">
+        {liveAnnouncement}
+      </output>
+
+      {/* Messages Area - Scrapbook vibe */}
+      <div className="flex-1 overflow-y-auto p-6 space-y-6 scroll-smooth bg-white relative">
+        {/* Fundo suave */}
+        <div className="absolute inset-0 opacity-[0.03] pointer-events-none" style={{ backgroundImage: 'radial-gradient(circle at 1px 1px, black 1px, transparent 0)', backgroundSize: '32px 32px' }}></div>
+
+        {messages.map((msg, idx) => {
+          const isLastModelMsg = msg.role === 'model' && idx === lastModelIndex;
+
+          return (
+            <div key={msg.id} className={`relative flex flex-col gap-2 ${msg.role === 'user' ? 'items-end' : 'items-start'} z-10`}>
+              <div className={`flex items-end gap-3 max-w-[90%] ${msg.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}>
+                {/* Avatar */}
+                <div className={`size-9 flex items-center justify-center shrink-0 rounded-full shadow-sm ${msg.role === 'user'
+                  ? 'bg-brand-dark text-white'
+                  : 'bg-white text-brand-vibrant border border-zinc-100'
+                  }`}>
+                  {msg.role === 'user' ? <User className="size-4" weight="fill" /> : <Robot className="size-5" weight="fill" />}
+                </div>
+
+                {/* Bubble */}
+                {msg.isAction ? (
+                  <div className="w-full relative mt-3 pt-4">
+                    {/* Passport Stamp Overlay */}
+                    <PassportStamp
+                      destination={msg.actionData?.destination || 'Viagem'}
+                      iataCode={msg.actionData?.iataCode}
+                      className="absolute top-[-25px] right-[-10px] sm:right-[5px] pointer-events-none"
+                    />
+                    <ChatLeadForm
+                      destination={msg.actionData?.destination}
+                      defaultBantSummary={msg.actionData?.bantSummary}
+                      getWhatsAppUrl={getLeadWhatsAppUrl}
+                      prepareLeadSubmitPayload={prepareLeadSubmitPayload}
+                      onFinalizeLead={finalizeLead}
+                      isSubmittingLead={isSubmittingLead}
+                    />
+                  </div>
+                ) : (
+                  <div
+                    data-testid={msg.role === 'user' ? 'chat-user-message' : undefined}
+                    className={`p-4 text-sm shadow-sm ${msg.role === 'user'
+                    ? 'bg-brand-vibrant text-white rounded-2xl rounded-br-sm'
+                    : 'bg-white text-zinc-800 border border-zinc-100 rounded-2xl rounded-bl-sm'
+                    }`}>
+                    {msg.role === 'model' ? (
+                      <div className="prose prose-sm max-w-none prose-p:text-zinc-700 prose-p:leading-relaxed prose-strong:text-zinc-900 prose-strong:font-bold prose-ul:text-zinc-700">
+                        <ReactMarkdown
+                          urlTransform={sanitizeAiLinkUrl}
+                          components={{
+                            a: ({ href, children, ...props }) => {
+                              if (!href) return <span>{children}</span>;
+                              // Internal SPA links stay in-tab; external (allowlisted)
+                              // links open in a new tab to preserve chat state.
+                              const isInternal = href.startsWith('/') && !href.startsWith('//');
+                              return (
+                                <a
+                                  href={href}
+                                  rel="noopener noreferrer"
+                                  target={isInternal ? undefined : '_blank'}
+                                  {...props}
+                                >
+                                  {children}
+                                </a>
+                              );
+                            },
+                          }}
+                        >
+                          {msg.text}
+                        </ReactMarkdown>
+                      </div>
+                    ) : (
+                      <div className="text-white font-medium leading-relaxed max-w-[300px] break-words">
+                        <FormattedText text={msg.text} />
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {/* Action Chips */}
+              {isLastModelMsg && msg.chips && msg.chips.length > 0 && (
+                <div className="flex flex-wrap gap-2 pl-12 mt-1">
+                  {msg.chips.map((chip) => (
+                    <button
+                      type="button"
+                      key={chip.id}
+                      onClick={() => onSubmitMessage(chip.label)}
+                      className="text-[13px] font-semibold text-zinc-600 bg-white border border-zinc-200 px-4 py-3 min-h-12 rounded-xl shadow-sm hover:shadow hover:border-brand-vibrant/30 hover:text-brand-vibrant hover:-translate-y-0.5 transition text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-vibrant/50"
+                    >
+                      {chip.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {isLoading && (
+          <div data-testid="chat-typing-indicator" className="flex items-end gap-3 z-10 relative">
+            <div className="size-9 bg-white rounded-full border border-zinc-100 text-brand-vibrant flex items-center justify-center shadow-sm">
+              <Robot className="size-5" weight="fill" />
+            </div>
+            <div className="bg-white px-4 py-3 border border-zinc-100 rounded-2xl rounded-bl-sm shadow-sm flex items-center gap-2.5">
+              <CircleNotch className="size-4 animate-spin text-brand-vibrant" weight="bold" />
+              <span className="text-xs font-medium text-zinc-400">Anhangá digitando…</span>
+            </div>
+          </div>
+        )}
+        <div ref={messagesEndRef} className="h-2" />
+      </div>
+    </>
+  );
+}
+
+type ChatComposerProps = Pick<AIChatPanelViewProps,
+  | 'inputRef'
+  | 'input'
+  | 'isLoading'
+  | 'onInput'
+  | 'onKeyDown'
+  | 'onSubmitMessage'
+>;
+
+function ChatComposer({
+  inputRef,
+  input,
+  isLoading,
+  onInput,
+  onKeyDown,
+  onSubmitMessage,
+}: ChatComposerProps) {
+  return (
+    <div className="p-4 sm:p-5 bg-white border-t border-zinc-100 shrink-0 z-10 shadow-[0_-4px_20px_rgba(0,0,0,0.02)]">
+      <div className="relative flex items-end bg-zinc-50 border border-zinc-200 rounded-2xl focus-within:border-brand-vibrant/40 focus-within:bg-white focus-within:ring-4 focus-within:ring-brand-vibrant/10 transition">
+        <label htmlFor="chat-textarea" className="sr-only">Sua mensagem</label>
+        <textarea
+          id="chat-textarea"
+          ref={inputRef}
+          value={input}
+          onChange={onInput}
+          onKeyDown={onKeyDown}
+          placeholder="Digite sua dúvida aqui..."
+          rows={1}
+          className="flex-1 max-h-[120px] pl-4 pr-[50px] py-4 bg-transparent outline-none text-sm text-zinc-700 font-medium placeholder-zinc-400 resize-none overflow-y-auto w-full leading-snug"
+        />
+        <button
+          type="button"
+          onClick={() => onSubmitMessage(input)}
+          disabled={isLoading || !input.trim()}
+          className="absolute right-2 bottom-1 min-h-12 min-w-12 flex items-center justify-center bg-brand-vibrant text-white rounded-[10px] shadow-sm hover:bg-brand-blue hover:shadow-md transition disabled:opacity-0 disabled:scale-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-vibrant/50"
+          aria-label="Enviar mensagem"
+        >
+          <PaperPlaneTilt className="size-5 ml-0.5" weight="fill" />
+        </button>
+      </div>
+      <p className="text-center text-[10px] text-zinc-400 mt-2">
+        Nossa IA pode cometer erros. Confirme os dados no WhatsApp.
+      </p>
+    </div>
+  );
+}
+
+export function AIChatPanelView({
+  dialogRef,
+  messagesEndRef,
+  inputRef,
+  messages,
+  lastModelIndex,
+  liveAnnouncement,
+  input,
+  isLoading,
+  isSubmittingLead,
+  getLeadWhatsAppUrl,
+  prepareLeadSubmitPayload,
+  finalizeLead,
+  onClose,
+  onInput,
+  onKeyDown,
+  onSubmitMessage,
+}: AIChatPanelViewProps) {
+  return (
+    <dialog
+      ref={dialogRef}
+      className="ai-chat-drawer fixed top-0 right-0 h-full w-full sm:w-[450px] z-[9999] m-0 ml-auto p-0 bg-white flex-col shadow-[-10px_0_40px_rgba(0,0,0,0.1)] sm:rounded-l-[2rem] overflow-hidden outline-none max-h-full max-w-full"
+      aria-labelledby="ai-chat-title"
+    >
+      <ChatPanelHeader onClose={onClose} />
+      <ChatMessageList
+        messagesEndRef={messagesEndRef}
+        messages={messages}
+        lastModelIndex={lastModelIndex}
+        liveAnnouncement={liveAnnouncement}
+        isLoading={isLoading}
+        isSubmittingLead={isSubmittingLead}
+        getLeadWhatsAppUrl={getLeadWhatsAppUrl}
+        prepareLeadSubmitPayload={prepareLeadSubmitPayload}
+        finalizeLead={finalizeLead}
+        onSubmitMessage={onSubmitMessage}
+      />
+      <ChatComposer
+        inputRef={inputRef}
+        input={input}
+        isLoading={isLoading}
+        onInput={onInput}
+        onKeyDown={onKeyDown}
+        onSubmitMessage={onSubmitMessage}
+      />
+    </dialog>
+  );
+}

--- a/components/destinations/DestinationsView.tsx
+++ b/components/destinations/DestinationsView.tsx
@@ -1,0 +1,306 @@
+import type { RefObject } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowRight, Compass, MapPin, Minus, Plus, Star, X } from 'lucide-react';
+import { SocialShare } from '../SocialShare';
+import { LazyImage } from '../ui/LazyImage';
+import { openContactModal } from '../../utils/contactForm';
+import { NOISE_TEXTURE_URL } from '../../lib/static-assets';
+import { FILTERS, type Destination } from '../../data/mapDestinations';
+
+const noiseTextureStyle = {
+    backgroundImage: `url("${NOISE_TEXTURE_URL}")`,
+};
+
+interface DestinationsHeaderProps {
+    activeFilter: string;
+    onFilterChange: (filter: string) => void;
+}
+
+function DestinationsHeader({ activeFilter, onFilterChange }: DestinationsHeaderProps) {
+    return (
+        <div className="flex flex-col md:flex-row justify-between items-end mb-12">
+            <div>
+                <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-dashed border-brand-dark bg-yellow-100 text-brand-dark font-black text-xs uppercase tracking-widest shadow-sm transform -rotate-1 mb-4">
+                    <Compass className="size-4" /> Mapa Mundi
+                </div>
+                <h2 className="text-4xl font-black text-brand-dark">Escolha seu <span className="text-brand-cyan relative inline-block">Pin 📍<svg className="absolute w-full h-3 -bottom-1 left-0 text-brand-cyan opacity-40" viewBox="0 0 100 10" preserveAspectRatio="none"><path d="M0 5 Q 50 10 100 5" stroke="currentColor" strokeWidth="4" fill="none" /></svg></span></h2>
+            </div>
+
+            {/* Filter Pills - Sticker Style */}
+            <div className="flex overflow-x-auto hide-scrollbar gap-3 pb-2 md:pb-0 w-full md:w-auto mt-6 md:mt-0 px-1">
+                {FILTERS.map(filter => (
+                    <button
+                        key={filter}
+                        type="button"
+                        onClick={() => onFilterChange(filter)}
+                        className={`px-5 py-2 rounded-lg text-sm font-bold border-2 transition whitespace-nowrap flex-shrink-0 shadow-[3px_3px_0px_rgba(0,0,0,0.1)] active:shadow-none active:translate-x-[2px] active:translate-y-[2px] ${activeFilter === filter
+                            ? 'bg-brand-dark text-white border-brand-dark transform -rotate-1'
+                            : 'bg-white text-zinc-600 border-zinc-100 hover:border-brand-vibrant hover:text-brand-vibrant'
+                            }`}
+                    >
+                        {filter}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+interface DestinationMapFrameProps {
+    mapRef: RefObject<HTMLDivElement | null>;
+    onZoom: (type: 'in' | 'out') => void;
+}
+
+function DestinationMapFrame({ mapRef, onZoom }: DestinationMapFrameProps) {
+    return (
+        <div className="relative mb-16 px-2">
+            {/* The Map Frame */}
+            <div className="relative w-full h-[500px] bg-white p-3 shadow-[0_20px_60px_-10px_rgba(0,0,0,0.2)] transform rotate-1 transition-transform duration-500 hover:rotate-0 group">
+                {/* Washi Tapes */}
+                <div className="absolute -top-3 -left-3 w-32 h-8 bg-red-400/80 rotate-[-45deg] z-30 backdrop-blur-sm shadow-sm opacity-90 border-l border-r border-white/30"></div>
+                <div className="absolute -bottom-3 -right-3 w-32 h-8 bg-brand-cyan/80 rotate-[-45deg] z-30 backdrop-blur-sm shadow-sm opacity-90 border-l border-r border-white/30"></div>
+                <div className="absolute -top-3 right-10 w-24 h-8 bg-yellow-400/80 rotate-[10deg] z-30 backdrop-blur-sm shadow-sm opacity-90 border-l border-r border-white/30"></div>
+
+                {/* Map Inner Border & Content */}
+                <div className="w-full h-full border-2 border-zinc-100 overflow-hidden relative bg-[#FAFAFA]">
+                    {/* Paper Texture Overlay */}
+                    <div className="absolute inset-0 z-[5] pointer-events-none opacity-[0.15] mix-blend-multiply" style={noiseTextureStyle}></div>
+
+                    {/* Inner Shadow for Depth */}
+                    <div className="absolute inset-0 z-[5] pointer-events-none shadow-[inset_0_0_40px_rgba(0,0,0,0.1)]"></div>
+
+                    <div ref={mapRef} className="w-full h-full z-0" />
+
+                    {/* Mobile Hint */}
+                    <div className="md:hidden absolute bottom-4 left-1/2 -translate-x-1/2 bg-white/90 backdrop-blur-sm px-4 py-2 rounded-full text-[10px] font-bold text-zinc-500 pointer-events-none z-[400] shadow-md border border-zinc-200">
+                        Use dois dedos para mover
+                    </div>
+                </div>
+
+                {/* Custom Controls (Stickers) */}
+                <div className="absolute bottom-6 right-6 flex flex-col gap-2 z-[400]">
+                    <button
+                        type="button"
+                        onClick={() => onZoom('in')}
+                        className="size-12 bg-white border-2 border-zinc-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition text-zinc-700 font-black"
+                        aria-label="Aumentar zoom no mapa"
+                    >
+                        <Plus className="size-5" />
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => onZoom('out')}
+                        className="size-12 bg-white border-2 border-zinc-200 rounded-full flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition text-zinc-700 font-black"
+                        aria-label="Diminuir zoom no mapa"
+                    >
+                        <Minus className="size-5" />
+                    </button>
+                </div>
+
+                {/* "Note" Sticker */}
+                <div className="hidden md:block absolute top-8 left-8 bg-yellow-100 p-4 rounded-sm shadow-md transform -rotate-3 z-[400] max-w-[150px] border border-yellow-200">
+                    <div className="size-3 rounded-full bg-red-400 mx-auto -mt-6 mb-2 shadow-sm border border-red-500"></div>
+                    <p className="font-serif italic text-zinc-700 text-sm leading-tight text-center">
+                        "O mundo é um livro e quem não viaja lê apenas uma página."
+                        <span className="block not-italic text-zinc-400 text-xs mt-1">(Santo Agostinho)</span>
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+interface DestinationCardsProps {
+    destinations: Destination[];
+    onDestinationSelect: (destination: Destination) => void;
+}
+
+function DestinationCards({ destinations, onDestinationSelect }: DestinationCardsProps) {
+    return (
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {destinations.slice(0, 3).map((destination) => (
+                <button
+                    type="button"
+                    key={`${destination.city}-${destination.country}`}
+                    aria-label={`Ver detalhes de ${destination.city}, ${destination.country}`}
+                    className="group bg-white rounded-[2rem] border-2 border-zinc-100 p-4 pb-0 shadow-[6px_6px_0px_rgba(0,0,0,0.05)] hover:shadow-[10px_10px_0px_rgba(0,0,0,0.08)] hover:-translate-y-2 transition cursor-pointer flex flex-col focus:outline-none focus-visible:ring-4 focus-visible:ring-brand-cyan w-full text-left"
+                    onClick={() => onDestinationSelect(destination)}
+                >
+                    <div className="relative h-56 rounded-[1.5rem] overflow-hidden mb-4 border border-zinc-100">
+                        <LazyImage
+                            src={destination.image}
+                            alt={`${destination.city}, ${destination.country} — pacote de viagem personalizado Anhangá Viagens`}
+                            width={600}
+                            height={400}
+                            className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
+                        />
+
+                        {/* Price Tag Sticker */}
+                        <div className="absolute top-4 right-4 bg-white text-brand-dark font-black px-3 py-1 rounded-md shadow-[3px_3px_0px_rgba(0,0,0,0.2)] text-sm rotate-3 group-hover:rotate-6 transition-transform border border-zinc-100">
+                            A partir de {destination.price}
+                        </div>
+                    </div>
+
+                    <div className="px-2 pb-6">
+                        <div className="flex justify-between items-center mb-2">
+                            <h3 className="text-2xl font-black text-zinc-800">{destination.city}</h3>
+                            <div className="flex items-center gap-1 text-yellow-500 font-bold text-sm bg-yellow-50 px-2 py-1 rounded-full border border-yellow-100">
+                                <Star className="size-3 fill-current" /> {destination.rating}
+                            </div>
+                        </div>
+                        <p className="text-zinc-500 text-sm font-medium mb-4">{destination.description}</p>
+
+                        <div className="flex items-center gap-2 text-brand-cyan font-bold text-sm uppercase tracking-wide group-hover:gap-3 transition-[gap,color]">
+                            Saiba Mais <ArrowRight className="size-4" />
+                        </div>
+                    </div>
+                </button>
+            ))}
+        </div>
+    );
+}
+
+interface DestinationDialogProps {
+    destination: Destination | null;
+    destinationModalRef: RefObject<HTMLDialogElement | null>;
+    onCloseModal: () => void;
+}
+
+function DestinationDialog({ destination, destinationModalRef, onCloseModal }: DestinationDialogProps) {
+    return (
+        <dialog
+            ref={destinationModalRef}
+            className="fixed inset-0 z-[9999] m-auto p-4 bg-transparent backdrop:bg-zinc-900/60 backdrop:backdrop-blur-sm max-w-4xl w-full"
+            aria-labelledby="dest-modal-title"
+        >
+            {destination && (
+                <div
+                    className="bg-brand-surface w-full rounded-[2.5rem] shadow-2xl overflow-hidden relative flex flex-col md:flex-row max-h-[90vh] border-8 border-white transform rotate-1"
+                >
+                    {/* Washi Tape Decor */}
+                    <div className="absolute -top-6 left-1/2 -translate-x-1/2 w-32 h-10 bg-red-400/80 rotate-1 backdrop-blur-sm z-20 shadow-sm border-l-2 border-r-2 border-white/40"></div>
+
+                    <button
+                        type="button"
+                        onClick={onCloseModal}
+                        className="absolute top-4 right-4 z-30 bg-white border-2 border-zinc-100 p-2 rounded-full shadow-md hover:scale-110 transition-transform text-zinc-800"
+                        aria-label="Fechar detalhes do destino"
+                    >
+                        <X className="size-5" />
+                    </button>
+
+                    <div className="w-full md:w-1/2 h-64 md:h-auto relative bg-zinc-100">
+                        <LazyImage
+                            src={destination.image}
+                            alt={destination.city}
+                            width={1200}
+                            height={800}
+                            className="w-full h-full object-cover"
+                        />
+                        <div className="absolute bottom-0 left-0 w-full h-32 bg-gradient-to-t from-black/60 to-transparent"></div>
+                        <div className="absolute bottom-6 left-6 text-white">
+                            <h2 id="dest-modal-title" className="text-4xl font-black mb-1 drop-shadow-md">{destination.city}</h2>
+                            <div className="flex items-center gap-2 font-medium opacity-90 drop-shadow-sm">
+                                <MapPin className="size-4" /> {destination.country}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="w-full md:w-1/2 p-8 md:p-10 overflow-y-auto" style={noiseTextureStyle}>
+                        <p className="text-zinc-600 mb-8 text-lg leading-relaxed font-medium font-serif italic">"{destination.details}"</p>
+
+                        <h4 className="font-black text-zinc-900 mb-4 flex items-center gap-2">
+                            <Star className="size-5 text-yellow-400 fill-current" /> Atrações Imperdíveis
+                        </h4>
+                        <div className="flex flex-wrap gap-3 mb-8">
+                            {destination.activities.map((activity) => (
+                                <span key={activity} className="bg-white border-2 border-zinc-100 px-4 py-2 rounded-xl text-sm text-zinc-700 font-bold shadow-sm transform hover:-rotate-1 transition-transform cursor-default">
+                                    {activity}
+                                </span>
+                            ))}
+                        </div>
+
+                        <div className="mb-8 p-4 bg-white/50 rounded-2xl border border-zinc-100">
+                            <p className="text-sm font-bold text-zinc-400 uppercase tracking-widest mb-3">Compartilhar destino</p>
+                            <SocialShare
+                                url="https://www.anhanga.tur.br/#destinos"
+                                title={`Confira esse destino na Anhangá Viagens: ${destination.city}`}
+                                excerpt={destination.details}
+                            />
+                        </div>
+
+                        <div className="flex flex-col gap-3">
+                            {destination.landingPage && (
+                                <Link
+                                    to={destination.landingPage}
+                                    onClick={onCloseModal}
+                                    className="w-full bg-white border-2 border-brand-dark text-brand-dark py-4 rounded-xl font-black text-lg hover:bg-zinc-50 transition shadow-[4px_4px_0px_#0f172a] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2"
+                                >
+                                    Ver detalhes do pacote <ArrowRight className="size-5" />
+                                </Link>
+                            )}
+                            <button
+                                type="button"
+                                onClick={(event) => {
+                                    event.preventDefault();
+                                    openContactModal({
+                                        source: 'destinations-modal',
+                                        destination: destination.city,
+                                    });
+                                    onCloseModal();
+                                }}
+                                className={`btn-whatsapp btn-specialist w-full bg-brand-dark text-white py-4 rounded-xl font-black text-lg hover:bg-brand-vibrant transition shadow-[4px_4px_0px_#94a3b8] active:shadow-none active:translate-y-1 flex items-center justify-center gap-2`}
+                                data-tracking={`modal-destinations-${destination.city.toLowerCase()}`}
+                            >
+                                Solicitar Orçamento
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </dialog>
+    );
+}
+
+export interface DestinationsViewProps {
+    activeFilter: string;
+    filteredDestinations: Destination[];
+    selectedDestination: Destination | null;
+    mapRef: RefObject<HTMLDivElement | null>;
+    destinationModalRef: RefObject<HTMLDialogElement | null>;
+    onFilterChange: (filter: string) => void;
+    onDestinationSelect: (destination: Destination) => void;
+    onCloseModal: () => void;
+    onZoom: (type: 'in' | 'out') => void;
+}
+
+export function DestinationsView({
+    activeFilter,
+    filteredDestinations,
+    selectedDestination,
+    mapRef,
+    destinationModalRef,
+    onFilterChange,
+    onDestinationSelect,
+    onCloseModal,
+    onZoom,
+}: DestinationsViewProps) {
+    return (
+        <section id="destinos" className="py-24 bg-brand-surface relative overflow-hidden">
+            {/* Background Doodles */}
+            <div className="absolute top-0 right-0 w-full h-full opacity-[0.03] pointer-events-none z-0" style={{ backgroundImage: 'radial-gradient(circle at 1px 1px, black 1px, transparent 0)', backgroundSize: '40px 40px' }}></div>
+
+            <div className="container mx-auto px-6 relative z-10">
+                <DestinationsHeader activeFilter={activeFilter} onFilterChange={onFilterChange} />
+                <DestinationMapFrame mapRef={mapRef} onZoom={onZoom} />
+                <DestinationCards destinations={filteredDestinations} onDestinationSelect={onDestinationSelect} />
+            </div>
+
+            <DestinationDialog
+                destination={selectedDestination}
+                destinationModalRef={destinationModalRef}
+                onCloseModal={onCloseModal}
+            />
+        </section>
+    );
+}

--- a/components/destinations/useDestinationMap.ts
+++ b/components/destinations/useDestinationMap.ts
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useRef } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { CONTINENT_COLORS, type Destination } from '../../data/mapDestinations';
+
+const MARKER_STYLE_ID = 'leaflet-marker-anim-styles';
+
+function ensureMarkerStyles() {
+    if (document.getElementById(MARKER_STYLE_ID)) return;
+
+    const style = document.createElement('style');
+    style.id = MARKER_STYLE_ID;
+    style.innerHTML = `
+            @keyframes bounce-in { 0% { opacity: 0; transform: scale(0.3) translateY(-10px); } 50% { opacity: 1; transform: scale(1.1) translateY(5px); } 70% { transform: scale(0.95) translateY(-2px); } 100% { opacity: 1; transform: scale(1) translateY(0); } }
+            @keyframes pin-shadow-pulse { 0% { opacity: 0.3; transform: scale(0.8); } 100% { opacity: 0.5; transform: scale(1.1); } }
+
+            /* CUSTOM STICKER MARKER */
+            .custom-marker-container { position: relative; display: flex; align-items: flex-end; justify-content: center; cursor: pointer; filter: drop-shadow(0px 4px 6px rgba(0,0,0,0.3)); }
+
+            /* Pin Animation */
+            .pin-animated { animation: bounce-in 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards; transform-origin: bottom center; }
+
+            /* Pin Shadow on Map */
+            .pin-shadow { position: absolute; bottom: 0px; width: 60%; height: 15%; background: black; border-radius: 50%; opacity: 0.3; filter: blur(3px); z-index: -1; transform: translateY(2px); animation: pin-shadow-pulse 2s infinite alternate; }
+
+            .leaflet-div-icon { background: transparent; border: none; }
+
+            /* Tooltip "Handwritten" Style - Updated for better Portuguese legibility */
+            .custom-dest-tooltip {
+                background-color: #ffffff !important;
+                color: #0f172a !important;
+                font-family: 'Poppins', sans-serif !important;
+                font-weight: 700 !important;
+                font-size: 14px !important;
+                border: 2px solid #fff !important;
+                box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06) !important;
+                border-radius: 8px !important;
+                padding: 6px 12px !important;
+                white-space: nowrap;
+                transform: rotate(-1deg);
+            }
+            .leaflet-tooltip-top.custom-dest-tooltip::before { border-top-color: #ffffff !important; }
+
+            /* MAP TILE STYLING - CartoDB Voyager (Clean, No strong borders) */
+            .leaflet-tile-pane {
+                /* High saturation to keep it fun, contrast for clarity */
+                filter: contrast(1.05) saturate(1.2);
+            }
+            /* Background matches Voyager water color */
+            .leaflet-container { background: #FAFAFA; font-family: 'Poppins', sans-serif; }
+
+            /* Hide Default Zoom Controls to replace with custom stickers */
+            .leaflet-control-zoom { display: none !important; }
+        `;
+    document.head.appendChild(style);
+}
+
+function createDestinationIcon(destination: Destination, index: number, isMobile: boolean) {
+    const markerWidth = isMobile ? 32 : 36;
+    const markerHeight = isMobile ? 48 : 54;
+    const baseColor = CONTINENT_COLORS[destination.continent] || '#0ea5e9';
+
+    return {
+        icon: L.divIcon({
+            className: 'bg-transparent border-none',
+            html: `
+                <div class="custom-marker-container" style="width: ${markerWidth}px; height: ${markerHeight}px;">
+                    <div class="pin-animated" style="animation-delay: ${index * 50}ms; opacity: 0; width: 100%; height: 100%;">
+                         <svg viewBox="0 0 32 48" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 100%; height: 100%; filter: drop-shadow(0 2px 3px rgba(0,0,0,0.2));">
+                            <!-- Stick -->
+                            <path d="M16 30V48" stroke="#555" stroke-width="2" stroke-linecap="round"/>
+                            <!-- Head -->
+                            <circle cx="16" cy="16" r="15" fill="${baseColor}" stroke="white" stroke-width="3"/>
+                            <!-- Inner Shine/Dot -->
+                            <circle cx="16" cy="16" r="5" fill="white"/>
+                            <!-- Reflection -->
+                            <path d="M16 4 Q 24 4 26 8" stroke="white" stroke-width="2" opacity="0.4" fill="none" stroke-linecap="round"/>
+                         </svg>
+                    </div>
+                    <div class="pin-shadow" style="width: 40%; height: 8%; opacity: 0.2;"></div>
+                </div>
+            `,
+            iconSize: [markerWidth, markerHeight],
+            iconAnchor: [markerWidth / 2, markerHeight],
+            popupAnchor: [0, -markerHeight],
+        }),
+        markerHeight,
+    };
+}
+
+export function useDestinationMap(
+    filteredDestinations: Destination[],
+    onSelect: (destination: Destination) => void,
+) {
+    const mapRef = useRef<HTMLDivElement>(null);
+    const mapInstance = useRef<L.Map | null>(null);
+    const markersLayerRef = useRef<L.FeatureGroup | null>(null);
+
+    useEffect(() => {
+        if (!mapRef.current || mapInstance.current) return;
+
+        const isMobile = window.innerWidth < 768;
+        ensureMarkerStyles();
+
+        const map = L.map(mapRef.current, {
+            scrollWheelZoom: false,
+            zoomControl: false,
+            dragging: !isMobile,
+            touchZoom: true,
+            zoomSnap: 0.5,
+            zoomDelta: 0.5
+        }).setView([20, -40], 3);
+        const markersLayer = L.featureGroup().addTo(map);
+
+        mapInstance.current = map;
+        markersLayerRef.current = markersLayer;
+
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+            maxZoom: 20
+        }).addTo(map);
+
+        return () => {
+            if (markersLayerRef.current === markersLayer) {
+                markersLayerRef.current = null;
+            }
+            if (mapInstance.current === map) {
+                mapInstance.current = null;
+            }
+            map.remove();
+        };
+    }, []);
+
+    useEffect(() => {
+        const map = mapInstance.current;
+        const markersLayer = markersLayerRef.current;
+        if (!map || !markersLayer) return;
+
+        markersLayer.clearLayers();
+        const destinationsByMarker = new Map<L.Marker, Destination>();
+        const isMobile = window.innerWidth < 768;
+
+        const handleMarkerClick = (event: L.LeafletMouseEvent) => {
+            const destination = destinationsByMarker.get(event.propagatedFrom as L.Marker);
+            if (!destination) return;
+
+            L.DomEvent.stopPropagation(event);
+            onSelect(destination);
+        };
+
+        filteredDestinations.forEach((destination, index) => {
+            const { icon, markerHeight } = createDestinationIcon(destination, index, isMobile);
+            const marker = L.marker(destination.coords, {
+                icon,
+                riseOnHover: true,
+                zIndexOffset: 100
+            });
+
+            marker.bindTooltip(destination.city, {
+                direction: 'top',
+                offset: [0, -(markerHeight + 5)],
+                className: 'custom-dest-tooltip',
+                permanent: false
+            });
+
+            destinationsByMarker.set(marker, destination);
+            marker.addTo(markersLayer);
+        });
+
+        markersLayer.on('click', handleMarkerClick);
+
+        let flyTimer: ReturnType<typeof setTimeout> | undefined;
+        if (markersLayer.getLayers().length > 0) {
+            flyTimer = setTimeout(() => {
+                try {
+                    map.invalidateSize();
+                    const bounds = markersLayer.getBounds();
+                    if (bounds.isValid()) {
+                        map.flyToBounds(bounds, {
+                            padding: isMobile ? [40, 40] : [80, 80],
+                            duration: 1.5,
+                            maxZoom: 5
+                        });
+                    }
+                } catch {
+                    return;
+                }
+            }, 100);
+        }
+
+        return () => {
+            if (flyTimer !== undefined) clearTimeout(flyTimer);
+            markersLayer.off('click', handleMarkerClick);
+            destinationsByMarker.clear();
+            markersLayer.clearLayers();
+        };
+    }, [filteredDestinations, onSelect]);
+
+    const handleZoom = useCallback((type: 'in' | 'out') => {
+        const map = mapInstance.current;
+        if (!map) return;
+
+        if (type === 'in') map.zoomIn();
+        else map.zoomOut();
+    }, []);
+
+    return { mapRef, handleZoom };
+}

--- a/components/destinations/useDestinationMap.ts
+++ b/components/destinations/useDestinationMap.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import { removeLeafletMapAfterActiveZoom } from '@/components/maps/removeLeafletMapAfterActiveZoom';
 import { CONTINENT_COLORS, type Destination } from '../../data/mapDestinations';
 
 const MARKER_STYLE_ID = 'leaflet-marker-anim-styles';
@@ -99,6 +100,13 @@ export function useDestinationMap(
     useEffect(() => {
         if (!mapRef.current || mapInstance.current) return;
 
+        let zoomInProgress = false;
+        const handleZoomStart = () => {
+            zoomInProgress = true;
+        };
+        const handleZoomEnd = () => {
+            zoomInProgress = false;
+        };
         const isMobile = window.innerWidth < 768;
         ensureMarkerStyles();
 
@@ -111,6 +119,8 @@ export function useDestinationMap(
             zoomDelta: 0.5
         }).setView([20, -40], 3);
         const markersLayer = L.featureGroup().addTo(map);
+        map.on('zoomstart', handleZoomStart);
+        map.on('zoomend', handleZoomEnd);
 
         mapInstance.current = map;
         markersLayerRef.current = markersLayer;
@@ -121,13 +131,16 @@ export function useDestinationMap(
         }).addTo(map);
 
         return () => {
+            const shouldWaitForZoomEnd = zoomInProgress;
+            map.off('zoomstart', handleZoomStart);
+            map.off('zoomend', handleZoomEnd);
             if (markersLayerRef.current === markersLayer) {
                 markersLayerRef.current = null;
             }
             if (mapInstance.current === map) {
                 mapInstance.current = null;
             }
-            map.remove();
+            removeLeafletMapAfterActiveZoom(map, shouldWaitForZoomEnd);
         };
     }, []);
 

--- a/components/landings/consultoria/ConsultoriaLandingSections.tsx
+++ b/components/landings/consultoria/ConsultoriaLandingSections.tsx
@@ -1,0 +1,439 @@
+import { Link } from 'react-router-dom';
+import { m } from 'framer-motion';
+import { ArrowRight, CheckCircle, MessageSquare, Users, Headphones, Compass } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { LazyImage } from '@/components/ui/LazyImage';
+import { fadeUp } from '@/components/landings/shared/constants';
+import { openContactModal } from '@/utils/contactForm';
+import { getDestinationImage } from '@/data/mediaConfig';
+
+// 4 itens, não 5: chunking ≤4 do critique — os antigos itens 4 e 5
+// ("viajantes frequentes" / "profissionais sem tempo") eram o mesmo perfil.
+const FOR_WHO = [
+  'Quem quer viajar bem sem precisar cuidar de cada detalhe',
+  'Famílias que buscam conforto e segurança no roteiro',
+  'Casais planejando viagem especial ou lua de mel',
+  'Viajantes frequentes sem tempo de pesquisar e comparar opções',
+];
+
+const HOW_IT_WORKS = [
+  {
+    step: '01',
+    title: 'Conversa inicial',
+    // Não prometer "sem formulário": o CTA da página abre o ContactModal, que
+    // é um formulário — Riley pegava a contradição na hora. Ver critique.
+    desc: 'Você fala com um consultor e conta o que precisa. Uma conversa de verdade, sem burocracia.'
+  },
+  {
+    step: '02',
+    title: 'Roteiro personalizado',
+    desc: 'Em até 5 dias úteis, você recebe um roteiro feito do zero para o seu perfil.'
+  },
+  {
+    step: '03',
+    title: 'Suporte durante a viagem',
+    desc: 'WhatsApp 24h com o mesmo consultor. Qualquer imprevisto tem resposta imediata.'
+  },
+];
+
+const PILLARS = [
+  {
+    icon: MessageSquare,
+    title: 'Sem pacote pronto',
+    desc: 'Cada roteiro começa do zero, no perfil de quem vai viajar. Nada de escolher entre opções genéricas.',
+    variant: 'light' as const
+  },
+  {
+    icon: Users,
+    title: 'Atendimento humano',
+    desc: 'Um consultor real do início ao fim. Não um chatbot, não uma central de atendimento.',
+    variant: 'filled' as const
+  },
+  {
+    icon: Headphones,
+    title: 'Suporte completo',
+    desc: 'Antes, durante e depois da viagem. WhatsApp direto com seu consultor para qualquer imprevisto.',
+    variant: 'light' as const
+  },
+];
+
+const CREDENTIALS = [
+  'Fundada em 2018',
+  'Nota 5.0 no Google',
+  'Atendimento humano',
+];
+
+export function ConsultoriaHero() {
+  return (
+    /* Hero */
+    /*
+      Espaçamento e tamanho do texto reduzidos em mobile (md: restaura os
+      valores originais): em telas curtas (~360-812px de altura) o CTA e o
+      disclaimer "Sem taxa..." caem perto do fim do viewport inicial, e o
+      banner de cookies (fixed bottom-0) os cobre antes de qualquer scroll
+      — combinado com CookieConsentBanner.tsx, que também foi compactado
+      no mobile. Ver critique de /consultoria-de-viagem.
+    */
+    /*
+      max-w-4xl (não 3xl): a 3xl o H1 text-6xl quebrava em 4 linhas e
+      empurrava o par CTA + "Sem taxa..." para fora da dobra a 1366×768
+      (laptop mais comum no Brasil). Ver critique de /consultoria-de-viagem.
+    */
+    <section className="pt-3 md:pt-16 pb-20 px-6">
+      <div className="max-w-4xl mx-auto">
+        <m.div
+          variants={fadeUp}
+          initial="hidden"
+          animate="visible"
+          custom={0}
+          className="inline-flex items-center gap-2 rounded-full border border-anhanga-blue/20 bg-anhanga-blue/5 px-3 py-0.5 md:py-1 mb-2 md:mb-5 text-[11px] md:text-xs font-black uppercase tracking-widest text-anhanga-blue"
+        >
+          {/*
+            "todo o Brasil", não "São Paulo": o badge é a primeira leitura da
+            página e cercava quem chega de fora de SP — a correção só aparecia
+            na 3ª pergunta do FAQ. O sinal local de SEO permanece no <title> e
+            no areaServed do ServiceSchema. Ver critique de /consultoria-de-viagem.
+          */}
+          <Compass className="size-3.5" aria-hidden="true" />
+          Consultoria de viagem · todo o Brasil
+        </m.div>
+        <m.h1
+          variants={fadeUp}
+          initial="hidden"
+          animate="visible"
+          custom={1}
+          className="text-balance text-4xl md:text-6xl font-black text-anhanga-dark mb-2 md:mb-6 leading-[1.1]"
+        >
+          Planeje uma viagem sob medida sem depender de pacote pronto
+        </m.h1>
+        <m.p
+          variants={fadeUp}
+          initial="hidden"
+          animate="visible"
+          custom={2}
+          className="text-base md:text-xl text-zinc-600 mb-3 md:mb-10 leading-relaxed max-w-2xl"
+        >
+          Um consultor da Anhangá entende seu perfil, destino, orçamento e restrições para desenhar o melhor caminho antes de você fechar.
+        </m.p>
+        <m.div variants={fadeUp} initial="hidden" animate="visible" custom={3}>
+          <Button
+            variant="cta"
+            size="lg"
+            onClick={() => openContactModal({ source: 'consultoria-viagem' })}
+            className="btn-whatsapp btn-specialist font-black"
+            rightIcon={<ArrowRight className="size-5" aria-hidden="true" />}
+            data-tracking="hero-consultoria-viagem"
+          >
+            Falar com um consultor
+          </Button>
+          <p className="mt-1 md:mt-4 text-sm text-zinc-600">Sem taxa de consultoria. Gratuito.</p>
+        </m.div>
+      </div>
+    </section>
+  );
+}
+
+export function ConsultoriaBenefits() {
+  return (
+    <section className="py-20 bg-white">
+      <div className="max-w-5xl mx-auto px-6">
+        {/*
+          margin de um viewport de altura (100%) abaixo do viewport (mesma
+          convenção em todas as seções seguintes): dispara a revelação antes da
+          seção entrar na tela, não quando já está visível. Sem isso, rolagem
+          rápida mostrava conteúdo semitransparente mesmo já dentro do viewport
+          — lia como página quebrada. Ver critique de /consultoria-de-viagem.
+        */}
+        <m.div
+          variants={fadeUp}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
+          custom={0}
+          className="mb-12"
+        >
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3">
+            Por que consultoria?
+          </h2>
+          <p className="text-zinc-600 text-lg">
+            Porque viajar bem não é só escolher um destino.
+          </p>
+        </m.div>
+        <div className="grid md:grid-cols-3 gap-6">
+          {PILLARS.map(({ icon: Icon, title, desc, variant }, idx) => (
+            <m.div
+              key={title}
+              variants={fadeUp}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
+              custom={idx + 1}
+              // Sem lift no hover: os cards não são clicáveis, e sombra que
+              // cresce ao passar o mouse é affordance de clique sem clique.
+              className={`p-8 rounded-2xl ${
+                variant === 'filled'
+                  ? 'bg-anhanga-blue text-white'
+                  : 'bg-anhanga-light shadow-float'
+              }`}
+            >
+              <div
+                className={`size-11 rounded-xl flex items-center justify-center mb-5 ${
+                  variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
+                }`}
+              >
+                <Icon
+                  className={`size-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`}
+                  aria-hidden="true"
+                />
+              </div>
+              <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
+                {title}
+              </h3>
+              <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-zinc-600 leading-relaxed'}>
+                {desc}
+              </p>
+            </m.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function ConsultoriaAudience() {
+  return (
+    <section className="py-20 bg-anhanga-light">
+      <div className="max-w-5xl mx-auto px-6">
+        <div className="md:grid md:grid-cols-2 md:gap-16 items-start">
+          <m.div
+            variants={fadeUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
+            custom={0}
+          >
+            <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-8">
+              Para quem é
+            </h2>
+            <ul className="space-y-4">
+              {FOR_WHO.map(item => (
+                <li key={item} className="flex items-start gap-3">
+                  <CheckCircle className="size-5 text-anhanga-blue flex-shrink-0 mt-0.5" aria-hidden="true" />
+                  <span className="text-zinc-700 leading-snug">{item}</span>
+                </li>
+              ))}
+            </ul>
+          </m.div>
+          <m.div
+            variants={fadeUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
+            custom={1}
+            className="mt-12 md:mt-0 overflow-hidden rounded-3xl bg-white shadow-float"
+          >
+            {/*
+              Depoimento pareado com o lugar real da viagem (não um ícone
+              genérico): reforça "lugares reais, não categorias de
+              produto" — a página inteira era só tipografia + ícones antes
+              desta correção. Ver critique de /consultoria-de-viagem.
+            */}
+            <LazyImage
+              src={getDestinationImage('Lisboa')}
+              alt="Lisboa, Portugal — destino da viagem relatada no depoimento"
+              width={640}
+              height={280}
+              className="h-48 w-full"
+            />
+            <div className="p-8">
+              <blockquote className="text-xl text-anhanga-dark font-semibold leading-relaxed">
+                "A Anhangá cuidou de cada detalhe. Só precisei aparecer no aeroporto."
+              </blockquote>
+              <p className="mt-4 text-zinc-600 text-sm">
+                R.M. · São Paulo · Viagem para Portugal, 2025
+              </p>
+            </div>
+          </m.div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function ConsultoriaProcess() {
+  return (
+    <section className="py-20 bg-white">
+      <div className="max-w-5xl mx-auto px-6">
+        <m.h2
+          variants={fadeUp}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
+          custom={0}
+          className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12"
+        >
+          Como funciona
+        </m.h2>
+        <div className="space-y-0">
+          {HOW_IT_WORKS.map(({ step, title, desc }, idx) => (
+            <m.div
+              key={step}
+              variants={fadeUp}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, amount: 0.3, margin: '0px 0px 100% 0px' }}
+              custom={idx + 1}
+              className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-zinc-100' : ''}`}
+            >
+              <div className="flex-shrink-0 size-12 rounded-full bg-anhanga-blue/10 flex items-center justify-center">
+                <span className="text-sm font-black text-anhanga-blue">{step}</span>
+              </div>
+              <div>
+                <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
+                <p className="text-zinc-600 leading-relaxed max-w-xl">{desc}</p>
+              </div>
+            </m.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function ConsultoriaAbout() {
+  return (
+    <section className="py-20 bg-anhanga-light">
+      <div className="max-w-5xl mx-auto px-6">
+        <div className="md:grid md:grid-cols-2 md:gap-16 items-center">
+          <m.div
+            variants={fadeUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
+            custom={0}
+            className="overflow-hidden rounded-3xl shadow-float"
+          >
+            {/*
+              Segunda foto real da página (a primeira é o depoimento de
+              Lisboa) — "Sobre" era só tipografia antes, contrariando
+              "lugares reais, não categorias" para um brief sobre viagens.
+              Ver critique de /consultoria-de-viagem (P2).
+            */}
+            <LazyImage
+              src={getDestinationImage('Rio de Janeiro')}
+              alt="Rio de Janeiro — um dos destinos planejados pela Anhangá Viagens"
+              width={640}
+              height={480}
+              className="h-64 md:h-80 w-full"
+            />
+          </m.div>
+          <m.div
+            variants={fadeUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
+            custom={1}
+            className="mt-10 md:mt-0 text-center md:text-left"
+          >
+            <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6">
+              Sobre a Anhangá Viagens
+            </h2>
+            <p className="text-lg text-zinc-600 leading-relaxed">
+              Agência de viagens em São Paulo, especializada em viagens personalizadas desde 2018. Atendimento humano, nota 5.0 no Google e consultor fixo do início ao fim da sua viagem.
+            </p>
+            <div className="mt-10 flex flex-wrap justify-center md:justify-start gap-3">
+              {CREDENTIALS.map(item => (
+                <span
+                  key={item}
+                  // Borda 1px, não shadow-float: pílula branca elevada parecia
+                  // clicável (spec de Badge do DESIGN.md: borda, sem sombra).
+                  className="inline-flex items-center gap-2 rounded-full bg-white border border-zinc-200 px-4 py-2 text-sm font-bold text-anhanga-dark"
+                >
+                  <CheckCircle className="size-4 text-anhanga-blue" aria-hidden="true" />
+                  {item}
+                </span>
+              ))}
+            </div>
+          </m.div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function ConsultoriaFinalCta() {
+  return (
+    <section className="py-20 bg-anhanga-blue">
+      <m.div
+        variants={fadeUp}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, amount: 0.3, margin: '0px 0px 100% 0px' }}
+        custom={0}
+        className="max-w-3xl mx-auto px-6 text-center"
+      >
+        <h2 className="text-3xl md:text-5xl font-black text-white mb-6">
+          Pronto para planejar sua viagem?
+        </h2>
+        <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
+          Fale com um consultor agora. Sem taxa, sem compromisso.
+        </p>
+        <Button
+          variant="cta"
+          size="lg"
+          onClick={() => openContactModal({ source: 'consultoria-viagem' })}
+          className="btn-whatsapp btn-specialist font-black"
+          rightIcon={<ArrowRight className="size-6" aria-hidden="true" />}
+          data-tracking="footer-consultoria-viagem"
+        >
+          Falar com um consultor
+        </Button>
+      </m.div>
+    </section>
+  );
+}
+
+export function ConsultoriaOtherServices() {
+  return (
+    <section className="py-16 bg-anhanga-light">
+      <div className="max-w-5xl mx-auto px-6">
+        <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
+        <div className="grid md:grid-cols-3 gap-4">
+          <Link
+            to="/corporativo/"
+            className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/5 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+          >
+            <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+              Viagens para Executivos
+            </div>
+            <div className="text-sm text-zinc-600 mt-1">
+              Planejamento com precisão para profissionais
+            </div>
+          </Link>
+          <Link
+            to="/cruzeiros/"
+            className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/5 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+          >
+            <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+              Curadoria de Cruzeiros
+            </div>
+            <div className="text-sm text-zinc-600 mt-1">
+              Escolha o navio e a cabine certos para você
+            </div>
+          </Link>
+          <Link
+            to="/"
+            className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/5 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+          >
+            <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+              Site principal
+            </div>
+            <div className="text-sm text-zinc-600 mt-1">
+              Conheça todos os serviços da Anhangá
+            </div>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landings/cruzeiros/CruiseOfferCards.tsx
+++ b/components/landings/cruzeiros/CruiseOfferCards.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { ArrowRight, MapPin, Moon, Ship } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { LazyImage } from '@/components/ui/LazyImage';
+import type { CruiseOffer } from '@/data/cruiseOffers';
+import { openContactModal } from '@/utils/contactForm';
+
+// Rótulo enviado ao CRM (campo `destination` → x_destino no Odoo) e mostrado no
+// ContactModal. A palavra "cruzeiro" auto-classifica o lead com a tag Cruzeiros
+// (lib/destination-region.ts). Também é o texto que o especialista vê primeiro.
+function offerCrmLabel(o: CruiseOffer): string {
+  return `Cruzeiro ${o.navio} · ${o.portoEmbarque} · ${o.saida}`;
+}
+
+// Mensagem natural pré-preenchida no WhatsApp quando o lead abre a conversa.
+function offerWhatsappMessage(o: CruiseOffer): string {
+  return `Olá! Tenho interesse no cruzeiro do ${o.navio} saindo de ${o.portoEmbarque} em ${o.saida}. Podem me ajudar?`;
+}
+
+function openOfferConversation(o: CruiseOffer): void {
+  openContactModal({
+    source: 'cruzeiros-oferta',
+    destination: offerCrmLabel(o),
+    message: offerWhatsappMessage(o),
+  });
+}
+
+function OfferMeta({ offer, className }: { offer: CruiseOffer; className?: string }): React.ReactElement {
+  return (
+    <dl className={`flex flex-wrap gap-x-6 gap-y-2 text-sm ${className ?? ''}`}>
+      <div className="flex items-center gap-1.5">
+        <Ship className="size-4 text-anhanga-action flex-shrink-0" aria-hidden="true" />
+        <dt className="sr-only">Navio</dt>
+        <dd className="font-semibold text-anhanga-dark">{offer.companhia}</dd>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <MapPin className="size-4 text-anhanga-action flex-shrink-0" aria-hidden="true" />
+        <dt className="sr-only">Roteiro</dt>
+        <dd className="text-zinc-600">{offer.roteiro.join(' · ')}</dd>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <Moon className="size-4 text-anhanga-action flex-shrink-0" aria-hidden="true" />
+        <dt className="sr-only">Duração</dt>
+        <dd className="text-zinc-600">{offer.noites} noites</dd>
+      </div>
+    </dl>
+  );
+}
+
+function ProfileTags({ perfis }: { perfis: string[] }): React.ReactElement {
+  return (
+    <ul className="flex flex-wrap gap-2" aria-label="Perfis indicados">
+      {perfis.map((p) => (
+        <li key={p} className="text-xs font-semibold text-anhanga-blue bg-anhanga-blue/10 rounded-full px-3 py-1">
+          {p}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function RegionBadge({ regiao, saida }: { regiao: string; saida: string }): React.ReactElement {
+  return (
+    <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-anhanga-action">
+      <span>{regiao}</span>
+      <span className="text-zinc-300" aria-hidden="true">·</span>
+      <span className="text-zinc-500">{saida}</span>
+    </div>
+  );
+}
+
+// shadow-float (não border): DESIGN.md §5 reserva border a inputs — cards
+// separam por sombra ou fundo tonalizado. Sem lift no hover: o card em si não
+// é clicável, só o botão dentro dele; sombra que cresce ao passar o mouse no
+// card inteiro seria affordance de clique sem clique (mesmo raciocínio do
+// PILLARS de /consultoria-de-viagem).
+export function FeaturedOffer({ offer }: { offer: CruiseOffer }): React.ReactElement {
+  return (
+    <article className="grid md:grid-cols-2 gap-0 rounded-3xl overflow-hidden bg-white shadow-float">
+      {/* w-full é obrigatório: o LazyImage aplica `aspect-ratio` inline a partir de
+          width/height, e sem uma largura explícita o container deriva a largura da
+          altura (h-full) e estoura a coluna do grid. */}
+      <LazyImage
+        src={offer.imagem}
+        alt={offer.imagemAlt}
+        width={800}
+        height={600}
+        sizes="(min-width: 768px) 50vw, 100vw"
+        className="w-full h-64 md:h-full"
+      />
+      <div className="p-8 md:p-10 flex flex-col">
+        <RegionBadge regiao={offer.regiao} saida={offer.saida} />
+        <h3 className="mt-3 text-2xl md:text-3xl font-black text-anhanga-dark leading-tight">
+          {offer.navio}
+        </h3>
+        <OfferMeta offer={offer} className="mt-4" />
+        <div className="mt-5 rounded-xl bg-anhanga-blue/[0.04] p-4">
+          <p className="text-xs font-black uppercase tracking-wide text-anhanga-blue mb-1.5">
+            Por que escolhemos
+          </p>
+          <p className="text-zinc-700 leading-relaxed">{offer.notaCuratorial}</p>
+        </div>
+        <div className="mt-6">
+          <ProfileTags perfis={offer.perfis} />
+        </div>
+        <Button
+          variant="primary"
+          size="lg"
+          onClick={() => openOfferConversation(offer)}
+          className="btn-whatsapp btn-specialist mt-8 self-start"
+          rightIcon={<ArrowRight className="size-5" aria-hidden="true" />}
+          aria-label={`Falar com um especialista sobre o cruzeiro ${offer.navio}`}
+          data-tracking={`oferta-featured-${offer.id}`}
+        >
+          Quero saber mais
+        </Button>
+      </div>
+    </article>
+  );
+}
+
+export function OfferCard({ offer }: { offer: CruiseOffer }): React.ReactElement {
+  return (
+    <article className="flex flex-col rounded-2xl overflow-hidden bg-white shadow-float">
+      <LazyImage
+        src={offer.imagem}
+        alt={offer.imagemAlt}
+        width={480}
+        height={300}
+        sizes="(min-width: 768px) 33vw, 100vw"
+        className="w-full h-48"
+      />
+      <div className="p-6 flex flex-col flex-1">
+        <RegionBadge regiao={offer.regiao} saida={offer.saida} />
+        <h3 className="mt-2 text-xl font-black text-anhanga-dark leading-tight">{offer.navio}</h3>
+        <OfferMeta offer={offer} className="mt-3" />
+        <div className="mt-4 rounded-lg bg-anhanga-blue/[0.04] p-3 flex-1">
+          <p className="text-[0.65rem] font-black uppercase tracking-wide text-anhanga-blue mb-1">
+            Por que escolhemos
+          </p>
+          <p className="text-sm text-zinc-600 leading-relaxed">{offer.notaCuratorial}</p>
+        </div>
+        <div className="mt-4">
+          <ProfileTags perfis={offer.perfis} />
+        </div>
+        <Button
+          variant="primary"
+          onClick={() => openOfferConversation(offer)}
+          className="btn-whatsapp btn-specialist mt-5 w-full"
+          rightIcon={<ArrowRight className="size-4" aria-hidden="true" />}
+          aria-label={`Falar com um especialista sobre o cruzeiro ${offer.navio}`}
+          data-tracking={`oferta-${offer.id}`}
+        >
+          Falar sobre este
+        </Button>
+      </div>
+    </article>
+  );
+}

--- a/components/landings/cruzeiros/CruzeirosLandingSections.tsx
+++ b/components/landings/cruzeiros/CruzeirosLandingSections.tsx
@@ -1,0 +1,423 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { m } from 'framer-motion';
+import { ArrowLeft, ArrowRight, CalendarCheck, Compass, MapPin } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { fadeUp } from '@/components/landings/shared/constants';
+import type { CruiseOffer } from '@/data/cruiseOffers';
+import { openContactModal } from '@/utils/contactForm';
+import { FeaturedOffer, OfferCard } from './CruiseOfferCards';
+
+const VIEWPORT_REVEAL = { once: true, amount: 0.2, margin: '0px 0px 100% 0px' } as const;
+
+const HOW_IT_WORKS = [
+  {
+    step: '01',
+    title: 'Conversa com especialista',
+    desc: 'Você conta o que busca — perfil, orçamento, datas — e o especialista faz as perguntas certas.'
+  },
+  {
+    step: '02',
+    title: 'Curadoria personalizada',
+    desc: 'Com base no seu perfil, indicamos o navio, a cabine e o roteiro que mais fazem sentido para você — inclusive fora da seleção do site.'
+  },
+  {
+    step: '03',
+    title: 'Reserva e suporte',
+    desc: 'Quando decidir, cuidamos da reserva e ficamos disponíveis até você embarcar.'
+  },
+];
+
+// `variant` não é decoração: DESIGN.md:261 proíbe cards idênticos em grade
+// repetida. O card preenchido quebra a repetição e ancora a leitura no meio —
+// mesma razão pela qual a seção de ofertas destaca uma saída em vez de listar
+// tudo com o mesmo peso.
+const WHY_CURATION = [
+  {
+    icon: Compass,
+    title: 'Navio certo para seu perfil',
+    desc: 'Cada companhia tem um DNA diferente. Indicamos o que combina com o que você quer viver a bordo.',
+    variant: 'light' as const,
+  },
+  {
+    icon: MapPin,
+    title: 'Roteiro que vale a viagem',
+    desc: 'Saída do Brasil ou internacional, escalas e temporada mudam o preço e a experiência. Analisamos tudo junto.',
+    variant: 'filled' as const,
+  },
+  {
+    icon: CalendarCheck,
+    title: 'Cabine sem arrependimento',
+    desc: 'Interna, varanda ou suíte: explicamos o que cada categoria entrega e o que vale para o seu caso.',
+    variant: 'light' as const,
+  },
+];
+
+interface CruiseOffersSectionProps {
+  featuredOffer?: CruiseOffer;
+  secondaryOffers: CruiseOffer[];
+}
+
+export function CruiseMiniHeader(): React.ReactElement {
+  return (
+    <header className="bg-white/90 backdrop-blur-sm border-b border-anhanga-blue/10 sticky top-0 z-50 py-3">
+      <div className="max-w-6xl mx-auto px-6 flex items-center justify-between">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 group"
+          aria-label="Voltar para o site principal da Anhangá Viagens"
+        >
+          <ArrowLeft className="size-4 text-zinc-400 group-hover:text-anhanga-blue transition-colors" />
+          <span className="size-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
+            <img src="/favicon.svg" alt="" aria-hidden="true" className="size-4" />
+          </span>
+          <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+            Anhangá Viagens
+          </span>
+        </Link>
+        <Button
+          variant="action"
+          size="sm"
+          onClick={() => openContactModal({ source: 'cruzeiros' })}
+          className="btn-whatsapp btn-specialist whitespace-nowrap"
+          data-tracking="header-cruzeiros"
+        >
+          Falar com especialista
+        </Button>
+      </div>
+    </header>
+  );
+}
+
+export function CruiseHero(): React.ReactElement {
+  return (
+    <section className="pt-16 pb-20 px-6 bg-anhanga-light">
+      <div className="max-w-3xl mx-auto">
+        <m.p
+          variants={fadeUp}
+          initial="hidden"
+          animate="visible"
+          custom={0}
+          className="text-sm font-semibold text-anhanga-blue mb-4 tracking-wide uppercase"
+        >
+          Cruzeiros · Brasil e internacionais
+        </m.p>
+        <m.h1
+          variants={fadeUp}
+          initial="hidden"
+          animate="visible"
+          custom={1}
+          className="text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1]"
+        >
+          Os cruzeiros que a gente escolheria
+        </m.h1>
+        <m.p
+          variants={fadeUp}
+          initial="hidden"
+          animate="visible"
+          custom={2}
+          className="text-xl text-zinc-600 mb-10 leading-relaxed max-w-2xl"
+        >
+          Uma seleção enxuta de saídas que valem a pena — no Brasil e pelo mundo — com um especialista para acertar navio, cabine e roteiro antes de você fechar.
+        </m.p>
+        <m.div variants={fadeUp} initial="hidden" animate="visible" custom={3}>
+          <Button
+            variant="cta"
+            size="lg"
+            onClick={() => openContactModal({ source: 'cruzeiros' })}
+            className="btn-whatsapp btn-specialist font-black"
+            rightIcon={<ArrowRight className="size-5" aria-hidden="true" />}
+            aria-label="Falar com um especialista em cruzeiros"
+            data-tracking="hero-cruzeiros"
+          >
+            Falar com um especialista
+          </Button>
+          <p className="mt-4 text-sm text-zinc-600">Sem taxa de curadoria. Gratuito.</p>
+        </m.div>
+      </div>
+    </section>
+  );
+}
+
+export function CruiseOffersSection({
+  featuredOffer,
+  secondaryOffers,
+}: CruiseOffersSectionProps): React.ReactElement | null {
+  if (!featuredOffer && secondaryOffers.length === 0) return null;
+
+  return (
+    <section className="py-20 bg-white" aria-labelledby="ofertas-titulo">
+      <div className="max-w-6xl mx-auto px-6">
+        <m.div
+          variants={fadeUp}
+          initial="hidden"
+          whileInView="visible"
+          viewport={VIEWPORT_REVEAL}
+          custom={0}
+          className="mb-10"
+        >
+          <h2 id="ofertas-titulo" className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3">
+            Seleção da temporada
+          </h2>
+          <p className="text-zinc-600 text-lg max-w-2xl">
+            Poucas saídas, escolhidas a dedo. Cada uma vem com o porquê de estar aqui — e um especialista para fechar a sua.
+          </p>
+        </m.div>
+
+        {featuredOffer ? (
+          <m.div
+            variants={fadeUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={VIEWPORT_REVEAL}
+            custom={1}
+            className="mb-6"
+          >
+            <FeaturedOffer offer={featuredOffer} />
+          </m.div>
+        ) : null}
+
+        {secondaryOffers.length > 0 ? (
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {secondaryOffers.map((offer, idx) => (
+              <m.div
+                key={offer.id}
+                variants={fadeUp}
+                initial="hidden"
+                whileInView="visible"
+                viewport={VIEWPORT_REVEAL}
+                custom={idx + 2}
+              >
+                <OfferCard offer={offer} />
+              </m.div>
+            ))}
+          </div>
+        ) : null}
+
+        <p className="mt-10 text-zinc-600">
+          Não achou a saída ideal?{' '}
+          <button
+            type="button"
+            onClick={() => openContactModal({ source: 'cruzeiros' })}
+            className="font-bold text-anhanga-blue underline underline-offset-2 hover:text-anhanga-darkBlue transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action rounded"
+            data-tracking="ofertas-fallback-cruzeiros"
+          >
+            Conte o que procura
+          </button>{' '}
+          — a gente busca fora da lista também.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export function CruiseProcess(): React.ReactElement {
+  return (
+    <section className="py-20 bg-anhanga-light">
+      <div className="max-w-5xl mx-auto px-6">
+        <m.h2
+          variants={fadeUp}
+          initial="hidden"
+          whileInView="visible"
+          viewport={VIEWPORT_REVEAL}
+          custom={0}
+          className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12"
+        >
+          Como funciona
+        </m.h2>
+        <div className="space-y-0">
+          {HOW_IT_WORKS.map(({ step, title, desc }, idx) => (
+            <m.div
+              key={step}
+              variants={fadeUp}
+              initial="hidden"
+              whileInView="visible"
+              viewport={VIEWPORT_REVEAL}
+              custom={idx + 1}
+              className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-anhanga-blue/10' : ''}`}
+            >
+              <div className="flex-shrink-0 size-12 rounded-full bg-white flex items-center justify-center shadow-sm">
+                <span className="text-sm font-black text-anhanga-blue">{step}</span>
+              </div>
+              <div>
+                <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
+                <p className="text-zinc-600 leading-relaxed max-w-xl">{desc}</p>
+              </div>
+            </m.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function CruiseCurationBenefits(): React.ReactElement {
+  return (
+    <section className="py-20 bg-white">
+      <div className="max-w-5xl mx-auto px-6">
+        <m.div
+          variants={fadeUp}
+          initial="hidden"
+          whileInView="visible"
+          viewport={VIEWPORT_REVEAL}
+          custom={0}
+          className="mb-12"
+        >
+          <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3">
+            Por que curadoria?
+          </h2>
+          <p className="text-zinc-600 text-lg">
+            Porque escolher um cruzeiro envolve mais variáveis do que parece.
+          </p>
+        </m.div>
+        <div className="grid md:grid-cols-3 gap-6">
+          {WHY_CURATION.map(({ icon: Icon, title, desc, variant }, idx) => (
+            <m.div
+              key={title}
+              variants={fadeUp}
+              initial="hidden"
+              whileInView="visible"
+              viewport={VIEWPORT_REVEAL}
+              custom={idx + 1}
+              className={`p-8 rounded-2xl ${variant === 'filled' ? 'bg-anhanga-blue' : 'bg-anhanga-light shadow-float'}`}
+            >
+              <div
+                className={`size-11 rounded-xl flex items-center justify-center mb-5 ${
+                  variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
+                }`}
+              >
+                <Icon className={`size-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`} />
+              </div>
+              <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
+                {title}
+              </h3>
+              <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-zinc-600 leading-relaxed'}>
+                {desc}
+              </p>
+            </m.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function CruiseAbout(): React.ReactElement {
+  return (
+    <section className="py-20 bg-anhanga-light">
+      <m.div
+        variants={fadeUp}
+        initial="hidden"
+        whileInView="visible"
+        viewport={VIEWPORT_REVEAL}
+        custom={0}
+        className="max-w-4xl mx-auto px-6 text-center"
+      >
+        <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6">
+          Sobre a Anhangá Viagens
+        </h2>
+        <p className="text-lg text-zinc-600 leading-relaxed max-w-2xl mx-auto">
+          Agência de viagens em São Paulo desde 2018, com especialistas em cruzeiros e roteiros personalizados. Nota 5.0 no Google e atendimento humano do início ao fim.
+        </p>
+        <div className="mt-12 flex flex-wrap justify-center gap-12">
+          {[
+            { label: 'Fundada em', value: '2018' },
+            { label: 'Nota Google', value: '5.0' },
+            { label: 'Especialistas', value: 'Em cruzeiros' },
+          ].map(({ label, value }) => (
+            <div key={label}>
+              <div className="text-4xl font-black text-anhanga-blue">{value}</div>
+              <div className="text-sm text-zinc-600 mt-1">{label}</div>
+            </div>
+          ))}
+        </div>
+      </m.div>
+    </section>
+  );
+}
+
+export function CruiseFinalCta(): React.ReactElement {
+  return (
+    <section className="py-20 bg-anhanga-blue">
+      <m.div
+        variants={fadeUp}
+        initial="hidden"
+        whileInView="visible"
+        viewport={VIEWPORT_REVEAL}
+        custom={0}
+        className="max-w-3xl mx-auto px-6 text-center"
+      >
+        <h2 className="text-3xl md:text-5xl font-black text-white mb-6">
+          Vamos achar o seu cruzeiro?
+        </h2>
+        <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
+          Fale com um consultor e resolva a escolha em uma conversa. Sem taxa, sem compromisso.
+        </p>
+        <Button
+          variant="cta"
+          size="lg"
+          onClick={() => openContactModal({ source: 'cruzeiros' })}
+          className="btn-whatsapp btn-specialist font-black focus-visible:outline-white"
+          rightIcon={<ArrowRight className="size-6" aria-hidden="true" />}
+          aria-label="Falar com um especialista em cruzeiros"
+          data-tracking="footer-cruzeiros"
+        >
+          Falar com um especialista
+        </Button>
+      </m.div>
+    </section>
+  );
+}
+
+export function CruiseOtherServices(): React.ReactElement {
+  return (
+    <section className="py-16 bg-anhanga-light">
+      <div className="max-w-5xl mx-auto px-6">
+        <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
+        <div className="grid md:grid-cols-3 gap-4">
+          <Link
+            to="/consultoria-de-viagem/"
+            className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+          >
+            <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+              Consultoria de Viagem
+            </div>
+            <div className="text-sm text-zinc-600 mt-1">
+              Roteiro sob medida com consultor humano
+            </div>
+          </Link>
+          <Link
+            to="/corporativo/"
+            className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+          >
+            <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+              Viagens para Executivos
+            </div>
+            <div className="text-sm text-zinc-600 mt-1">
+              Planejamento com precisão para profissionais
+            </div>
+          </Link>
+          <Link
+            to="/"
+            className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+          >
+            <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
+              Site principal
+            </div>
+            <div className="text-sm text-zinc-600 mt-1">
+              Conheça todos os serviços da Anhangá
+            </div>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function CruiseLandingFooter(): React.ReactElement {
+  return (
+    <footer className="py-8 bg-anhanga-light border-t border-anhanga-blue/10 text-center text-sm text-zinc-600">
+      <p>Anhangá Viagens · Agência de viagens em São Paulo</p>
+    </footer>
+  );
+}

--- a/components/landings/lollapalooza/VenueMap.tsx
+++ b/components/landings/lollapalooza/VenueMap.tsx
@@ -18,7 +18,9 @@ const VenueMap: React.FC = () => {
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
 
   useEffect(() => {
-    let a11yTimer: ReturnType<typeof setTimeout>;
+    let a11yTimer: ReturnType<typeof setTimeout> | undefined;
+    let ownedMap: L.Map | null = null;
+    const markerDisposers: Array<() => void> = [];
     if (mapContainerRef.current && !mapInstanceRef.current) {
       const interlagosCoords: [number, number] = [-23.701186, -46.697076];
 
@@ -31,6 +33,7 @@ const VenueMap: React.FC = () => {
         zoomControl: false, // Vamos adicionar manualmente
         keyboard: true
       });
+      ownedMap = map;
 
       // Adiciona controle de zoom no canto inferior direito (mais fácil em mobile)
       L.control.zoom({
@@ -118,10 +121,13 @@ const VenueMap: React.FC = () => {
           </div>
         `);
 
-        marker.on('click', () => {
+        const handleMarkerClick = () => {
           setActiveIndex(index);
           map.flyTo(poi.coords, 13, { animate: true, duration: 1 });
-        });
+        };
+
+        marker.on('click', handleMarkerClick);
+        markerDisposers.push(() => marker.off('click', handleMarkerClick));
 
         markersRef.current.push(marker);
         markers.push(marker);
@@ -132,7 +138,20 @@ const VenueMap: React.FC = () => {
 
       mapInstanceRef.current = map;
     }
-    return () => clearTimeout(a11yTimer);
+    return () => {
+      if (a11yTimer !== undefined) clearTimeout(a11yTimer);
+      markerDisposers.forEach((dispose) => dispose());
+      markersRef.current = [];
+
+      if (ownedMap) {
+        ownedMap.off();
+        ownedMap.remove();
+      }
+
+      if (mapInstanceRef.current === ownedMap) {
+        mapInstanceRef.current = null;
+      }
+    };
   }, []);
 
   // Efeito para rolar a lista até o item ativo quando selecionado via Mapa

--- a/components/landings/lollapalooza/VenueMap.tsx
+++ b/components/landings/lollapalooza/VenueMap.tsx
@@ -3,54 +3,9 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { MapPin } from 'lucide-react';
+import { removeLeafletMapAfterActiveZoom } from '@/components/maps/removeLeafletMapAfterActiveZoom';
 import { POIS, getPoiStyle } from './venueMapData';
 import { VenuePoiList } from './VenuePoiList';
-
-const LEAFLET_ZOOM_FALLBACK_MS = 300;
-
-const removeMapAfterActiveZoom = (map: L.Map, zoomInProgress: boolean) => {
-  if (!zoomInProgress) {
-    map.remove();
-    return;
-  }
-
-  let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
-  let removalTimer: ReturnType<typeof setTimeout> | undefined;
-  let removed = false;
-  let handleZoomEnd: (() => void) | undefined;
-
-  const clearOwnedResources = () => {
-    if (handleZoomEnd) {
-      map.off('zoomend', handleZoomEnd);
-      handleZoomEnd = undefined;
-    }
-    if (fallbackTimer !== undefined) {
-      clearTimeout(fallbackTimer);
-      fallbackTimer = undefined;
-    }
-    if (removalTimer !== undefined) {
-      clearTimeout(removalTimer);
-      removalTimer = undefined;
-    }
-  };
-
-  const removeMap = () => {
-    if (removed) return;
-    removed = true;
-    clearOwnedResources();
-    map.remove();
-  };
-
-  const queueRemoval = () => {
-    if (removed || removalTimer !== undefined) return;
-    removalTimer = setTimeout(removeMap, 0);
-  };
-
-  handleZoomEnd = queueRemoval;
-  map.on('zoomend', handleZoomEnd);
-  // Leaflet's CSS zoom fallback runs after 250 ms; this guarantees eventual teardown.
-  fallbackTimer = setTimeout(removeMap, LEAFLET_ZOOM_FALLBACK_MS);
-};
 
 const VenueMap: React.FC = () => {
   const mapContainerRef = useRef<HTMLDivElement>(null);
@@ -222,7 +177,7 @@ const VenueMap: React.FC = () => {
           mapInstanceRef.current = null;
         }
 
-        removeMapAfterActiveZoom(ownedMap, shouldWaitForZoomEnd);
+        removeLeafletMapAfterActiveZoom(ownedMap, shouldWaitForZoomEnd);
         ownedMap = null;
       }
     };

--- a/components/landings/lollapalooza/VenueMap.tsx
+++ b/components/landings/lollapalooza/VenueMap.tsx
@@ -6,6 +6,52 @@ import { MapPin } from 'lucide-react';
 import { POIS, getPoiStyle } from './venueMapData';
 import { VenuePoiList } from './VenuePoiList';
 
+const LEAFLET_ZOOM_FALLBACK_MS = 300;
+
+const removeMapAfterActiveZoom = (map: L.Map, zoomInProgress: boolean) => {
+  if (!zoomInProgress) {
+    map.remove();
+    return;
+  }
+
+  let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
+  let removalTimer: ReturnType<typeof setTimeout> | undefined;
+  let removed = false;
+  let handleZoomEnd: (() => void) | undefined;
+
+  const clearOwnedResources = () => {
+    if (handleZoomEnd) {
+      map.off('zoomend', handleZoomEnd);
+      handleZoomEnd = undefined;
+    }
+    if (fallbackTimer !== undefined) {
+      clearTimeout(fallbackTimer);
+      fallbackTimer = undefined;
+    }
+    if (removalTimer !== undefined) {
+      clearTimeout(removalTimer);
+      removalTimer = undefined;
+    }
+  };
+
+  const removeMap = () => {
+    if (removed) return;
+    removed = true;
+    clearOwnedResources();
+    map.remove();
+  };
+
+  const queueRemoval = () => {
+    if (removed || removalTimer !== undefined) return;
+    removalTimer = setTimeout(removeMap, 0);
+  };
+
+  handleZoomEnd = queueRemoval;
+  map.on('zoomend', handleZoomEnd);
+  // Leaflet's CSS zoom fallback runs after 250 ms; this guarantees eventual teardown.
+  fallbackTimer = setTimeout(removeMap, LEAFLET_ZOOM_FALLBACK_MS);
+};
+
 const VenueMap: React.FC = () => {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
@@ -22,7 +68,14 @@ const VenueMap: React.FC = () => {
     let ownedMap: L.Map | null = null;
     let ownedGroup: L.FeatureGroup | null = null;
     let handleGroupClick: ((event: L.LeafletEvent) => void) | null = null;
+    let zoomInProgress = false;
     const markerIndexes = new Map<L.Marker, number>();
+    const handleZoomStart = () => {
+      zoomInProgress = true;
+    };
+    const handleZoomEnd = () => {
+      zoomInProgress = false;
+    };
     if (mapContainerRef.current && !mapInstanceRef.current) {
       const interlagosCoords: [number, number] = [-23.701186, -46.697076];
 
@@ -36,6 +89,8 @@ const VenueMap: React.FC = () => {
         keyboard: true
       });
       ownedMap = map;
+      ownedMap.on('zoomstart', handleZoomStart);
+      ownedMap.on('zoomend', handleZoomEnd);
 
       // Adiciona controle de zoom no canto inferior direito (mais fácil em mobile)
       L.control.zoom({
@@ -158,16 +213,17 @@ const VenueMap: React.FC = () => {
       markerIndexes.clear();
       markersRef.current = [];
 
-      const mapToRemove = ownedMap;
-      ownedMap = null;
+      if (ownedMap) {
+        const shouldWaitForZoomEnd = zoomInProgress;
+        ownedMap.off('zoomstart', handleZoomStart);
+        ownedMap.off('zoomend', handleZoomEnd);
 
-      if (mapInstanceRef.current === mapToRemove) {
-        mapInstanceRef.current = null;
-      }
+        if (mapInstanceRef.current === ownedMap) {
+          mapInstanceRef.current = null;
+        }
 
-      if (mapToRemove) {
-        mapToRemove.off();
-        mapToRemove.remove();
+        removeMapAfterActiveZoom(ownedMap, shouldWaitForZoomEnd);
+        ownedMap = null;
       }
     };
   }, []);

--- a/components/landings/lollapalooza/VenueMap.tsx
+++ b/components/landings/lollapalooza/VenueMap.tsx
@@ -20,7 +20,9 @@ const VenueMap: React.FC = () => {
   useEffect(() => {
     let a11yTimer: ReturnType<typeof setTimeout> | undefined;
     let ownedMap: L.Map | null = null;
-    const markerDisposers: Array<() => void> = [];
+    let ownedGroup: L.FeatureGroup | null = null;
+    let handleGroupClick: ((event: L.LeafletEvent) => void) | null = null;
+    const markerIndexes = new Map<L.Marker, number>();
     if (mapContainerRef.current && !mapInstanceRef.current) {
       const interlagosCoords: [number, number] = [-23.701186, -46.697076];
 
@@ -121,35 +123,51 @@ const VenueMap: React.FC = () => {
           </div>
         `);
 
-        const handleMarkerClick = () => {
-          setActiveIndex(index);
-          map.flyTo(poi.coords, 13, { animate: true, duration: 1 });
-        };
-
-        marker.on('click', handleMarkerClick);
-        markerDisposers.push(() => marker.off('click', handleMarkerClick));
-
+        markerIndexes.set(marker, index);
         markersRef.current.push(marker);
         markers.push(marker);
       });
 
-      const group = new L.FeatureGroup(markers);
-      map.fitBounds(group.getBounds(), { padding: [50, 50] });
+      ownedGroup = new L.FeatureGroup(markers);
+      handleGroupClick = (event) => {
+        const index = markerIndexes.get(event.propagatedFrom as L.Marker);
+        if (index === undefined) return;
+
+        const poi = POIS[index];
+        setActiveIndex(index);
+        map.flyTo(poi.coords, 13, { animate: true, duration: 1 });
+      };
+
+      ownedGroup.on('click', handleGroupClick);
+      map.fitBounds(ownedGroup.getBounds(), { padding: [50, 50] });
 
       mapInstanceRef.current = map;
     }
     return () => {
-      if (a11yTimer !== undefined) clearTimeout(a11yTimer);
-      markerDisposers.forEach((dispose) => dispose());
-      markersRef.current = [];
-
-      if (ownedMap) {
-        ownedMap.off();
-        ownedMap.remove();
+      if (a11yTimer !== undefined) {
+        clearTimeout(a11yTimer);
+        a11yTimer = undefined;
       }
 
-      if (mapInstanceRef.current === ownedMap) {
+      if (ownedGroup && handleGroupClick) {
+        ownedGroup.off('click', handleGroupClick);
+        ownedGroup.clearLayers();
+      }
+      ownedGroup = null;
+      handleGroupClick = null;
+      markerIndexes.clear();
+      markersRef.current = [];
+
+      const mapToRemove = ownedMap;
+      ownedMap = null;
+
+      if (mapInstanceRef.current === mapToRemove) {
         mapInstanceRef.current = null;
+      }
+
+      if (mapToRemove) {
+        mapToRemove.off();
+        mapToRemove.remove();
       }
     };
   }, []);

--- a/components/maps/removeLeafletMapAfterActiveZoom.ts
+++ b/components/maps/removeLeafletMapAfterActiveZoom.ts
@@ -1,0 +1,47 @@
+import type L from 'leaflet';
+
+const LEAFLET_ZOOM_FALLBACK_MS = 300;
+
+export function removeLeafletMapAfterActiveZoom(map: L.Map, zoomInProgress: boolean) {
+  if (!zoomInProgress) {
+    map.remove();
+    return;
+  }
+
+  let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
+  let removalTimer: ReturnType<typeof setTimeout> | undefined;
+  let removed = false;
+  let handleZoomEnd: (() => void) | undefined;
+
+  const clearOwnedResources = () => {
+    if (handleZoomEnd) {
+      map.off('zoomend', handleZoomEnd);
+      handleZoomEnd = undefined;
+    }
+    if (fallbackTimer !== undefined) {
+      clearTimeout(fallbackTimer);
+      fallbackTimer = undefined;
+    }
+    if (removalTimer !== undefined) {
+      clearTimeout(removalTimer);
+      removalTimer = undefined;
+    }
+  };
+
+  const removeMap = () => {
+    if (removed) return;
+    removed = true;
+    clearOwnedResources();
+    map.remove();
+  };
+
+  const queueRemoval = () => {
+    if (removed || removalTimer !== undefined) return;
+    removalTimer = setTimeout(removeMap, 0);
+  };
+
+  handleZoomEnd = queueRemoval;
+  map.on('zoomend', handleZoomEnd);
+  // Leaflet's CSS zoom fallback runs after 250 ms; this guarantees eventual teardown.
+  fallbackTimer = setTimeout(removeMap, LEAFLET_ZOOM_FALLBACK_MS);
+}

--- a/components/search/useSearchFormController.ts
+++ b/components/search/useSearchFormController.ts
@@ -1,0 +1,308 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  BUDGET_TIERS,
+  getDaysInMonth,
+  normalizeStr,
+  PRE_NORMALIZED_DB,
+  TRIP_OPTIONS,
+} from '../../data/destinations';
+import { getGuestSummary, isDateInPast } from './helpers';
+import type { DestinationOption, OpenPanel } from './types';
+import { useSearchFormDismiss, type PanelRegistryEntry } from './useSearchFormDismiss';
+import { useSearchSubmission } from './useSearchSubmission';
+
+type ActivePanel = Exclude<OpenPanel, null>;
+
+export function useSearchFormController(onDestinationMatch: (city: string | null) => void) {
+  const [inputValue, setInputValue] = useState('');
+  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
+  const [openPanel, setOpenPanel] = useState<OpenPanel>(null);
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
+  const [currentMonth, setCurrentMonth] = useState(new Date());
+  const [adults, setAdults] = useState(2);
+  const [children, setChildren] = useState(0);
+  const [childAges, setChildAges] = useState<string[]>([]);
+  const [tripType, setTripType] = useState('');
+  const [budget, setBudget] = useState('');
+  const [showTripType, setShowTripType] = useState(false);
+
+  const {
+    isSearchLoading,
+    validationError,
+    markStarted,
+    handleSearch,
+  } = useSearchSubmission({
+    inputValue,
+    startDate,
+    endDate,
+    adults,
+    children,
+    childAges,
+    tripType,
+    budget,
+  });
+
+  const guestDropdownRef = useRef<HTMLDivElement>(null);
+  const destRef = useRef<HTMLDivElement>(null);
+  const destinationInputRef = useRef<HTMLInputElement>(null);
+  const calendarRef = useRef<HTMLDivElement>(null);
+  const tripTypeRef = useRef<HTMLDivElement>(null);
+  const budgetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (showTripType) {
+      tripTypeRef.current?.querySelector<HTMLButtonElement>('[data-testid="trip-type-filter-btn"]')?.focus();
+    }
+  }, [showTripType]);
+
+  const closePanel = useCallback((panel: ActivePanel) => {
+    setOpenPanel((prev) => (prev === panel ? null : prev));
+  }, []);
+
+  const closeAllPanels = useCallback(() => setOpenPanel(null), []);
+
+  const togglePanel = useCallback((panel: ActivePanel) => {
+    setOpenPanel((prev) => (prev === panel ? null : panel));
+    void import('../../utils/haptics').then(m => m.triggerHaptic('light'));
+  }, []);
+
+  const panelRegistry = useMemo<PanelRegistryEntry[]>(() => ([
+    { panel: 'dest', ref: destRef },
+    { panel: 'calendar', ref: calendarRef },
+    { panel: 'guests', ref: guestDropdownRef },
+    { panel: 'trip', ref: tripTypeRef },
+    { panel: 'budget', ref: budgetRef },
+  ]), []);
+
+  useSearchFormDismiss(panelRegistry, openPanel, closePanel, closeAllPanels);
+
+  const calendarDays = useMemo(() => getDaysInMonth(currentMonth), [currentMonth]);
+
+  const filteredDestinations = useMemo(() => {
+    if (!inputValue) return [];
+    const search = normalizeStr(inputValue);
+    return PRE_NORMALIZED_DB.filter((destination) => destination.nLabel.includes(search)).slice(0, 8);
+  }, [inputValue]);
+
+  const guestSummary = useMemo(() => getGuestSummary(adults, children), [adults, children]);
+  const selectedTripObj = useMemo(() => TRIP_OPTIONS.find((option) => option.label === tripType), [tripType]);
+  const selectedBudgetObj = useMemo(() => BUDGET_TIERS.find((tier) => tier.label === budget), [budget]);
+
+  const handleDestinationChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setInputValue(value);
+    if (value.trim()) markStarted('destination');
+    setOpenPanel('dest');
+    setActiveSuggestionIndex(-1);
+
+    const search = normalizeStr(value);
+    const exactMatch = PRE_NORMALIZED_DB.find((destination) => (
+      destination.nLabel === search || destination.nCity === search
+    ));
+
+    onDestinationMatch(exactMatch ? exactMatch.city : null);
+  }, [onDestinationMatch, markStarted]);
+
+  const handleDestinationSelect = useCallback((destination: DestinationOption) => {
+    setInputValue(destination.label);
+    onDestinationMatch(destination.city);
+    closePanel('dest');
+    setActiveSuggestionIndex(-1);
+  }, [onDestinationMatch, closePanel]);
+
+  const handleDestinationKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (openPanel !== 'dest' || filteredDestinations.length === 0) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveSuggestionIndex((prev) => (prev < filteredDestinations.length - 1 ? prev + 1 : 0));
+      void import('../../utils/haptics').then(m => m.triggerHaptic('light'));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveSuggestionIndex((prev) => (prev > 0 ? prev - 1 : filteredDestinations.length - 1));
+      void import('../../utils/haptics').then(m => m.triggerHaptic('light'));
+    } else if (event.key === 'Enter') {
+      if (activeSuggestionIndex >= 0) {
+        event.preventDefault();
+        handleDestinationSelect(filteredDestinations[activeSuggestionIndex]);
+      }
+    } else if (event.key === 'Escape') {
+      closePanel('dest');
+      setActiveSuggestionIndex(-1);
+    }
+  }, [openPanel, filteredDestinations, activeSuggestionIndex, handleDestinationSelect, closePanel]);
+
+  const handleClearDestination = useCallback(() => {
+    setInputValue('');
+    onDestinationMatch(null);
+    closePanel('dest');
+    setActiveSuggestionIndex(-1);
+    if (destinationInputRef.current) {
+      destinationInputRef.current.focus();
+    }
+    void import('../../utils/haptics').then(m => m.triggerHaptic('light'));
+  }, [onDestinationMatch, closePanel]);
+
+  const handleAdultsChange = useCallback((nextValue: number) => {
+    setAdults(nextValue);
+    void import('../../utils/haptics').then(m => m.triggerHaptic('light'));
+  }, []);
+
+  const handleChildCountChange = useCallback((operation: 'add' | 'remove') => {
+    void import('../../utils/haptics').then(m => m.triggerHaptic('light'));
+    if (operation === 'add') {
+      setChildren((previous) => previous + 1);
+      setChildAges((previous) => [...previous, '']);
+      return;
+    }
+
+    setChildren((previous) => (previous > 0 ? previous - 1 : 0));
+    setChildAges((previous) => (previous.length > 0 ? previous.slice(0, -1) : []));
+  }, []);
+
+  const handleChildAgeChange = useCallback((index: number, value: string) => {
+    setChildAges((previous) => {
+      const nextAges = [...previous];
+      nextAges[index] = value;
+      return nextAges;
+    });
+    void import('../../utils/haptics').then(m => m.triggerHaptic('light'));
+  }, []);
+
+  const handleDateClick = useCallback((date: Date) => {
+    if (isDateInPast(date)) return;
+
+    if (!startDate || endDate) {
+      setStartDate(date);
+      setEndDate(null);
+      markStarted('date');
+      return;
+    }
+
+    if (date < startDate) {
+      setStartDate(date);
+      setEndDate(startDate);
+      return;
+    }
+
+    setEndDate(date);
+    closePanel('calendar');
+  }, [startDate, endDate, closePanel, markStarted]);
+
+  const isDateSelected = useCallback((date: Date) => {
+    if (!startDate) return false;
+    if (startDate.toDateString() === date.toDateString()) return true;
+    return !!endDate && endDate.toDateString() === date.toDateString();
+  }, [startDate, endDate]);
+
+  const isDateInRange = useCallback((date: Date) => {
+    if (!startDate || !endDate) return false;
+    return date > startDate && date < endDate;
+  }, [startDate, endDate]);
+
+  const handleMonthChange = useCallback((offset: number) => {
+    setCurrentMonth((prevMonth) => {
+      const nextMonth = new Date(prevMonth);
+      nextMonth.setMonth(nextMonth.getMonth() + offset);
+
+      const today = new Date();
+      const nextYear = nextMonth.getFullYear();
+      const nextMonthIndex = nextMonth.getMonth();
+      const currentYear = today.getFullYear();
+      const currentMonthIndex = today.getMonth();
+
+      if (nextYear < currentYear || (nextYear === currentYear && nextMonthIndex < currentMonthIndex)) {
+        return prevMonth;
+      }
+
+      return nextMonth;
+    });
+  }, []);
+
+  const canGoToPreviousMonth = useMemo(() => {
+    const today = new Date();
+    return currentMonth.getFullYear() > today.getFullYear()
+      || (currentMonth.getFullYear() === today.getFullYear() && currentMonth.getMonth() > today.getMonth());
+  }, [currentMonth]);
+
+  const handleTripTypeSelect = useCallback((label: string) => {
+    setTripType(label);
+    closePanel('trip');
+  }, [closePanel]);
+
+  const revealTripType = useCallback(() => {
+    setShowTripType(true);
+  }, []);
+
+  const handleBudgetSelect = useCallback((label: string) => {
+    setBudget(label);
+    markStarted('budget');
+    closePanel('budget');
+  }, [closePanel, markStarted]);
+
+  const handleSubmit = useCallback((event: React.FormEvent) => {
+    event.preventDefault();
+    handleSearch();
+  }, [handleSearch]);
+
+  const toggleCalendar = useCallback(() => togglePanel('calendar'), [togglePanel]);
+  const toggleGuestDropdown = useCallback(() => togglePanel('guests'), [togglePanel]);
+  const closeGuestDropdown = useCallback(() => closePanel('guests'), [closePanel]);
+  const toggleTripTypeDropdown = useCallback(() => togglePanel('trip'), [togglePanel]);
+  const toggleBudgetDropdown = useCallback(() => togglePanel('budget'), [togglePanel]);
+  const onDestinationFocus = useCallback(() => {
+    setOpenPanel('dest');
+    setActiveSuggestionIndex(-1);
+  }, []);
+
+  return {
+    inputValue,
+    activeSuggestionIndex,
+    openPanel,
+    startDate,
+    endDate,
+    currentMonth,
+    adults,
+    children,
+    childAges,
+    tripType,
+    budget,
+    showTripType,
+    filteredDestinations,
+    calendarDays,
+    guestSummary,
+    selectedTripObj,
+    selectedBudgetObj,
+    canGoToPreviousMonth,
+    isSearchLoading,
+    validationError,
+    guestDropdownRef,
+    destRef,
+    destinationInputRef,
+    calendarRef,
+    tripTypeRef,
+    budgetRef,
+    handleSubmit,
+    handleDestinationChange,
+    handleDestinationSelect,
+    handleDestinationKeyDown,
+    handleClearDestination,
+    handleAdultsChange,
+    handleChildCountChange,
+    handleChildAgeChange,
+    handleDateClick,
+    isDateSelected,
+    isDateInRange,
+    handleMonthChange,
+    handleTripTypeSelect,
+    revealTripType,
+    handleBudgetSelect,
+    toggleCalendar,
+    toggleGuestDropdown,
+    closeGuestDropdown,
+    toggleTripTypeDropdown,
+    toggleBudgetDropdown,
+    onDestinationFocus,
+  };
+}

--- a/components/search/useSearchSubmission.ts
+++ b/components/search/useSearchSubmission.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { openAiChat } from '../../utils/aiChat';
+import { pushFormAnalyticsEvent } from '../../utils/formAnalytics';
+import { buildSearchMessage } from './helpers';
+
+interface SearchSubmissionInput {
+  inputValue: string;
+  startDate: Date | null;
+  endDate: Date | null;
+  adults: number;
+  children: number;
+  childAges: string[];
+  tripType: string;
+  budget: string;
+}
+
+type TrackedField = 'destination' | 'date' | 'budget';
+
+export function useSearchSubmission({
+  inputValue,
+  startDate,
+  endDate,
+  adults,
+  children,
+  childAges,
+  tripType,
+  budget,
+}: SearchSubmissionInput) {
+  const [isSearchLoading, setIsSearchLoading] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const errorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startedRef = useRef(false);
+  const completedFields = useRef<Set<TrackedField> | null>(null);
+
+  useEffect(() => {
+    pushFormAnalyticsEvent({
+      event: 'form_view',
+      formType: 'home_search',
+      formId: 'hero-search',
+    });
+  }, []);
+
+  const markStarted = useCallback((fieldName: TrackedField) => {
+    if (!startedRef.current) {
+      startedRef.current = true;
+      pushFormAnalyticsEvent({
+        event: 'form_start',
+        formType: 'home_search',
+        formId: 'hero-search',
+      });
+    }
+    const trackedFields = completedFields.current ?? (completedFields.current = new Set());
+    if (!trackedFields.has(fieldName)) {
+      trackedFields.add(fieldName);
+      pushFormAnalyticsEvent({
+        event: 'field_complete',
+        formType: 'home_search',
+        formId: 'hero-search',
+        fieldName,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    const timerRef = errorTimeoutRef;
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleSearch = useCallback(() => {
+    if (!inputValue.trim()) {
+      if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current);
+      setValidationError("Por favor, informe o destino.");
+      pushFormAnalyticsEvent({
+        event: 'field_error',
+        formType: 'home_search',
+        formId: 'hero-search',
+        fieldName: 'destination',
+        errorType: 'required',
+      });
+      void import('../../utils/haptics').then(m => m.triggerHaptic('medium'));
+      errorTimeoutRef.current = setTimeout(() => setValidationError(null), 4000);
+      return;
+    }
+
+    setIsSearchLoading(true);
+    setValidationError(null);
+    pushFormAnalyticsEvent({
+      event: 'submit_attempt',
+      formType: 'home_search',
+      formId: 'hero-search',
+      destination: inputValue,
+    });
+
+    openAiChat({
+      haptic: 'medium',
+      message: buildSearchMessage({
+        inputValue,
+        startDate,
+        endDate,
+        adults,
+        children,
+        childAges,
+        tripType,
+        budget,
+      }),
+    });
+    pushFormAnalyticsEvent({
+      event: 'submit_success',
+      formType: 'home_search',
+      formId: 'hero-search',
+      destination: inputValue,
+    });
+
+    setTimeout(() => {
+      setIsSearchLoading(false);
+    }, 1000);
+  }, [inputValue, startDate, endDate, adults, children, childAges, tripType, budget]);
+
+  return { isSearchLoading, validationError, markStarted, handleSearch };
+}

--- a/docs/superpowers/plans/2026-07-17-react-doctor-top-three.md
+++ b/docs/superpowers/plans/2026-07-17-react-doctor-top-three.md
@@ -1,0 +1,840 @@
+# React Doctor Top Three Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove all eight occurrences of the three requested React Doctor rules while preserving user-visible behavior and leaving the other 21 current findings untouched.
+
+**Architecture:** Keep state at its current owner, extract presentation sections into typed components, and isolate Leaflet ownership in lifecycle-focused hooks/effects. Use React 19 `useEffectEvent` for the pending chat callback and explicit matching teardown for every map timer/listener/resource.
+
+**Tech Stack:** React 19, TypeScript, Vite, Leaflet, Framer Motion, node:test, Playwright, React Doctor 0.7.8+
+
+## Global Constraints
+
+- Fix exactly `react-doctor/no-giant-component`, `react-doctor/prefer-use-effect-event`, and `react-doctor/effect-needs-cleanup`.
+- Preserve copy, rendered semantics, Tailwind classes, analytics, routes, animations, and conversion behavior.
+- Do not add suppressions, edit React Doctor configuration, change dependencies, or fix unrelated diagnostics.
+- Use the baseline `npx react-doctor@latest --verbose` output as the RED check and require the final real-tool scan to remove all eight requested occurrences.
+- Apply repo standards to every touched TypeScript/TSX file and run `pnpm lint:changed` before completion.
+
+## File Structure
+
+- Create `components/ai-chat/AIChatPanelView.tsx`: chat header, message history/action cards, typing state, and composer.
+- Modify `components/AIChatPanel.tsx`: chat state/orchestration, dialog effects, lead submission, pending-message effects, and composition.
+- Create `components/destinations/useDestinationMap.ts`: Leaflet map and marker lifecycle.
+- Create `components/destinations/DestinationsView.tsx`: filters, framed map, cards, and details dialog.
+- Modify `components/Destinations.tsx`: selected destination/filter state and view composition.
+- Create `components/search/useSearchFormController.ts`: form state, derived values, and field interactions.
+- Create `components/search/useSearchSubmission.ts`: analytics lifecycle, validation, and AI-chat submission.
+- Modify `components/SearchForm.tsx`: existing field-component composition only.
+- Modify `components/landings/lollapalooza/VenueMap.tsx`: explicit Leaflet teardown.
+- Create `components/landings/consultoria/ConsultoriaLandingSections.tsx`: consultoria content sections.
+- Modify `pages/landings/ConsultoriaDeViagemLanding.tsx`: metadata, shell, and section composition.
+- Create `components/landings/cruzeiros/CruiseOfferCards.tsx`: offer card primitives and offer conversation shaping.
+- Create `components/landings/cruzeiros/CruzeirosLandingSections.tsx`: cruzeiros content sections.
+- Modify `pages/landings/CruzeirosLanding.tsx`: metadata, offer selection, shell, and section composition.
+
+---
+
+### Task 1: Stabilize pending-chat effects with Effect Events
+
+**Files:**
+- Modify: `components/AIChatPanel.tsx:1,114-122,369-387`
+
+**Interfaces:**
+- Consumes: `AIChatPanelProps.onConsumePending: () => void`
+- Produces: `onConsumePendingEvent: () => void`, callable only from effects
+
+- [ ] **Step 1: Re-run the focused RED check**
+
+Run:
+
+```bash
+npx react-doctor@latest --verbose
+```
+
+Expected: `react-doctor/prefer-use-effect-event` is reported at `components/AIChatPanel.tsx`.
+
+- [ ] **Step 2: Bind the latest callback with React 19 `useEffectEvent`**
+
+Update the React import and add the binding immediately after props are destructured:
+
+```tsx
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+const onConsumePendingEvent = useEffectEvent(onConsumePending);
+```
+
+Replace the two pending effects with:
+
+```tsx
+useEffect(() => {
+  if (!initialAutoSendMessage) return;
+
+  const timer = setTimeout(() => {
+    void submitMessageRef.current(initialAutoSendMessage, false);
+    onConsumePendingEvent();
+  }, initialAutoSendDelayMs ?? 500);
+
+  return () => clearTimeout(timer);
+}, [initialAutoSendMessage, initialAutoSendDelayMs]);
+
+useEffect(() => {
+  if (!initialInputPrefill) return;
+  setInput(initialInputPrefill);
+  onConsumePendingEvent();
+}, [initialInputPrefill]);
+```
+
+- [ ] **Step 3: Verify GREEN for the focused rule and contracts**
+
+Run:
+
+```bash
+pnpm typecheck
+npx react-doctor@latest --verbose
+```
+
+Expected: typecheck passes and `prefer-use-effect-event` is absent.
+
+- [ ] **Step 4: Commit the focused fix**
+
+```bash
+git add components/AIChatPanel.tsx
+git commit -m "fix(chat): stabilize pending message effects"
+```
+
+### Task 2: Make VenueMap teardown own every Leaflet allocation
+
+**Files:**
+- Modify: `components/landings/lollapalooza/VenueMap.tsx:20-136`
+
+**Interfaces:**
+- Consumes: Leaflet `Map`, `Marker`, and timer handles created on mount
+- Produces: one idempotent effect cleanup that unregisters marker handlers and removes the map
+
+- [ ] **Step 1: Confirm the RED diagnostic**
+
+Run:
+
+```bash
+npx react-doctor@latest --verbose
+```
+
+Expected: `effect-needs-cleanup` remains at `VenueMap.tsx:20`.
+
+- [ ] **Step 2: Capture owned resources and matching disposers**
+
+At the top of the effect, replace the uninitialized timer with:
+
+```tsx
+let a11yTimer: ReturnType<typeof setTimeout> | undefined;
+let ownedMap: L.Map | null = null;
+const markerDisposers: Array<() => void> = [];
+```
+
+After `L.map(...)`, assign `ownedMap = map`. Replace each anonymous POI registration with a named handler and disposer:
+
+```tsx
+const handleMarkerClick = () => {
+  setActiveIndex(index);
+  map.flyTo(poi.coords, 13, { animate: true, duration: 1 });
+};
+
+marker.on('click', handleMarkerClick);
+markerDisposers.push(() => marker.off('click', handleMarkerClick));
+```
+
+- [ ] **Step 3: Replace the timer-only cleanup with complete teardown**
+
+```tsx
+return () => {
+  if (a11yTimer !== undefined) clearTimeout(a11yTimer);
+  markerDisposers.forEach((dispose) => dispose());
+  markersRef.current = [];
+
+  if (ownedMap) {
+    ownedMap.off();
+    ownedMap.remove();
+  }
+
+  if (mapInstanceRef.current === ownedMap) {
+    mapInstanceRef.current = null;
+  }
+};
+```
+
+- [ ] **Step 4: Verify the map fix**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm exec playwright test tests/e2e/landing-no-aichat.spec.ts
+npx react-doctor@latest --verbose
+```
+
+Expected: typecheck and Playwright pass; the `VenueMap.tsx` cleanup diagnostic is absent.
+
+- [ ] **Step 5: Commit the focused fix**
+
+```bash
+git add components/landings/lollapalooza/VenueMap.tsx
+git commit -m "fix(lollapalooza): release venue map resources"
+```
+
+### Task 3: Split AIChatPanel presentation from orchestration
+
+**Files:**
+- Create: `components/ai-chat/AIChatPanelView.tsx`
+- Modify: `components/AIChatPanel.tsx:20-100,389-570`
+
+**Interfaces:**
+- Produces: exported `ChatMessage` type and `AIChatPanelView` component
+- Consumes: messages, refs, loading/input state, close/input/submit handlers, and lead-form callbacks
+
+- [ ] **Step 1: Confirm the giant-component RED diagnostic**
+
+Run:
+
+```bash
+npx react-doctor@latest --verbose
+```
+
+Expected: `no-giant-component` reports `AIChatPanel`.
+
+- [ ] **Step 2: Create typed view boundaries**
+
+Create `components/ai-chat/AIChatPanelView.tsx` with these public types and component boundaries:
+
+```tsx
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'model';
+  text: string;
+  chips?: Array<{ id: string; label: string }>;
+  isAction?: boolean;
+  actionData?: {
+    destination: string;
+    bantSummary: string;
+    iataCode?: string;
+  };
+}
+
+interface AIChatPanelViewProps {
+  dialogRef: React.RefObject<HTMLDialogElement | null>;
+  messagesEndRef: React.RefObject<HTMLDivElement | null>;
+  inputRef: React.RefObject<HTMLTextAreaElement | null>;
+  messages: ChatMessage[];
+  lastModelIndex: number;
+  liveAnnouncement: string;
+  input: string;
+  isLoading: boolean;
+  isSubmittingLead: boolean;
+  getLeadWhatsAppUrl: ReturnType<typeof useLeadCapture>['getLeadWhatsAppUrl'];
+  prepareLeadSubmitPayload: (payload: LeadFinalizePayload, eventId: string) => SubmitLeadRequest;
+  finalizeLead: (payload: SubmitLeadRequest) => Promise<LeadFinalizeResult>;
+  onClose: () => void;
+  onInput: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onSubmitMessage: (text: string) => void;
+}
+```
+
+Move the existing `FormattedText` implementation unchanged into this file. Extract the existing JSX ranges into these focused private components without changing their markup or classes:
+
+- `ChatPanelHeader`: current `AIChatPanel.tsx:395-424`
+- `ChatMessageList`: current `AIChatPanel.tsx:426-541`
+- `ChatComposer`: current `AIChatPanel.tsx:543-570`
+
+Compose them in:
+
+```tsx
+export function AIChatPanelView(props: AIChatPanelViewProps) {
+  return (
+    <dialog
+      ref={props.dialogRef}
+      className="ai-chat-drawer fixed top-0 right-0 h-full w-full sm:w-[450px] z-[9999] m-0 ml-auto p-0 bg-white flex-col shadow-[-10px_0_40px_rgba(0,0,0,0.1)] sm:rounded-l-[2rem] overflow-hidden outline-none max-h-full max-w-full"
+      aria-labelledby="ai-chat-title"
+    >
+      <ChatPanelHeader onClose={props.onClose} />
+      <ChatMessageList {...props} />
+      <ChatComposer {...props} />
+    </dialog>
+  );
+}
+```
+
+- [ ] **Step 3: Reduce AIChatPanel to orchestration and composition**
+
+Import `AIChatPanelView` and `ChatMessage`, replace the local `Message` type with `ChatMessage`, remove presentation-only imports, and replace the former dialog JSX with:
+
+```tsx
+return (
+  <AIChatPanelView
+    dialogRef={dialogRef}
+    messagesEndRef={messagesEndRef}
+    inputRef={inputRef}
+    messages={messages}
+    lastModelIndex={lastModelIndex}
+    liveAnnouncement={liveAnnouncement}
+    input={input}
+    isLoading={isLoading}
+    isSubmittingLead={isSubmittingLead}
+    getLeadWhatsAppUrl={getLeadWhatsAppUrl}
+    prepareLeadSubmitPayload={handlePrepareLeadSubmitPayload}
+    finalizeLead={handleFinalizeLead}
+    onClose={closeChatDrawer}
+    onInput={handleInput}
+    onKeyDown={handleKeyDown}
+    onSubmitMessage={(text) => void submitMessage(text)}
+  />
+);
+```
+
+- [ ] **Step 4: Verify behavior and diagnostic removal**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm exec playwright test tests/e2e/ai-chat-lazy-load.spec.ts tests/e2e/chatbot-lead-submit.spec.ts
+npx react-doctor@latest --verbose
+```
+
+Expected: tests pass; `AIChatPanel` is absent from `no-giant-component`; the Effect Event warning remains absent.
+
+- [ ] **Step 5: Commit the extraction**
+
+```bash
+git add components/AIChatPanel.tsx components/ai-chat/AIChatPanelView.tsx
+git commit -m "refactor(chat): split panel presentation"
+```
+
+### Task 4: Isolate Destinations map lifecycle and views
+
+**Files:**
+- Create: `components/destinations/useDestinationMap.ts`
+- Create: `components/destinations/DestinationsView.tsx`
+- Modify: `components/Destinations.tsx`
+
+**Interfaces:**
+- Produces: `useDestinationMap(filteredDestinations, onSelect)` returning `mapRef` and `handleZoom`
+- Produces: `DestinationsView` consuming filter state, selected destination, map ref, and actions
+
+- [ ] **Step 1: Confirm both Destinations RED diagnostics**
+
+Run:
+
+```bash
+npx react-doctor@latest --verbose
+```
+
+Expected: `Destinations` is reported by `no-giant-component` and `effect-needs-cleanup`.
+
+- [ ] **Step 2: Extract the Leaflet owner hook with explicit listener cleanup**
+
+Move the current map initialization and filter-marker effects (`Destinations.tsx:75-236`) into:
+
+```tsx
+export function useDestinationMap(
+  filteredDestinations: Destination[],
+  onSelect: (destination: Destination) => void,
+) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstance = useRef<L.Map | null>(null);
+  const markersLayerRef = useRef<L.FeatureGroup | null>(null);
+
+  const handleZoom = useCallback((type: 'in' | 'out') => {
+    const map = mapInstance.current;
+    if (!map) return;
+    if (type === 'in') map.zoomIn();
+    else map.zoomOut();
+  }, []);
+
+  return { mapRef, handleZoom };
+}
+```
+
+Inside the moved filter effect, use an owned registration list:
+
+```tsx
+const markerRegistrations: Array<{
+  marker: L.Marker;
+  handler: (event: L.LeafletMouseEvent) => void;
+}> = [];
+
+const handleMarkerClick = (event: L.LeafletMouseEvent) => {
+  L.DomEvent.stopPropagation(event);
+  onSelect(dest);
+};
+
+marker.on('click', handleMarkerClick);
+markerRegistrations.push({ marker, handler: handleMarkerClick });
+
+return () => {
+  if (flyTimer !== undefined) clearTimeout(flyTimer);
+  markerRegistrations.forEach(({ marker, handler }) => {
+    marker.off('click', handler);
+  });
+  markersLayer.clearLayers();
+};
+```
+
+The effect depends on `[filteredDestinations, onSelect]`; remove the redundant `activeFilter` dependency because the filtered array already represents it.
+
+- [ ] **Step 3: Extract the view sections**
+
+Move existing JSX without copy/class changes into `DestinationsView.tsx`:
+
+- `DestinationsHeader`: current `Destinations.tsx:254-279`
+- `DestinationMapFrame`: current `Destinations.tsx:281-336`
+- `DestinationCards`: current `Destinations.tsx:338-379`
+- `DestinationDialog`: current `Destinations.tsx:381-473`
+
+Expose one typed composition boundary:
+
+```tsx
+interface DestinationsViewProps {
+  activeFilter: string;
+  filteredDestinations: Destination[];
+  selectedDestination: Destination | null;
+  mapRef: React.RefObject<HTMLDivElement | null>;
+  destinationModalRef: React.RefObject<HTMLDialogElement | null>;
+  onFilterChange: (filter: string) => void;
+  onDestinationSelect: (destination: Destination) => void;
+  onCloseModal: () => void;
+  onZoom: (type: 'in' | 'out') => void;
+}
+```
+
+- [ ] **Step 4: Compose the small state owner**
+
+`components/Destinations.tsx` keeps filter/selection state plus dialog effects and renders:
+
+```tsx
+const { mapRef, handleZoom } = useDestinationMap(filteredDestinations, setSelectedDestination);
+
+return (
+  <DestinationsView
+    activeFilter={activeFilter}
+    filteredDestinations={filteredDestinations}
+    selectedDestination={selectedDestination}
+    mapRef={mapRef}
+    destinationModalRef={destinationModalRef}
+    onFilterChange={setActiveFilter}
+    onDestinationSelect={setSelectedDestination}
+    onCloseModal={closeModal}
+    onZoom={handleZoom}
+  />
+);
+```
+
+- [ ] **Step 5: Verify both Destinations fixes**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm test:regression
+npx react-doctor@latest --verbose --scope changed
+```
+
+Expected: regression and typecheck pass; neither requested rule reports `Destinations`.
+
+- [ ] **Step 6: Commit the extraction**
+
+```bash
+git add components/Destinations.tsx components/destinations
+git commit -m "refactor(destinations): isolate map and views"
+```
+
+### Task 5: Split SearchForm coordination from composition
+
+**Files:**
+- Create: `components/search/useSearchSubmission.ts`
+- Create: `components/search/useSearchFormController.ts`
+- Modify: `components/SearchForm.tsx`
+
+**Interfaces:**
+- Consumes: `onDestinationMatch: (city: string | null) => void`
+- Produces: `SearchFormController` with field props, panel state, refs, validation, and submit handler
+
+- [ ] **Step 1: Confirm the SearchForm RED diagnostic**
+
+Run:
+
+```bash
+npx react-doctor@latest --verbose
+```
+
+Expected: `no-giant-component` reports `SearchForm`.
+
+- [ ] **Step 2: Extract analytics and submission lifecycle**
+
+Create `useSearchSubmission.ts` with this boundary:
+
+```tsx
+interface SearchSubmissionInput {
+  inputValue: string;
+  startDate: Date | null;
+  endDate: Date | null;
+  adults: number;
+  children: number;
+  childAges: string[];
+  tripType: string;
+  budget: string;
+}
+
+export function useSearchSubmission(values: SearchSubmissionInput) {
+  const [isSearchLoading, setIsSearchLoading] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const errorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startedRef = useRef(false);
+  const completedFields = useRef<Set<'destination' | 'date' | 'budget'> | null>(null);
+}
+```
+
+Move the complete implementations of the current form-view effect (`SearchForm.tsx:46-52`), `markStarted` (`54-73`), timeout cleanup (`75-81`), and search submission (`283-331`) below those declarations. Return `{ isSearchLoading, validationError, markStarted, handleSearch }`. The moved timeout cleanup must retain the current `clearTimeout(errorTimeoutRef.current)` behavior.
+
+- [ ] **Step 3: Extract the bounded controller**
+
+Move state, refs, panel registry, derived values, and field callbacks from `SearchForm.tsx:28-281` into `useSearchFormController.ts`. Its return type must expose the exact values consumed by the current JSX:
+
+```tsx
+export function useSearchFormController(onDestinationMatch: (city: string | null) => void) {
+  const submission = useSearchSubmission({
+    inputValue,
+    startDate,
+    endDate,
+    adults,
+    children,
+    childAges,
+    tripType,
+    budget,
+  });
+
+  const handleSubmit = useCallback((event: React.FormEvent) => {
+    event.preventDefault();
+    submission.handleSearch();
+  }, [submission.handleSearch]);
+
+  return {
+    inputValue,
+    activeSuggestionIndex,
+    openPanel,
+    startDate,
+    endDate,
+    currentMonth,
+    adults,
+    children,
+    childAges,
+    tripType,
+    budget,
+    showTripType,
+    filteredDestinations,
+    calendarDays,
+    guestSummary,
+    selectedTripObj,
+    selectedBudgetObj,
+    canGoToPreviousMonth,
+    isSearchLoading: submission.isSearchLoading,
+    validationError: submission.validationError,
+    guestDropdownRef,
+    destRef,
+    destinationInputRef,
+    calendarRef,
+    tripTypeRef,
+    budgetRef,
+    handleSubmit,
+    handleDestinationChange,
+    handleDestinationSelect,
+    handleDestinationKeyDown,
+    handleClearDestination,
+    handleAdultsChange,
+    handleChildCountChange,
+    handleChildAgeChange,
+    handleDateClick,
+    isDateSelected,
+    isDateInRange,
+    handleMonthChange,
+    handleTripTypeSelect,
+    revealTripType,
+    handleBudgetSelect,
+    toggleCalendar,
+    toggleGuestDropdown,
+    closeGuestDropdown,
+    toggleTripTypeDropdown,
+    toggleBudgetDropdown,
+    onDestinationFocus,
+  };
+}
+```
+
+- [ ] **Step 4: Keep SearchForm as the existing view composition**
+
+Replace `SearchForm.tsx:28-347` with `const controller = useSearchFormController(onDestinationMatch);`. Keep the complete return tree from current lines 349-442 unchanged. Destructure every identifier that tree consumes from `controller` once before the return so the existing field props and form class remain byte-for-byte unchanged.
+
+- [ ] **Step 5: Verify search behavior and size**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm exec playwright test tests/e2e/hero_ux.spec.ts
+npx react-doctor@latest --verbose --scope changed
+```
+
+Expected: search interactions pass and `SearchForm` is absent from `no-giant-component`.
+
+- [ ] **Step 6: Commit the extraction**
+
+```bash
+git add components/SearchForm.tsx components/search/useSearchFormController.ts components/search/useSearchSubmission.ts
+git commit -m "refactor(search): split form coordination"
+```
+
+### Task 6: Split Consultoria landing sections
+
+**Files:**
+- Create: `components/landings/consultoria/ConsultoriaLandingSections.tsx`
+- Modify: `pages/landings/ConsultoriaDeViagemLanding.tsx`
+
+**Interfaces:**
+- Produces: `ConsultoriaHero`, `ConsultoriaBenefits`, `ConsultoriaAudience`, `ConsultoriaProcess`, `ConsultoriaAbout`, `ConsultoriaFinalCta`, and `ConsultoriaOtherServices`
+- Consumes: module-local static arrays moved with the sections
+
+- [ ] **Step 1: Confirm the landing RED diagnostic**
+
+Run:
+
+```bash
+npx react-doctor@latest --verbose
+```
+
+Expected: `no-giant-component` reports `ConsultoriaDeViagemLanding`.
+
+- [ ] **Step 2: Move section data and JSX into focused components**
+
+Move `FOR_WHO`, `HOW_IT_WORKS`, `PILLARS`, and `CREDENTIALS` plus these exact JSX ranges into `ConsultoriaLandingSections.tsx` without changing content or classes:
+
+- `ConsultoriaHero`: lines 137-201
+- `ConsultoriaBenefits`: lines 203-265
+- `ConsultoriaAudience`: lines 267-322
+- `ConsultoriaProcess`: lines 324-359
+- `ConsultoriaAbout`: lines 361-417
+- `ConsultoriaFinalCta`: lines 419-446
+- `ConsultoriaOtherServices`: lines 448-488
+
+Export each moved range as a parameterless function named `ConsultoriaHero`, `ConsultoriaBenefits`, `ConsultoriaAudience`, `ConsultoriaProcess`, `ConsultoriaAbout`, `ConsultoriaFinalCta`, and `ConsultoriaOtherServices`, respectively. Each function returns its listed `<section>` range exactly.
+
+- [ ] **Step 3: Compose the route shell**
+
+Keep FAQ/schema/nav/footer ownership in the route and replace the moved sections with:
+
+```tsx
+<LandingNav source="consultoria-viagem" />
+<ConsultoriaHero />
+<ConsultoriaBenefits />
+<ConsultoriaAudience />
+<ConsultoriaProcess />
+<ConsultoriaAbout />
+<ConsultoriaFinalCta />
+<ConsultoriaOtherServices />
+<LandingFAQ
+  items={FAQ_ITEMS}
+  title="Dúvidas sobre consultoria de viagem"
+  subtitle="Tire suas dúvidas sobre como funciona a consultoria personalizada da Anhangá."
+/>
+<LandingFooter />
+```
+
+- [ ] **Step 4: Verify landing behavior and diagnostic removal**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm exec playwright test tests/e2e/landing-consultoria-content.spec.ts tests/e2e/landing-no-aichat.spec.ts
+npx react-doctor@latest --verbose --scope changed
+```
+
+Expected: landing tests pass and `ConsultoriaDeViagemLanding` is absent from `no-giant-component`.
+
+- [ ] **Step 5: Commit the extraction**
+
+```bash
+git add pages/landings/ConsultoriaDeViagemLanding.tsx components/landings/consultoria
+git commit -m "refactor(consultoria): split landing sections"
+```
+
+### Task 7: Split Cruzeiros offer and landing sections
+
+**Files:**
+- Create: `components/landings/cruzeiros/CruiseOfferCards.tsx`
+- Create: `components/landings/cruzeiros/CruzeirosLandingSections.tsx`
+- Modify: `pages/landings/CruzeirosLanding.tsx`
+
+**Interfaces:**
+- Produces: offer card components and section components
+- Consumes: `featuredOffer?: CruiseOffer` and `secondaryOffers: CruiseOffer[]`
+
+- [ ] **Step 1: Confirm the landing RED diagnostic**
+
+Run:
+
+```bash
+npx react-doctor@latest --verbose
+```
+
+Expected: `no-giant-component` reports `CruzeirosLanding`.
+
+- [ ] **Step 2: Move offer presentation and conversation shaping**
+
+Move `offerCrmLabel`, `offerWhatsappMessage`, `openOfferConversation`, `OfferMeta`, `ProfileTags`, `RegionBadge`, `FeaturedOffer`, and `OfferCard` from current lines 26-233 into `CruiseOfferCards.tsx`. Export only the two existing card components with these signatures:
+
+```tsx
+export function FeaturedOffer({ offer }: { offer: CruiseOffer }): React.ReactElement;
+export function OfferCard({ offer }: { offer: CruiseOffer }): React.ReactElement;
+```
+
+Keep the formatting helpers private to that module.
+
+- [ ] **Step 3: Move static content sections**
+
+Move `HOW_IT_WORKS`, `WHY_CURATION`, and the listed current JSX ranges into focused exports. The exact signature for the only data-bearing boundary is:
+
+```tsx
+interface CruiseOffersSectionProps {
+  featuredOffer?: CruiseOffer;
+  secondaryOffers: CruiseOffer[];
+}
+
+export function CruiseOffersSection({
+  featuredOffer,
+  secondaryOffers,
+}: CruiseOffersSectionProps): React.ReactElement | null;
+```
+
+Export the remaining ranges as parameterless functions: `CruiseMiniHeader` (273-299), `CruiseHero` (301-346), `CruiseProcess` (415-450), `CruiseCurationBenefits` (452-498), `CruiseAbout` (500-529), `CruiseFinalCta` (531-559), `CruiseOtherServices` (561-601), and `CruiseLandingFooter` (610-613). Each function body uses that exact existing markup, copy, classes, motion variants, tracking values, and CTA sources.
+
+- [ ] **Step 4: Compose the route shell**
+
+Replace the former page body sections with:
+
+```tsx
+<CruiseMiniHeader />
+<CruiseHero />
+<CruiseOffersSection
+  featuredOffer={FEATURED_OFFER}
+  secondaryOffers={SECONDARY_OFFERS}
+/>
+<CruiseProcess />
+<CruiseCurationBenefits />
+<CruiseAbout />
+<CruiseFinalCta />
+<CruiseOtherServices />
+<LandingFAQ
+  items={FAQ_ITEMS}
+  title="Dúvidas sobre cruzeiros"
+  subtitle="Tire suas dúvidas antes de escolher seu cruzeiro."
+/>
+<CruiseLandingFooter />
+```
+
+The offers component returns `null` when both `featuredOffer` is absent and `secondaryOffers` is empty, preserving the existing empty-season behavior.
+
+- [ ] **Step 5: Verify offer behavior and diagnostic removal**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm exec playwright test tests/e2e/cruzeiros-ofertas.spec.ts tests/e2e/cruzeiros-redirect.spec.ts
+npx react-doctor@latest --verbose --scope changed
+```
+
+Expected: offer/redirect tests pass and `CruzeirosLanding` is absent from `no-giant-component`.
+
+- [ ] **Step 6: Commit the extraction**
+
+```bash
+git add pages/landings/CruzeirosLanding.tsx components/landings/cruzeiros
+git commit -m "refactor(cruzeiros): split landing sections"
+```
+
+### Task 8: Run full completion verification
+
+**Files:**
+- Verify all files changed in Tasks 1-7
+- Do not edit unrelated diagnostics
+
+**Interfaces:**
+- Produces: evidence that tests, build, lint ratchet, and the actual latest React Doctor agree
+
+- [ ] **Step 1: Check the final diff scope**
+
+Run:
+
+```bash
+git status --short
+git diff --check main...HEAD
+git diff --stat main...HEAD
+```
+
+Expected: only the design/plan and files listed above are changed; no whitespace errors.
+
+- [ ] **Step 2: Run repository gates**
+
+```bash
+pnpm test:regression
+pnpm typecheck
+pnpm lint:changed
+pnpm run build
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 3: Run the relevant browser regression set**
+
+```bash
+pnpm exec playwright test \
+  tests/e2e/ai-chat-lazy-load.spec.ts \
+  tests/e2e/chatbot-lead-submit.spec.ts \
+  tests/e2e/hero_ux.spec.ts \
+  tests/e2e/landing-consultoria-content.spec.ts \
+  tests/e2e/landing-no-aichat.spec.ts \
+  tests/e2e/cruzeiros-ofertas.spec.ts \
+  tests/e2e/cruzeiros-redirect.spec.ts
+```
+
+Expected: every selected test passes.
+
+- [ ] **Step 4: Run the authoritative React Doctor scan**
+
+```bash
+npx react-doctor@latest --verbose
+```
+
+Expected:
+
+- no `react-doctor/no-giant-component`
+- no `react-doctor/prefer-use-effect-event`
+- no `react-doctor/effect-needs-cleanup`
+- unrelated findings remain unmodified for the follow-up
+
+- [ ] **Step 5: Inspect final history and working tree**
+
+```bash
+git log --oneline main..HEAD
+git status --short
+```
+
+Expected: focused conventional commits and a clean working tree except for this plan if it was intentionally left uncommitted.

--- a/docs/superpowers/specs/2026-07-17-react-doctor-top-three-design.md
+++ b/docs/superpowers/specs/2026-07-17-react-doctor-top-three-design.md
@@ -1,0 +1,99 @@
+# React Doctor Top Three Design
+
+## Goal
+
+Remove every occurrence of the three requested React Doctor rule families without suppressing diagnostics or changing user-visible behavior:
+
+- `react-doctor/no-giant-component` (5 occurrences)
+- `react-doctor/prefer-use-effect-event` (1 occurrence)
+- `react-doctor/effect-needs-cleanup` (2 occurrences)
+
+All other findings from the current React Doctor scan remain out of scope for a follow-up pass.
+
+## Baseline
+
+The isolated branch starts from `main` at `55552c7`. The baseline has:
+
+- 969 passing regression tests
+- React Doctor 0.7.8 score: 64/100
+- 29 live findings, including the same eight requested occurrences from the supplied 26-finding report
+
+The supplied `diagnostics.json` contains no `fixGroupId` property. Each requested rule family is therefore one task, and its repeated locations are occurrences within that task.
+
+## Constraints
+
+- Follow the current no-cache canonical React Doctor validation and fix recipes.
+- Do not add suppressions, change React Doctor configuration, or hide registrations from static analysis.
+- Preserve page copy, markup semantics, styling classes, analytics events, routes, animation behavior, and contact/chat behavior.
+- Do not fix unrelated React Doctor findings, dependency warnings, or legacy lint debt.
+- Keep React 19, TypeScript, Vite, Leaflet, Framer Motion, and the existing test stack unchanged.
+
+## Architecture
+
+### AI chat panel
+
+`components/AIChatPanel.tsx` remains the owner of chat state, Gemini orchestration, dialog lifecycle, and lead submission. Presentation-only regions move into `components/ai-chat/AIChatPanelView.tsx`:
+
+- drawer header
+- message history, action cards, chips, and typing indicator
+- message composer
+
+The parent passes explicit data and event callbacks to these view components. A React 19 `useEffectEvent` binding calls the latest `onConsumePending` implementation from the delayed auto-send and prefill effects without making callback identity a reason to restart either effect.
+
+### Destinations section
+
+Leaflet setup and marker lifecycle move to `components/destinations/useDestinationMap.ts`. The hook owns the map, marker layer, filter-driven markers, animation timer, and every marker click registration.
+
+The UI is decomposed into focused components under `components/destinations/` for the section header/filter controls, framed map, destination cards, and destination dialog. `components/Destinations.tsx` remains the small stateful coordinator.
+
+Each marker click callback is stored as a named handler and removed with the matching Leaflet `off` call before the marker layer is cleared. This makes allocation ownership explicit even though the previous `clearLayers()` teardown already removed layers from the map.
+
+### Search form
+
+The existing field components remain unchanged. Coordination moves from `components/SearchForm.tsx` into a bounded controller hook under `components/search/`.
+
+The controller owns form state, panel coordination, date/guest/destination handlers, and the values consumed by the view. Analytics and submit orchestration are separated into a smaller helper hook so the controller does not merely become a renamed giant unit. `SearchForm.tsx` becomes the form composition layer.
+
+### Lollapalooza venue map
+
+The mount effect in `components/landings/lollapalooza/VenueMap.tsx` retains direct ownership of the Leaflet map. Its returned teardown clears the accessibility timer, unregisters marker click callbacks, removes marker listeners, removes the Leaflet map, resets refs, and releases the marker list.
+
+This prevents map instances and event callbacks from surviving route changes or remounts.
+
+### Static landing pages
+
+The already-labelled sections of the consultoria and cruzeiros pages move into page-specific components under:
+
+- `components/landings/consultoria/`
+- `components/landings/cruzeiros/`
+
+The route files retain SEO/schema declarations, no-JavaScript fallback, Motion configuration, navigation/footer composition, and page-level data selection. Extracted sections receive only the data they need. Existing offer card components move with the cruzeiros sections rather than being duplicated.
+
+## Data Flow
+
+- State remains at the nearest existing owner; presentation components receive values and callbacks through typed props.
+- No new global state, context, reducer, network call, or persistence layer is introduced.
+- Leaflet resources are created and destroyed in the same effect lifecycle.
+- `useEffectEvent` reads the latest pending-consumption callback while the pending message/prefill values remain the effects' reactive triggers.
+
+## Error Handling
+
+Existing chat, lead submission, map guard, and form validation behavior remains unchanged. The refactor adds no new error states. Leaflet cleanup must tolerate partial initialization and repeated unmount cleanup through null checks and idempotent teardown APIs.
+
+## Verification
+
+The baseline React Doctor scan is the failing red check for the requested structural and lifecycle rules. Verification proceeds in focused batches:
+
+1. Implement explicit Leaflet cleanup and the Effect Event fix, then run changed-file typecheck/lint and focused tests.
+2. Extract the five giant components, then run their existing chat/search/landing tests.
+3. Run the repository completion gates: `pnpm test:regression`, `pnpm typecheck`, `pnpm lint:changed`, and `pnpm run build`.
+4. Run relevant Playwright suites for chat/search, consultoria, cruzeiros, and landing navigation.
+5. Run `npx react-doctor@latest --verbose` and confirm all eight requested occurrences are absent while unrelated findings remain untouched.
+
+## Out of Scope
+
+- The remaining 21 findings in the current 29-finding scan
+- Copy, visual design, CRO, SEO, or analytics changes
+- Dependency cleanup
+- React Doctor suppression or false-positive configuration
+- Opening or merging a pull request

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { m, MotionConfig } from 'framer-motion';
+import { MotionConfig } from 'framer-motion';
 import { Seo } from '@/components/Seo';
 import { LandingFAQ } from '@/components/LandingFAQ';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
 import { ServiceSchema } from '@/components/schemas/ServiceSchema';
-import { Button } from '@/components/ui/Button';
-import { LazyImage } from '@/components/ui/LazyImage';
 import { LandingNav } from '@/components/landings/shared/LandingNav';
 import { LandingFooter } from '@/components/landings/shared/LandingFooter';
-import { fadeUp } from '@/components/landings/shared/constants';
-import { openContactModal } from '@/utils/contactForm';
-import { getDestinationImage } from '@/data/mediaConfig';
-import { ArrowRight, CheckCircle, MessageSquare, Users, Headphones, Compass } from 'lucide-react';
+import {
+  ConsultoriaAbout,
+  ConsultoriaAudience,
+  ConsultoriaBenefits,
+  ConsultoriaFinalCta,
+  ConsultoriaHero,
+  ConsultoriaOtherServices,
+  ConsultoriaProcess,
+} from '@/components/landings/consultoria/ConsultoriaLandingSections';
 
 const FAQ_ITEMS = [
   {
@@ -38,62 +40,6 @@ const FAQ_ITEMS = [
     question: 'Qual o prazo para montar um roteiro?',
     answer: 'Entre 2 e 5 dias úteis após a conversa inicial, dependendo da complexidade do destino e do número de viajantes.'
   }
-];
-
-// 4 itens, não 5: chunking ≤4 do critique — os antigos itens 4 e 5
-// ("viajantes frequentes" / "profissionais sem tempo") eram o mesmo perfil.
-const FOR_WHO = [
-  'Quem quer viajar bem sem precisar cuidar de cada detalhe',
-  'Famílias que buscam conforto e segurança no roteiro',
-  'Casais planejando viagem especial ou lua de mel',
-  'Viajantes frequentes sem tempo de pesquisar e comparar opções',
-];
-
-const HOW_IT_WORKS = [
-  {
-    step: '01',
-    title: 'Conversa inicial',
-    // Não prometer "sem formulário": o CTA da página abre o ContactModal, que
-    // é um formulário — Riley pegava a contradição na hora. Ver critique.
-    desc: 'Você fala com um consultor e conta o que precisa. Uma conversa de verdade, sem burocracia.'
-  },
-  {
-    step: '02',
-    title: 'Roteiro personalizado',
-    desc: 'Em até 5 dias úteis, você recebe um roteiro feito do zero para o seu perfil.'
-  },
-  {
-    step: '03',
-    title: 'Suporte durante a viagem',
-    desc: 'WhatsApp 24h com o mesmo consultor. Qualquer imprevisto tem resposta imediata.'
-  },
-];
-
-const PILLARS = [
-  {
-    icon: MessageSquare,
-    title: 'Sem pacote pronto',
-    desc: 'Cada roteiro começa do zero, no perfil de quem vai viajar. Nada de escolher entre opções genéricas.',
-    variant: 'light' as const
-  },
-  {
-    icon: Users,
-    title: 'Atendimento humano',
-    desc: 'Um consultor real do início ao fim. Não um chatbot, não uma central de atendimento.',
-    variant: 'filled' as const
-  },
-  {
-    icon: Headphones,
-    title: 'Suporte completo',
-    desc: 'Antes, durante e depois da viagem. WhatsApp direto com seu consultor para qualquer imprevisto.',
-    variant: 'light' as const
-  },
-];
-
-const CREDENTIALS = [
-  'Fundada em 2018',
-  'Nota 5.0 no Google',
-  'Atendimento humano',
 ];
 
 const ConsultoriaDeViagemLanding: React.FC = () => {
@@ -133,367 +79,18 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
         <FAQPageSchema items={FAQ_ITEMS} />
 
         <LandingNav source="consultoria-viagem" />
-
-        {/* Hero */}
-        {/*
-          Espaçamento e tamanho do texto reduzidos em mobile (md: restaura os
-          valores originais): em telas curtas (~360-812px de altura) o CTA e o
-          disclaimer "Sem taxa..." caem perto do fim do viewport inicial, e o
-          banner de cookies (fixed bottom-0) os cobre antes de qualquer scroll
-          — combinado com CookieConsentBanner.tsx, que também foi compactado
-          no mobile. Ver critique de /consultoria-de-viagem.
-        */}
-        {/*
-          max-w-4xl (não 3xl): a 3xl o H1 text-6xl quebrava em 4 linhas e
-          empurrava o par CTA + "Sem taxa..." para fora da dobra a 1366×768
-          (laptop mais comum no Brasil). Ver critique de /consultoria-de-viagem.
-        */}
-        <section className="pt-3 md:pt-16 pb-20 px-6">
-          <div className="max-w-4xl mx-auto">
-            <m.div
-              variants={fadeUp}
-              initial="hidden"
-              animate="visible"
-              custom={0}
-              className="inline-flex items-center gap-2 rounded-full border border-anhanga-blue/20 bg-anhanga-blue/5 px-3 py-0.5 md:py-1 mb-2 md:mb-5 text-[11px] md:text-xs font-black uppercase tracking-widest text-anhanga-blue"
-            >
-              {/*
-                "todo o Brasil", não "São Paulo": o badge é a primeira leitura da
-                página e cercava quem chega de fora de SP — a correção só aparecia
-                na 3ª pergunta do FAQ. O sinal local de SEO permanece no <title> e
-                no areaServed do ServiceSchema. Ver critique de /consultoria-de-viagem.
-              */}
-              <Compass className="size-3.5" aria-hidden="true" />
-              Consultoria de viagem · todo o Brasil
-            </m.div>
-            <m.h1
-              variants={fadeUp}
-              initial="hidden"
-              animate="visible"
-              custom={1}
-              className="text-balance text-4xl md:text-6xl font-black text-anhanga-dark mb-2 md:mb-6 leading-[1.1]"
-            >
-              Planeje uma viagem sob medida sem depender de pacote pronto
-            </m.h1>
-            <m.p
-              variants={fadeUp}
-              initial="hidden"
-              animate="visible"
-              custom={2}
-              className="text-base md:text-xl text-zinc-600 mb-3 md:mb-10 leading-relaxed max-w-2xl"
-            >
-              Um consultor da Anhangá entende seu perfil, destino, orçamento e restrições para desenhar o melhor caminho antes de você fechar.
-            </m.p>
-            <m.div variants={fadeUp} initial="hidden" animate="visible" custom={3}>
-              <Button
-                variant="cta"
-                size="lg"
-                onClick={() => openContactModal({ source: 'consultoria-viagem' })}
-                className="btn-whatsapp btn-specialist font-black"
-                rightIcon={<ArrowRight className="size-5" aria-hidden="true" />}
-                data-tracking="hero-consultoria-viagem"
-              >
-                Falar com um consultor
-              </Button>
-              <p className="mt-1 md:mt-4 text-sm text-zinc-600">Sem taxa de consultoria. Gratuito.</p>
-            </m.div>
-          </div>
-        </section>
-
-        {/* Por que consultoria? */}
-        <section className="py-20 bg-white">
-          <div className="max-w-5xl mx-auto px-6">
-            {/*
-              margin de um viewport de altura (100%) abaixo do viewport (mesma
-              convenção em todas as seções seguintes): dispara a revelação antes da
-              seção entrar na tela, não quando já está visível. Sem isso, rolagem
-              rápida mostrava conteúdo semitransparente mesmo já dentro do viewport
-              — lia como página quebrada. Ver critique de /consultoria-de-viagem.
-            */}
-            <m.div
-              variants={fadeUp}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
-              custom={0}
-              className="mb-12"
-            >
-              <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3">
-                Por que consultoria?
-              </h2>
-              <p className="text-zinc-600 text-lg">
-                Porque viajar bem não é só escolher um destino.
-              </p>
-            </m.div>
-            <div className="grid md:grid-cols-3 gap-6">
-              {PILLARS.map(({ icon: Icon, title, desc, variant }, idx) => (
-                <m.div
-                  key={title}
-                  variants={fadeUp}
-                  initial="hidden"
-                  whileInView="visible"
-                  viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
-                  custom={idx + 1}
-                  // Sem lift no hover: os cards não são clicáveis, e sombra que
-                  // cresce ao passar o mouse é affordance de clique sem clique.
-                  className={`p-8 rounded-2xl ${
-                    variant === 'filled'
-                      ? 'bg-anhanga-blue text-white'
-                      : 'bg-anhanga-light shadow-float'
-                  }`}
-                >
-                  <div
-                    className={`size-11 rounded-xl flex items-center justify-center mb-5 ${
-                      variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
-                    }`}
-                  >
-                    <Icon
-                      className={`size-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`}
-                      aria-hidden="true"
-                    />
-                  </div>
-                  <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
-                    {title}
-                  </h3>
-                  <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-zinc-600 leading-relaxed'}>
-                    {desc}
-                  </p>
-                </m.div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Para quem é */}
-        <section className="py-20 bg-anhanga-light">
-          <div className="max-w-5xl mx-auto px-6">
-            <div className="md:grid md:grid-cols-2 md:gap-16 items-start">
-              <m.div
-                variants={fadeUp}
-                initial="hidden"
-                whileInView="visible"
-                viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
-                custom={0}
-              >
-                <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-8">
-                  Para quem é
-                </h2>
-                <ul className="space-y-4">
-                  {FOR_WHO.map(item => (
-                    <li key={item} className="flex items-start gap-3">
-                      <CheckCircle className="size-5 text-anhanga-blue flex-shrink-0 mt-0.5" aria-hidden="true" />
-                      <span className="text-zinc-700 leading-snug">{item}</span>
-                    </li>
-                  ))}
-                </ul>
-              </m.div>
-              <m.div
-                variants={fadeUp}
-                initial="hidden"
-                whileInView="visible"
-                viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
-                custom={1}
-                className="mt-12 md:mt-0 overflow-hidden rounded-3xl bg-white shadow-float"
-              >
-                {/*
-                  Depoimento pareado com o lugar real da viagem (não um ícone
-                  genérico): reforça "lugares reais, não categorias de
-                  produto" — a página inteira era só tipografia + ícones antes
-                  desta correção. Ver critique de /consultoria-de-viagem.
-                */}
-                <LazyImage
-                  src={getDestinationImage('Lisboa')}
-                  alt="Lisboa, Portugal — destino da viagem relatada no depoimento"
-                  width={640}
-                  height={280}
-                  className="h-48 w-full"
-                />
-                <div className="p-8">
-                  <blockquote className="text-xl text-anhanga-dark font-semibold leading-relaxed">
-                    "A Anhangá cuidou de cada detalhe. Só precisei aparecer no aeroporto."
-                  </blockquote>
-                  <p className="mt-4 text-zinc-600 text-sm">
-                    R.M. · São Paulo · Viagem para Portugal, 2025
-                  </p>
-                </div>
-              </m.div>
-            </div>
-          </div>
-        </section>
-
-        {/* Como funciona */}
-        <section className="py-20 bg-white">
-          <div className="max-w-5xl mx-auto px-6">
-            <m.h2
-              variants={fadeUp}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
-              custom={0}
-              className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12"
-            >
-              Como funciona
-            </m.h2>
-            <div className="space-y-0">
-              {HOW_IT_WORKS.map(({ step, title, desc }, idx) => (
-                <m.div
-                  key={step}
-                  variants={fadeUp}
-                  initial="hidden"
-                  whileInView="visible"
-                  viewport={{ once: true, amount: 0.3, margin: '0px 0px 100% 0px' }}
-                  custom={idx + 1}
-                  className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-zinc-100' : ''}`}
-                >
-                  <div className="flex-shrink-0 size-12 rounded-full bg-anhanga-blue/10 flex items-center justify-center">
-                    <span className="text-sm font-black text-anhanga-blue">{step}</span>
-                  </div>
-                  <div>
-                    <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
-                    <p className="text-zinc-600 leading-relaxed max-w-xl">{desc}</p>
-                  </div>
-                </m.div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Sobre a Anhangá */}
-        <section className="py-20 bg-anhanga-light">
-          <div className="max-w-5xl mx-auto px-6">
-            <div className="md:grid md:grid-cols-2 md:gap-16 items-center">
-              <m.div
-                variants={fadeUp}
-                initial="hidden"
-                whileInView="visible"
-                viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
-                custom={0}
-                className="overflow-hidden rounded-3xl shadow-float"
-              >
-                {/*
-                  Segunda foto real da página (a primeira é o depoimento de
-                  Lisboa) — "Sobre" era só tipografia antes, contrariando
-                  "lugares reais, não categorias" para um brief sobre viagens.
-                  Ver critique de /consultoria-de-viagem (P2).
-                */}
-                <LazyImage
-                  src={getDestinationImage('Rio de Janeiro')}
-                  alt="Rio de Janeiro — um dos destinos planejados pela Anhangá Viagens"
-                  width={640}
-                  height={480}
-                  className="h-64 md:h-80 w-full"
-                />
-              </m.div>
-              <m.div
-                variants={fadeUp}
-                initial="hidden"
-                whileInView="visible"
-                viewport={{ once: true, amount: 0.2, margin: '0px 0px 100% 0px' }}
-                custom={1}
-                className="mt-10 md:mt-0 text-center md:text-left"
-              >
-                <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6">
-                  Sobre a Anhangá Viagens
-                </h2>
-                <p className="text-lg text-zinc-600 leading-relaxed">
-                  Agência de viagens em São Paulo, especializada em viagens personalizadas desde 2018. Atendimento humano, nota 5.0 no Google e consultor fixo do início ao fim da sua viagem.
-                </p>
-                <div className="mt-10 flex flex-wrap justify-center md:justify-start gap-3">
-                  {CREDENTIALS.map(item => (
-                    <span
-                      key={item}
-                      // Borda 1px, não shadow-float: pílula branca elevada parecia
-                      // clicável (spec de Badge do DESIGN.md: borda, sem sombra).
-                      className="inline-flex items-center gap-2 rounded-full bg-white border border-zinc-200 px-4 py-2 text-sm font-bold text-anhanga-dark"
-                    >
-                      <CheckCircle className="size-4 text-anhanga-blue" aria-hidden="true" />
-                      {item}
-                    </span>
-                  ))}
-                </div>
-              </m.div>
-            </div>
-          </div>
-        </section>
-
-        {/* CTA Final */}
-        <section className="py-20 bg-anhanga-blue">
-          <m.div
-            variants={fadeUp}
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true, amount: 0.3, margin: '0px 0px 100% 0px' }}
-            custom={0}
-            className="max-w-3xl mx-auto px-6 text-center"
-          >
-            <h2 className="text-3xl md:text-5xl font-black text-white mb-6">
-              Pronto para planejar sua viagem?
-            </h2>
-            <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
-              Fale com um consultor agora. Sem taxa, sem compromisso.
-            </p>
-            <Button
-              variant="cta"
-              size="lg"
-              onClick={() => openContactModal({ source: 'consultoria-viagem' })}
-              className="btn-whatsapp btn-specialist font-black"
-              rightIcon={<ArrowRight className="size-6" aria-hidden="true" />}
-              data-tracking="footer-consultoria-viagem"
-            >
-              Falar com um consultor
-            </Button>
-          </m.div>
-        </section>
-
-        {/* Outros serviços */}
-        <section className="py-16 bg-anhanga-light">
-          <div className="max-w-5xl mx-auto px-6">
-            <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
-            <div className="grid md:grid-cols-3 gap-4">
-              <Link
-                to="/corporativo/"
-                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/5 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
-              >
-                <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
-                  Viagens para Executivos
-                </div>
-                <div className="text-sm text-zinc-600 mt-1">
-                  Planejamento com precisão para profissionais
-                </div>
-              </Link>
-              <Link
-                to="/cruzeiros/"
-                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/5 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
-              >
-                <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
-                  Curadoria de Cruzeiros
-                </div>
-                <div className="text-sm text-zinc-600 mt-1">
-                  Escolha o navio e a cabine certos para você
-                </div>
-              </Link>
-              <Link
-                to="/"
-                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/5 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
-              >
-                <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
-                  Site principal
-                </div>
-                <div className="text-sm text-zinc-600 mt-1">
-                  Conheça todos os serviços da Anhangá
-                </div>
-              </Link>
-            </div>
-          </div>
-        </section>
-
-        {/* FAQ */}
+        <ConsultoriaHero />
+        <ConsultoriaBenefits />
+        <ConsultoriaAudience />
+        <ConsultoriaProcess />
+        <ConsultoriaAbout />
+        <ConsultoriaFinalCta />
+        <ConsultoriaOtherServices />
         <LandingFAQ
           items={FAQ_ITEMS}
           title="Dúvidas sobre consultoria de viagem"
           subtitle="Tire suas dúvidas sobre como funciona a consultoria personalizada da Anhangá."
         />
-
         <LandingFooter />
       </div>
       </MotionConfig>

--- a/pages/landings/CruzeirosLanding.tsx
+++ b/pages/landings/CruzeirosLanding.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { m, MotionConfig } from 'framer-motion';
+import { MotionConfig } from 'framer-motion';
 import { Seo } from '@/components/Seo';
 import { LandingFAQ } from '@/components/LandingFAQ';
 import { BreadcrumbSchema } from '@/components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '@/components/schemas/FAQPageSchema';
 import { ServiceSchema } from '@/components/schemas/ServiceSchema';
-import { Button } from '@/components/ui/Button';
-import { LazyImage } from '@/components/ui/LazyImage';
-import { fadeUp } from '@/components/landings/shared/constants';
-import { openContactModal } from '@/utils/contactForm';
-import { CRUISE_OFFERS, type CruiseOffer } from '@/data/cruiseOffers';
+import {
+  CruiseAbout,
+  CruiseCurationBenefits,
+  CruiseFinalCta,
+  CruiseHero,
+  CruiseLandingFooter,
+  CruiseMiniHeader,
+  CruiseOffersSection,
+  CruiseOtherServices,
+  CruiseProcess,
+} from '@/components/landings/cruzeiros/CruzeirosLandingSections';
+import { CRUISE_OFFERS } from '@/data/cruiseOffers';
 import { getActiveOffers } from '@/lib/cruise-offers-schedule.js';
-import { ArrowLeft, ArrowRight, Compass, Ship, MapPin, CalendarCheck, Moon } from 'lucide-react';
 
 // Filtra as ofertas vencidas no topo do módulo (import-time), não no render:
 // o prerender (build) e o cliente rodam este mesmo caminho e concordam sobre a
@@ -20,28 +25,6 @@ import { ArrowLeft, ArrowRight, Compass, Ship, MapPin, CalendarCheck, Moon } fro
 const ACTIVE_OFFERS = getActiveOffers(CRUISE_OFFERS);
 const FEATURED_OFFER = ACTIVE_OFFERS.find((o) => o.featured);
 const SECONDARY_OFFERS = ACTIVE_OFFERS.filter((o) => o !== FEATURED_OFFER);
-
-const VIEWPORT_REVEAL = { once: true, amount: 0.2, margin: '0px 0px 100% 0px' } as const;
-
-// Rótulo enviado ao CRM (campo `destination` → x_destino no Odoo) e mostrado no
-// ContactModal. A palavra "cruzeiro" auto-classifica o lead com a tag Cruzeiros
-// (lib/destination-region.ts). Também é o texto que o especialista vê primeiro.
-function offerCrmLabel(o: CruiseOffer): string {
-  return `Cruzeiro ${o.navio} · ${o.portoEmbarque} · ${o.saida}`;
-}
-
-// Mensagem natural pré-preenchida no WhatsApp quando o lead abre a conversa.
-function offerWhatsappMessage(o: CruiseOffer): string {
-  return `Olá! Tenho interesse no cruzeiro do ${o.navio} saindo de ${o.portoEmbarque} em ${o.saida}. Podem me ajudar?`;
-}
-
-function openOfferConversation(o: CruiseOffer): void {
-  openContactModal({
-    source: 'cruzeiros-oferta',
-    destination: offerCrmLabel(o),
-    message: offerWhatsappMessage(o),
-  });
-}
 
 const FAQ_ITEMS = [
   {
@@ -66,175 +49,7 @@ const FAQ_ITEMS = [
   }
 ];
 
-const HOW_IT_WORKS = [
-  {
-    step: '01',
-    title: 'Conversa com especialista',
-    desc: 'Você conta o que busca — perfil, orçamento, datas — e o especialista faz as perguntas certas.'
-  },
-  {
-    step: '02',
-    title: 'Curadoria personalizada',
-    desc: 'Com base no seu perfil, indicamos o navio, a cabine e o roteiro que mais fazem sentido para você — inclusive fora da seleção do site.'
-  },
-  {
-    step: '03',
-    title: 'Reserva e suporte',
-    desc: 'Quando decidir, cuidamos da reserva e ficamos disponíveis até você embarcar.'
-  },
-];
-
-// `variant` não é decoração: DESIGN.md:261 proíbe cards idênticos em grade
-// repetida. O card preenchido quebra a repetição e ancora a leitura no meio —
-// mesma razão pela qual a seção de ofertas destaca uma saída em vez de listar
-// tudo com o mesmo peso.
-const WHY_CURATION = [
-  {
-    icon: Compass,
-    title: 'Navio certo para seu perfil',
-    desc: 'Cada companhia tem um DNA diferente. Indicamos o que combina com o que você quer viver a bordo.',
-    variant: 'light' as const,
-  },
-  {
-    icon: MapPin,
-    title: 'Roteiro que vale a viagem',
-    desc: 'Saída do Brasil ou internacional, escalas e temporada mudam o preço e a experiência. Analisamos tudo junto.',
-    variant: 'filled' as const,
-  },
-  {
-    icon: CalendarCheck,
-    title: 'Cabine sem arrependimento',
-    desc: 'Interna, varanda ou suíte: explicamos o que cada categoria entrega e o que vale para o seu caso.',
-    variant: 'light' as const,
-  },
-];
-
-const OfferMeta: React.FC<{ offer: CruiseOffer; className?: string }> = ({ offer, className }) => (
-  <dl className={`flex flex-wrap gap-x-6 gap-y-2 text-sm ${className ?? ''}`}>
-    <div className="flex items-center gap-1.5">
-      <Ship className="size-4 text-anhanga-action flex-shrink-0" aria-hidden="true" />
-      <dt className="sr-only">Navio</dt>
-      <dd className="font-semibold text-anhanga-dark">{offer.companhia}</dd>
-    </div>
-    <div className="flex items-center gap-1.5">
-      <MapPin className="size-4 text-anhanga-action flex-shrink-0" aria-hidden="true" />
-      <dt className="sr-only">Roteiro</dt>
-      <dd className="text-zinc-600">{offer.roteiro.join(' · ')}</dd>
-    </div>
-    <div className="flex items-center gap-1.5">
-      <Moon className="size-4 text-anhanga-action flex-shrink-0" aria-hidden="true" />
-      <dt className="sr-only">Duração</dt>
-      <dd className="text-zinc-600">{offer.noites} noites</dd>
-    </div>
-  </dl>
-);
-
-const ProfileTags: React.FC<{ perfis: string[] }> = ({ perfis }) => (
-  <ul className="flex flex-wrap gap-2" aria-label="Perfis indicados">
-    {perfis.map((p) => (
-      <li key={p} className="text-xs font-semibold text-anhanga-blue bg-anhanga-blue/10 rounded-full px-3 py-1">
-        {p}
-      </li>
-    ))}
-  </ul>
-);
-
-const RegionBadge: React.FC<{ regiao: string; saida: string }> = ({ regiao, saida }) => (
-  <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-anhanga-action">
-    <span>{regiao}</span>
-    <span className="text-zinc-300" aria-hidden="true">·</span>
-    <span className="text-zinc-500">{saida}</span>
-  </div>
-);
-
-// shadow-float (não border): DESIGN.md §5 reserva border a inputs — cards
-// separam por sombra ou fundo tonalizado. Sem lift no hover: o card em si não
-// é clicável, só o botão dentro dele; sombra que cresce ao passar o mouse no
-// card inteiro seria affordance de clique sem clique (mesmo raciocínio do
-// PILLARS de /consultoria-de-viagem).
-const FeaturedOffer: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
-  <article className="grid md:grid-cols-2 gap-0 rounded-3xl overflow-hidden bg-white shadow-float">
-    {/* w-full é obrigatório: o LazyImage aplica `aspect-ratio` inline a partir de
-        width/height, e sem uma largura explícita o container deriva a largura da
-        altura (h-full) e estoura a coluna do grid. */}
-    <LazyImage
-      src={offer.imagem}
-      alt={offer.imagemAlt}
-      width={800}
-      height={600}
-      sizes="(min-width: 768px) 50vw, 100vw"
-      className="w-full h-64 md:h-full"
-    />
-    <div className="p-8 md:p-10 flex flex-col">
-      <RegionBadge regiao={offer.regiao} saida={offer.saida} />
-      <h3 className="mt-3 text-2xl md:text-3xl font-black text-anhanga-dark leading-tight">
-        {offer.navio}
-      </h3>
-      <OfferMeta offer={offer} className="mt-4" />
-      <div className="mt-5 rounded-xl bg-anhanga-blue/[0.04] p-4">
-        <p className="text-xs font-black uppercase tracking-wide text-anhanga-blue mb-1.5">
-          Por que escolhemos
-        </p>
-        <p className="text-zinc-700 leading-relaxed">{offer.notaCuratorial}</p>
-      </div>
-      <div className="mt-6">
-        <ProfileTags perfis={offer.perfis} />
-      </div>
-      <Button
-        variant="primary"
-        size="lg"
-        onClick={() => openOfferConversation(offer)}
-        className="btn-whatsapp btn-specialist mt-8 self-start"
-        rightIcon={<ArrowRight className="size-5" aria-hidden="true" />}
-        aria-label={`Falar com um especialista sobre o cruzeiro ${offer.navio}`}
-        data-tracking={`oferta-featured-${offer.id}`}
-      >
-        Quero saber mais
-      </Button>
-    </div>
-  </article>
-);
-
-const OfferCard: React.FC<{ offer: CruiseOffer }> = ({ offer }) => (
-  <article className="flex flex-col rounded-2xl overflow-hidden bg-white shadow-float">
-    <LazyImage
-      src={offer.imagem}
-      alt={offer.imagemAlt}
-      width={480}
-      height={300}
-      sizes="(min-width: 768px) 33vw, 100vw"
-      className="w-full h-48"
-    />
-    <div className="p-6 flex flex-col flex-1">
-      <RegionBadge regiao={offer.regiao} saida={offer.saida} />
-      <h3 className="mt-2 text-xl font-black text-anhanga-dark leading-tight">{offer.navio}</h3>
-      <OfferMeta offer={offer} className="mt-3" />
-      <div className="mt-4 rounded-lg bg-anhanga-blue/[0.04] p-3 flex-1">
-        <p className="text-[0.65rem] font-black uppercase tracking-wide text-anhanga-blue mb-1">
-          Por que escolhemos
-        </p>
-        <p className="text-sm text-zinc-600 leading-relaxed">{offer.notaCuratorial}</p>
-      </div>
-      <div className="mt-4">
-        <ProfileTags perfis={offer.perfis} />
-      </div>
-      <Button
-        variant="primary"
-        onClick={() => openOfferConversation(offer)}
-        className="btn-whatsapp btn-specialist mt-5 w-full"
-        rightIcon={<ArrowRight className="size-4" aria-hidden="true" />}
-        aria-label={`Falar com um especialista sobre o cruzeiro ${offer.navio}`}
-        data-tracking={`oferta-${offer.id}`}
-      >
-        Falar sobre este
-      </Button>
-    </div>
-  </article>
-);
-
 const CruzeirosLanding: React.FC = () => {
-  const hasOffers = ACTIVE_OFFERS.length > 0;
-
   return (
     <>
       {/*
@@ -248,370 +63,46 @@ const CruzeirosLanding: React.FC = () => {
         <style>{`[data-cruzeiros-landing] [style*="opacity"]{opacity:1!important}`}</style>
       </noscript>
       <MotionConfig reducedMotion="user">
-      <div data-cruzeiros-landing className="bg-anhanga-light min-h-screen font-sans">
-        <Seo
-          title="Cruzeiros — Ofertas e Curadoria | Anhangá Viagens"
-          description="Ofertas selecionadas de cruzeiros no Brasil e internacionais, com curadoria consultiva para escolher navio, cabine e roteiro certos antes de fechar."
-          canonical="https://www.anhanga.tur.br/cruzeiros/"
-          noHreflang
-        />
-        <ServiceSchema
-          name="Cruzeiros — Ofertas e Curadoria"
-          description="Seleção de cruzeiros no Brasil e internacionais com atendimento consultivo para escolher navio, cabine, roteiro e datas ideais. Para casais, famílias e primeira viagem."
-          serviceUrl="https://www.anhanga.tur.br/cruzeiros/"
-          serviceType="Cruzeiros"
-          areaServed="Brasil"
-        />
-        <BreadcrumbSchema
-          items={[
-            { name: 'Home', item: 'https://www.anhanga.tur.br/' },
-            { name: 'Cruzeiros', item: 'https://www.anhanga.tur.br/cruzeiros/' }
-          ]}
-        />
-        <FAQPageSchema items={FAQ_ITEMS} />
+        <div data-cruzeiros-landing className="bg-anhanga-light min-h-screen font-sans">
+          <Seo
+            title="Cruzeiros — Ofertas e Curadoria | Anhangá Viagens"
+            description="Ofertas selecionadas de cruzeiros no Brasil e internacionais, com curadoria consultiva para escolher navio, cabine e roteiro certos antes de fechar."
+            canonical="https://www.anhanga.tur.br/cruzeiros/"
+            noHreflang
+          />
+          <ServiceSchema
+            name="Cruzeiros — Ofertas e Curadoria"
+            description="Seleção de cruzeiros no Brasil e internacionais com atendimento consultivo para escolher navio, cabine, roteiro e datas ideais. Para casais, famílias e primeira viagem."
+            serviceUrl="https://www.anhanga.tur.br/cruzeiros/"
+            serviceType="Cruzeiros"
+            areaServed="Brasil"
+          />
+          <BreadcrumbSchema
+            items={[
+              { name: 'Home', item: 'https://www.anhanga.tur.br/' },
+              { name: 'Cruzeiros', item: 'https://www.anhanga.tur.br/cruzeiros/' }
+            ]}
+          />
+          <FAQPageSchema items={FAQ_ITEMS} />
 
-        {/* Mini Header */}
-        <header className="bg-white/90 backdrop-blur-sm border-b border-anhanga-blue/10 sticky top-0 z-50 py-3">
-          <div className="max-w-6xl mx-auto px-6 flex items-center justify-between">
-            <Link
-              to="/"
-              className="inline-flex items-center gap-2 group"
-              aria-label="Voltar para o site principal da Anhangá Viagens"
-            >
-              <ArrowLeft className="size-4 text-zinc-400 group-hover:text-anhanga-blue transition-colors" />
-              <span className="size-7 bg-anhanga-blue/10 rounded-lg flex items-center justify-center flex-shrink-0">
-                <img src="/favicon.svg" alt="" aria-hidden="true" className="size-4" />
-              </span>
-              <span className="text-sm font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
-                Anhangá Viagens
-              </span>
-            </Link>
-            <Button
-              variant="action"
-              size="sm"
-              onClick={() => openContactModal({ source: 'cruzeiros' })}
-              className="btn-whatsapp btn-specialist whitespace-nowrap"
-              data-tracking="header-cruzeiros"
-            >
-              Falar com especialista
-            </Button>
-          </div>
-        </header>
-
-        {/* Hero */}
-        <section className="pt-16 pb-20 px-6 bg-anhanga-light">
-          <div className="max-w-3xl mx-auto">
-            <m.p
-              variants={fadeUp}
-              initial="hidden"
-              animate="visible"
-              custom={0}
-              className="text-sm font-semibold text-anhanga-blue mb-4 tracking-wide uppercase"
-            >
-              Cruzeiros · Brasil e internacionais
-            </m.p>
-            <m.h1
-              variants={fadeUp}
-              initial="hidden"
-              animate="visible"
-              custom={1}
-              className="text-4xl md:text-6xl font-black text-anhanga-dark mb-6 leading-[1.1]"
-            >
-              Os cruzeiros que a gente escolheria
-            </m.h1>
-            <m.p
-              variants={fadeUp}
-              initial="hidden"
-              animate="visible"
-              custom={2}
-              className="text-xl text-zinc-600 mb-10 leading-relaxed max-w-2xl"
-            >
-              Uma seleção enxuta de saídas que valem a pena — no Brasil e pelo mundo — com um especialista para acertar navio, cabine e roteiro antes de você fechar.
-            </m.p>
-            <m.div variants={fadeUp} initial="hidden" animate="visible" custom={3}>
-              <Button
-                variant="cta"
-                size="lg"
-                onClick={() => openContactModal({ source: 'cruzeiros' })}
-                className="btn-whatsapp btn-specialist font-black"
-                rightIcon={<ArrowRight className="size-5" aria-hidden="true" />}
-                aria-label="Falar com um especialista em cruzeiros"
-                data-tracking="hero-cruzeiros"
-              >
-                Falar com um especialista
-              </Button>
-              <p className="mt-4 text-sm text-zinc-600">Sem taxa de curadoria. Gratuito.</p>
-            </m.div>
-          </div>
-        </section>
-
-        {/* Ofertas — protagonista. Some quando não há oferta válida (a curadoria
-            abaixo sustenta a página nesse estado). */}
-        {hasOffers ? (
-          <section className="py-20 bg-white" aria-labelledby="ofertas-titulo">
-            <div className="max-w-6xl mx-auto px-6">
-              <m.div
-                variants={fadeUp}
-                initial="hidden"
-                whileInView="visible"
-                viewport={VIEWPORT_REVEAL}
-                custom={0}
-                className="mb-10"
-              >
-                <h2 id="ofertas-titulo" className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3">
-                  Seleção da temporada
-                </h2>
-                <p className="text-zinc-600 text-lg max-w-2xl">
-                  Poucas saídas, escolhidas a dedo. Cada uma vem com o porquê de estar aqui — e um especialista para fechar a sua.
-                </p>
-              </m.div>
-
-              {FEATURED_OFFER ? (
-                <m.div
-                  variants={fadeUp}
-                  initial="hidden"
-                  whileInView="visible"
-                  viewport={VIEWPORT_REVEAL}
-                  custom={1}
-                  className="mb-6"
-                >
-                  <FeaturedOffer offer={FEATURED_OFFER} />
-                </m.div>
-              ) : null}
-
-              {SECONDARY_OFFERS.length > 0 ? (
-                <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                  {SECONDARY_OFFERS.map((offer, idx) => (
-                    <m.div
-                      key={offer.id}
-                      variants={fadeUp}
-                      initial="hidden"
-                      whileInView="visible"
-                      viewport={VIEWPORT_REVEAL}
-                      custom={idx + 2}
-                    >
-                      <OfferCard offer={offer} />
-                    </m.div>
-                  ))}
-                </div>
-              ) : null}
-
-              <p className="mt-10 text-zinc-600">
-                Não achou a saída ideal?{' '}
-                <button
-                  type="button"
-                  onClick={() => openContactModal({ source: 'cruzeiros' })}
-                  className="font-bold text-anhanga-blue underline underline-offset-2 hover:text-anhanga-darkBlue transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action rounded"
-                  data-tracking="ofertas-fallback-cruzeiros"
-                >
-                  Conte o que procura
-                </button>{' '}
-                — a gente busca fora da lista também.
-              </p>
-            </div>
-          </section>
-        ) : null}
-
-        {/* Como funciona */}
-        <section className="py-20 bg-anhanga-light">
-          <div className="max-w-5xl mx-auto px-6">
-            <m.h2
-              variants={fadeUp}
-              initial="hidden"
-              whileInView="visible"
-              viewport={VIEWPORT_REVEAL}
-              custom={0}
-              className="text-3xl md:text-4xl font-black text-anhanga-dark mb-12"
-            >
-              Como funciona
-            </m.h2>
-            <div className="space-y-0">
-              {HOW_IT_WORKS.map(({ step, title, desc }, idx) => (
-                <m.div
-                  key={step}
-                  variants={fadeUp}
-                  initial="hidden"
-                  whileInView="visible"
-                  viewport={VIEWPORT_REVEAL}
-                  custom={idx + 1}
-                  className={`flex gap-6 py-8 ${idx < HOW_IT_WORKS.length - 1 ? 'border-b border-anhanga-blue/10' : ''}`}
-                >
-                  <div className="flex-shrink-0 size-12 rounded-full bg-white flex items-center justify-center shadow-sm">
-                    <span className="text-sm font-black text-anhanga-blue">{step}</span>
-                  </div>
-                  <div>
-                    <h3 className="text-xl font-black text-anhanga-dark mb-2">{title}</h3>
-                    <p className="text-zinc-600 leading-relaxed max-w-xl">{desc}</p>
-                  </div>
-                </m.div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Por que curadoria */}
-        <section className="py-20 bg-white">
-          <div className="max-w-5xl mx-auto px-6">
-            <m.div
-              variants={fadeUp}
-              initial="hidden"
-              whileInView="visible"
-              viewport={VIEWPORT_REVEAL}
-              custom={0}
-              className="mb-12"
-            >
-              <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3">
-                Por que curadoria?
-              </h2>
-              <p className="text-zinc-600 text-lg">
-                Porque escolher um cruzeiro envolve mais variáveis do que parece.
-              </p>
-            </m.div>
-            <div className="grid md:grid-cols-3 gap-6">
-              {WHY_CURATION.map(({ icon: Icon, title, desc, variant }, idx) => (
-                <m.div
-                  key={title}
-                  variants={fadeUp}
-                  initial="hidden"
-                  whileInView="visible"
-                  viewport={VIEWPORT_REVEAL}
-                  custom={idx + 1}
-                  className={`p-8 rounded-2xl ${variant === 'filled' ? 'bg-anhanga-blue' : 'bg-anhanga-light shadow-float'}`}
-                >
-                  <div
-                    className={`size-11 rounded-xl flex items-center justify-center mb-5 ${
-                      variant === 'filled' ? 'bg-white/15' : 'bg-anhanga-blue/10'
-                    }`}
-                  >
-                    <Icon className={`size-5 ${variant === 'filled' ? 'text-white' : 'text-anhanga-blue'}`} />
-                  </div>
-                  <h3 className={`text-xl font-black mb-3 ${variant === 'filled' ? 'text-white' : 'text-anhanga-dark'}`}>
-                    {title}
-                  </h3>
-                  <p className={variant === 'filled' ? 'text-blue-100 leading-relaxed' : 'text-zinc-600 leading-relaxed'}>
-                    {desc}
-                  </p>
-                </m.div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Sobre a Anhangá */}
-        <section className="py-20 bg-anhanga-light">
-          <m.div
-            variants={fadeUp}
-            initial="hidden"
-            whileInView="visible"
-            viewport={VIEWPORT_REVEAL}
-            custom={0}
-            className="max-w-4xl mx-auto px-6 text-center"
-          >
-            <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-6">
-              Sobre a Anhangá Viagens
-            </h2>
-            <p className="text-lg text-zinc-600 leading-relaxed max-w-2xl mx-auto">
-              Agência de viagens em São Paulo desde 2018, com especialistas em cruzeiros e roteiros personalizados. Nota 5.0 no Google e atendimento humano do início ao fim.
-            </p>
-            <div className="mt-12 flex flex-wrap justify-center gap-12">
-              {[
-                { label: 'Fundada em', value: '2018' },
-                { label: 'Nota Google', value: '5.0' },
-                { label: 'Especialistas', value: 'Em cruzeiros' },
-              ].map(({ label, value }) => (
-                <div key={label}>
-                  <div className="text-4xl font-black text-anhanga-blue">{value}</div>
-                  <div className="text-sm text-zinc-600 mt-1">{label}</div>
-                </div>
-              ))}
-            </div>
-          </m.div>
-        </section>
-
-        {/* CTA Final */}
-        <section className="py-20 bg-anhanga-blue">
-          <m.div
-            variants={fadeUp}
-            initial="hidden"
-            whileInView="visible"
-            viewport={VIEWPORT_REVEAL}
-            custom={0}
-            className="max-w-3xl mx-auto px-6 text-center"
-          >
-            <h2 className="text-3xl md:text-5xl font-black text-white mb-6">
-              Vamos achar o seu cruzeiro?
-            </h2>
-            <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
-              Fale com um consultor e resolva a escolha em uma conversa. Sem taxa, sem compromisso.
-            </p>
-            <Button
-              variant="cta"
-              size="lg"
-              onClick={() => openContactModal({ source: 'cruzeiros' })}
-              className="btn-whatsapp btn-specialist font-black focus-visible:outline-white"
-              rightIcon={<ArrowRight className="size-6" aria-hidden="true" />}
-              aria-label="Falar com um especialista em cruzeiros"
-              data-tracking="footer-cruzeiros"
-            >
-              Falar com um especialista
-            </Button>
-          </m.div>
-        </section>
-
-        {/* Outros serviços */}
-        <section className="py-16 bg-anhanga-light">
-          <div className="max-w-5xl mx-auto px-6">
-            <h2 className="text-2xl font-black text-anhanga-dark mb-8">Outros serviços</h2>
-            <div className="grid md:grid-cols-3 gap-4">
-              <Link
-                to="/consultoria-de-viagem/"
-                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
-              >
-                <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
-                  Consultoria de Viagem
-                </div>
-                <div className="text-sm text-zinc-600 mt-1">
-                  Roteiro sob medida com consultor humano
-                </div>
-              </Link>
-              <Link
-                to="/corporativo/"
-                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
-              >
-                <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
-                  Viagens para Executivos
-                </div>
-                <div className="text-sm text-zinc-600 mt-1">
-                  Planejamento com precisão para profissionais
-                </div>
-              </Link>
-              <Link
-                to="/"
-                className="block p-5 rounded-xl bg-white hover:bg-anhanga-blue/10 transition-colors group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
-              >
-                <div className="font-bold text-anhanga-dark group-hover:text-anhanga-blue transition-colors">
-                  Site principal
-                </div>
-                <div className="text-sm text-zinc-600 mt-1">
-                  Conheça todos os serviços da Anhangá
-                </div>
-              </Link>
-            </div>
-          </div>
-        </section>
-
-        {/* FAQ */}
-        <LandingFAQ
-          items={FAQ_ITEMS}
-          title="Dúvidas sobre cruzeiros"
-          subtitle="Tire suas dúvidas antes de escolher seu cruzeiro."
-        />
-
-        {/* Footer */}
-        <footer className="py-8 bg-anhanga-light border-t border-anhanga-blue/10 text-center text-sm text-zinc-600">
-          <p>Anhangá Viagens · Agência de viagens em São Paulo</p>
-        </footer>
-      </div>
+          <CruiseMiniHeader />
+          <CruiseHero />
+          <CruiseOffersSection
+            featuredOffer={FEATURED_OFFER}
+            secondaryOffers={SECONDARY_OFFERS}
+          />
+          <CruiseProcess />
+          <CruiseCurationBenefits />
+          <CruiseAbout />
+          <CruiseFinalCta />
+          <CruiseOtherServices />
+          <LandingFAQ
+            items={FAQ_ITEMS}
+            title="Dúvidas sobre cruzeiros"
+            subtitle="Tire suas dúvidas antes de escolher seu cruzeiro."
+          />
+          <CruiseLandingFooter />
+        </div>
       </MotionConfig>
     </>
   );

--- a/tests/e2e/cruzeiros-ofertas.spec.ts
+++ b/tests/e2e/cruzeiros-ofertas.spec.ts
@@ -2,7 +2,8 @@ import { test, expect } from '@playwright/test';
 
 // A landing /cruzeiros mostra ofertas selecionadas; o CTA de cada oferta abre o
 // ContactModal já carregado com o contexto da oferta (linha "Sobre:"), que
-// também viaja ao CRM via `destination`. Ver pages/landings/CruzeirosLanding.tsx.
+// também viaja ao CRM via `destination`. Ver
+// components/landings/cruzeiros/CruiseOfferCards.tsx.
 //
 // ACOPLAMENTO AO CALENDÁRIO (intencional): o filtro de expiração
 // (lib/cruise-offers-schedule.js) usa o relógio real, então estes specs dependem

--- a/tests/e2e/destinations-map-lifecycle.spec.ts
+++ b/tests/e2e/destinations-map-lifecycle.spec.ts
@@ -22,7 +22,31 @@ test('Destinations map keeps marker selection working after SPA remount', async 
   await expect(dialog).toBeVisible();
   await expect(dialog.getByRole('heading', { name: 'Orlando' })).toBeVisible();
 
-  await page.getByRole('link', { name: 'Ver detalhes do pacote' }).click();
+  await destinations.evaluate(async section => {
+    const mapElement = section.querySelector<HTMLElement>('.leaflet-container');
+    const zoomInButton = section.querySelector<HTMLButtonElement>('button[aria-label="Aumentar zoom no mapa"]');
+    const detailsLink = [...document.querySelectorAll<HTMLAnchorElement>('a')]
+      .find(link => link.textContent?.includes('Ver detalhes do pacote'));
+
+    if (!mapElement) throw new Error('Destinations Leaflet map not found');
+    if (!zoomInButton) throw new Error('Destinations zoom-in button not found');
+    if (!detailsLink) throw new Error('Destination details link not found');
+
+    const waitForZoomAnimation = async (active: boolean) => {
+      const deadline = performance.now() + 1_000;
+      while (performance.now() < deadline) {
+        const mapPane = mapElement.querySelector('.leaflet-map-pane');
+        if (mapPane?.classList.contains('leaflet-zoom-anim') === active) return;
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+      }
+      throw new Error(`Leaflet zoom animation did not become ${active ? 'active' : 'idle'}`);
+    };
+
+    await waitForZoomAnimation(false);
+    zoomInButton.click();
+    await waitForZoomAnimation(true);
+    detailsLink.click();
+  });
   await expect(page).toHaveURL(/\/orlando\/?$/);
   await expect(destinations).toHaveCount(0);
 
@@ -37,5 +61,5 @@ test('Destinations map keeps marker selection working after SPA remount', async 
   await expect(dialog).toBeVisible();
   await expect(dialog.getByRole('heading', { name: 'Orlando' })).toBeVisible();
 
-  expect(pageErrors.filter(message => /Map container is already initialized|Map container is being reused|leaflet/i.test(message))).toEqual([]);
+  expect(pageErrors.filter(message => /Map container is already initialized|Map container is being reused|_leaflet_pos|leaflet/i.test(message))).toEqual([]);
 });

--- a/tests/e2e/destinations-map-lifecycle.spec.ts
+++ b/tests/e2e/destinations-map-lifecycle.spec.ts
@@ -11,13 +11,14 @@ test('Destinations map keeps marker selection working after SPA remount', async 
 
   const destinations = page.locator('section#destinos');
   const map = destinations.locator('.leaflet-container');
+  const orlandoMarker = map.locator('.leaflet-marker-icon').first();
   const dialog = page.getByRole('dialog');
 
   await expect(destinations.getByText('Mapa Mundi')).toBeVisible({ timeout: 10_000 });
   await expect(map).toBeVisible();
   await expect(map.locator('.leaflet-marker-icon')).toHaveCount(22);
 
-  await map.locator('.leaflet-marker-icon').first().click();
+  await orlandoMarker.dispatchEvent('click');
   await expect(dialog).toBeVisible();
   await expect(dialog.getByRole('heading', { name: 'Orlando' })).toBeVisible();
 
@@ -32,7 +33,7 @@ test('Destinations map keeps marker selection working after SPA remount', async 
   await expect(map).toBeVisible({ timeout: 10_000 });
   await expect(map.locator('.leaflet-marker-icon')).toHaveCount(22);
 
-  await map.locator('.leaflet-marker-icon').first().click();
+  await orlandoMarker.dispatchEvent('click');
   await expect(dialog).toBeVisible();
   await expect(dialog.getByRole('heading', { name: 'Orlando' })).toBeVisible();
 

--- a/tests/e2e/destinations-map-lifecycle.spec.ts
+++ b/tests/e2e/destinations-map-lifecycle.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+test('Destinations map keeps marker selection working after SPA remount', async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', error => pageErrors.push(error.message));
+
+  await page.route('https://*.basemaps.cartocdn.com/**', route => route.abort());
+  await page.goto('/');
+  await page.evaluate(() => window.dispatchEvent(new Event('scroll')));
+  await page.locator('div#destinos').scrollIntoViewIfNeeded();
+
+  const destinations = page.locator('section#destinos');
+  const map = destinations.locator('.leaflet-container');
+  const dialog = page.getByRole('dialog');
+
+  await expect(destinations.getByText('Mapa Mundi')).toBeVisible({ timeout: 10_000 });
+  await expect(map).toBeVisible();
+  await expect(map.locator('.leaflet-marker-icon')).toHaveCount(22);
+
+  await map.locator('.leaflet-marker-icon').first().click();
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole('heading', { name: 'Orlando' })).toBeVisible();
+
+  await page.getByRole('link', { name: 'Ver detalhes do pacote' }).click();
+  await expect(page).toHaveURL(/\/orlando\/?$/);
+  await expect(destinations).toHaveCount(0);
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.evaluate(() => window.dispatchEvent(new Event('scroll')));
+  await page.locator('div#destinos').scrollIntoViewIfNeeded();
+  await expect(map).toBeVisible({ timeout: 10_000 });
+  await expect(map.locator('.leaflet-marker-icon')).toHaveCount(22);
+
+  await map.locator('.leaflet-marker-icon').first().click();
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole('heading', { name: 'Orlando' })).toBeVisible();
+
+  expect(pageErrors.filter(message => /Map container is already initialized|Map container is being reused|leaflet/i.test(message))).toEqual([]);
+});

--- a/tests/e2e/lollapalooza-map-lifecycle.spec.ts
+++ b/tests/e2e/lollapalooza-map-lifecycle.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+
+test('VenueMap survives SPA unmount and remount without Leaflet lifecycle errors', async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', error => pageErrors.push(error.message));
+
+  await page.route('https://*.basemaps.cartocdn.com/**', route => route.abort());
+  await page.goto('/lollapalooza');
+
+  const map = page.locator('section.leaflet-container[aria-label="Mapa interativo com pontos de interesse"]');
+  await expect(map).toBeVisible();
+  await expect(map.locator('.leaflet-marker-icon')).toHaveCount(6);
+
+  await page.getByRole('link', { name: 'Voltar para o site principal' }).click();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(map).toHaveCount(0);
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/lollapalooza\/?$/);
+  await expect(map).toBeVisible();
+  await expect(map.locator('.leaflet-marker-icon')).toHaveCount(6);
+
+  await map.getByRole('button', { name: 'Aeroporto de Congonhas (CGH)', exact: true }).click();
+  await expect(map.locator('.leaflet-popup-content')).toContainText('Aeroporto de Congonhas (CGH)');
+  await expect(page.locator('button').filter({ hasText: 'Aeroporto de Congonhas (CGH)' })).toHaveClass(/border-anhanga-blue/);
+
+  expect(pageErrors.filter(message => /Map container is already initialized|Map container is being reused|leaflet/i.test(message))).toEqual([]);
+});

--- a/tests/e2e/lollapalooza-map-lifecycle.spec.ts
+++ b/tests/e2e/lollapalooza-map-lifecycle.spec.ts
@@ -11,7 +11,29 @@ test('VenueMap survives SPA unmount and remount without Leaflet lifecycle errors
   await expect(map).toBeVisible();
   await expect(map.locator('.leaflet-marker-icon')).toHaveCount(6);
 
-  await page.getByRole('link', { name: 'Voltar para o site principal' }).click();
+  await map.evaluate(async mapElement => {
+    const zoomInButton = mapElement.querySelector<HTMLAnchorElement>('.leaflet-control-zoom-in');
+    const backLink = [...document.querySelectorAll<HTMLAnchorElement>('a')]
+      .find(link => link.textContent?.includes('Voltar para o site principal'));
+
+    if (!zoomInButton) throw new Error('Zoom-in button not found');
+    if (!backLink) throw new Error('Back link not found');
+
+    const waitForZoomAnimation = async (active: boolean) => {
+      const deadline = performance.now() + 1_000;
+      while (performance.now() < deadline) {
+        const mapPane = mapElement.querySelector('.leaflet-map-pane');
+        if (mapPane?.classList.contains('leaflet-zoom-anim') === active) return;
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+      }
+      throw new Error(`Leaflet zoom animation did not become ${active ? 'active' : 'idle'}`);
+    };
+
+    await waitForZoomAnimation(false);
+    zoomInButton.click();
+    await waitForZoomAnimation(true);
+    backLink.click();
+  });
   await expect(page).toHaveURL(/\/$/);
   await expect(map).toHaveCount(0);
 
@@ -24,5 +46,5 @@ test('VenueMap survives SPA unmount and remount without Leaflet lifecycle errors
   await expect(map.locator('.leaflet-popup-content')).toContainText('Aeroporto de Congonhas (CGH)');
   await expect(page.locator('button').filter({ hasText: 'Aeroporto de Congonhas (CGH)' })).toHaveClass(/border-anhanga-blue/);
 
-  expect(pageErrors.filter(message => /Map container is already initialized|Map container is being reused|leaflet/i.test(message))).toEqual([]);
+  expect(pageErrors.filter(message => /Map container is already initialized|Map container is being reused|_leaflet_pos|leaflet/i.test(message))).toEqual([]);
 });

--- a/tests/static-media-assets.test.ts
+++ b/tests/static-media-assets.test.ts
@@ -215,7 +215,7 @@ test('festival landings should use managed static imagery', async () => {
 test('home decorative textures should not hotlink grain overlays from third-party hosts', async () => {
   const [hero, destinations, indexHtml] = await Promise.all([
     readRepoFile('components/Hero.tsx'),
-    readRepoFile('components/Destinations.tsx'),
+    readRepoFile('components/destinations/DestinationsView.tsx'),
     readRepoFile('index.html'),
   ]);
 
@@ -229,7 +229,7 @@ test('home decorative textures should not hotlink grain overlays from third-part
   assertMissingHosts(
     destinations,
     ['grainy-gradients.vercel.app'],
-    'components/Destinations.tsx',
+    'components/destinations/DestinationsView.tsx',
   );
   assert.match(destinations, /assets\/noise\.svg|NOISE_TEXTURE_URL/);
 
@@ -314,10 +314,10 @@ test('remaining runtime media dependencies should use managed Cloudflare assets'
 test('hero videos should all point to the media zone /videos/ path with .mp4 extension', async () => {
   const mediaConfig = await readRepoFile('data/mediaConfig.ts');
 
-  const videoUrlMatches = [...mediaConfig.matchAll(/getMediaUrl\(['\"](videos\/.+?\.mp4)['"]\)/g)];
+  const videoUrlMatches = [...mediaConfig.matchAll(/getMediaUrl\(['"](videos\/.+?\.mp4)['"]\)/g)];
   assert.ok(videoUrlMatches.length >= 5, `Expected at least 5 hero video URLs, found ${videoUrlMatches.length}`);
 
-  const posterMatches = [...mediaConfig.matchAll(/getMediaUrl\(['\"](images\/hero\/.+?-poster\.jpg)['"]\)/g)];
+  const posterMatches = [...mediaConfig.matchAll(/getMediaUrl\(['"](images\/hero\/.+?-poster\.jpg)['"]\)/g)];
   assert.ok(posterMatches.length >= 5, `Expected at least 5 poster URLs, found ${posterMatches.length}`);
 });
 


### PR DESCRIPTION
## Summary

- split the five giant components into focused views, sections, and controller hooks
- stabilize AI chat pending-message effects with useEffectEvent
- give both Leaflet maps explicit listener, layer, timer, and instance teardown
- preserve VenueMap zoom animation while safely deferring removal during an active Leaflet transition

## React Doctor

Fresh npx react-doctor@latest --verbose result after integrating main (v0.8.0):

- no-giant-component: 0
- prefer-use-effect-event: 0
- effect-needs-cleanup: 0
- 22 unrelated diagnostics remain for a follow-up pass

No rules were suppressed or silenced.

## Verification

- pnpm test:regression — 969/969 passed
- pnpm typecheck — passed
- pnpm lint:changed — passed
- pnpm run build — passed, including SSR prerender
- Lollapalooza lifecycle stress test on Mobile Chrome and Mobile Safari — 6/6 passed
- affected Consultoria and Cruzeiros Chromium tests after integrating main — 7/7 passed
- git diff --check — passed

The broader browser matrix exposed a branch-introduced Leaflet teardown race. It is now fixed and covered by a deterministic test.