### PR TITLE
fix: corrige hierarquia de heading (H2 pulado) em MelhorIdadeLanding e BlogList

### DIFF
--- a/pages/BlogList.tsx
+++ b/pages/BlogList.tsx
@@ -133,9 +133,9 @@ const BlogList: React.FC = () => {
                                             {post.category}
                                         </span>
                                     </div>
-                                    <h4 className="text-2xl font-extrabold text-zinc-800 mb-3 leading-tight group-hover:text-brand-cyan transition-colors">
+                                    <h2 className="text-2xl font-extrabold text-zinc-800 mb-3 leading-tight group-hover:text-brand-cyan transition-colors">
                                         {post.title}
-                                    </h4>
+                                    </h2>
                                     <p className="text-zinc-500 font-medium leading-relaxed mb-6 flex-1 line-clamp-3">
                                         {post.excerpt}
                                     </p>

--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -134,7 +134,7 @@ const MelhorIdadeLanding: React.FC = () => {
               <div className="size-16 bg-brand-cyan/10 rounded-2xl flex items-center justify-center text-brand-cyan mb-6">
                 <ShieldCheck className="size-8" />
               </div>
-              <h3 className="text-2xl font-black text-brand-dark">Segurança em 1º lugar</h3>
+              <h2 className="text-2xl font-black text-brand-dark">Segurança em 1º lugar</h2>
               <p className="text-zinc-500 font-medium leading-relaxed">
                 Hotéis com acessibilidade, seguro-viagem premium e suporte 24h para você viajar com tranquilidade total.
               </p>
@@ -143,7 +143,7 @@ const MelhorIdadeLanding: React.FC = () => {
               <div className="size-16 bg-orange-100 rounded-2xl flex items-center justify-center text-orange-600 mb-6">
                 <Coffee className="size-8" />
               </div>
-              <h3 className="text-2xl font-black text-brand-dark">Ritmo Desacelerado</h3>
+              <h2 className="text-2xl font-black text-brand-dark">Ritmo Desacelerado</h2>
               <p className="text-zinc-500 font-medium leading-relaxed">
                 Nada de correrias. Roteiros desenhados para respeitar o seu tempo, com pausas estratégicas e menos deslocamentos.
               </p>
@@ -152,7 +152,7 @@ const MelhorIdadeLanding: React.FC = () => {
               <div className="size-16 bg-brand-vibrant/10 rounded-2xl flex items-center justify-center text-brand-vibrant mb-6">
                 <Sparkles className="size-8" />
               </div>
-              <h3 className="text-2xl font-black text-brand-dark">Curadoria Personalizada</h3>
+              <h2 className="text-2xl font-black text-brand-dark">Curadoria Personalizada</h2>
               <p className="text-zinc-500 font-medium leading-relaxed">
                 Experiências gastronômicas, culturais e de lazer selecionadas a dedo para viajantes exigentes e experientes.
               </p>


### PR DESCRIPTION
## Summary
- `MelhorIdadeLanding.tsx`: os 3 cards da seção "PILARES" usavam `<h3>` sem nenhum `<h2>` pai antes deles. Trocados para `<h2>` (a seção seguinte já tem seu próprio `<h2>`, então múltiplos H2 irmãos são válidos).
- `BlogList.tsx`: os cards do índice do blog usavam `<h4>` sem H2/H3 intermediário entre o H1 da página e os cards. Trocado para `<h2>` (não há outro H2 antes do CTA final da página).

## Test plan
- [x] `pnpm test:regression` (980 testes, todos verdes)
- [x] `pnpm typecheck`
- [x] `eslint` nos dois arquivos tocados (sem findings)

Fixes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmiK3yUpGzQuR7uwXqhYRy