### PR TITLE
chore(deps): bump fast-uri to 3.1.4 (Dependabot #48)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   js-yaml@3: ^3.15.0
   '@ungap/structured-clone@1': ^1.3.2
   sharp: ^0.35.3
+  fast-uri@3: ^3.1.4
 
 importers:
 
@@ -3140,8 +3141,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -7648,7 +7649,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8677,7 +8678,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,6 +48,12 @@ overrides:
   # ainda está em cooldown (minimumReleaseAge); override global para 0.35.3
   # unifica com a versão já usada como dependência direta (scripts de imagem).
   sharp: "^0.35.3"
+  # Dependabot #48 (high): GHSA-v2hh-gcrm-f6hx — fast-uri <= 4.1.0 não trata
+  # `\` como delimitador de authority, gerando host confusion entre o parser
+  # de fast-uri e a WHATWG URL nativa do Node (fetch/undici), risco de SSRF.
+  # Transitivo via ajv (react-doctor > conf > ajv-formats), só dev. 3.1.4
+  # corrige; override escopado a "@3" porque só existe a linha 3.x na árvore.
+  "fast-uri@3": "^3.1.4"
 
 legacyPeerDeps: true
 nodeLinker: hoisted


### PR DESCRIPTION
## Summary
- Bumps `fast-uri` 3.1.3 → 3.1.4 via `pnpm-workspace.yaml` override, fixing [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) / CVE-2026-16221 ([Dependabot alert #48](https://github.com/felipewilliam2/AV-SITE/security/dependabot/48))
- `fast-uri` <= 4.1.0 doesn't treat a literal backslash (`\`) as an authority delimiter, so it can extract a different host than Node's native WHATWG URL parser (`fetch`/`undici`) for the same string — host confusion that can defeat host-based allowlists/SSRF filters
- Transitive dependency only, via `ajv` (`react-doctor` → `conf` → `ajv-formats`), devDependency — no production runtime uses `fast-uri` directly
- Fix was blocked ~2h by pnpm's own `minimumReleaseAge` cooldown (3.1.4 published 2026-07-19T07:42:54Z, 7-day quarantine); waited it out rather than bypassing the check, consistent with how #45 (js-yaml) and #47 (sharp) were handled

## Test plan
- [x] `pnpm install` resolves `fast-uri@3.1.4` (confirmed via `pnpm why fast-uri`)
- [x] `pnpm test:regression` — 994/994 passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)