### PR TITLE
fix(deps): remove duplicate es-module-lexer key from pnpm-lock

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3108,8 +3108,6 @@ packages:
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
-  es-module-lexer@2.3.1:
-    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -8588,7 +8586,6 @@ snapshots:
 
   es-module-lexer@2.3.1: {}
 
-  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.2:
     dependencies:


### PR DESCRIPTION
## Resumo

- **O que muda:** Remove uma entrada `es-module-lexer@2.3.1` duplicada (byte a byte) do `pnpm-lock.yaml` — a duplicata existia tanto na seção `packages:` quanto na `snapshots:` (3 linhas redundantes no total).
- **Por quê:** O merge do dependabot de `tsx@4.23.1` (#1243, HEAD atual do `main`) deixou chaves de mapeamento YAML duplicadas. YAML rejeita chaves duplicadas, então o pnpm falha com `ERR_PNPM_BROKEN_LOCKFILE`. Isso quebra **todos** os passos `pnpm install --frozen-lockfile` do CI (ci, playwright, release, refresh-reviews, etc.) e o build do Cloudflare Pages.
- **Impacto para o usuário:** Nenhum em runtime — só destrava instalação de dependências no CI/deploy. Sem mudança de resolução de dependências (nenhuma versão foi alterada).
- **Nível de risco:** baixo

## Issue relacionada

Sem issue. Regressão detectada por auditoria de dependências agendada; introduzida involuntariamente no merge #1243.

## Tipo de mudança

- [x] 🐛 Bug fix
- [x] ⚙️ Infra / CI

## Testes

Mudança é somente no lockfile (nenhuma mudança de comportamento de código), portanto sem teste automatizado novo. Validado que o lockfile deduplicado é parseável e resolve a árvore completa.

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only)
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível)

Comandos executados:

```text
pnpm audit          # antes: ERR_PNPM_BROKEN_LOCKFILE; depois: parseia OK, "No known vulnerabilities found"
grep de chaves com 3+ ocorrências no lockfile: nenhuma restante
diff confirma remoção de exatamente as 3 linhas duplicadas
```

## API & Segurança

- [x] Não se aplica

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`feat:`, `fix:`, `chore:`, `docs:`, `perf:`, `test:`, `refactor:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

Sem teste automatizado novo porque a mudança é exclusivamente do `pnpm-lock.yaml` (sem código de comportamento). O `diff` remove apenas as 3 linhas byte-a-byte duplicadas; nenhuma versão de dependência muda. Idealmente o lockfile seria regenerado via `pnpm install` em Node 24, mas a remoção da duplicata exata é suficiente e mínima. Recomendo verificar por que o merge do dependabot introduziu a duplicata (possível conflito de merge mal resolvido no lockfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6j9cC1iB3Bo9HgobN3w3H

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6j9cC1iB3Bo9HgobN3w3H)_