### PR TITLE
fix(consultoria): aponta CTA de agendamento para o Cal.com Cloud

### DIFF
--- a/components/landings/consultoria/ConsultoriaLandingSections.tsx
+++ b/components/landings/consultoria/ConsultoriaLandingSections.tsx
@@ -7,9 +7,11 @@ import { fadeUp } from '@/components/landings/shared/constants';
 import { openContactModal } from '@/utils/contactForm';
 import { getDestinationImage } from '@/data/mediaConfig';
 
-// Event type do Cal.com self-hosted onde o cliente agenda e paga a sessão
-// (R$250) via Stripe. Ver memória project-consultoria-modelo-pago.
-const CONSULTORIA_BOOKING_URL = 'https://cal.anhanga.tur.br/felipe/consultoria';
+// Event type do Cal.com Cloud (plano gratuito) onde o cliente agenda e paga a
+// sessão (R$250) via Stripe. Cloud, não self-hosted: a imagem self-host estava
+// sem patch de segurança desde março/2026 e não é recomendada para produção —
+// inaceitável no caminho do pagamento. Ver memória project-consultoria-modelo-pago.
+const CONSULTORIA_BOOKING_URL = 'https://cal.com/anhanga-viagens/consultoria';
 
 // A autosseleção da página (grilling 24/07): a consultoria paga é para os
 // casos NÃO-comissionáveis. Quem vai fechar a viagem com a Anhangá cai na

--- a/tests/e2e/landing-consultoria-content.spec.ts
+++ b/tests/e2e/landing-consultoria-content.spec.ts
@@ -71,7 +71,7 @@ test('CTAs pagos linkam para o Cal.com (não abrem mais o ContactModal)', async 
   // rodapé deixaram de abrir o modal (onClick) e passaram a ser <a> para o
   // agendamento. toHaveAttribute('href', ...) pega tanto um typo na URL quanto
   // uma regressão que volte o CTA a <button> (sem href) abrindo o modal.
-  const bookingUrl = 'https://cal.anhanga.tur.br/felipe/consultoria';
+  const bookingUrl = 'https://cal.com/anhanga-viagens/consultoria';
 
   await expect(page.locator('[data-tracking="hero-consultoria-viagem"]')).toHaveAttribute('href', bookingUrl);
 


### PR DESCRIPTION
Hotfix da #1296 (mergeada por engano apontando para o Cal.com self-hosted).

## O que muda
`CONSULTORIA_BOOKING_URL`: `cal.anhanga.tur.br/felipe/consultoria` (self-host, imagem Docker sem patch de segurança desde mar/2026, não recomendada para produção) → `cal.com/anhanga-viagens/consultoria` (**Cal.com Cloud**, plano gratuito, mantido pela equipe). Atualiza a expectativa do teste de href.

## Por que forward-swap e não revert
Com o event type do Cloud já criado, apontar para o destino seguro preserva todo o redesign da #1296 e resolve o risco (rotar clientes de pagamento para serviço sem patch). Supersede o revert #1298.

## Pagamento
Stripe (R$ 250) é configurado no event type do Cal.com, não no código — a troca de URL não depende disso e pode deployar já. O usuário liga o Stripe no Cal.com em paralelo, sem redeploy.

## Verificação
- e2e `landing-consultoria-content` (href → Cloud) verde em chromium e Mobile Chrome (12/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)