### PR TITLE
fix(copy): corrige ano de fundação e alcance nacional nas landings de consultoria e cruzeiros

### DIFF
--- a/components/landings/consultoria/ConsultoriaLandingSections.tsx
+++ b/components/landings/consultoria/ConsultoriaLandingSections.tsx
@@ -58,7 +58,7 @@ const PILLARS = [
 ];
 
 const CREDENTIALS = [
-  'Fundada em 2018',
+  'Fundada em 2025',
   'Nota 5.0 no Google',
   'Atendimento humano',
 ];
@@ -126,7 +126,7 @@ export function ConsultoriaHero() {
           >
             Falar com um consultor
           </Button>
-          <p className="mt-1 md:mt-4 text-sm text-zinc-600">Sem taxa de consultoria. Gratuito.</p>
+          <p className="mt-1 md:mt-4 text-sm text-zinc-600">Sem taxa, sem compromisso.</p>
         </m.div>
       </div>
     </section>
@@ -339,7 +339,7 @@ export function ConsultoriaAbout() {
               Sobre a Anhangá Viagens
             </h2>
             <p className="text-lg text-zinc-600 leading-relaxed">
-              Agência de viagens em São Paulo, especializada em viagens personalizadas desde 2018. Atendimento humano, nota 5.0 no Google e consultor fixo do início ao fim da sua viagem.
+              Agência de viagens fundada em São Paulo em 2025, hoje atendendo viajantes de todo o Brasil. Atendimento humano, nota 5.0 no Google e consultor fixo do início ao fim da sua viagem.
             </p>
             <div className="mt-10 flex flex-wrap justify-center md:justify-start gap-3">
               {CREDENTIALS.map(item => (

--- a/components/landings/cruzeiros/CruzeirosLandingSections.tsx
+++ b/components/landings/cruzeiros/CruzeirosLandingSections.tsx
@@ -328,7 +328,7 @@ export function CruiseAbout(): React.ReactElement {
           Sobre a Anhangá Viagens
         </h2>
         <p className="text-lg text-zinc-600 leading-relaxed max-w-2xl mx-auto">
-          Agência de viagens em São Paulo desde 2018, com especialistas em cruzeiros e roteiros personalizados. Nota 5.0 no Google e atendimento humano do início ao fim.
+          Agência de viagens fundada em São Paulo em 2025, hoje atendendo viajantes de todo o Brasil, com especialistas em cruzeiros e roteiros personalizados. Nota 5.0 no Google e atendimento humano do início ao fim.
         </p>
         <div className="mt-12 flex flex-wrap justify-center gap-12">
           {/* Terceiro item ("Especialistas / Em cruzeiros") removido: não é um
@@ -336,7 +336,7 @@ export function CruiseAbout(): React.ReactElement {
               do trio e já era dito no parágrafo acima ("com especialistas em
               cruzeiros"). Redundante, não uma estatística real. */}
           {[
-            { label: 'Fundada em', value: '2018' },
+            { label: 'Fundada em', value: '2025' },
             { label: 'Nota Google', value: '5.0' },
           ].map(({ label, value }) => (
             <div key={label}>
@@ -431,7 +431,7 @@ export function CruiseOtherServices(): React.ReactElement {
 export function CruiseLandingFooter(): React.ReactElement {
   return (
     <footer className="py-8 bg-anhanga-light border-t border-anhanga-blue/10 text-center text-sm text-zinc-600">
-      <p>Anhangá Viagens · Agência de viagens em São Paulo</p>
+      <p>Anhangá Viagens · Agência de viagens de São Paulo para todo o Brasil</p>
     </footer>
   );
 }

--- a/tests/e2e/landing-consultoria-content.spec.ts
+++ b/tests/e2e/landing-consultoria-content.spec.ts
@@ -41,7 +41,10 @@ test.describe('CTA do hero não fica coberto pelo banner de cookies em mobile cu
     await expect(banner).toBeVisible();
 
     const cta = page.locator('[data-tracking="hero-consultoria-viagem"]');
-    const disclaimer = page.getByText('Sem taxa, sem compromisso.');
+    // exact: true — sem isso o locator também casa com o CTA final da
+    // página ("...Sem taxa, sem compromisso."), que contém o mesmo texto
+    // como substring e agora usa a mesma frase do disclaimer do hero.
+    const disclaimer = page.getByText('Sem taxa, sem compromisso.', { exact: true });
 
     await waitForStableBoxes([cta, disclaimer]);
 

--- a/tests/e2e/landing-consultoria-content.spec.ts
+++ b/tests/e2e/landing-consultoria-content.spec.ts
@@ -41,7 +41,7 @@ test.describe('CTA do hero não fica coberto pelo banner de cookies em mobile cu
     await expect(banner).toBeVisible();
 
     const cta = page.locator('[data-tracking="hero-consultoria-viagem"]');
-    const disclaimer = page.getByText('Sem taxa de consultoria. Gratuito.');
+    const disclaimer = page.getByText('Sem taxa, sem compromisso.');
 
     await waitForStableBoxes([cta, disclaimer]);
 


### PR DESCRIPTION
## Resumo

- Corrige o ano de fundação da Anhangá de 2018 para 2025 (credencial e stat) nas landings de `/consultoria-de-viagem/` e `/cruzeiros/`.
- Alinha o texto "Sobre" e o footer da página de cruzeiros ao mesmo alcance nacional já comunicado no badge do hero da consultoria ("todo o Brasil"), evitando reintroduzir mais abaixo na página a fricção "só atende SP" que o hero já corrige.
- Unifica o disclaimer do hero da consultoria ("Sem taxa de consultoria. Gratuito." → "Sem taxa, sem compromisso.") com a fraseação já usada no CTA final da mesma página.

Escopo deliberadamente restrito à prosa visível — não mexe em `<title>`, `ServiceSchema`/`areaServed` ou outros sinais de SEO local, que preservam São Paulo de propósito.

## Nota

O lint local (`pnpm lint:changed`) está quebrado neste momento por um problema de ambiente pré-existente e não relacionado — `@typescript-eslint` 8.63.0 incompatível com `typescript` 7.0.2 (introduzido pelo merge do Dependabot #1225). Reproduzido também em arquivos totalmente não tocados por esta PR. Rastreado separadamente na issue #1232; o CI provavelmente vai falhar/pular o step de lint até isso ser corrigido, independentemente desta PR.

## Test plan

- [ ] Conferir visualmente `/consultoria-de-viagem/` e `/cruzeiros/` no preview (ano de fundação, texto "todo o Brasil", disclaimer do hero)
- [ ] Confirmar que o CI não falha por causa desta mudança (só pelo problema pré-existente da issue #1232, se ainda não corrigido)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJxzkq8FQKWDAfUieiMdq8