### PR TITLE
fix: eliminar débito existente do lint global (#1234)

### DIFF
--- a/api/markdown.ts
+++ b/api/markdown.ts
@@ -330,7 +330,7 @@ export default async function handler(req: Request): Promise<Response> {
                 }
             }
             // Sanitize before including in response body
-            const safeDisplay = rawPath.slice(0, 80).replace(/[^\w\-\/]/g, '');
+            const safeDisplay = rawPath.slice(0, 80).replace(/[^\w\-/]/g, '');
             return markdownResponse(
                 `# Página não encontrada\n\nNão há versão em Markdown para o caminho \`${safeDisplay}\`.\n\nConsulte [${SITE_BASE}](${SITE_BASE}) para o conteúdo completo.\n`,
                 404

--- a/components/ChatLeadForm.tsx
+++ b/components/ChatLeadForm.tsx
@@ -263,7 +263,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
 
         <ChatLeadFormActions
           isSubmitting={isSubmittingLead || isLocallySubmitting}
-          onSubmit={submitLeadForm}
+          onSubmit={(e) => void submitLeadForm(e)}
           onOpenDirectWhatsApp={openDirectWhatsApp}
         />
       </div>

--- a/components/Faq.tsx
+++ b/components/Faq.tsx
@@ -21,7 +21,7 @@ const FAQItem = memo(({ question, answer, idx }: FAQItemProps) => {
 
     const handleToggle = useCallback(() => {
         setIsOpen(prev => !prev);
-        import('../utils/haptics').then(m => m.triggerHaptic('light'));
+        void import('../utils/haptics').then(m => m.triggerHaptic('light'));
     }, []);
 
     return (

--- a/components/Highlights.tsx
+++ b/components/Highlights.tsx
@@ -24,11 +24,6 @@ const fadeUp = {
     }),
 };
 
-const cardHover = {
-    rest: { scale: 1, rotate: 'var(--card-rotate)', y: 0, transition: { type: 'spring', stiffness: 400, damping: 20 } },
-    hover: { scale: 1.03, rotate: 0, y: -8, transition: { type: 'spring', stiffness: 400, damping: 20 } },
-};
-
 interface HighlightItem {
     icon: React.ElementType;
     title: string;

--- a/components/landings/beto-carrero/BetoCarreroApp.tsx
+++ b/components/landings/beto-carrero/BetoCarreroApp.tsx
@@ -9,7 +9,6 @@ import Faq from './Faq';
 import Footer from './Footer';
 import Button from './Button';
 import { Menu, X } from 'lucide-react';
-import { Link } from 'react-router-dom';
 import { getBetoAssetUrl } from './assetPath';
 
 const SITE_URL = 'https://www.anhanga.tur.br';

--- a/components/landings/beto-carrero/Faq.tsx
+++ b/components/landings/beto-carrero/Faq.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import SectionTitle from './SectionTitle';
 import Button from './Button';
 import { FAQItem } from './types';
-import { ChevronDown, HelpCircle, Sparkles, ArrowRight } from 'lucide-react';
+import { ChevronDown, HelpCircle, Sparkles } from 'lucide-react';
 
 const items: FAQItem[] = [
   { question: "Os pacotes incluem ingresso do Beto Carrero?", answer: "Sim! Trabalhamos com ingressos oficiais. Você recebe o QR Code direto no seu WhatsApp e entra no parque sem pegar fila na bilheteria." },

--- a/components/landings/lollapalooza/Hero.tsx
+++ b/components/landings/lollapalooza/Hero.tsx
@@ -42,7 +42,7 @@ const Hero: React.FC = () => {
     if (navigator.share) {
       try {
         await navigator.share(shareData);
-      } catch (err) {
+      } catch {
         // User cancelled or share failed, ignore
       }
     } else {
@@ -148,7 +148,7 @@ const Hero: React.FC = () => {
           
           <button
             type="button"
-            onClick={handleShare}
+            onClick={() => void handleShare()}
             className={`
               group relative flex items-center justify-center gap-2 px-6 py-4 rounded-full border-2 transition duration-300 w-full sm:w-auto
               ${shareStatus === 'copied' 

--- a/components/landings/lollapalooza/WaitlistSection.tsx
+++ b/components/landings/lollapalooza/WaitlistSection.tsx
@@ -186,7 +186,7 @@ const WaitlistSection: React.FC = () => {
                 <div className="h-1 w-20 bg-anhanga-yellow mt-4 mx-auto lg:mx-0" />
               </div>
 
-              <form className="space-y-8" onSubmit={handleSubmit} noValidate>
+              <form className="space-y-8" onSubmit={(event) => void handleSubmit(event)} noValidate>
                 {/* Honeypot: hidden from humans, blind form-fillers populate it. */}
                 <input {...honeypotProps} />
 

--- a/components/landings/lollapalooza/hooks/useIntersectionObserver.ts
+++ b/components/landings/lollapalooza/hooks/useIntersectionObserver.ts
@@ -27,7 +27,6 @@ const useIntersectionObserver = (threshold = 0.1) => {
     );
 
     if (element) {
-      /* eslint-disable-next-line react-doctor/no-adjust-state-on-prop-change */
       observer.observe(element);
     }
 

--- a/components/ui/PassportStamp.tsx
+++ b/components/ui/PassportStamp.tsx
@@ -15,6 +15,17 @@ const generatePseudoIata = (city: string): string => {
     return clean.substring(0, 3);
 };
 
+// Deterministic rotation derived from the instance's useId, instead of Math.random:
+// calling an impure function during render breaks React's purity rules (and would
+// mismatch between server and client render passes).
+export const deriveRotation = (seed: string): number => {
+    let hash = 0;
+    for (let i = 0; i < seed.length; i++) {
+        hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+    }
+    return (Math.abs(hash) % 31) - 15;
+};
+
 export const PassportStamp: React.FC<PassportStampProps> = ({
     destination,
     date = new Date().toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' }).replace(/ de /g, '/').toUpperCase(),
@@ -23,12 +34,12 @@ export const PassportStamp: React.FC<PassportStampProps> = ({
 }) => {
     const displayIata = iataCode || generatePseudoIata(destination);
 
-    // Random rotation between -15 and 15 degrees for an organic look
-    const rotation = React.useMemo(() => Math.floor(Math.random() * 30) - 15, []);
-
     // Unique animation name per instance so concurrent stamps don't overwrite each other's keyframes
     const uid = React.useId().replace(/:/g, '');
     const animName = `stamp-${uid}`;
+
+    // Rotation between -15 and 15 degrees for an organic look, deterministic per instance
+    const rotation = React.useMemo(() => deriveRotation(uid), [uid]);
 
     React.useEffect(() => {
         const style = document.createElement('style');

--- a/components/ui/PassportStamp.tsx
+++ b/components/ui/PassportStamp.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { deriveRotation } from './passport-stamp-rotation';
 
 interface PassportStampProps {
     destination: string;
@@ -13,17 +14,6 @@ const generatePseudoIata = (city: string): string => {
     const clean = city.replace(/[^a-zA-Z]/g, '').toUpperCase();
     if (clean.length < 3) return 'UNK';
     return clean.substring(0, 3);
-};
-
-// Deterministic rotation derived from the instance's useId, instead of Math.random:
-// calling an impure function during render breaks React's purity rules (and would
-// mismatch between server and client render passes).
-export const deriveRotation = (seed: string): number => {
-    let hash = 0;
-    for (let i = 0; i < seed.length; i++) {
-        hash = (hash * 31 + seed.charCodeAt(i)) | 0;
-    }
-    return (Math.abs(hash) % 31) - 15;
 };
 
 export const PassportStamp: React.FC<PassportStampProps> = ({

--- a/components/ui/passport-stamp-rotation.ts
+++ b/components/ui/passport-stamp-rotation.ts
@@ -1,0 +1,10 @@
+// Deterministic rotation derived from a PassportStamp instance's useId, instead
+// of Math.random: calling an impure function during render breaks React's
+// purity rules (and would mismatch between server and client render passes).
+export const deriveRotation = (seed: string): number => {
+    let hash = 0;
+    for (let i = 0; i < seed.length; i++) {
+        hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+    }
+    return (Math.abs(hash) % 31) - 15;
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,7 @@ export default tseslint.config(
       'public/**',
       '.worktrees/**',
       '.claude/**',
+      '.deepsec/**',
     ],
   },
   js.configs.recommended,

--- a/lib/head.tsx
+++ b/lib/head.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, use, useEffect } from 'react';
+import { createContext, use, useEffect } from 'react';
 
 export interface HeadTag {
   tagName: 'title' | 'meta' | 'link' | 'script';

--- a/lib/waitlist-logic.ts
+++ b/lib/waitlist-logic.ts
@@ -1,31 +1,6 @@
 import { isValidEmail, normalizeNullable, normalizeTracking, normalizeUtms } from './lead-logic';
 import type { SubmitWaitlistRequest } from '../types/waitlist';
 
-function splitWaitlistName(name: string): { firstName: string; lastName: string } {
-    const parts = name.trim().split(/\s+/).filter(Boolean);
-    const [firstName = '', ...rest] = parts;
-
-    return {
-        firstName,
-        lastName: rest.join(' '),
-    };
-}
-
-function buildWaitlistNoteBody(payload: SubmitWaitlistRequest): string {
-    const lines = [
-        'Lista de Espera Lollapalooza 2027',
-        `Nome: ${payload.name}`,
-        `Email: ${payload.email}`,
-        `Origem da captura: ${payload.sourcePage}`,
-    ];
-
-    if (payload.utms.utm_source) lines.push(`UTM Source: ${payload.utms.utm_source}`);
-    if (payload.utms.utm_medium) lines.push(`UTM Medium: ${payload.utms.utm_medium}`);
-    if (payload.utms.utm_campaign) lines.push(`UTM Campaign: ${payload.utms.utm_campaign}`);
-
-    return lines.join('\n');
-}
-
 export function validateWaitlistPayload(
     payload: unknown,
 ): { valid: true; data: SubmitWaitlistRequest } | { valid: false; error: string } {

--- a/pages/BlogPost.tsx
+++ b/pages/BlogPost.tsx
@@ -14,7 +14,7 @@ import { getBlogHomeUrl, getBlogPostUrl } from '../utils/blog';
 
 function isValidSlug(value: unknown): value is string {
     if (typeof value !== 'string') return false;
-    return /^[a-zA-Z0-9\-\/]+$/.test(value);
+    return /^[a-zA-Z0-9\-/]+$/.test(value);
 }
 
 // Carregado no nível do módulo para o Vite processar em build time

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, Suspense, lazy } from 'react';
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import Hero from '../components/Hero';
 import TrustBar from '../components/TrustBar';
 

--- a/pages/NotFound.tsx
+++ b/pages/NotFound.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { MapPin, Home as HomeIcon, Compass, BookOpen, ArrowLeft } from 'lucide-react';
 import { Seo } from '../components/Seo';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';

--- a/pages/NpsPage.tsx
+++ b/pages/NpsPage.tsx
@@ -219,7 +219,7 @@ export default function NpsPage() {
             )}
 
             {token && pageState === 'form' && (
-              <form onSubmit={handleSubmit} noValidate>
+              <form onSubmit={(e) => void handleSubmit(e)} noValidate>
                 {/* Honeypot: hidden from humans, blind form-fillers populate it. */}
                 <input {...honeypotProps} />
                 <h1 className="text-3xl sm:text-4xl font-extrabold tracking-tight mb-3">

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -337,7 +337,7 @@ export default function QuizAnhangaLanding() {
                                 onAnswerQ={answerQ}
                                 onNextQ={nextQ}
                                 onBackQ={backQ}
-                                onLeadSubmit={handleLeadSubmit}
+                                onLeadSubmit={(data, skipped) => void handleLeadSubmit(data, skipped)}
                                 onRestart={restart}
                                 onGo={go}
                                 onPhoneSubmit={handlePhoneSubmit}

--- a/tests/chatbot-regressions.test.ts
+++ b/tests/chatbot-regressions.test.ts
@@ -214,7 +214,7 @@ test('system prompt should document IATA code rules for the budget tool', () => 
 });
 
 test('system prompt should prefer structured JSON line for chips', () => {
-    assert.match(SYSTEM_INSTRUCTION, /\{\"chips\":\[\"Opção 1\",\"Opção 2\",\"Opção 3\"\]\}/);
+    assert.match(SYSTEM_INSTRUCTION, /\{"chips":\["Opção 1","Opção 2","Opção 3"\]\}/);
 });
 
 test('system prompt should define out-of-scope handling', () => {

--- a/tests/e2e/chaos.spec.ts
+++ b/tests/e2e/chaos.spec.ts
@@ -9,8 +9,8 @@ test.describe('Chaos & Unhappy Path Suite', () => {
     const aiChat = new AIChat(page);
 
     // Mock the API response to return a 500 error
-    await page.route('**/api/generate', route => {
-      route.fulfill({
+    await page.route('**/api/generate', async route => {
+      await route.fulfill({
         status: 500,
         contentType: 'application/json',
         body: JSON.stringify({ error: 'Internal Server Error' }),
@@ -32,7 +32,7 @@ test.describe('Chaos & Unhappy Path Suite', () => {
     // Simulate slow network for the API call
     await page.route('**/api/generate', async route => {
       await new Promise(resolve => setTimeout(resolve, 3000));
-      route.fulfill({
+      await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({ text: 'Respondendo após delay' }),
@@ -70,8 +70,8 @@ test.describe('Chaos & Unhappy Path Suite', () => {
 
   test('should handle API 500 error in corporativo form', async ({ page }) => {
     const landing = new CorporativoPage(page);
-    await page.route('**/api/submit-lead', route => {
-      route.fulfill({
+    await page.route('**/api/submit-lead', async route => {
+      await route.fulfill({
         status: 500,
         contentType: 'application/json',
         body: JSON.stringify({ error: 'Internal Server Error', code: 'SERVER_ERROR' }),

--- a/tests/e2e/destructive.spec.ts
+++ b/tests/e2e/destructive.spec.ts
@@ -71,7 +71,7 @@ test.describe('Destructive & Security Suite', () => {
     await page.locator('input[placeholder="Nome"]').fill(xssPayload);
     await page.locator('input[placeholder="Sobrenome"]').fill('Test');
     await page.locator('input[placeholder="E-mail"]').fill('test@example.com');
-    await page.locator('input[placeholder=\"WhatsApp\"]').fill('(11) 98831-4487');
+    await page.locator('input[placeholder="WhatsApp"]').fill('(11) 98831-4487');
     await acceptLgpd(page);
 
     await page.getByRole('button', { name: 'Salvar e abrir WhatsApp' }).click();
@@ -107,7 +107,7 @@ test.describe('Destructive & Security Suite', () => {
     await page.locator('input[placeholder="Nome"]').fill('Rage');
     await page.locator('input[placeholder="Sobrenome"]').fill('Tester');
     await page.locator('input[placeholder="E-mail"]').fill('rage@test.com');
-    await page.locator('input[placeholder=\"WhatsApp\"]').fill('(11) 98831-4487');
+    await page.locator('input[placeholder="WhatsApp"]').fill('(11) 98831-4487');
     await acceptLgpd(page);
 
     const submitBtn = page.getByRole('button', { name: 'Salvar e abrir WhatsApp' });
@@ -159,7 +159,7 @@ test.describe('Destructive & Security Suite', () => {
     await page.locator('input[placeholder="Nome"]').fill('Valid');
     await page.locator('input[placeholder="Sobrenome"]').fill('Name');
     await page.locator('input[placeholder="E-mail"]').fill('test@test.com');
-    await page.locator('input[placeholder=\"WhatsApp\"]').fill('(11) 98831-4487');
+    await page.locator('input[placeholder="WhatsApp"]').fill('(11) 98831-4487');
     await submitBtn.click();
     await expect(page.getByText('Você deve aceitar os termos')).toBeVisible();
   });

--- a/tests/e2e/seo_smoke.spec.ts
+++ b/tests/e2e/seo_smoke.spec.ts
@@ -44,7 +44,7 @@ test.describe('SEO Smoke Check', () => {
       console.log(`Route: ${route} | Canonical: ${canonical}`);
       // Regex explanation: https://www.anhanga.tur.br/ followed by anything (or nothing) and a trailing slash
       // The home route is exactly https://www.anhanga.tur.br/
-      expect(canonical).toMatch(/^https:\/\/www\.anhanga\.tur\.br\/([^\/].*\/|)$/);
+      expect(canonical).toMatch(/^https:\/\/www\.anhanga\.tur\.br\/([^/].*\/|)$/);
 
       // 4. Check Robots
       const robotsLocator = page.locator('meta[name="robots"]');

--- a/tests/e2e/testimonials-google.spec.ts
+++ b/tests/e2e/testimonials-google.spec.ts
@@ -68,7 +68,7 @@ test.describe('Testimonials — Google data (fixture)', () => {
 
   test.afterAll(() => {
     copyFileSync(BACKUP_PATH, REVIEWS_PATH);
-    try { unlinkSync(BACKUP_PATH); } catch {}
+    try { unlinkSync(BACKUP_PATH); } catch { /* backup already removed */ }
   });
 
   test('summary bar shows rating and review count', async ({ page }) => {

--- a/tests/passport-stamp.test.ts
+++ b/tests/passport-stamp.test.ts
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveRotation } from '../components/ui/PassportStamp';
+
+test('deriveRotation is deterministic for the same seed', () => {
+    assert.equal(deriveRotation('abc123'), deriveRotation('abc123'));
+});
+
+test('deriveRotation stays within the -15..15 range', () => {
+    const seeds = ['', 'a', 'r0', 'r1', 'r2', 'r3', 'r4', 'stamp-instance-42', 'São Paulo'];
+    for (const seed of seeds) {
+        const rotation = deriveRotation(seed);
+        assert.ok(rotation >= -15 && rotation <= 15, `rotation ${rotation} out of range for seed "${seed}"`);
+    }
+});
+
+test('deriveRotation varies across different seeds', () => {
+    const rotations = new Set(['r0', 'r1', 'r2', 'r3', 'r4'].map(deriveRotation));
+    assert.ok(rotations.size > 1, 'expected different seeds to produce more than one distinct rotation');
+});

--- a/tests/passport-stamp.test.ts
+++ b/tests/passport-stamp.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { deriveRotation } from '../components/ui/PassportStamp';
+import { deriveRotation } from '../components/ui/passport-stamp-rotation';
 
 test('deriveRotation is deterministic for the same seed', () => {
     assert.equal(deriveRotation('abc123'), deriveRotation('abc123'));

--- a/tests/polyfills.test.ts
+++ b/tests/polyfills.test.ts
@@ -23,7 +23,7 @@ test('polyfill installs Object.hasOwn when missing', () => {
     }
 
     assert.equal(typeof Object.hasOwn, 'function', 'polyfill must install a function');
-    assert.equal(Object.propertyIsEnumerable('hasOwn'), false, 'polyfill must be non-enumerable');
+    assert.equal(Object.prototype.propertyIsEnumerable.call(Object, 'hasOwn'), false, 'polyfill must be non-enumerable');
     assert.equal(Object.hasOwn({ a: 1 }, 'a'), true);
     assert.equal(Object.hasOwn({ a: 1 }, 'b'), false);
     assert.equal(Object.hasOwn(Object.create({ inherited: true }), 'inherited'), false);

--- a/utils/whatsapp.ts
+++ b/utils/whatsapp.ts
@@ -28,7 +28,6 @@ export interface WhatsAppLinkOptions {
 
 export type TrackingData = Record<string, string>;
 
-let cachedTrackingData: string | null = null;
 let cachedTrackingObject: TrackingData | null = null;
 let hasInitialized = false;
 
@@ -201,7 +200,6 @@ function persistTrackingData(trackingData: TrackingData): TrackingData | null {
     }
 
     setCookie(COOKIE_NAME, dataString, 30);
-    cachedTrackingData = dataString;
     cachedTrackingObject = { ...trackingData };
 
     if (typeof window !== 'undefined' && window.dataLayer) {
@@ -218,7 +216,6 @@ function getCookieTrackingData(): TrackingData | null {
     const cookieData = getCookie(COOKIE_NAME);
     if (!cookieData) return null;
 
-    cachedTrackingData = cookieData;
     cachedTrackingObject = parseTrackingDataString(cookieData);
     return { ...cachedTrackingObject };
 }
@@ -238,15 +235,6 @@ const captureTrackingDataObject = (): TrackingData | null => {
     }
 
     return getCookieTrackingData();
-};
-
-const captureTrackingData = (): string | null => {
-    const objectData = captureTrackingDataObject();
-    if (!objectData) return null;
-
-    const serialized = serializeTrackingData(objectData);
-    cachedTrackingData = serialized || null;
-    return cachedTrackingData;
 };
 
 const initializeTracking = () => {


### PR DESCRIPTION
## Resumo

Corrige os 40 diagnósticos reais expostos pela restauração da infraestrutura do ESLint (#1232): 30 erros + 10 warnings, agrupados por causa raiz em commits separados. `pnpm lint` volta a terminar com exit code 0, sem desligar, ignorar ou suprimir nenhuma regra.

Fixes #1234

## O que foi corrigido

- **`react-doctor/no-adjust-state-on-prop-change`**: comentário `eslint-disable` órfão referenciando uma regra que não é um plugin ESLint registrado neste repo — removido.
- **`no-useless-escape`** (5 arquivos): barra e aspas duplas escapadas sem necessidade em regex/strings — só sintaxe, sem mudança de comportamento.
- **`no-empty`** / **`no-prototype-builtins`**: catch vazio documentado com comentário; `propertyIsEnumerable` chamado via `Object.prototype.call()`.
- **`no-floating-promises`**: `route.fulfill()` sem `await` em 3 mocks do Playwright (`chaos.spec.ts`) e um dynamic import sem `void` em `Faq.tsx` (mesmo padrão já usado em `SocialShare.tsx`, hooks de busca etc.).
- **`no-misused-promises`**: handlers `async` passados diretamente para props tipadas como `void` (`onClick`/`onSubmit`/`onLeadSubmit`) em `ChatLeadForm`, `WaitlistSection`, `NpsPage`, `QuizAnhangaLanding` e `Hero` (Lollapalooza) — envolvidos com o padrão `(args) => void handler(args)` já usado em `CorpContactForm`/`ContactModal`.
- **`react-hooks/purity`**: `PassportStamp.tsx` chamava `Math.random()` durante o render (rule nova do `eslint-plugin-react-hooks` v7). Troquei por uma rotação determinística derivada do `useId()` da instância — mantém a variação "orgânica" entre carimbos, mas é pura e segura para SSR (o componente teria hidratação divergente entre servidor e cliente com o código antigo). A função pura foi extraída para `components/ui/passport-stamp-rotation.ts` (achado do React Doctor: um arquivo de componente não deve exportar não-componentes, quebra o Fast Refresh) e ganhou teste de regressão em `tests/passport-stamp.test.ts`.
- **`no-unused-vars`** (8 arquivos): imports/variáveis órfãos removidos; e código morto sem nenhum call site removido por completo (`Highlights.tsx#cardHover`, dois helpers pré-cutover-Odoo em `lib/waitlist-logic.ts`, `captureTrackingData`/`cachedTrackingData` em `utils/whatsapp.ts`).
- **`eslint.config.js`**: adicionado `.deepsec/**` aos `ignores`. Esse diretório é um workspace local de uma ferramenta de scan de segurança, gitignored, não faz parte do source do repo — mesmo padrão já aplicado a `.worktrees/**` e `.claude/**`. **Não afeta CI** (o diretório não existe lá, é puramente local) e não tem relação com os 40 diagnósticos reais da issue; sem essa entrada, `pnpm lint` local acusava 3 erros de parsing adicionais vindos de arquivos de config dessa ferramenta.

## Critérios de aceite

- [x] `pnpm lint` termina com exit code 0
- [x] `pnpm lint:changed` continua funcionando (25 arquivos lintados, 0 erros)
- [x] `pnpm typecheck` passa
- [x] `pnpm test:regression` passa — **exceto** `tests/site-positioning.test.ts`, que já falha em `main` sem nenhuma mudança desta branch (confirmado via `git stash`); não é tocado por este PR e é sobre positioning de um doc de SEO, fora do escopo de lint. Vou abrir uma issue separada para isso.
- [x] React Doctor não reporta regressões nos componentes alterados (`--scope changed`: 100/100, 0 issues, após mover `deriveRotation`)
- [x] Nenhuma regra foi desligada ou silenciada

## Test plan

- [x] `pnpm lint` (0 problemas)
- [x] `pnpm lint:changed` (0 erros em 25 arquivos)
- [x] `pnpm typecheck`
- [x] `pnpm test:regression` (979 passam, 1 falha pré-existente não relacionada)
- [x] `pnpm exec react-doctor --scope changed -y` (100/100)
- [x] `pnpm exec playwright test tests/e2e/{chaos,destructive,seo_smoke,testimonials-google}.spec.ts` (60 passam)