### PR TITLE
fix(consent): remove duplicate Consent Mode commands

### DIFF
--- a/docs/superpowers/specs/2026-07-23-sgtm-hybrid-consent-design.md
+++ b/docs/superpowers/specs/2026-07-23-sgtm-hybrid-consent-design.md
@@ -180,10 +180,9 @@ window.addAnhangaConsentListener = function (callback) {
 
 No listener existente de `anhanga:marketing-consent`:
 
-1. manter o `gtag('consent', 'update', ...)` para compatibilidade com a
-   integração atual;
-2. notificar cada callback com `marketing`;
-3. somente depois empurrar:
+1. notificar cada callback com `marketing`; o Consent Bridge é o único
+   responsável por chamar `updateConsentState`, evitando transições duplicadas;
+2. somente depois empurrar:
 
 ```js
 window.dataLayer.push({

--- a/index.html
+++ b/index.html
@@ -82,14 +82,6 @@
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
-    var _consentInit = (function () { try { return localStorage.getItem('anhanga_cookie_consent'); } catch (e) { return null; } })();
-    gtag('consent', 'default', {
-      analytics_storage: 'granted',
-      ad_storage: _consentInit === 'marketing' ? 'granted' : 'denied',
-      ad_personalization: _consentInit === 'marketing' ? 'granted' : 'denied',
-      ad_user_data: _consentInit === 'marketing' ? 'granted' : 'denied',
-      wait_for_update: 2000
-    });
   </script>
   <script type="module" src="/index.tsx"></script>
   <!-- Defer third-party scripts to protect mobile TBT -->
@@ -216,9 +208,6 @@
       window.addEventListener('anhanga:marketing-consent', function () {
         _consentChoice = 'marketing';
         loadMautic();
-        if (typeof gtag === 'function') {
-          gtag('consent', 'update', { ad_storage: 'granted', ad_personalization: 'granted', ad_user_data: 'granted' });
-        }
         notifyConsentListeners('marketing');
         window.dataLayer.push({
           event: 'marketing_consent_granted',
@@ -228,9 +217,6 @@
 
       window.addEventListener('anhanga:revoke-consent', function () {
         _consentChoice = 'essential';
-        if (typeof gtag === 'function') {
-          gtag('consent', 'update', { ad_storage: 'denied', ad_personalization: 'denied', ad_user_data: 'denied' });
-        }
         notifyConsentListeners('essential');
         window.dataLayer.push({
           anhanga_marketing_consent: false

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
   <script>window.dataLayer = window.dataLayer || [];</script>
   <script>
     window.dataLayer = window.dataLayer || [];
+    // Required by the deferred UTM tracker to query the GA4 client_id.
     function gtag() { dataLayer.push(arguments); }
   </script>
   <script type="module" src="/index.tsx"></script>

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -75,17 +75,17 @@ test('design system documents the production Poppins font weights', () => {
   assert.match(designSystemCss, /Poppins is loaded with 400\/600\/700\/900 only/);
 });
 
-test('index.html configura gtag consent defaults antes da IIFE de scripts lazy', () => {
-  const consentBlockIndex = indexHtml.indexOf("gtag('consent', 'default'");
-  const iifeIndex = indexHtml.indexOf('var analyticsLoaded');
-
-  assert.ok(consentBlockIndex > -1, 'bloco gtag consent default deve existir');
-  assert.ok(iifeIndex > -1, 'IIFE de scripts lazy deve existir');
-  assert.ok(consentBlockIndex < iifeIndex, 'consent default deve vir antes da IIFE');
-
-  assert.match(indexHtml, /analytics_storage:\s*'granted'/, 'analytics_storage deve ser granted por padrão (legítimo interesse)');
-  assert.match(indexHtml, /ad_storage:.*'denied'/, 'ad_storage deve ser denied por padrão');
-  assert.match(indexHtml, /wait_for_update:\s*2000/, 'wait_for_update deve ser 2000ms');
+test('index.html delega os defaults de consentimento ao Consent Bridge do GTM', () => {
+  // O template Anhangá Consent Bridge roda em Consent Initialization e usa
+  // setDefaultConsentState. Manter também um gtag('consent', 'default') inline
+  // cria dois defaults e permite que a sincronização da escolha persistida seja
+  // processada antes do segundo, gerando update-before-default no Tag Assistant.
+  // Os updates também pertencem ao Bridge para não duplicar transições.
+  assert.doesNotMatch(
+    indexHtml,
+    /gtag\(\s*['"]consent['"]/,
+    'o Consent Bridge deve ser a única fonte dos comandos de consentimento',
+  );
 });
 
 test('loadGtm tem gate de host para não poluir o GA4 de produção em dev/CI', () => {

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -5,6 +5,8 @@ import path from 'node:path';
 
 const indexHtmlPath = path.resolve(process.cwd(), 'index.html');
 const indexHtml = fs.readFileSync(indexHtmlPath, 'utf8');
+const utmTrackingPath = path.resolve(process.cwd(), 'public/utm-tracking.js');
+const utmTrackingScript = fs.readFileSync(utmTrackingPath, 'utf8');
 const designSystemCssPath = path.resolve(process.cwd(), 'docs/design/brand-system', 'colors_and_type.css');
 assert.ok(fs.existsSync(designSystemCssPath), 'design system colors_and_type.css should exist at docs/design/brand-system');
 
@@ -51,6 +53,19 @@ test('index.html lazy-loads GTM through the deferred analytics loader', () => {
   assert.ok(loadGtmIndex > -1, 'GTM loader should be called from the analytics trigger');
   assert.ok(utmInjectIndex > -1, 'UTM tracking loader should still be present');
   assert.ok(loadGtmIndex < utmInjectIndex, 'GTM should be queued before UTM reads GA client data');
+});
+
+test('index.html keeps the global gtag wrapper used by the deferred UTM tracker', () => {
+  assert.match(
+    indexHtml,
+    /function\s+gtag\s*\(\)\s*\{\s*dataLayer\.push\(arguments\);\s*\}/,
+    'the UTM tracker needs a global gtag wrapper to query the GA4 client_id',
+  );
+  assert.match(
+    utmTrackingScript,
+    /gtag\(\s*['"]get['"]\s*,\s*GA4_MEASUREMENT_ID\s*,\s*['"]client_id['"]/,
+    'the deferred UTM tracker should continue querying the GA4 client_id through gtag',
+  );
 });
 
 test('index.html loads only the required Poppins font weights', () => {


### PR DESCRIPTION
## Contexto

Follow-up da #1261. O site e o template nativo Anhangá Consent Bridge estavam emitindo comandos de Consent Mode em paralelo. Isso criava defaults e updates duplicados, e o Tag Assistant registrava atualização antes do default.

## Alterações

- remove os comandos inline de consentimento do index.html
- mantém o Consent Bridge do GTM como única fonte de defaults e updates
- adiciona regressão que proíbe comandos gtag de consentimento no HTML

## Evidências

- teste focado: 19/19
- regressão: 989/989
- typecheck: aprovado
- build de produção: aprovado
- ESLint focado: aprovado
- React Doctor: 91/100, sem novos achados
- git diff --check: aprovado

## Operação relacionada

O ID inválido 518319657 foi removido da configuração do Google Analytics no Mautic. O mtc.js público deixou de emitir esse destino e o erro Cannot parse target desapareceu em nova sessão do Tag Assistant.

Após o deploy, validar novamente os caminhos de consentimento negado e concedido antes de publicar o hotfix pendente no GTM Web.