### PR TITLE
fix(analytics): emitir generate_lead no formulário de contato

### DIFF
--- a/hooks/useContactForm.ts
+++ b/hooks/useContactForm.ts
@@ -13,6 +13,7 @@ import type { ContactFormFields, SubmitContactRequest, SubmitContactResponse } f
 import type { LeadTracking } from '../types/leadCapture';
 import type { ContactModalOptions } from '../utils/contactForm';
 import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
+import { pushGenerateLeadConversionEvent } from '../utils/generate-lead-analytics';
 
 const EMPTY_FIELDS: ContactFormFields = {
     firstName: '',
@@ -38,15 +39,11 @@ function pushContactDataLayerEvent(
     if (typeof window === 'undefined' || !window.dataLayer) return;
 
     // 1. Canonical conversion event consumed by GTM web and sGTM.
-    window.dataLayer.push({
-        event: 'generate_lead',
-        event_id: eventId,
+    pushGenerateLeadConversionEvent({
+        eventId,
         destination: destination ?? action,
-        utm_source: utms?.utm_source,
-        utm_medium: utms?.utm_medium,
-        utm_campaign: utms?.utm_campaign,
-        ga_client_id: tracking?.cid,
-        ga_session_id: tracking?.sid,
+        utms,
+        tracking,
     });
 
     // 2. Internal contact event

--- a/hooks/useContactForm.ts
+++ b/hooks/useContactForm.ts
@@ -31,10 +31,25 @@ function pushContactDataLayerEvent(
     eventId: string,
     action: 'whatsapp' | 'callback',
     source?: string,
+    tracking?: LeadTracking,
+    utms?: SubmitContactRequest['utms'],
+    destination?: string,
 ): void {
     if (typeof window === 'undefined' || !window.dataLayer) return;
 
-    // 1. Internal contact event
+    // 1. Canonical conversion event consumed by GTM web and sGTM.
+    window.dataLayer.push({
+        event: 'generate_lead',
+        event_id: eventId,
+        destination: destination ?? action,
+        utm_source: utms?.utm_source,
+        utm_medium: utms?.utm_medium,
+        utm_campaign: utms?.utm_campaign,
+        ga_client_id: tracking?.cid,
+        ga_session_id: tracking?.sid,
+    });
+
+    // 2. Internal contact event
     window.dataLayer.push({
         event: 'contact_form_submission',
         event_id: eventId,
@@ -43,7 +58,7 @@ function pushContactDataLayerEvent(
         page_location: window.location.href,
     });
 
-    // 2. Unified form submission event for GA4/Ads
+    // 3. Unified form submission event for GA4/Ads
     window.dataLayer.push({
         event: 'form_submission',
         form_type: 'contact_modal',
@@ -209,7 +224,14 @@ export function useContactForm(options: ContactModalOptions = {}) {
                     return;
                 }
 
-                pushContactDataLayerEvent(eventId, action, options.source);
+                pushContactDataLayerEvent(
+                    eventId,
+                    action,
+                    options.source,
+                    tracking,
+                    utms,
+                    options.destination,
+                );
                 pushFormAnalyticsEvent({
                     event: 'submit_success',
                     formType: 'contact_modal',

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -4,6 +4,7 @@ import { getTrackingDataObject, getWhatsAppLink } from '../utils/whatsapp';
 import type { LeadTracking, LeadUtms, SubmitLeadRequest } from '../types/leadCapture';
 import { cleanString, normalizeWhatsappNumber } from '../lib/lead-logic';
 import { extractUtms, normalizeLeadTracking } from '../lib/tracking-normalization';
+import { pushGenerateLeadConversionEvent } from '../utils/generate-lead-analytics';
 
 export interface LeadDraft {
     firstName: string;
@@ -210,15 +211,11 @@ export function pushGenerateLeadDataLayerEvent(
     }
 
     // 1. Internal generation event
-    window.dataLayer.push({
-        event: 'generate_lead',
-        event_id: payload.event_id,
+    pushGenerateLeadConversionEvent({
+        eventId: payload.event_id,
         destination: payload.destination,
-        utm_source: payload.utms.utm_source,
-        utm_medium: payload.utms.utm_medium,
-        utm_campaign: payload.utms.utm_campaign,
-        ga_client_id: payload.tracking?.cid,
-        ga_session_id: payload.tracking?.sid,
+        utms: payload.utms,
+        tracking: payload.tracking,
     });
 
     // 2. Unified form submission event for GA4/Ads

--- a/tests/e2e/contact-form.spec.ts
+++ b/tests/e2e/contact-form.spec.ts
@@ -171,6 +171,48 @@ test.describe('Contact form modal', () => {
 
     await expect(page.getByText(/recebemos seu contato/i)).toBeVisible();
     await expect(page.getByText('Abrimos o WhatsApp para você continuar com a nossa equipe.')).toBeVisible();
+
+    const generateLeadEvents = await page.evaluate(() =>
+      window.dataLayer?.filter((entry) => entry.event === 'generate_lead') ?? [],
+    );
+    const [submittedRequest] = capturedSubmitContactRequests.get(page) ?? [];
+
+    expect(submittedRequest).toBeDefined();
+    expect(generateLeadEvents).toHaveLength(1);
+    expect(generateLeadEvents[0]).toMatchObject({
+      event: 'generate_lead',
+      event_id: submittedRequest.eventId,
+      destination: 'whatsapp',
+    });
+  });
+
+  test('não gera conversão no caminho WhatsApp quando a API rejeita o contato', async ({
+    page,
+    isMobile,
+  }) => {
+    await page.unroute('**/api/submit-contact');
+    await page.route('**/api/submit-contact', route =>
+      route.fulfill({
+        status: 502,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: false,
+          error: 'Não foi possível enviar. Tente novamente.',
+          code: 'CRM_UNAVAILABLE',
+        }),
+      }),
+    );
+    await openHeaderContactModal(page, isMobile);
+
+    await page.locator('#contact-firstName').fill('Maria');
+    await page.locator('#contact-whatsapp').fill('11987654321');
+    await page.locator('#contact-whatsapp').press('Enter');
+
+    await expect(page.getByText('Abrimos o WhatsApp para você continuar com a nossa equipe.')).toBeVisible();
+    const generateLeadEvents = await page.evaluate(() =>
+      window.dataLayer?.filter((entry) => entry.event === 'generate_lead') ?? [],
+    );
+    expect(generateLeadEvents).toHaveLength(0);
   });
 
   test('fecha com tecla Escape', async ({ page, isMobile }) => {

--- a/tests/e2e/contact-form.spec.ts
+++ b/tests/e2e/contact-form.spec.ts
@@ -1,13 +1,21 @@
 import { expect, test, type Page } from '@playwright/test';
+import type { SubmitContactRequest } from '../../types/contactCapture';
+
+const capturedSubmitContactRequests = new WeakMap<Page, SubmitContactRequest[]>();
 
 async function mockSubmitContact(page: Page) {
-  await page.route('**/api/submit-contact', route =>
-    route.fulfill({
+  const capturedRequests: SubmitContactRequest[] = [];
+  capturedSubmitContactRequests.set(page, capturedRequests);
+
+  await page.route('**/api/submit-contact', route => {
+    capturedRequests.push(route.request().postDataJSON() as SubmitContactRequest);
+
+    return route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({ ok: true, requestId: 'req_contact_e2e' }),
-    }),
-  );
+    });
+  });
 }
 
 async function openHeaderContactModal(page: Page, isMobile: boolean) {
@@ -76,6 +84,7 @@ test.describe('Contact form modal', () => {
   });
 
   test('envia o pedido de retorno e exibe confirmação', async ({ page, isMobile }) => {
+    await page.goto('/?utm_source=google&utm_medium=cpc&utm_campaign=issue-1261');
     await openHeaderContactModal(page, isMobile);
 
     await page.locator('#contact-firstName').fill('Maria');
@@ -86,6 +95,71 @@ test.describe('Contact form modal', () => {
     await expect(page.getByText('Nossa equipe chama você em breve pelo WhatsApp.')).toBeVisible();
     await expect(contactDialog(page).getByRole('status')).toContainText(/recebemos seu contato/i);
     await expect(contactDialog(page).getByRole('button', { name: /^fechar$/i }).last()).toBeFocused();
+
+    const generateLeadEvents = await page.evaluate(() =>
+      window.dataLayer?.filter((entry) => entry.event === 'generate_lead') ?? [],
+    );
+    const [submittedRequest] = capturedSubmitContactRequests.get(page) ?? [];
+
+    expect(submittedRequest).toBeDefined();
+    expect(generateLeadEvents).toHaveLength(1);
+    expect(generateLeadEvents[0]).toMatchObject({
+      event: 'generate_lead',
+      event_id: submittedRequest.eventId,
+      destination: 'callback',
+      utm_source: submittedRequest.utms.utm_source,
+      utm_medium: submittedRequest.utms.utm_medium,
+      utm_campaign: submittedRequest.utms.utm_campaign,
+      ga_client_id: submittedRequest.tracking?.cid,
+      ga_session_id: submittedRequest.tracking?.sid,
+    });
+    expect(generateLeadEvents[0]?.event_id).toMatch(/^lead_/);
+  });
+
+  test('não gera conversão quando a API rejeita o contato', async ({ page, isMobile }) => {
+    await page.unroute('**/api/submit-contact');
+    await page.route('**/api/submit-contact', route =>
+      route.fulfill({
+        status: 502,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: false,
+          error: 'Não foi possível enviar. Tente novamente.',
+          code: 'CRM_UNAVAILABLE',
+        }),
+      }),
+    );
+    await openHeaderContactModal(page, isMobile);
+
+    await page.locator('#contact-firstName').fill('Maria');
+    await page.locator('#contact-whatsapp').fill('11987654321');
+    await page.getByRole('button', { name: /^prefiro que me chamem$/i }).click();
+
+    await expect(
+      contactDialog(page).getByText('Não foi possível enviar. Tente novamente.'),
+    ).toBeVisible();
+    const generateLeadEvents = await page.evaluate(() =>
+      window.dataLayer?.filter((entry) => entry.event === 'generate_lead') ?? [],
+    );
+    expect(generateLeadEvents).toHaveLength(0);
+  });
+
+  test('não gera conversão quando a requisição falha na rede', async ({ page, isMobile }) => {
+    await page.unroute('**/api/submit-contact');
+    await page.route('**/api/submit-contact', route => route.abort('failed'));
+    await openHeaderContactModal(page, isMobile);
+
+    await page.locator('#contact-firstName').fill('Maria');
+    await page.locator('#contact-whatsapp').fill('11987654321');
+    await page.getByRole('button', { name: /^prefiro que me chamem$/i }).click();
+
+    await expect(
+      contactDialog(page).getByText('Erro de conexão. Verifique sua internet e tente novamente.'),
+    ).toBeVisible();
+    const generateLeadEvents = await page.evaluate(() =>
+      window.dataLayer?.filter((entry) => entry.event === 'generate_lead') ?? [],
+    );
+    expect(generateLeadEvents).toHaveLength(0);
   });
 
   test('envia o caminho principal ao pressionar Enter', async ({ page, isMobile }) => {

--- a/utils/generate-lead-analytics.ts
+++ b/utils/generate-lead-analytics.ts
@@ -1,0 +1,30 @@
+import type { LeadTracking, LeadUtms } from '../types/leadCapture';
+
+interface GenerateLeadConversionEvent {
+    eventId?: string;
+    destination: string;
+    utms?: Pick<LeadUtms, 'utm_source' | 'utm_medium' | 'utm_campaign'>;
+    tracking?: Pick<LeadTracking, 'cid' | 'sid'>;
+}
+
+export function pushGenerateLeadConversionEvent({
+    eventId,
+    destination,
+    utms,
+    tracking,
+}: GenerateLeadConversionEvent): void {
+    if (typeof window === 'undefined' || !window.dataLayer) {
+        return;
+    }
+
+    window.dataLayer.push({
+        event: 'generate_lead',
+        event_id: eventId,
+        destination,
+        utm_source: utms?.utm_source,
+        utm_medium: utms?.utm_medium,
+        utm_campaign: utms?.utm_campaign,
+        ga_client_id: tracking?.cid,
+        ga_session_id: tracking?.sid,
+    });
+}


### PR DESCRIPTION
## Resumo
- emite o evento canônico generate_lead somente após sucesso de /api/submit-contact
- reutiliza o mesmo event_id enviado ao backend para correlação e deduplicação Web/Meta CAPI
- encaminha destino, UTMs e identificadores GA para o dataLayer
- compartilha o emissor canônico entre useContactForm e useLeadCapture, mantendo os eventos específicos em cada fluxo
- cobre sucesso e rejeição da API tanto no caminho callback quanto no CTA principal de WhatsApp

## Validação
- pnpm exec playwright test tests/e2e/contact-form.spec.ts --project=chromium (14/14)
- pnpm exec tsx --test tests/lead-whatsapp.test.ts tests/hooks-useLeadCapture.test.ts (26/26)
- pnpm test:regression (989/989)
- pnpm typecheck
- pnpm exec eslint hooks/useContactForm.ts hooks/useLeadCapture.ts utils/generate-lead-analytics.ts tests/e2e/contact-form.spec.ts
- pnpm run build
- pnpm exec react-doctor --verbose --scope changed --base main (sem issues; score API indisponível localmente)
- Preview GTM/sGTM: GA4, Meta CAPI e TikTok Events API concluídos uma vez com G111 e event_id correlacionado

## Configuração externa
O rascunho do GTM/sGTM foi validado, mas ainda não foi publicado. A publicação deve ocorrer após merge/deploy deste patch. A issue permanece aberta até a validação de performance e o monitoramento pós-cutover.

Refs #1261