### PR TITLE
chore(deps): override body-parser to >=1.20.6 (GHSA-v422-hmwv-36x6)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   '@ungap/structured-clone@1': ^1.3.2
   sharp: ^0.35.3
   fast-uri@3: ^3.1.4
+  body-parser@1: ^1.20.6
 
 importers:
 
@@ -2377,8 +2378,8 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  body-parser@1.20.5:
-    resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
+  body-parser@1.20.6:
+    resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   bottleneck@2.19.5:
@@ -7650,7 +7651,7 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@1.20.5:
+  body-parser@1.20.6:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -8493,7 +8494,7 @@ snapshots:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.5
+      body-parser: 1.20.6
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,8 +54,12 @@ overrides:
   # Transitivo via ajv (react-doctor > conf > ajv-formats), só dev. 3.1.4
   # corrige; override escopado a "@3" porque só existe a linha 3.x na árvore.
   "fast-uri@3": "^3.1.4"
-
-legacyPeerDeps: true
+  # pnpm audit (low): GHSA-v422-hmwv-36x6 — body-parser < 1.20.6 desabilita
+  # silenciosamente o enforcement de tamanho quando recebe um `limit` inválido
+  # (DoS). Transitivo dev-only via decap-server > express@4 > body-parser
+  # (proxy local do Decap CMS, `pnpm cms:proxy`). 1.20.6 corrige; escopado a
+  # "@1" porque express 4.x consome a linha 1.x — a 2.x quebraria a API.
+  "body-parser@1": "^1.20.6"
 nodeLinker: hoisted
 minimumReleaseAge: 10080
 blockExoticSubdeps: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,6 +60,8 @@ overrides:
   # (proxy local do Decap CMS, `pnpm cms:proxy`). 1.20.6 corrige; escopado a
   # "@1" porque express 4.x consome a linha 1.x — a 2.x quebraria a API.
   "body-parser@1": "^1.20.6"
+
+legacyPeerDeps: true
 nodeLinker: hoisted
 minimumReleaseAge: 10080
 blockExoticSubdeps: true


### PR DESCRIPTION
## Resumo

- **O que muda:** Adiciona um override `pnpm` `"body-parser@1": "^1.20.6"` em `pnpm-workspace.yaml` (+ atualização do `pnpm-lock.yaml`).
- **Por quê:** `pnpm audit` reporta `GHSA-v422-hmwv-36x6` (low) — `body-parser < 1.20.6` desabilita silenciosamente o enforcement de tamanho do request quando recebe um `limit` inválido, abrindo uma via de DoS. Chega na árvore **dev-only** via `decap-server > express@4 > body-parser` (o proxy local do Decap CMS, `pnpm cms:proxy`).
- **Impacto para o usuário:** Nenhum em produção — a dependência é dev-only e não entra no bundle enviado. Fecha 1 dos advisories abertos do `pnpm audit`.
- **Nível de risco:** baixo

Override escopado a `@1` de propósito: o `express@4` consome a linha `1.x` do `body-parser`; um bump para `2.x` quebraria a API. `1.20.6` é a última `1.x`, é `> 1.20.5` (respeita `trustPolicy: no-downgrade`) e foi publicada em 2026-07-09, já fora da janela de `minimumReleaseAge` (7 dias).

### Advisories deixados de fora deste PR (deferidos, com motivo)

Este PR nasceu de uma auditoria de dependências. Dos 3 advisories encontrados, só o `body-parser` é corrigível agora dentro das políticas do repo. Os outros dois ficam de fora:

- **`brace-expansion` — HIGH, `GHSA-mh99-v99m-4gvg`** (DoS/OOM): dev-only, entra pela toolchain do ESLint/typescript-eslint (não é shippado). O único patch é `5.0.8`, publicada em **2026-07-23** — ainda dentro do cooldown de `minimumReleaseAge: 10080` (7 dias). Adicionar o override hoje **quebraria o `pnpm install`**. Fica elegível por volta de **2026-07-30**; override pronto para adicionar então: `"brace-expansion@5": "^5.0.8"` (não há backport na linha `1.x`).
- **`react-router` — HIGH, `GHSA-qwww-vcr4-c8h2`** (CSRF bypass): afeta **apenas o RSC mode**. Verificado em `App.tsx` — o app usa `BrowserRouter`/`MemoryRouter` + `<Routes>` (SPA clássico, não-RSC), então **não há exposição na prática**. A correção é uma migração major para `react-router-dom` v8 (não existe patch na linha `7.x`) — fora do escopo de um override de deps.

## Issue relacionada

Sem issue — trabalho originado de uma rotina agendada de auditoria de dependências. As duas correções deferidas acima são candidatas naturais a follow-up (o `brace-expansion` assim que sair do cooldown).

## Tipo de mudança

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] ♻️ Refatoração (sem mudança de comportamento)
- [x] ⚙️ Infra / CI
- [ ] 📚 Documentação
- [ ] 🔍 SEO / GEO
- [ ] ⚡ Performance

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only) — mudança de resolução de dependência dev-only, sem comportamento de runtime da aplicação para cobrir; validada via `pnpm audit`.
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível)

Comandos executados:

```text
pnpm install --lockfile-only   # aplica o override, regenera o lockfile — sem violar minimumReleaseAge
pnpm audit                     # low: 1 -> 0; body-parser resolvido para 1.20.6 na árvore
```

## API & Segurança

- [ ] Não se aplica
- [x] Inputs validados/sanitizados na borda, antes de side effects ou chamadas a providers <!-- N/A a nível de código; o PR é uma correção de advisory de segurança em dependência -->
- [x] Respostas e códigos de erro permanecem estruturados; helpers compartilhados reutilizados <!-- inalterado -->
- [x] Sem secrets ou PII bruta em logs
- [x] `dangerouslySetInnerHTML` não foi introduzido sem fonte controlada e justificativa

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`chore:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

- Só o `pnpm-workspace.yaml` e o `pnpm-lock.yaml` mudam; `package.json` fica intacto (pnpm 11 não lê mais o campo `pnpm` do `package.json` — os overrides vivem no `pnpm-workspace.yaml`).
- Auditoria feita no sandbox com Node 22 (o repo pede `>=24`); a resolução de deps não depende da versão do Node, mas vale revalidar `pnpm audit` no CI (Node 24).
- Restam 2 advisories HIGH abertos **de propósito** (ver seção "Advisories deixados de fora" acima) — nenhum é corrigível agora sem quebrar `install` (cooldown) ou fazer uma migração major (react-router v8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFqKNVzKQna56pWZD2Tnov

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFqKNVzKQna56pWZD2Tnov)_