### PR TITLE
feat: adiciona credencial Pastore à landing Melhor Idade

### DIFF
--- a/docs/superpowers/plans/2026-07-21-melhor-idade-pastore-credential.md
+++ b/docs/superpowers/plans/2026-07-21-melhor-idade-pastore-credential.md
@@ -1,0 +1,138 @@
+# Credencial Pastore na Melhor Idade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Exibir a credencial textual `Parceira Pastore Turismo` na seção “Por que planejar sua viagem 50+ com a Anhangá?” sem quebrar o layout mobile.
+
+**Architecture:** A mudança permanece local a `MelhorIdadeLanding.tsx`: uma pill informativa e não interativa será inserida entre o título da seção e o conteúdo editorial, reutilizando as classes visuais da credencial de consultoria. Um teste Playwright dedicado verificará conteúdo, posição, ausência de sombra e overflow em uma viewport móvel estreita.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS, Lucide React e Playwright.
+
+## Global Constraints
+
+- Exibir somente a credencial textual `Parceira Pastore Turismo`.
+- Posicionar a credencial imediatamente abaixo do título da seção “Por que planejar sua viagem 50+ com a Anhangá?” e antes do conteúdo editorial.
+- Usar pill branca, borda fina, cantos totalmente arredondados, ícone de confirmação e nenhuma sombra.
+- Usar tokens Tailwind canônicos `anhanga-*` no novo código.
+- Não alterar FAQ, conteúdo editorial, demais parcerias ou criar um componente compartilhado.
+
+---
+
+### Task 1: Credencial Pastore responsiva
+
+**Files:**
+- Create: `tests/e2e/melhor-idade-credential.spec.ts`
+- Modify: `pages/landings/MelhorIdadeLanding.tsx:8,167-170`
+
+**Interfaces:**
+- Consumes: rota pública `/melhor-idade/` e o ícone `CheckCircle` de `lucide-react`.
+- Produces: conteúdo informativo visível com o nome acessível `Parceira Pastore Turismo`; não produz nova prop, função ou API compartilhada.
+
+- [ ] **Step 1: Escrever o teste Playwright que descreve a credencial e o layout mobile**
+
+Criar `tests/e2e/melhor-idade-credential.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test.describe('credencial Pastore na landing Melhor Idade', () => {
+  test.use({ viewport: { width: 320, height: 568 } });
+
+  test('aparece entre o título e o conteúdo, sem sombra nem overflow horizontal', async ({ page }) => {
+    await page.goto('/melhor-idade/');
+
+    const heading = page.getByRole('heading', {
+      level: 2,
+      name: 'Por que planejar sua viagem 50+ com a Anhangá?',
+    });
+    const credential = page.getByText('Parceira Pastore Turismo', { exact: true });
+    const firstParagraph = page.getByText('Viajar na maturidade exige um olhar diferente.', {
+      exact: false,
+    });
+
+    await heading.scrollIntoViewIfNeeded();
+    await expect(credential).toBeVisible();
+    await expect(credential).toHaveCSS('box-shadow', 'none');
+    await expect(credential).toHaveCSS('border-top-style', 'solid');
+
+    const headingBox = await heading.boundingBox();
+    const credentialBox = await credential.boundingBox();
+    const paragraphBox = await firstParagraph.boundingBox();
+    expect(headingBox).not.toBeNull();
+    expect(credentialBox).not.toBeNull();
+    expect(paragraphBox).not.toBeNull();
+    expect(credentialBox!.y).toBeGreaterThanOrEqual(headingBox!.y + headingBox!.height);
+    expect(paragraphBox!.y).toBeGreaterThanOrEqual(credentialBox!.y + credentialBox!.height);
+
+    const hasHorizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    expect(hasHorizontalOverflow).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Executar o teste e confirmar o RED**
+
+Run:
+
+```bash
+pnpm exec playwright test tests/e2e/melhor-idade-credential.spec.ts --project=chromium
+```
+
+Expected: FAIL porque `getByText('Parceira Pastore Turismo')` não encontra o elemento.
+
+- [ ] **Step 3: Implementar a pill mínima na seção aprovada**
+
+Em `pages/landings/MelhorIdadeLanding.tsx`, ampliar o import do Lucide:
+
+```ts
+import { ShieldCheck, Heart, Sparkles, Coffee, CheckCircle } from 'lucide-react';
+```
+
+Trocar a margem inferior do título de `mb-12` para `mb-6` e inserir imediatamente depois dele:
+
+```tsx
+<div className="flex justify-center mb-12">
+  <span className="inline-flex items-center gap-2 rounded-full bg-white border border-zinc-200 px-4 py-2 text-sm font-bold text-anhanga-dark">
+    <CheckCircle className="size-4 text-anhanga-blue" aria-hidden="true" />
+    Parceira Pastore Turismo
+  </span>
+</div>
+```
+
+- [ ] **Step 4: Executar o teste focado e confirmar o GREEN**
+
+Run:
+
+```bash
+pnpm exec playwright test tests/e2e/melhor-idade-credential.spec.ts --project=chromium
+```
+
+Expected: PASS; a pill fica entre o título e o primeiro parágrafo, tem borda sólida, `box-shadow: none` e não provoca overflow em 320 px.
+
+- [ ] **Step 5: Executar as verificações completas proporcionais à mudança**
+
+Run:
+
+```bash
+pnpm test:regression
+pnpm typecheck
+pnpm lint:changed
+pnpm exec react-doctor --verbose --scope changed --base main
+```
+
+Expected: todos os comandos passam; o React Doctor não apresenta novos diagnósticos no escopo alterado.
+
+- [ ] **Step 6: Revisar o diff e criar o commit de implementação**
+
+Run:
+
+```bash
+git diff --check
+git diff -- pages/landings/MelhorIdadeLanding.tsx tests/e2e/melhor-idade-credential.spec.ts
+git add pages/landings/MelhorIdadeLanding.tsx tests/e2e/melhor-idade-credential.spec.ts
+git commit -m "feat: adiciona credencial Pastore na landing 50+"
+```
+
+Expected: diff restrito à importação do ícone, à pill aprovada e ao teste de regressão mobile; commit criado com sucesso.

--- a/docs/superpowers/specs/2026-07-21-melhor-idade-pastore-credential-design.md
+++ b/docs/superpowers/specs/2026-07-21-melhor-idade-pastore-credential-design.md
@@ -1,0 +1,56 @@
+# Credencial Pastore na landing Melhor Idade
+
+## Objetivo
+
+Adicionar uma prova de confiança específica para o público 50+ à landing
+`/melhor-idade/`, comunicando a parceria comercial já confirmada entre a
+Anhangá Viagens e a Pastore Turismo.
+
+## Escopo
+
+- Exibir somente a credencial textual `Parceira Pastore Turismo`.
+- Posicioná-la na seção `Por que planejar sua viagem 50+ com a Anhangá?`,
+  imediatamente abaixo do título e antes do conteúdo editorial.
+- Reutilizar o padrão visual das credenciais de `/consultoria-de-viagem/`:
+  pill branca, borda fina, cantos totalmente arredondados, ícone de confirmação
+  e nenhuma sombra.
+- Usar os tokens Tailwind canônicos `anhanga-*` no novo código.
+
+## Fora do escopo
+
+- Alterar o FAQ ou outro conteúdo editorial da landing.
+- Adicionar todas as demais parcerias da Anhangá. Cadastur, Beto Carrero World,
+  Hopi Hari e Norwegian Cruise Line já são apresentados no contexto institucional
+  da página `/sobre/`; repeti-los aqui diluiria a credencial relevante ao público
+  50+.
+- Criar um componente compartilhado ou um novo padrão visual para uma única pill.
+- Adicionar logotipo, link externo ou alegações além do wording confirmado pela
+  issue.
+
+## Comportamento e acessibilidade
+
+A credencial será conteúdo informativo, não um controle interativo. Ela será
+renderizada como texto com ícone decorativo marcado com `aria-hidden="true"`.
+O contêiner será centralizado e dimensionado pelo conteúdo, sem largura fixa,
+para não provocar overflow em telas estreitas.
+
+## Testes e validação
+
+O fluxo será implementado com TDD:
+
+1. Adicionar um teste de regressão que exija a credencial na landing e valide o
+   padrão sem sombra; confirmar que ele falha antes da implementação.
+2. Inserir a pill na seção definida e confirmar que o teste passa.
+3. Executar o teste focado, a suíte de regressão, `pnpm typecheck` e
+   `pnpm lint:changed`.
+4. Fazer uma verificação browser-visible em viewport mobile estreita para
+   confirmar visibilidade e ausência de overflow horizontal.
+
+## Critérios de aceite
+
+- `Parceira Pastore Turismo` aparece na seção `Por que planejar sua viagem 50+
+  com a Anhangá?`.
+- A credencial segue a linguagem visual de pill com borda e sem sombra já usada
+  na landing de consultoria.
+- A landing não apresenta overflow nem quebra de layout em mobile estreito.
+- Nenhum FAQ ou conteúdo fora da credencial é alterado.

--- a/pages/landings/MelhorIdadeLanding.tsx
+++ b/pages/landings/MelhorIdadeLanding.tsx
@@ -7,7 +7,7 @@ import { FAQPageSchema } from '../../components/schemas/FAQPageSchema';
 import { ServiceSchema } from '../../components/schemas/ServiceSchema';
 import { openContactModal } from '../../utils/contactForm';
 import { m } from 'framer-motion';
-import { ShieldCheck, Heart, Sparkles, Coffee } from 'lucide-react';
+import { ShieldCheck, Heart, Sparkles, Coffee, CheckCircle } from 'lucide-react';
 
 const MELHOR_IDADE_FAQ_ITEMS = [
   {
@@ -164,7 +164,13 @@ const MelhorIdadeLanding: React.FC = () => {
       {/* CONTENT RICH SECTION FOR GEO */}
       <section className="py-24 bg-brand-surface">
         <div className="container mx-auto px-6 max-w-4xl">
-          <h2 className="text-3xl md:text-5xl font-black text-brand-dark mb-12 text-center">Por que planejar sua viagem 50+ com a Anhangá?</h2>
+          <h2 className="text-3xl md:text-5xl font-black text-brand-dark mb-6 text-center">Por que planejar sua viagem 50+ com a Anhangá?</h2>
+          <div className="flex justify-center mb-12">
+            <span className="inline-flex items-center gap-2 rounded-full bg-white border border-zinc-200 px-4 py-2 text-sm font-bold text-anhanga-dark">
+              <CheckCircle className="size-4 text-anhanga-blue" aria-hidden="true" />
+              Parceira Pastore Turismo
+            </span>
+          </div>
           
           <div className="prose prose-lg prose-brand max-w-none text-zinc-700 font-medium leading-[1.8]">
             <p>

--- a/tests/e2e/melhor-idade-credential.spec.ts
+++ b/tests/e2e/melhor-idade-credential.spec.ts
@@ -18,7 +18,10 @@ test.describe('credencial Pastore na landing Melhor Idade', () => {
     await heading.scrollIntoViewIfNeeded();
     await expect(credential).toBeVisible();
     await expect(credential).toHaveCSS('box-shadow', 'none');
+    await expect(credential).toHaveCSS('background-color', 'rgb(255, 255, 255)');
     await expect(credential).toHaveCSS('border-top-style', 'solid');
+    await expect(credential).toHaveCSS('border-top-width', '1px');
+    await expect(credential.locator('svg')).toHaveAttribute('aria-hidden', 'true');
 
     const headingBox = await heading.boundingBox();
     const credentialBox = await credential.boundingBox();
@@ -26,6 +29,10 @@ test.describe('credencial Pastore na landing Melhor Idade', () => {
     expect(headingBox).not.toBeNull();
     expect(credentialBox).not.toBeNull();
     expect(paragraphBox).not.toBeNull();
+    const borderRadius = await credential.evaluate((element) =>
+      Number.parseFloat(getComputedStyle(element).borderTopLeftRadius),
+    );
+    expect(borderRadius).toBeGreaterThanOrEqual(credentialBox!.height / 2);
     expect(credentialBox!.y).toBeGreaterThanOrEqual(headingBox!.y + headingBox!.height);
     expect(paragraphBox!.y).toBeGreaterThanOrEqual(credentialBox!.y + credentialBox!.height);
 

--- a/tests/e2e/melhor-idade-credential.spec.ts
+++ b/tests/e2e/melhor-idade-credential.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('credencial Pastore na landing Melhor Idade', () => {
+  test.use({ viewport: { width: 320, height: 568 } });
+
+  test('aparece entre o título e o conteúdo, sem sombra nem overflow horizontal', async ({ page }) => {
+    await page.goto('/melhor-idade/');
+
+    const heading = page.getByRole('heading', {
+      level: 2,
+      name: 'Por que planejar sua viagem 50+ com a Anhangá?',
+    });
+    const credential = page.getByText('Parceira Pastore Turismo', { exact: true });
+    const firstParagraph = page.getByText('Viajar na maturidade exige um olhar diferente.', {
+      exact: false,
+    });
+
+    await heading.scrollIntoViewIfNeeded();
+    await expect(credential).toBeVisible();
+    await expect(credential).toHaveCSS('box-shadow', 'none');
+    await expect(credential).toHaveCSS('border-top-style', 'solid');
+
+    const headingBox = await heading.boundingBox();
+    const credentialBox = await credential.boundingBox();
+    const paragraphBox = await firstParagraph.boundingBox();
+    expect(headingBox).not.toBeNull();
+    expect(credentialBox).not.toBeNull();
+    expect(paragraphBox).not.toBeNull();
+    expect(credentialBox!.y).toBeGreaterThanOrEqual(headingBox!.y + headingBox!.height);
+    expect(paragraphBox!.y).toBeGreaterThanOrEqual(credentialBox!.y + credentialBox!.height);
+
+    const hasHorizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    expect(hasHorizontalOverflow).toBe(false);
+  });
+});


### PR DESCRIPTION
## O que mudou

- adiciona a credencial textual **Parceira Pastore Turismo** à seção “Por que planejar sua viagem 50+ com a Anhangá?”
- reutiliza o padrão visual de pill com borda e sem sombra da landing de consultoria
- mantém o ícone decorativo fora da árvore de acessibilidade
- adiciona cobertura Playwright em viewport de 320 px para posição, estilo e ausência de overflow horizontal

## Por quê

A parceria com a Pastore Turismo é uma prova de confiança diretamente relevante para o público 50+. A landing ainda não apresentava essa credencial no conteúdo principal.

## Impacto

A página `/melhor-idade/` passa a comunicar a parceria sem alterar FAQ, conteúdo editorial ou outras credenciais. Não há mudança de API ou dependências.

## Validação

- `pnpm test:regression` — 986 testes aprovados
- `pnpm typecheck`
- `pnpm lint:changed`
- `pnpm exec playwright test tests/e2e/melhor-idade-credential.spec.ts --project=chromium`
- `npx react-doctor@latest --verbose --diff` — 100/100, sem issues

Closes #1268
