### PR TITLE
chore: mark dead social-announcement automation for deletion

### DIFF
--- a/.github/workflows/notify-social-automation.yml
+++ b/.github/workflows/notify-social-automation.yml
@@ -1,3 +1,10 @@
+# TODO(dead code): o workflow n8n do outro lado deste webhook nunca foi
+# implementado — a divulgação social de posts do blog passou a ser feita
+# manualmente via Postiz (ver conversa de 26/07/2026). Deletar este arquivo,
+# scripts/notify-blog-published.ts, lib/social-announcement.ts,
+# docs/ops/social-automation.md e os testes correspondentes
+# (tests/notify-blog-published.test.ts, tests/social-announcement.test.ts,
+# tests/notify-social-automation-workflow.test.ts) juntos, na mesma PR.
 name: Notify Social Automation
 
 on:

--- a/docs/ops/social-automation.md
+++ b/docs/ops/social-automation.md
@@ -1,5 +1,14 @@
 # Automação de posts sociais no publish do blog
 
+> **TODO(dead code):** o workflow n8n que receberia este webhook nunca foi
+> implementado. A divulgação social de posts do blog passou a ser feita
+> manualmente via Postiz (ver conversa de 26/07/2026). Deletar este doc
+> junto com `.github/workflows/notify-social-automation.yml`,
+> `scripts/notify-blog-published.ts`, `lib/social-announcement.ts` e os
+> testes correspondentes (`tests/notify-blog-published.test.ts`,
+> `tests/social-announcement.test.ts`,
+> `tests/notify-social-automation-workflow.test.ts`).
+
 ## Escopo
 
 Só o publish de um novo post do blog é automatizado. Posts sociais avulsos

--- a/lib/social-announcement.ts
+++ b/lib/social-announcement.ts
@@ -3,6 +3,16 @@
  * webhook. `scripts/notify-blog-published.ts` is the only caller today; kept
  * here (rather than inline in the script) so the shaping logic is unit
  * testable without touching the filesystem or network.
+ *
+ * TODO(dead code): the n8n workflow on the receiving end was never built —
+ * blog social announcements are now scheduled by hand via Postiz (see
+ * conversation from 2026-07-26). Delete this file together with
+ * `scripts/notify-blog-published.ts`,
+ * `.github/workflows/notify-social-automation.yml`,
+ * `docs/ops/social-automation.md`, and their tests
+ * (`tests/social-announcement.test.ts`,
+ * `tests/notify-blog-published.test.ts`,
+ * `tests/notify-social-automation-workflow.test.ts`).
  */
 import type { BlogPostFrontmatter } from '../types/blog';
 

--- a/scripts/notify-blog-published.ts
+++ b/scripts/notify-blog-published.ts
@@ -7,6 +7,15 @@
  * payload per file to the n8n webhook that schedules the post in Postiz.
  *
  * Not wired into `pnpm build`/`pnpm dev` — this only runs in CI, after merge.
+ *
+ * TODO(dead code): the n8n workflow on the receiving end was never built —
+ * blog social announcements are now scheduled by hand via Postiz (see
+ * conversation from 2026-07-26). Delete this file together with
+ * `.github/workflows/notify-social-automation.yml`,
+ * `lib/social-announcement.ts`, `docs/ops/social-automation.md`, and their
+ * tests (`tests/notify-blog-published.test.ts`,
+ * `tests/social-announcement.test.ts`,
+ * `tests/notify-social-automation-workflow.test.ts`).
  */
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';


### PR DESCRIPTION
## Summary
- Revisão dos posts agendados do blog levou à descoberta de que a automação de anúncio social (`notify-social-automation.yml` → `notify-blog-published.ts` → webhook n8n → Postiz) nunca teve o workflow n8n do outro lado implementado — é dead code sem consumidor funcional.
- Marca TODO em cada arquivo da pipeline explicando o motivo e listando tudo que deve sair junto numa PR de remoção futura: o workflow, o script, o payload builder e o doc, além dos 3 testes correspondentes.
- Nenhum comportamento muda nesta PR — só comentários/anotações, nada de lógica removida ainda.

## Contexto adicional (fora do repo)
Como parte da mesma sessão, os 4 posts do blog agendados para publicação (26/07, 28/07, 04/08, 11/08) tiveram seus anúncios para X, Threads e Facebook agendados manualmente no Postiz, já revisados pela skill `/stop-slop`. Isso não gera diff neste repositório.

## Test plan
- [ ] Não há mudança de comportamento — apenas comentários `TODO`. `pnpm typecheck` e `pnpm lint:changed` continuam válidos, sem necessidade de rodar suíte de testes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)