### PR TITLE
perf: remove atraso fixo de 12s dos scripts de terceiros e limpa preconnects (#1259)

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,9 +140,11 @@
         mt('send', 'pageview');
       };
 
+      var absoluteFallbackTimer = null;
       var loadAnalytics = function () {
         if (analyticsLoaded) return;
         analyticsLoaded = true;
+        if (absoluteFallbackTimer !== null) clearTimeout(absoluteFallbackTimer);
         loadGtm();
         loadMautic();
         if (!utmLoaded) {
@@ -178,6 +180,13 @@
       } else {
         window.addEventListener('load', scheduleFallback, { once: true });
       }
+      // Teto absoluto INDEPENDENTE do 'load': em rotas com iframe/tiles do Leaflet (ex.:
+      // /lollapalooza) o evento 'load' pode atrasar ou nunca disparar se um terceiro travar —
+      // sem este backstop, sessões sem interação lá deixariam de gerar analytics. É idempotente
+      // (loadAnalytics é guardado por analyticsLoaded), então no caminho normal o path ocioso
+      // pós-load já rodou antes dos 10s e este timer é limpo em loadAnalytics — não reintroduz
+      // o pinning de ~12s no lab, onde 'load' dispara cedo e o analytics carrega no primeiro ocioso.
+      absoluteFallbackTimer = setTimeout(triggerAnalytics, 10000);
 
       window.addEventListener('anhanga:marketing-consent', function () {
         _consentChoice = 'marketing';

--- a/index.html
+++ b/index.html
@@ -41,10 +41,11 @@
   <link rel="preconnect" href="https://media.anhanga.tur.br" crossorigin>
   <link rel="dns-prefetch" href="https://media.anhanga.tur.br">
 
-  <!-- Stape sGTM — warm DNS/TLS before deferred loader fires -->
-  <link rel="preconnect" href="https://load.sst.anhanga.tur.br" crossorigin>
+  <!-- Stape sGTM — apenas dns-prefetch (barato): o loader difere os scripts de terceiros para
+       depois do LCP, então um preconnect mantido aberto no load só desperdiça uma conexão e é
+       apontado como "pré-conexão não usada" pelo Lighthouse (issue #1259). A conexão real é
+       estabelecida quando o loader dispara, com o DNS já resolvido. -->
   <link rel="dns-prefetch" href="https://load.sst.anhanga.tur.br">
-  <link rel="preconnect" href="https://sst.anhanga.tur.br" crossorigin>
   <link rel="dns-prefetch" href="https://sst.anhanga.tur.br">
 
   <!-- Fonts -->
@@ -158,15 +159,25 @@
         window.addEventListener(eventName, triggerAnalytics, { passive: true, once: true });
       });
 
-      if ('requestIdleCallback' in window) {
-        requestIdleCallback(function () { setTimeout(triggerAnalytics, 12000); }, { timeout: 25000 });
+      // Fallback para sessões sem interação: dispara no primeiro tempo ocioso após o load.
+      // ANTES havia um atraso fixo de ~12s. Em testes de laboratório (Lighthouse/PageSpeed com
+      // throttling simulado) esse atraso empurrava a atividade dos scripts de terceiros para
+      // DENTRO da janela de medição, fixando TTI/TBT em ~12s (issue #1259). O LCP é o hero
+      // pré-renderizado, já pintado bem antes disso, então adiar só até o primeiro ocioso
+      // pós-load protege o LCP/TBT reais, encurta a janela do lab e ainda cobre analytics de
+      // quem não interage (na prática, captura MAIS sessões que dão bounce antes dos 12s).
+      var scheduleFallback = function () {
+        if ('requestIdleCallback' in window) {
+          requestIdleCallback(triggerAnalytics, { timeout: 4000 });
+        } else {
+          setTimeout(triggerAnalytics, 4000);
+        }
+      };
+      if (document.readyState === 'complete') {
+        scheduleFallback();
       } else {
-        setTimeout(triggerAnalytics, 15000);
+        window.addEventListener('load', scheduleFallback, { once: true });
       }
-
-      window.addEventListener('load', function () {
-        setTimeout(triggerAnalytics, 12000);
-      }, { once: true });
 
       window.addEventListener('anhanga:marketing-consent', function () {
         _consentChoice = 'marketing';

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -131,6 +131,19 @@ test('index.html difere terceiros sem atraso fixo de ~12s que fixa TTI no lab (i
   assert.match(indexHtml, /scheduleFallback/, 'fallback pós-load deve estar agendado');
 });
 
+test('index.html mantém teto absoluto de analytics independente do evento load', () => {
+  // Se o 'load' atrasar/travar (iframe, tiles do Leaflet em /lollapalooza), o fallback de
+  // analytics ainda precisa disparar para sessões sem interação. O backstop absoluto roda no
+  // parse do script (não gated no load) e é idempotente/limpo via analyticsLoaded.
+  assert.match(indexHtml, /absoluteFallbackTimer\s*=\s*setTimeout\(\s*triggerAnalytics\s*,\s*10000\s*\)/, 'backstop absoluto (10s) independente do load deve existir');
+  assert.match(indexHtml, /clearTimeout\(absoluteFallbackTimer\)/, 'backstop deve ser limpo quando o analytics carrega (idempotência)');
+
+  // A limpeza do timer deve ocorrer dentro de loadAnalytics, após marcar analyticsLoaded.
+  const loadAnalyticsMatch = indexHtml.match(/var loadAnalytics\s*=\s*function\s*\(\)\s*\{([\s\S]*?)\n\s{6}\};/);
+  assert.ok(loadAnalyticsMatch, 'loadAnalytics deve estar definida');
+  assert.match(loadAnalyticsMatch[1], /clearTimeout\(absoluteFallbackTimer\)/, 'clearTimeout deve estar dentro de loadAnalytics');
+});
+
 test('index.html não abre preconnect ocioso para os hosts sGTM (pré-conexão não usada)', () => {
   const headHtml = getHeadHtml(indexHtml);
   // Os hosts sGTM só são contatados quando o loader difere dispara (após o LCP). Um preconnect

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -118,6 +118,38 @@ test('loadMautic tem gate de consentimento LGPD', () => {
   assert.match(body, /_consentChoice\s*!==\s*'marketing'/, 'loadMautic deve ter gate de consentimento');
 });
 
+test('index.html difere terceiros sem atraso fixo de ~12s que fixa TTI no lab (issue #1259)', () => {
+  // O atraso fixo antigo (setTimeout ~12s / 15s / requestIdleCallback timeout 25s) empurrava a
+  // atividade dos scripts de terceiros para dentro da janela de medição do Lighthouse/PageSpeed,
+  // fixando TTI/TBT em ~12s. O fallback agora dispara no primeiro tempo ocioso pós-load.
+  assert.doesNotMatch(indexHtml, /setTimeout\(\s*triggerAnalytics\s*,\s*1[25]000\s*\)/, 'sem atraso fixo de 12s/15s no trigger de analytics');
+  assert.doesNotMatch(indexHtml, /requestIdleCallback\([^)]*\{\s*timeout:\s*25000/, 'sem requestIdleCallback com timeout de 25s');
+
+  // O fallback ocioso curto (<= 4s) e os gatilhos de interação devem continuar presentes.
+  assert.match(indexHtml, /requestIdleCallback\(\s*triggerAnalytics\s*,\s*\{\s*timeout:\s*4000\s*\}\s*\)/, 'fallback ocioso curto deve existir');
+  assert.match(indexHtml, /\['scroll',\s*'pointerdown',\s*'keydown',\s*'touchstart'\]/, 'gatilhos de interação devem permanecer');
+  assert.match(indexHtml, /scheduleFallback/, 'fallback pós-load deve estar agendado');
+});
+
+test('index.html não abre preconnect ocioso para os hosts sGTM (pré-conexão não usada)', () => {
+  const headHtml = getHeadHtml(indexHtml);
+  // Os hosts sGTM só são contatados quando o loader difere dispara (após o LCP). Um preconnect
+  // mantido aberto no load é apontado como "pré-conexão não usada" pelo Lighthouse (issue #1259).
+  assert.doesNotMatch(headHtml, /rel="preconnect"[^>]*sst\.anhanga\.tur\.br/, 'sst não deve usar preconnect');
+  assert.doesNotMatch(headHtml, /sst\.anhanga\.tur\.br[^>]*rel="preconnect"/, 'sst não deve usar preconnect (ordem invertida)');
+  // dns-prefetch (barato) deve permanecer para os dois hosts.
+  assert.match(headHtml, /rel="dns-prefetch"\s+href="https:\/\/load\.sst\.anhanga\.tur\.br"/, 'dns-prefetch de load.sst deve permanecer');
+  assert.match(headHtml, /rel="dns-prefetch"\s+href="https:\/\/sst\.anhanga\.tur\.br"/, 'dns-prefetch de sst deve permanecer');
+});
+
+test('index.html mantém no máximo 4 preconnects no head (guia de performance)', () => {
+  const headHtml = getHeadHtml(indexHtml);
+  const preconnects = [...headHtml.matchAll(/rel="preconnect"/g)];
+  assert.ok(preconnects.length <= 4, `esperado <= 4 preconnects, encontrado ${preconnects.length}`);
+  // O preconnect do CDN de mídia (origem do LCP) deve permanecer.
+  assert.match(headHtml, /rel="preconnect"\s+href="https:\/\/media\.anhanga\.tur\.br"/, 'preconnect do CDN de mídia (LCP) deve permanecer');
+});
+
 test('index.html não carrega scripts do HubSpot (ferramenta descontinuada)', () => {
   assert.doesNotMatch(indexHtml, /hs-scripts\.com/i, 'script do HubSpot não deve ser injetado');
   assert.doesNotMatch(indexHtml, /loadHubspot/i, 'loader do HubSpot não deve existir');


### PR DESCRIPTION
## Resumo

- **O que muda:** No carregamento diferido de terceiros (`index.html`), troca o atraso fixo de ~12s (`setTimeout 12000/15000` + `requestIdleCallback timeout 25000`) por um fallback que dispara no primeiro tempo ocioso pós-`load` (`requestIdleCallback` com timeout de 4s). Também remove os dois `preconnect` ociosos para os hosts sGTM (`load.sst`/`sst.anhanga.tur.br`), mantendo só `dns-prefetch`.
- **Por quê:** Sob throttling *simulado* (padrão do Lighthouse/PageSpeed), o atraso fixo de ~12s empurrava a atividade dos scripts de terceiros para **dentro da janela de medição**, fixando TTI/TBT em ~12s — que é exatamente o LCP/TTI reportados na #1259 (11–13s). Como o LCP é o hero pré-renderizado (já pintado bem antes disso), adiar só até o primeiro ocioso pós-load protege o LCP/TBT reais, encurta a janela do lab e ainda cobre analytics de quem não interage — na prática capturando **mais** sessões que davam bounce antes dos 12s. Os `preconnect` para os hosts sGTM eram apontados como "pré-conexão não usada" pelo Lighthouse, já que esses hosts só são contatados quando o loader difere dispara (após o LCP).
- **Impacto para o usuário:** LCP/TBT reais protegidos; gatilhos por interação (scroll/pointer/key/touch) inalterados; cobertura de analytics mantida (e ligeiramente ampliada). Head fica com 3 preconnects (mídia + 2 fontes), sob o limite de 4.
- **Nível de risco:** baixo

## Issue relacionada

Refs #1259 (FEL-352). Endereça os itens **4** (preconnects não usados) e a causa dominante do LCP/TTI no lab. O item **1** (pixels pesados — Meta/TikTok/`capiParamBuilder`) é injetado pelo **container do GTM/sGTM**, não pelo repo: já roda via Stape (`load.sst`), e reduzir o peso client-side restante é config de server-side tagging no GTM, fora deste código. Por isso **não** dou `Closes`.

## Tipo de mudança

- [x] ⚡ Performance
- [x] 🐛 Bug fix

## Testes

- [x] Testes automatizados adicionados/atualizados (novos casos em `tests/index-third-party-scripts.test.ts`: sem atraso fixo de 12s/15s, fallback ocioso curto presente, hosts sGTM sem `preconnect`, head com ≤ 4 preconnects)
- [x] Menor camada de teste correta foi usada (`node:test` — a lógica de defer/preconnect vive no HTML estático)

Comandos executados:

```text
pnpm build                    # build + prerender OK
pnpm typecheck                # tsc --noEmit → limpo
node_modules/.bin/tsc --noEmit  # exit 0
eslint tests/index-third-party-scripts.test.ts  # exit 0
pnpm test:regression          # 985/985 passam
```

**Verificação manual de performance (ressalva):** o critério de aceite (PSI mobile > 70, LCP < 4s em Home, um post de blog e `/beto-carrero/`) precisa ser confirmado no PageSpeed Insights **após o deploy** — não há seam de teste de performance automatizado no repo, e o ambiente de CI/sandbox não reproduz o throttling real do Lighthouse sobre a origem de produção. Medição local com throttling mobile (4× CPU, 1.6 Mbps) via Chromium não mostrou regressão de LCP (~1,36s, mesmos bytes de JS/CSS).

## API & Segurança

- [x] Não se aplica — mudança só em `index.html` (carregamento de scripts client-side) e testes; sem handlers de `api/` nem input externo. Gates de consentimento LGPD e de host (dev/CI) preservados.

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`perf:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

- O atraso de 12s foi originalmente adicionado "para proteger o TBT mobile", mas sob throttling simulado ele era contraproducente: mantinha a página ocupada tarde e estendia a janela de medição do lab, fixando as métricas em ~12s. A troca para fallback ocioso curto move as long tasks de terceiros para depois do LCP, mas cedo o suficiente para a janela do lab fechar rápido.
- Follow-up sugerido (fora deste PR): revisar o container do GTM/sGTM para mover Meta Pixel/TikTok/CAPI para server-side tagging e cortar o peso client-side restante (item 1 da #1259).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfFiWbKLorBczrj2Bb2gte)_