### PR TITLE
fix: corrige ordem física do corpo do post no SSR (MDX lazy → eager)

### DIFF
--- a/components/blog/BlogPostContent.tsx
+++ b/components/blog/BlogPostContent.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { Clock } from 'lucide-react';
 import { PostMeta } from '../../lib/mdx';
@@ -12,7 +12,7 @@ import { optimizeRemoteImageUrl } from '../../data/mediaConfig';
 interface BlogPostContentProps {
     post: PostMeta;
     canonicalUrl: string;
-    MdxContent: React.LazyExoticComponent<React.ComponentType> | null;
+    MdxContent: React.ComponentType | null;
     relatedPosts: PostMeta[];
 }
 
@@ -61,15 +61,7 @@ export const BlogPostContent: React.FC<BlogPostContentProps> = ({ post, canonica
                         prose-blockquote:border-2 prose-blockquote:border-brand-yellow/40 prose-blockquote:bg-yellow-50 prose-blockquote:py-4 prose-blockquote:px-8 prose-blockquote:rounded-2xl prose-blockquote:not-italic prose-blockquote:font-serif prose-blockquote:text-brand-dark [&_blockquote_p]:text-brand-dark
                         first-letter:text-[3rem] first-letter:md:text-[4.5rem] first-letter:font-black first-letter:text-brand-dark first-letter:float-left first-letter:leading-none first-letter:mr-2 first-letter:mt-1
                     ">
-                        <Suspense fallback={
-                            <div className="animate-pulse space-y-4">
-                                <div className="h-4 bg-zinc-200 rounded w-3/4" />
-                                <div className="h-4 bg-zinc-200 rounded w-full" />
-                                <div className="h-4 bg-zinc-200 rounded w-5/6" />
-                            </div>
-                        }>
-                            <MdxContent />
-                        </Suspense>
+                        <MdxContent />
                     </div>
                 </MDXProvider>
             ) : (

--- a/pages/BlogPost.tsx
+++ b/pages/BlogPost.tsx
@@ -20,27 +20,20 @@ function isValidSlug(value: unknown): value is string {
 // Carregado no nível do módulo para o Vite processar em build time
 const allMdxPosts = getAllPosts();
 
-// import.meta.glob deve ficar no nível do módulo para o Vite processar em build time
+// eager: true resolve todos os módulos MDX em build time, no nível do módulo — sem
+// React.lazy/Suspense, o conteúdo do post fica disponível de forma síncrona durante o
+// SSR (renderToPipeableStream nunca aguarda um Suspense boundary suspenso: sem esse
+// eager, o corpo real do post caía num streaming fora de ordem, resolvido só por JS
+// no cliente — ver issue #1249). BlogPost já é uma rota lazy-carregada em App.tsx, então
+// empacotar os ~29 posts juntos não afeta o bundle inicial da aplicação.
 const mdxModuleMap = import.meta.glob<{ default: React.ComponentType }>(
-    '/content/blog/*.mdx'
+    '/content/blog/*.mdx',
+    { eager: true }
 );
 
-// Cache de lazy components por slug para evitar re-criação a cada render
-const lazyComponentCache: Record<
-    string,
-    React.LazyExoticComponent<React.ComponentType>
-> = {};
-
-function getMdxComponent(
-    slug: string
-): React.LazyExoticComponent<React.ComponentType> | null {
+function getMdxComponent(slug: string): React.ComponentType | null {
     const key = `/content/blog/${slug}.mdx`;
-    const importFn = mdxModuleMap[key];
-    if (!importFn) return null;
-    if (!lazyComponentCache[slug]) {
-        lazyComponentCache[slug] = React.lazy(importFn);
-    }
-    return lazyComponentCache[slug];
+    return mdxModuleMap[key]?.default ?? null;
 }
 
 const BlogPost: React.FC = () => {

--- a/tests/blog-post-content-mdx-order.test.ts
+++ b/tests/blog-post-content-mdx-order.test.ts
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { BlogPostContent } from '../components/blog/BlogPostContent.tsx';
+import type { PostMeta } from '../types/blog.ts';
+
+const post: PostMeta = {
+    title: 'Post de teste',
+    excerpt: 'Excerpt de teste',
+    date: '2026-01-01',
+    author: 'felipe-william',
+    category: 'Dicas',
+    image: 'https://media.anhanga.tur.br/images/blog/teste.jpg',
+    tags: [],
+    slug: 'post-de-teste',
+    readingTime: '4 min de leitura',
+};
+
+const relatedPosts: PostMeta[] = [];
+
+const StubMdxContent: React.FC = () => React.createElement('h2', null, 'H2 real do artigo MDX');
+
+test('BlogPostContent renderiza o corpo do MDX antes de "Leia Também" na ordem física do HTML', () => {
+    const html = renderToStaticMarkup(
+        React.createElement(BlogPostContent, {
+            post,
+            canonicalUrl: 'https://www.anhanga.tur.br/blog/post-de-teste/',
+            MdxContent: StubMdxContent,
+            relatedPosts,
+        })
+    );
+
+    const mdxIndex = html.indexOf('H2 real do artigo MDX');
+    const leiaTambemIndex = html.indexOf('Leia Também');
+
+    assert.notEqual(mdxIndex, -1, 'o corpo do MDX deve estar presente no HTML');
+    assert.notEqual(leiaTambemIndex, -1, 'a seção "Leia Também" deve estar presente no HTML');
+    assert.ok(
+        mdxIndex < leiaTambemIndex,
+        'o corpo real do MDX deve vir antes de "Leia Também" na ordem física do HTML (regressão #1249)'
+    );
+});
+
+test('BlogPostContent não envolve o MDX num Suspense/skeleton — MdxContent eager não suspende', () => {
+    const html = renderToStaticMarkup(
+        React.createElement(BlogPostContent, {
+            post,
+            canonicalUrl: 'https://www.anhanga.tur.br/blog/post-de-teste/',
+            MdxContent: StubMdxContent,
+            relatedPosts,
+        })
+    );
+
+    assert.ok(!html.includes('animate-pulse'), 'não deve renderizar o skeleton de loading do antigo Suspense boundary');
+});


### PR DESCRIPTION
## Summary
- `components/blog/BlogPostContent.tsx` envolvia o MDX em `React.lazy` + `<Suspense>`. Com `renderToPipeableStream`, qualquer boundary que suspenda gera streaming fora de ordem: o conteúdo real cai num `<div hidden>` resolvido só por `<script>$RC(...)</script>`, fisicamente **atrás** do H3 "Leia Também" e do H3/H4 da sidebar (que não estão sob esse boundary e resolvem primeiro).
- `pages/BlogPost.tsx`: troca o glob de MDX para `import.meta.glob(..., { eager: true })`, resolvendo todos os módulos em build time — elimina o `React.lazy`/cache manual e o Suspense boundary ao redor do corpo do artigo.

## Verificação empírica (`pnpm build` antes/depois)
Medi o HTML prerenderizado de `/blog/disney-ou-beto-carrero/` antes e depois:

| | antes | depois |
|---|---|---|
| segmentos `$RC()` fora de ordem | 2 | 1 (o boundary de rota em `App.tsx`, pré-existente em toda rota lazy — fora de escopo aqui) |
| ordem física dos headings | H1 → Leia Também → sidebar → **H2s reais do MDX** | H1 → **H2s reais do MDX** → Leia Também → sidebar |

## Tradeoff aceito
Empacotar os MDX eager significa que a página de **um** post carrega o conteúdo dos ~29 posts no mesmo chunk (`BlogPost-*.js` passa de ~24KB para ~324KB raw / ~90KB gzip). Não é gate de CI (`bundlesize.config.json` só cobre `index-*.js`, `react-vendor-*.js` e `AIChatPanel-*.js`, e `BlogPost` é rota lazy — não afeta o bundle inicial do site), e é exatamente o fix sugerido pela issue. Registrando aqui para visibilidade.

## Test plan
- [x] `pnpm build` completo + inspeção manual do HTML prerenderizado (ordem de headings, contagem de `$RC()`)
- [x] Novo teste `tests/blog-post-content-mdx-order.test.ts`: renderiza `BlogPostContent` com um `MdxContent` stub síncrono e garante que o corpo do MDX aparece antes de "Leia Também" na ordem física do HTML; garante também que não há mais o skeleton `animate-pulse` do Suspense antigo
- [x] `pnpm test:regression` (982 testes, todos verdes)
- [x] `pnpm typecheck`
- [x] `eslint` nos arquivos tocados (sem findings)

Fixes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmiK3yUpGzQuR7uwXqhYRy