### PR TITLE
fix: encurta meta description de /sobre para caber no limite do SERP

### DIFF
--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -95,7 +95,7 @@ const About: React.FC = () => {
       </noscript>
       <Seo
         title="Sobre a Anhangá Viagens | Agência de Viagens em São Paulo"
-        description="Anhangá Viagens: agência registrada no Cadastur (CNPJ 37.036.732/0001-41), com sede em São Paulo, agente credenciado Beto Carrero World e Hopi Hari e parceira Norwegian Cruise Line. Atendimento consultivo e roteiros personalizados."
+        description="Agência de viagens em São Paulo com atendimento consultivo e roteiros sob medida — sem pacote pronto. Credenciada Cadastur, agente Beto Carrero World."
         canonical="https://www.anhanga.tur.br/sobre/"
       />
       <OrganizationSchema


### PR DESCRIPTION
## Summary
- Meta description de `/sobre/` tinha 231 caracteres; Google corta por volta de 160, escondendo o diferencial (atendimento consultivo, roteiros sob medida) atrás de dados institucionais.
- Os dados institucionais cortados (CNPJ, credenciamentos Beto Carrero World/Hopi Hari/Norwegian Cruise Line) já estão expostos em `OrganizationSchema` (`taxID`, `memberOf`) — não é perda de sinal de entidade/GEO, só reorganização do que aparece no snippet clicável do Google.
- Nova description (150 caracteres): "Agência de viagens em São Paulo com atendimento consultivo e roteiros sob medida — sem pacote pronto. Credenciada Cadastur, agente Beto Carrero World."

## Contexto
Decisão discutida e aprovada no Odoo task #38 (projeto Marketing), originada do achado `meta-description-too-long` em `docs/seo/site-audit-2026-07.md`.

## Test plan
- [x] Mudança é copy-only em uma prop de string (`Seo description`), sem alteração de comportamento/renderização — enquadra na exceção de `docs/standards/testing.md` para mudanças de copy estático.
- [ ] `pnpm lint:changed` — sem findings (nenhum arquivo alterado detectado antes do commit; confirmar em CI)
- [ ] Verificar visualmente o snippet no Google Search Console / preview de SERP após deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmiK3yUpGzQuR7uwXqhYRy