### PR TITLE
revert: reverte #1296 (CTA aponta para self-host inseguro)

### DIFF
--- a/components/landings/consultoria/ConsultoriaLandingSections.tsx
+++ b/components/landings/consultoria/ConsultoriaLandingSections.tsx
@@ -1,66 +1,58 @@
 import { Link } from 'react-router-dom';
 import { m } from 'framer-motion';
-import { ArrowRight, CheckCircle, Eye, FileText, Compass } from 'lucide-react';
+import { ArrowRight, CheckCircle, MessageSquare, Users, Headphones, Compass } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { LazyImage } from '@/components/ui/LazyImage';
 import { fadeUp } from '@/components/landings/shared/constants';
 import { openContactModal } from '@/utils/contactForm';
 import { getDestinationImage } from '@/data/mediaConfig';
 
-// Event type do Cal.com self-hosted onde o cliente agenda e paga a sessão
-// (R$250) via Stripe. Ver memória project-consultoria-modelo-pago.
-const CONSULTORIA_BOOKING_URL = 'https://cal.anhanga.tur.br/felipe/consultoria';
-
-// A autosseleção da página (grilling 24/07): a consultoria paga é para os
-// casos NÃO-comissionáveis. Quem vai fechar a viagem com a Anhangá cai na
-// porta gratuita (ContactModal), sinalizada no callout de ConsultoriaAudience.
+// 4 itens, não 5: chunking ≤4 do critique — os antigos itens 4 e 5
+// ("viajantes frequentes" / "profissionais sem tempo") eram o mesmo perfil.
 const FOR_WHO = [
-  'Você já comprou a viagem e quer um roteiro que aproveite cada dia',
-  'Vai usar milhas próprias e quer emitir do jeito certo',
-  'Tem uma viagem de trabalho e quer emendar uns dias de lazer',
-  'Quer o olhar de um especialista antes de decidir, sem pacote pronto',
+  'Quem quer viajar bem sem precisar cuidar de cada detalhe',
+  'Famílias que buscam conforto e segurança no roteiro',
+  'Casais planejando viagem especial ou lua de mel',
+  'Viajantes frequentes sem tempo de pesquisar e comparar opções',
 ];
 
 const HOW_IT_WORKS = [
   {
     step: '01',
-    title: 'Agende e reserve seu horário',
-    desc: 'Escolha o horário, pague a sessão e receba o link da videochamada no e-mail.'
+    title: 'Conversa inicial',
+    // Não prometer "sem formulário": o CTA da página abre o ContactModal, que
+    // é um formulário — Riley pegava a contradição na hora. Ver critique.
+    desc: 'Você fala com um consultor e conta o que precisa. Uma conversa de verdade, sem burocracia.'
   },
   {
     step: '02',
-    title: 'Sessão de 50 minutos',
-    desc: 'Você conta o caso e o consultor diagnostica destino, roteiro, milhas e orçamento.'
+    title: 'Roteiro personalizado',
+    desc: 'Em até 5 dias úteis, você recebe um roteiro feito do zero para o seu perfil.'
   },
   {
     step: '03',
-    title: 'Seu plano por escrito',
-    desc: 'Em até 48h chega um documento com o diagnóstico, o que recomendamos e por onde começar.'
-  },
-  {
-    step: '04',
-    title: 'Se quiser, a gente executa',
-    desc: 'O roteiro completo é orçado à parte, e os R$ 250 da sessão entram no valor.'
+    title: 'Suporte durante a viagem',
+    desc: 'WhatsApp 24h com o mesmo consultor. Qualquer imprevisto tem resposta imediata.'
   },
 ];
 
 const PILLARS = [
   {
-    icon: Eye,
-    title: 'Um olhar de quem faz isso todo dia',
-    desc: 'Quem planeja viagens para viver enxerga a sua de um jeito que buscador nenhum entrega.',
+    icon: MessageSquare,
+    title: 'Sem pacote pronto',
+    desc: 'Cada roteiro começa do zero, no perfil de quem vai viajar. Nada de escolher entre opções genéricas.',
     variant: 'light' as const
   },
   {
-    icon: FileText,
-    title: 'Você sai com um plano',
-    desc: 'Não paramos na conversa. Em até 48h você recebe um documento com o diagnóstico e os próximos passos.',
+    icon: Users,
+    title: 'Atendimento humano',
+    desc: 'Um consultor real do início ao fim. Não um chatbot, não uma central de atendimento.',
     variant: 'filled' as const
   },
   {
-    icon: Compass,
-    title: 'Conselho sobre a sua viagem, não sobre o catálogo',
-    desc: 'A gente recomenda o que é melhor pra você, mesmo quando não é o que temos para vender.',
+    icon: Headphones,
+    title: 'Suporte completo',
+    desc: 'Antes, durante e depois da viagem. WhatsApp direto com seu consultor para qualquer imprevisto.',
     variant: 'light' as const
   },
 ];
@@ -76,16 +68,16 @@ export function ConsultoriaHero() {
     /* Hero */
     /*
       Espaçamento e tamanho do texto reduzidos em mobile (md: restaura os
-      valores originais): em telas curtas (~360-812px de altura) o CTA e a
-      sub-linha logo abaixo dele caem perto do fim do viewport inicial, e o
+      valores originais): em telas curtas (~360-812px de altura) o CTA e o
+      disclaimer "Sem taxa..." caem perto do fim do viewport inicial, e o
       banner de cookies (fixed bottom-0) os cobre antes de qualquer scroll
       — combinado com CookieConsentBanner.tsx, que também foi compactado
-      no mobile. Regressão travada em landing-consultoria-content.spec.ts.
+      no mobile. Ver critique de /consultoria-de-viagem.
     */
     /*
-      max-w-4xl (não 3xl): a 3xl o H1 text-6xl quebrava em linhas demais e
-      empurrava o par CTA + sub-linha para fora da dobra a 1366×768 (laptop
-      mais comum no Brasil). Ver landing-consultoria-content.spec.ts.
+      max-w-4xl (não 3xl): a 3xl o H1 text-6xl quebrava em 4 linhas e
+      empurrava o par CTA + "Sem taxa..." para fora da dobra a 1366×768
+      (laptop mais comum no Brasil). Ver critique de /consultoria-de-viagem.
     */
     <section className="pt-3 md:pt-16 pb-20 px-6">
       <div className="max-w-4xl mx-auto">
@@ -103,7 +95,7 @@ export function ConsultoriaHero() {
             no areaServed do ServiceSchema. Ver critique de /consultoria-de-viagem.
           */}
           <Compass className="size-3.5" aria-hidden="true" />
-          Consultoria de viagem · online, todo o Brasil
+          Consultoria de viagem · todo o Brasil
         </m.div>
         <m.h1
           variants={fadeUp}
@@ -112,7 +104,7 @@ export function ConsultoriaHero() {
           custom={1}
           className="text-balance text-4xl md:text-6xl font-black text-anhanga-dark mb-2 md:mb-6 leading-[1.1]"
         >
-          Um especialista para pensar a sua viagem
+          Planeje uma viagem sob medida sem depender de pacote pronto
         </m.h1>
         <m.p
           variants={fadeUp}
@@ -121,55 +113,20 @@ export function ConsultoriaHero() {
           custom={2}
           className="text-base md:text-xl text-zinc-600 mb-3 md:mb-10 leading-relaxed max-w-2xl"
         >
-          Uma sessão de 50 minutos para diagnosticar a sua viagem e te entregar um plano por escrito.
+          Um consultor da Anhangá entende seu perfil, destino, orçamento e restrições para desenhar o melhor caminho antes de você fechar.
         </m.p>
         <m.div variants={fadeUp} initial="hidden" animate="visible" custom={3}>
-          {/*
-            CTA pago: <a> real para o Cal.com (asChild) em vez de onClick, e SEM
-            as classes btn-whatsapp/btn-specialist — public/utm-tracking.js
-            dispara whatsapp_cta_click em qualquer .btn-whatsapp, o que seria um
-            evento de WhatsApp falso num link de agendamento. data-no-specialist-cta
-            também evita o falso specialist_cta_click: o texto "Agendar consultoria"
-            casaria no heurístico textual de isSpecialistCtaText (contém "consultoria").
-          */}
           <Button
-            asChild
             variant="cta"
             size="lg"
-            className="font-black"
+            onClick={() => openContactModal({ source: 'consultoria-viagem' })}
+            className="btn-whatsapp btn-specialist font-black"
+            rightIcon={<ArrowRight className="size-5" aria-hidden="true" />}
+            data-tracking="hero-consultoria-viagem"
           >
-            <a href={CONSULTORIA_BOOKING_URL} data-tracking="hero-consultoria-viagem" data-no-specialist-cta>
-              Agendar consultoria · R$ 250
-              <ArrowRight className="size-5" aria-hidden="true" />
-            </a>
+            Falar com um consultor
           </Button>
-          {/*
-            UMA sub-linha (não duas): em 375×667 com o banner de cookies (fixed
-            bottom-0), cada linha extra empurra o conteúdo para baixo da dobra —
-            o hero foi calibrado a ferro para isso (ver landing-consultoria-
-            content.spec.ts). A porta gratuita fica embutida aqui, não numa
-            segunda linha, para proteger o funil do core sem estourar a dobra.
-          */}
-          <p className="mt-1 md:mt-4 text-sm text-zinc-600">
-            Vai viajar com a Anhangá?{' '}
-            {/*
-              data-specialist-cta: opt-in explícito no specialist_cta_click. O
-              texto "Fale com um consultor" não casa no heurístico textual de
-              isSpecialistCtaText ("consultor" ≠ "consultoria"), então sem este
-              atributo a porta gratuita ficaria fora da métrica do funil. Sem
-              btn-whatsapp (abre modal, não é link de WhatsApp).
-            */}
-            <button
-              type="button"
-              onClick={() => openContactModal({ source: 'consultoria-viagem-gratuito' })}
-              className="font-bold text-anhanga-blue underline underline-offset-2 hover:text-anhanga-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
-              data-tracking="hero-consultoria-porta-gratuita"
-              data-specialist-cta
-            >
-              Fale com um consultor
-            </button>
-            , é grátis.
-          </p>
+          <p className="mt-1 md:mt-4 text-sm text-zinc-600">Sem taxa, sem compromisso.</p>
         </m.div>
       </div>
     </section>
@@ -196,10 +153,10 @@ export function ConsultoriaBenefits() {
           className="mb-12"
         >
           <h2 className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3">
-            Por que uma consultoria paga?
+            Por que consultoria?
           </h2>
           <p className="text-zinc-600 text-lg">
-            Um bom plano de viagem dá trabalho. E trabalho rende mais quando começa a sério.
+            Porque viajar bem não é só escolher um destino.
           </p>
         </m.div>
         <div className="grid md:grid-cols-3 gap-6">
@@ -266,26 +223,6 @@ export function ConsultoriaAudience() {
                 </li>
               ))}
             </ul>
-            {/*
-              Porta gratuita da autosseleção (grilling 24/07): quem vai fechar
-              a viagem com a Anhangá dá comissão e não deve pagar a sessão —
-              este callout o desvia para o ContactModal antes do checkout pago.
-            */}
-            <div className="mt-8 rounded-2xl border border-anhanga-blue/20 bg-white p-5">
-              <p className="text-zinc-700 leading-snug">
-                Vai fechar a viagem com a Anhangá? A conversa é outra, e é gratuita.{' '}
-                {/* data-specialist-cta: mesma razão do link do hero — mantém a porta gratuita no specialist_cta_click. */}
-                <button
-                  type="button"
-                  onClick={() => openContactModal({ source: 'consultoria-viagem-gratuito' })}
-                  className="font-bold text-anhanga-blue underline underline-offset-2 hover:text-anhanga-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
-                  data-tracking="audience-consultoria-porta-gratuita"
-                  data-specialist-cta
-                >
-                  Fale com um consultor
-                </button>
-              </p>
-            </div>
           </m.div>
           <m.div
             variants={fadeUp}
@@ -436,22 +373,20 @@ export function ConsultoriaFinalCta() {
         className="max-w-3xl mx-auto px-6 text-center"
       >
         <h2 className="text-3xl md:text-5xl font-black text-white mb-6">
-          Vamos pensar a sua próxima viagem
+          Pronto para planejar sua viagem?
         </h2>
         <p className="text-blue-100 text-lg mb-10 max-w-xl mx-auto">
-          50 minutos com um consultor da Anhangá e um plano por escrito. Se você seguir com a consultoria completa, os R$ 250 entram no valor.
+          Fale com um consultor agora. Sem taxa, sem compromisso.
         </p>
-        {/* Sem btn-whatsapp/btn-specialist e com data-no-specialist-cta: link de agendamento, não CTA de contato (ver Hero). */}
         <Button
-          asChild
           variant="cta"
           size="lg"
-          className="font-black"
+          onClick={() => openContactModal({ source: 'consultoria-viagem' })}
+          className="btn-whatsapp btn-specialist font-black"
+          rightIcon={<ArrowRight className="size-6" aria-hidden="true" />}
+          data-tracking="footer-consultoria-viagem"
         >
-          <a href={CONSULTORIA_BOOKING_URL} data-tracking="footer-consultoria-viagem" data-no-specialist-cta>
-            Agendar consultoria · R$ 250
-            <ArrowRight className="size-6" aria-hidden="true" />
-          </a>
+          Falar com um consultor
         </Button>
       </m.div>
     </section>

--- a/pages/landings/ConsultoriaDeViagemLanding.tsx
+++ b/pages/landings/ConsultoriaDeViagemLanding.tsx
@@ -19,36 +19,26 @@ import {
 
 const FAQ_ITEMS = [
   {
-    question: 'O que é a consultoria de viagem da Anhangá?',
-    answer: 'É uma sessão paga com um consultor humano para diagnosticar a sua viagem (destino, roteiro, milhas, orçamento) e te entregar um plano por escrito. Serve para quem está começando a planejar e para quem já comprou a viagem e quer aproveitá-la melhor.'
+    question: 'O que é uma consultoria de viagem?',
+    answer: 'É uma sessão com um consultor humano da Anhangá para entender seu perfil, destino e orçamento e montar o melhor roteiro — sem pacote pronto e sem improviso.'
   },
   {
-    question: 'Quanto custa?',
-    answer: 'R$ 250 por uma sessão de 50 minutos, com o plano por escrito incluído. Se você seguir com a consultoria completa (o roteiro executado pela gente), esse valor é abatido.'
-  },
-  {
-    question: 'Vocês não são uma agência? Por que a consultoria é paga?',
-    answer: 'Somos. Organizar e emitir a sua viagem, o agenciamento, continua sendo uma conversa gratuita. A consultoria paga é para quando você quer o diagnóstico e o roteiro em si: passagem já emitida, milhas próprias, extensão de uma viagem de trabalho.'
-  },
-  {
-    question: 'E se eu precisar remarcar ou não puder comparecer?',
-    answer: 'Você pode remarcar uma vez até 24h antes, sem custo. Em caso de falta, o valor vira um crédito de 90 dias, usável numa nova sessão ou na consultoria completa.'
-  },
-  {
-    question: 'Posso desistir e pedir reembolso?',
-    answer: 'Pode. Se desistir em até 7 dias e antes de a sessão acontecer, devolvemos o valor. Depois disso, ou se a sessão já ocorreu, o valor fica como crédito.'
-  },
-  {
-    question: 'A sessão é presencial?',
-    answer: 'Não. É por videochamada, com link no e-mail de confirmação. Atendemos viajantes de todo o Brasil.'
-  },
-  {
-    question: 'Em quanto tempo recebo o plano?',
-    answer: 'Em até 48h úteis após a sessão.'
+    question: 'Quanto custa a consultoria?',
+    // Sem "no momento": a ressalva plantava a dúvida que o hero ("Gratuito.")
+    // trabalha para matar. Ver critique de /consultoria-de-viagem.
+    answer: 'Nada. Você fala com um consultor gratuitamente, sem compromisso, e decide se quer fechar sua viagem com a Anhangá.'
   },
   {
     question: 'Vocês fazem viagens internacionais?',
     answer: 'Sim. A Anhangá Viagens planeja viagens internacionais para Europa, América do Norte, América do Sul, Ásia e Caribe, com foco em roteiros personalizados e suporte durante toda a viagem.'
+  },
+  {
+    question: 'Qual o diferencial da Anhangá?',
+    answer: 'Atendimento consultivo com consultor fixo do início ao fim, roteiro feito do zero para o seu perfil e suporte 24h via WhatsApp durante a viagem.'
+  },
+  {
+    question: 'Qual o prazo para montar um roteiro?',
+    answer: 'Entre 2 e 5 dias úteis após a conversa inicial, dependendo da complexidade do destino e do número de viajantes.'
   }
 ];
 
@@ -68,14 +58,14 @@ const ConsultoriaDeViagemLanding: React.FC = () => {
       <MotionConfig reducedMotion="user">
       <div data-consultoria-landing className="bg-white min-h-screen font-sans">
         <Seo
-          title="Consultoria de Viagem com Especialista — Anhangá Viagens"
-          description="Sessão de 50 min com um consultor para diagnosticar sua viagem: destino, roteiro, milhas, orçamento. Você sai com um plano por escrito. R$ 250, abatidos na consultoria completa."
+          title="Consultoria de Viagem Sob Medida em SP — Anhangá Viagens"
+          description="Planeje sua viagem com consultores humanos. Sem pacote pronto, sem improviso. Roteiro personalizado com suporte antes, durante e depois."
           canonical="https://www.anhanga.tur.br/consultoria-de-viagem/"
           noHreflang
         />
         <ServiceSchema
-          name="Consultoria de Viagem com Especialista"
-          description="Sessão paga de diagnóstico de viagem com consultor humano: destino, roteiro, milhas e orçamento, com plano por escrito entregue em até 48h. Por videochamada, para viajantes de todo o Brasil."
+          name="Consultoria de Viagem Sob Medida"
+          description="Planejamento personalizado de viagens com consultor humano, sem pacote pronto. Atendimento consultivo com suporte antes, durante e depois da viagem."
           serviceUrl="https://www.anhanga.tur.br/consultoria-de-viagem/"
           serviceType="Consultoria de Viagem"
           areaServed="São Paulo e Brasil"

--- a/public/utm-tracking.js
+++ b/public/utm-tracking.js
@@ -131,12 +131,6 @@
     }
 
     function trackSpecialistClick(target) {
-        // Opt-out explícito: CTAs marcados data-no-specialist-cta (ex.: o link de
-        // agendamento pago da consultoria, cujo texto "Agendar consultoria" casaria
-        // no heurístico textual isSpecialistCtaText) não são pedidos de contato com
-        // especialista da porta gratuita e não devem disparar specialist_cta_click.
-        if (target.closest('[data-no-specialist-cta]')) return;
-
         const { specialistButton, clickable } = getSpecialistSourceElement(target);
         const sourceElement = specialistButton || clickable;
         const buttonText = specialistButton

--- a/tests/e2e/landing-consultoria-content.spec.ts
+++ b/tests/e2e/landing-consultoria-content.spec.ts
@@ -34,18 +34,17 @@ test.describe('CTA do hero não fica coberto pelo banner de cookies em mobile cu
     });
   });
 
-  test('CTA "Agendar consultoria" e a sub-linha ficam acima do banner', async ({ page }) => {
+  test('CTA "Falar com um consultor" e o disclaimer ficam acima do banner', async ({ page }) => {
     await page.goto('/consultoria-de-viagem');
 
     const banner = page.getByRole('dialog', { name: 'Preferências de cookies' });
     await expect(banner).toBeVisible();
 
     const cta = page.locator('[data-tracking="hero-consultoria-viagem"]');
-    // A sub-linha do hero é UMA <p> (abatimento + porta gratuita embutida). Ela
-    // é o elemento mais baixo do bloco de entrada — se ela clareia o banner,
-    // tudo acima também clareia. O count de sub-linhas do hero é load-bearing
-    // para a dobra em 375×667: não re-adicionar uma segunda linha aqui.
-    const disclaimer = page.getByText(/Vai viajar com a Anhangá/);
+    // exact: true — sem isso o locator também casa com o CTA final da
+    // página ("...Sem taxa, sem compromisso."), que contém o mesmo texto
+    // como substring e agora usa a mesma frase do disclaimer do hero.
+    const disclaimer = page.getByText('Sem taxa, sem compromisso.', { exact: true });
 
     await waitForStableBoxes([cta, disclaimer]);
 
@@ -62,38 +61,6 @@ test.describe('CTA do hero não fica coberto pelo banner de cookies em mobile cu
     expect(ctaBox!.y + ctaBox!.height).toBeLessThanOrEqual(bannerBox!.y);
     expect(disclaimerBox!.y + disclaimerBox!.height).toBeLessThanOrEqual(bannerBox!.y);
   });
-});
-
-test('CTAs pagos linkam para o Cal.com (não abrem mais o ContactModal)', async ({ page }) => {
-  await page.goto('/consultoria-de-viagem');
-
-  // A mudança de comportamento central do produto pago: os CTAs do hero e do
-  // rodapé deixaram de abrir o modal (onClick) e passaram a ser <a> para o
-  // agendamento. toHaveAttribute('href', ...) pega tanto um typo na URL quanto
-  // uma regressão que volte o CTA a <button> (sem href) abrindo o modal.
-  const bookingUrl = 'https://cal.anhanga.tur.br/felipe/consultoria';
-
-  await expect(page.locator('[data-tracking="hero-consultoria-viagem"]')).toHaveAttribute('href', bookingUrl);
-
-  const footerCta = page.locator('[data-tracking="footer-consultoria-viagem"]');
-  await footerCta.scrollIntoViewIfNeeded();
-  await expect(footerCta).toHaveAttribute('href', bookingUrl);
-});
-
-test('CTAs carregam a classificação de tracking correta (specialist vs. opt-out)', async ({ page }) => {
-  await page.goto('/consultoria-de-viagem');
-
-  // A porta gratuita (abre o ContactModal) precisa contar em specialist_cta_click,
-  // mas o texto "Fale com um consultor" NÃO casa no heurístico textual de
-  // public/utm-tracking.js ("consultor" ≠ "consultoria") — daí o opt-in explícito
-  // data-specialist-cta nos dois convites in-content.
-  await expect(page.locator('[data-tracking="hero-consultoria-porta-gratuita"][data-specialist-cta]')).toHaveCount(1);
-  await expect(page.locator('[data-tracking="audience-consultoria-porta-gratuita"][data-specialist-cta]')).toHaveCount(1);
-
-  // O CTA pago (link Cal.com) NÃO deve contar como specialist, apesar de o texto
-  // "Agendar consultoria" casar no heurístico textual — daí o opt-out.
-  await expect(page.locator('[data-tracking="hero-consultoria-viagem"][data-no-specialist-cta]')).toHaveCount(1);
-  await expect(page.locator('[data-tracking="footer-consultoria-viagem"][data-no-specialist-cta]')).toHaveCount(1);
 });
 
 test('landing de consultoria mostra uma foto real do destino junto ao depoimento', async ({ page }) => {

--- a/tests/e2e/landing-no-aichat.spec.ts
+++ b/tests/e2e/landing-no-aichat.spec.ts
@@ -11,12 +11,9 @@ test.describe('Landing pages de campanha não renderizam overlays flutuantes', (
     await expect(page.getByRole('button', { name: 'Abrir assistente virtual' })).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Voltar ao topo' })).toHaveCount(0);
 
-    // O CTA do hero agora é o produto pago (link externo para o Cal.com) e não
-    // abre modal. A porta gratuita fica no link do hero ("Fale com um consultor"
-    // → ContactModal), que é visível em qualquer viewport — ao contrário do CTA
-    // do nav desktop (hidden sm:block, some no Mobile Chrome). O CTA do nav
-    // mobile tem cobertura própria no teste abaixo.
-    await page.locator('[data-tracking="hero-consultoria-porta-gratuita"]').click();
+    // O CTA do hero, especificamente: o nav agora também tem um botão com o
+    // mesmo nome acessível (versão mobile fica oculta em viewport desktop).
+    await page.locator('[data-tracking="hero-consultoria-viagem"]').click();
     await expect(page.getByRole('heading', { name: 'Fale com um consultor' })).toBeVisible();
   });
 

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -68,29 +68,6 @@ test('index.html keeps the global gtag wrapper used by the deferred UTM tracker'
   );
 });
 
-test('UTM tracker respeita o opt-out data-no-specialist-cta antes de disparar specialist_cta_click', () => {
-  // O heurístico textual isSpecialistCtaText casa em qualquer clicável com
-  // "consultoria"/"especialista"/"orçamento" no texto — o CTA pago de
-  // agendamento ("Agendar consultoria") casaria e poluiria a métrica da porta
-  // gratuita. O guard early-return por data-no-specialist-cta precisa existir e
-  // vir ANTES de getSpecialistSourceElement/isSpecialistCtaText.
-  const guardIndex = utmTrackingScript.search(
-    /if\s*\(\s*target\.closest\(\s*['"]\[data-no-specialist-cta\]['"]\s*\)\s*\)\s*return;/,
-  );
-  assert.ok(guardIndex > -1, 'trackSpecialistClick deve ter o early-return de opt-out');
-
-  // Ancorar na desestruturação (só existe no corpo de trackSpecialistClick),
-  // não em getSpecialistSourceElement — cujo primeiro match seria a definição.
-  const callIndex = utmTrackingScript.indexOf(
-    'const { specialistButton, clickable } = getSpecialistSourceElement(target)',
-  );
-  assert.ok(callIndex > -1, 'trackSpecialistClick deve chamar getSpecialistSourceElement');
-  assert.ok(
-    guardIndex < callIndex,
-    'o opt-out deve vir antes da classificação por texto/atributo',
-  );
-});
-
 test('index.html loads only the required Poppins font weights', () => {
   const fontUrls = [...indexHtml.matchAll(/href="([^"]*fonts\.googleapis\.com\/css2[^"]*)"/g)]
     .map((match) => match[1])


### PR DESCRIPTION
Reverte a #1296, que foi mergeada por engano antes da troca do URL de agendamento.

## Motivo
A #1296 deixou `CONSULTORIA_BOOKING_URL` apontando para `cal.anhanga.tur.br` (Cal.com **self-hosted**), que roda uma imagem Docker sem patch de segurança desde março/2026 e não é recomendada para produção. Com a #1296 em produção, o CTA de pagamento (R$ 250 via Stripe) rota clientes reais para esse serviço — exatamente o risco que a migração para o Cal.com Cloud existe para evitar.

Este revert restaura o estado anterior conhecido da `/consultoria-de-viagem/` (página gratuita, sem link de pagamento, sem risco).

## Próximo passo
Re-aplicar a feature apontando para o Cal.com **Cloud** (`cal.com/anhanga-viagens/consultoria`) assim que o event type estiver salvo e com Stripe configurado. É reverter este revert + trocar o URL + atualizar o teste de href.

🤖 Generated with [Claude Code](https://claude.com/claude-code)