### PR TITLE
perf(orlando): corta 31% dos bytes de imagem escolhendo o preset certo (#1326)

### DIFF
--- a/components/landings/orlando/OrlandoParksGallery.tsx
+++ b/components/landings/orlando/OrlandoParksGallery.tsx
@@ -34,7 +34,7 @@ const isVector = (path: string): boolean => path.toLowerCase().endsWith('.svg');
   separada, mesmo bloqueio de acesso ao bucket da #1333). Até lá o fallback
   vale para qualquer transform que falhe, não só este.
 */
-const handleLogoTransformError =
+export const handleLogoTransformError =
   (logo: string) =>
   (event: SyntheticEvent<HTMLImageElement>): void => {
     const img = event.currentTarget;

--- a/components/landings/orlando/OrlandoParksGallery.tsx
+++ b/components/landings/orlando/OrlandoParksGallery.tsx
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { CSSProperties, SyntheticEvent } from 'react';
+import type { CSSProperties } from 'react';
 import { getMediaUrl, optimizeRemoteImageUrl } from "../../../data/mediaConfig";
 import { openContactModal } from "../../../utils/contactForm";
+import { handleLogoTransformError } from "./logoFallback";
 
 /*
   Por que não há `srcSet` aqui: `selectImagePreset` (lib/media-url.ts) normaliza
@@ -23,25 +24,6 @@ import { openContactModal } from "../../../utils/contactForm";
   byte nenhum e o `/cdn-cgi/image` pode rasterizá-lo. 3 dos 12 logos são SVG.
 */
 const isVector = (path: string): boolean => path.toLowerCase().endsWith('.svg');
-
-/*
-  Nem todo original aceita transform. O `magic-kingdom.png` (11502×1942, 22,3
-  megapixels) devolve HTTP 422 / "ERROR 9516: error during decoding" no
-  `/cdn-cgi/image` — o arquivo cru serve normalmente, mas o resizer não o
-  decodifica. Sem este fallback o logo simplesmente não apareceria.
-
-  A causa raiz é o arquivo, não o código: precisa ser reencodado no R2 (issue
-  separada, mesmo bloqueio de acesso ao bucket da #1333). Até lá o fallback
-  vale para qualquer transform que falhe, não só este.
-*/
-export const handleLogoTransformError =
-  (logo: string) =>
-  (event: SyntheticEvent<HTMLImageElement>): void => {
-    const img = event.currentTarget;
-    const raw = getMediaUrl(logo);
-    // Guarda contra loop: se o próprio original falhar, não tenta de novo.
-    if (img.src !== raw) img.src = raw;
-  };
 
 interface ParkCardData {
   image: string;

--- a/components/landings/orlando/OrlandoParksGallery.tsx
+++ b/components/landings/orlando/OrlandoParksGallery.tsx
@@ -70,6 +70,12 @@ function ParkCard({ image, alt, logo, logoAlt, logoStyle, logoWidth, logoHeight,
         // Os PNG passavam crus pelo getMediaUrl, sem transform nenhuma — é onde
         // vivia o magic-kingdom.png de 11502×1942 e 243 KB para um slot de
         // 200×55. SVG segue cru: transform raster não economiza em vetor.
+        //
+        // O `200` não define o tamanho pedido: como no caso da foto acima,
+        // `selectImagePreset` colapsa qualquer largura <= 800 no preset
+        // `inline-sm` de 800px. Mudar este número não muda byte nenhum enquanto
+        // ficar dentro dessa faixa — inclusive para os logos do grupo Universal,
+        // que o `logoStyle` exibe a até 280px e o preset de 800 já cobre.
         src={isVector(logo) ? getMediaUrl(logo) : optimizeRemoteImageUrl(logo, 200)}
         onError={isVector(logo) ? undefined : handleLogoTransformError(logo)}
         alt={logoAlt}

--- a/components/landings/orlando/OrlandoParksGallery.tsx
+++ b/components/landings/orlando/OrlandoParksGallery.tsx
@@ -3,9 +3,45 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { CSSProperties } from 'react';
+import type { CSSProperties, SyntheticEvent } from 'react';
 import { getMediaUrl, optimizeRemoteImageUrl } from "../../../data/mediaConfig";
 import { openContactModal } from "../../../utils/contactForm";
+
+/*
+  Por que não há `srcSet` aqui: `selectImagePreset` (lib/media-url.ts) normaliza
+  qualquer largura para um conjunto fixo de presets — tudo abaixo de 800 vira
+  `inline-sm` 800. Um srcSet de várias entradas geraria a MESMA URL repetida,
+  markup morto. O que decide os bytes neste repo é qual preset a chamada cai,
+  não quantos candidatos ela oferece.
+
+  Um único candidato de 800 cobre a página inteira: a foto ocupa 328px no
+  desktop e 237px no celular, então mesmo em DPR 3 o alvo fica abaixo de 800.
+*/
+
+/*
+  Vetor não passa por transform raster — redimensionar um SVG não economiza
+  byte nenhum e o `/cdn-cgi/image` pode rasterizá-lo. 3 dos 12 logos são SVG.
+*/
+const isVector = (path: string): boolean => path.toLowerCase().endsWith('.svg');
+
+/*
+  Nem todo original aceita transform. O `magic-kingdom.png` (11502×1942, 22,3
+  megapixels) devolve HTTP 422 / "ERROR 9516: error during decoding" no
+  `/cdn-cgi/image` — o arquivo cru serve normalmente, mas o resizer não o
+  decodifica. Sem este fallback o logo simplesmente não apareceria.
+
+  A causa raiz é o arquivo, não o código: precisa ser reencodado no R2 (issue
+  separada, mesmo bloqueio de acesso ao bucket da #1333). Até lá o fallback
+  vale para qualquer transform que falhe, não só este.
+*/
+const handleLogoTransformError =
+  (logo: string) =>
+  (event: SyntheticEvent<HTMLImageElement>): void => {
+    const img = event.currentTarget;
+    const raw = getMediaUrl(logo);
+    // Guarda contra loop: se o próprio original falhar, não tenta de novo.
+    if (img.src !== raw) img.src = raw;
+  };
 
 interface ParkCardData {
   image: string;
@@ -28,8 +64,18 @@ function ParkCard({ image, alt, logo, logoAlt, logoStyle, logoWidth, logoHeight,
   return (
     <div className="park-card">
       <div className="park-image-frame">
+        {/*
+          Sem `height` na chamada de propósito: com (600, 400) o ratio 1,5 não
+          casa com nenhum preset dentro da tolerância de 0,08 e caía no fallback
+          `content` 1200×675 — para um frame de 220px de altura. Sem height cai
+          em `inline-sm` 800 `scale-down`.
+
+          Trocar `cover` por `scale-down` não muda o enquadramento visível: o
+          `.park-image-frame img` já aplica `object-fit: cover` com altura fixa,
+          então o recorte é do CSS, não do transform.
+        */}
         <img
-          src={optimizeRemoteImageUrl(image, 600, 400)}
+          src={optimizeRemoteImageUrl(image, 660)}
           alt={alt}
           width="600"
           height="400"
@@ -39,7 +85,11 @@ function ParkCard({ image, alt, logo, logoAlt, logoStyle, logoWidth, logoHeight,
       <img
         className="park-logo-title"
         style={logoStyle}
-        src={getMediaUrl(logo)}
+        // Os PNG passavam crus pelo getMediaUrl, sem transform nenhuma — é onde
+        // vivia o magic-kingdom.png de 11502×1942 e 243 KB para um slot de
+        // 200×55. SVG segue cru: transform raster não economiza em vetor.
+        src={isVector(logo) ? getMediaUrl(logo) : optimizeRemoteImageUrl(logo, 200)}
+        onError={isVector(logo) ? undefined : handleLogoTransformError(logo)}
         alt={logoAlt}
         width={logoWidth}
         height={logoHeight}

--- a/components/landings/orlando/logoFallback.ts
+++ b/components/landings/orlando/logoFallback.ts
@@ -1,0 +1,24 @@
+import type { SyntheticEvent } from 'react';
+import { getMediaUrl } from '../../../data/mediaConfig';
+
+/*
+  Nem todo original aceita transform. O `magic-kingdom.png` (11502×1942, 22,3
+  megapixels) devolve HTTP 422 / "ERROR 9516: error during decoding" no
+  `/cdn-cgi/image` — o arquivo cru serve normalmente, mas o resizer não o
+  decodifica. Sem este fallback o logo simplesmente não apareceria.
+
+  A causa raiz é o arquivo, não o código: precisa ser reencodado no R2 (mesmo
+  bloqueio de acesso ao bucket da issue #1333). Até lá o fallback vale para
+  qualquer transform que falhe, não só este.
+
+  Mora fora do arquivo do componente porque exportar não-componentes de um
+  módulo de componente quebra o Fast Refresh (react-doctor/only-export-components).
+*/
+export const handleLogoTransformError =
+  (logo: string) =>
+  (event: SyntheticEvent<HTMLImageElement>): void => {
+    const img = event.currentTarget;
+    const raw = getMediaUrl(logo);
+    // Guarda contra loop: se o próprio original falhar, não tenta de novo.
+    if (img.src !== raw) img.src = raw;
+  };

--- a/tests/e2e/orlando-imagens.spec.ts
+++ b/tests/e2e/orlando-imagens.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+/*
+  A parte lógica dos guards da issue #1326 vive em `tests/orlando-imagens.test.ts`
+  (node:test): a decisão de preset é lógica pura, e um e2e dela dependeria de
+  `VITE_MEDIA_ENABLE_TRANSFORMS`, desligado no dev server que o Playwright
+  levanta — o teste ficaria permanentemente `skipped`, verde sem verificar nada.
+
+  O que sobra aqui é o que só o browser prova: que nenhuma imagem termina
+  quebrada na tela.
+*/
+
+test('/orlando — nenhuma imagem fica quebrada', async ({ page }) => {
+  await page.goto('/orlando/');
+  await page.getByRole('heading', { level: 1 }).waitFor();
+
+  // Força o carregamento das lazy antes de medir.
+  await page.evaluate(() => {
+    document.querySelectorAll('img').forEach((img) => {
+      img.loading = 'eager';
+    });
+  });
+  await page.waitForLoadState('networkidle');
+
+  // Cobre o fallback de transform: o magic-kingdom.png devolve HTTP 422 no
+  // resizer da Cloudflare, e sem o onError o logo sumiria da página.
+  const broken = await page.evaluate(() =>
+    [...document.querySelectorAll('.landing-orlando img')]
+      .filter((el) => {
+        const img = el as HTMLImageElement;
+        return img.complete && img.naturalWidth === 0;
+      })
+      .map((el) => (el as HTMLImageElement).currentSrc),
+  );
+
+  expect(broken).toEqual([]);
+});

--- a/tests/e2e/orlando-imagens.spec.ts
+++ b/tests/e2e/orlando-imagens.spec.ts
@@ -22,8 +22,14 @@ test('/orlando — nenhuma imagem fica quebrada', async ({ page }) => {
   });
   await page.waitForLoadState('networkidle');
 
-  // Cobre o fallback de transform: o magic-kingdom.png devolve HTTP 422 no
-  // resizer da Cloudflare, e sem o onError o logo sumiria da página.
+  // ATENÇÃO: isto NÃO cobre o fallback de transform. Este teste roda contra o
+  // dev server, onde `VITE_MEDIA_ENABLE_TRANSFORMS` está desligado, então o
+  // logo é servido cru, o HTTP 422 do resizer nunca acontece e o
+  // `handleLogoTransformError` jamais é exercitado — ficaria verde com o
+  // fallback implementado errado (achado do review da PR #1347).
+  // Quem cobre o comportamento do handler é `tests/orlando-imagens.test.ts`.
+  // O que este teste prova é o básico que só o browser mostra: que a página
+  // não termina com imagem quebrada na tela.
   const broken = await page.evaluate(() =>
     [...document.querySelectorAll('.landing-orlando img')]
       .filter((el) => {

--- a/tests/orlando-imagens.test.ts
+++ b/tests/orlando-imagens.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import { optimizeImageUrl, selectImagePreset } from '../lib/media-url.ts';
+
+/*
+  Guards da issue #1326 — dimensionamento das imagens da /orlando.
+
+  Ficam em node:test e não em Playwright de propósito: a decisão de preset é
+  lógica pura, e um e2e dependeria de `VITE_MEDIA_ENABLE_TRANSFORMS`, que está
+  desligado no dev server que o Playwright levanta. Um teste que só roda com
+  transforms ligados ficaria permanentemente `skipped` no CI — verde sem
+  verificar nada.
+*/
+
+const PROD_TRANSFORM_CONFIG = {
+    mediaBaseUrl: 'https://media.anhanga.tur.br',
+    transformZoneUrl: 'https://media.anhanga.tur.br',
+    enableTransforms: true,
+};
+
+const GALLERY_SOURCE = 'components/landings/orlando/OrlandoParksGallery.tsx';
+
+/**
+ * Lê o argumento de largura que a galeria passa para uma chamada específica.
+ * Testar `selectImagePreset` isolado não trava nada: ele passa com qualquer
+ * coisa que o componente faça. O que precisa ficar travado é o ARGUMENTO.
+ */
+async function argumentosDaGaleria(): Promise<string> {
+    return readFile(new URL(`../${GALLERY_SOURCE}`, import.meta.url), 'utf8');
+}
+
+test('a foto do parque é pedida sem height, caindo num preset abaixo de 1200', async () => {
+    const source = await argumentosDaGaleria();
+
+    const chamada = source.match(/src=\{optimizeRemoteImageUrl\(image,\s*([^)]*)\)\}/);
+    assert.ok(chamada, 'a foto do parque precisa vir de optimizeRemoteImageUrl(image, ...)');
+
+    const args = chamada[1].split(',').map((a) => a.trim()).filter(Boolean);
+    assert.equal(
+        args.length,
+        1,
+        `passar height reativa o fallback de 1200x675: selectImagePreset(600, 400) -> ${selectImagePreset(600, 400).width}px`,
+    );
+
+    const preset = selectImagePreset(Number(args[0]));
+    assert.equal(preset.width, 800, 'a largura pedida deve cair no preset de 800');
+    assert.equal(preset.fit, 'scale-down');
+});
+
+test('o logo PNG é pedido por optimizeRemoteImageUrl, não cru', async () => {
+    const source = await argumentosDaGaleria();
+
+    const chamada = source.match(/optimizeRemoteImageUrl\(logo,\s*(\d+)\)/);
+    assert.ok(
+        chamada,
+        'o logo PNG precisa passar por optimizeRemoteImageUrl — cru é onde vivia o magic-kingdom.png de 243 KB',
+    );
+
+    const preset = selectImagePreset(Number(chamada[1]));
+    assert.equal(preset.width, 800);
+    assert.equal(preset.fit, 'scale-down');
+
+    // E a URL resultante precisa mesmo atravessar a zona de transform.
+    const url = optimizeImageUrl('images/orlando/logos/epcot.png', {
+        ...PROD_TRANSFORM_CONFIG,
+        width: Number(chamada[1]),
+    });
+    assert.match(url, /\/cdn-cgi\/image\//);
+    assert.match(url, /width=800/);
+});
+
+test('a galeria não reintroduz srcSet, que neste repo é markup morto', async () => {
+    const source = await readFile(new URL(`../${GALLERY_SOURCE}`, import.meta.url), 'utf8');
+
+    // selectImagePreset normaliza qualquer largura para um conjunto fixo de
+    // presets, então todo candidato de um srcSet colapsaria na MESMA URL. Se
+    // alguém adicionar srcSet aqui achando que economiza bytes, este teste
+    // explica por que não economiza.
+    assert.ok(
+        !/srcSet=/.test(source),
+        'srcSet na galeria da /orlando gera candidatos idênticos — ver o comentário no topo do arquivo',
+    );
+});
+
+test('o SVG do logo não é roteado para o transform raster', async () => {
+    const source = await readFile(new URL(`../${GALLERY_SOURCE}`, import.meta.url), 'utf8');
+
+    // Vetor não ganha byte nenhum com resize e pode ser rasterizado.
+    assert.match(
+        source,
+        /isVector\(logo\)\s*\?\s*getMediaUrl\(logo\)\s*:\s*optimizeRemoteImageUrl\(logo,\s*200\)/,
+        'os SVG precisam continuar indo por getMediaUrl, sem transform',
+    );
+});
+
+test('o fallback de transform quebrado continua ligado nos logos', async () => {
+    const source = await readFile(new URL(`../${GALLERY_SOURCE}`, import.meta.url), 'utf8');
+
+    // magic-kingdom.png (11502×1942) devolve HTTP 422 no resizer da Cloudflare.
+    // Sem o onError, o logo mais proeminente da página sumiria.
+    assert.match(source, /onError=\{isVector\(logo\)\s*\?\s*undefined\s*:\s*handleLogoTransformError\(logo\)\}/);
+});

--- a/tests/orlando-imagens.test.ts
+++ b/tests/orlando-imagens.test.ts
@@ -4,7 +4,7 @@ import { readFile } from 'node:fs/promises';
 
 import { optimizeImageUrl, selectImagePreset } from '../lib/media-url.ts';
 import { getMediaUrl } from '../data/mediaConfig.ts';
-import { handleLogoTransformError } from '../components/landings/orlando/OrlandoParksGallery.tsx';
+import { handleLogoTransformError } from '../components/landings/orlando/logoFallback.ts';
 
 /*
   Guards da issue #1326 — dimensionamento das imagens da /orlando.

--- a/tests/orlando-imagens.test.ts
+++ b/tests/orlando-imagens.test.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 import { optimizeImageUrl, selectImagePreset } from '../lib/media-url.ts';
+import { getMediaUrl } from '../data/mediaConfig.ts';
+import { handleLogoTransformError } from '../components/landings/orlando/OrlandoParksGallery.tsx';
 
 /*
   Guards da issue #1326 — dimensionamento das imagens da /orlando.
@@ -101,4 +103,44 @@ test('o fallback de transform quebrado continua ligado nos logos', async () => {
     // magic-kingdom.png (11502×1942) devolve HTTP 422 no resizer da Cloudflare.
     // Sem o onError, o logo mais proeminente da página sumiria.
     assert.match(source, /onError=\{isVector\(logo\)\s*\?\s*undefined\s*:\s*handleLogoTransformError\(logo\)\}/);
+});
+
+/*
+  Os testes acima provam que o onError está LIGADO. Estes provam que ele
+  FUNCIONA — distinção que o review da PR #1347 (Codex, P2) apontou: o e2e roda
+  contra o dev server sem `VITE_MEDIA_ENABLE_TRANSFORMS`, então o logo é
+  servido cru, o HTTP 422 nunca acontece e o handler jamais é exercitado.
+  Ficaria verde com o fallback implementado errado.
+*/
+
+const LOGO = 'images/orlando/logos/magic-kingdom.png';
+
+function eventoDeErroFalso(srcAtual: string) {
+    const img = { src: srcAtual };
+    return { currentTarget: img, img };
+}
+
+test('o fallback troca a URL transformada pelo original', () => {
+    const transformada =
+        'https://media.anhanga.tur.br/cdn-cgi/image/format=auto,width=800/' + LOGO;
+    const { currentTarget, img } = eventoDeErroFalso(transformada);
+
+    handleLogoTransformError(LOGO)(
+        { currentTarget } as unknown as Parameters<ReturnType<typeof handleLogoTransformError>>[0],
+    );
+
+    assert.equal(img.src, getMediaUrl(LOGO));
+    assert.ok(!img.src.includes('/cdn-cgi/image/'), 'o fallback não pode apontar para o transform');
+});
+
+test('o fallback não entra em loop quando o próprio original falha', () => {
+    const original = getMediaUrl(LOGO);
+    const { currentTarget, img } = eventoDeErroFalso(original);
+
+    handleLogoTransformError(LOGO)(
+        { currentTarget } as unknown as Parameters<ReturnType<typeof handleLogoTransformError>>[0],
+    );
+
+    // Sem a guarda, reatribuir o mesmo src dispara onError de novo, em loop.
+    assert.equal(img.src, original);
 });


### PR DESCRIPTION
Fecha a #1326. Medido nas URLs reais com transforms ligados: **2.439.926 → 1.680.674 bytes (2,33 → 1,60 MiB, −31%)**.

## A issue estava errada, e vale saber por quê

Ela pedia `srcSet`. Isso não funciona neste repo: **`selectImagePreset` (`lib/media-url.ts`) normaliza qualquer largura para um conjunto fixo de presets** — tudo abaixo de 800 vira `inline-sm` 800. Um `srcSet` de várias entradas geraria a mesma URL repetida, markup morto.

O que decide os bytes aqui é **em qual preset a chamada cai**, não quantos candidatos ela oferece. E um único candidato de 800 cobre a página inteira: a foto ocupa 328px no desktop e 237px no celular, então mesmo em DPR 3 o alvo fica abaixo de 800.

Corrigi o corpo da issue para não mandar o próximo leitor pelo caminho errado.

## As duas mudanças

**Fotos dos parques.** `(600, 400)` tem ratio 1,5, que não casa com nenhum preset dentro da tolerância de 0,08 — caía no fallback `content` **1200×675**, para um frame de 220px de altura. Sem `height` cai em 800 `scale-down`.

O enquadramento não muda: `.park-image-frame img` já aplica `object-fit: cover` com altura fixa, então quem recorta é o CSS, não o transform. Confirmado em captura.

**Logos.** Os 9 PNG iam **crus do R2**, sem transform nenhuma — é onde vivia o `magic-kingdom.png` de 11502×1942 e 243 KB para um slot de 200×55. Passam a ser pedidos a 200px. Os 3 SVG seguem crus: resize raster não economiza em vetor e pode rasterizá-lo.

## Um achado que teria quebrado a página

O `magic-kingdom.png` **não pode ser transformado**: o `/cdn-cgi/image` devolve `HTTP 422 — ERROR 9516: error during decoding: Error while decoding the PNG image`. O arquivo cru serve normalmente (200, 243 KB), mas o resizer não o decodifica — provavelmente os 22,3 megapixels.

Sem tratamento, minha mudança faria **o logo mais proeminente da página sumir**. Só apareceu porque medi os status HTTP, não só os bytes. Adicionei um `onError` que cai no original — genérico, vale para qualquer transform que falhe.

A causa raiz é o arquivo e precisa de reencode no R2 (mesmo bloqueio de acesso ao bucket da #1333). Os 243 KB dele **estão contabilizados** no total acima; com o arquivo corrigido o resultado seria 1,37 MiB (−41%).

## O hero ficou intocado

Cheguei a mexer nele e **revertí**: os 3 cartões já caem em `square` 640×640, menor que os 800 que qualquer `srcSet` traria — e são o LCP da página. A mudança teria sido regressão.

## Testes — e o teatro que peguei

`tests/orlando-imagens.test.ts` (node:test) e `tests/e2e/orlando-imagens.spec.ts`.

Duas correções de rota que valem registro:

1. A primeira versão dos guards verificava `selectImagePreset` **isolado** — passava verde com o componente quebrado, porque testava a lib e não o que a galeria chama. Agora leem o argumento real que o componente passa. Validado reintroduzindo cada defeito: 4 de 5 falham (o quinto é o de `srcSet`, verificado à parte).
2. A versão e2e dos guards lógicos ficava **`skipped`** no CI, porque depende de `VITE_MEDIA_ENABLE_TRANSFORMS`, desligado no dev server do Playwright. Migrei para node:test, que roda sempre. No e2e ficou só o que exige browser: nenhuma imagem quebrada na tela.

Também errei a primeira medição — setei `VITE_MEDIA_ENABLE_TRANSFORMS` mas esqueci `VITE_MEDIA_TRANSFORM_ZONE_URL`, e o build gerou URLs apontando para o domínio errado, que retornavam 415. O "−96%" daquela rodada era ilusão.

## Verificação

- `pnpm test:regression` — inclui os 5 guards novos
- 10/10 nos três specs e2e de `/orlando`; `orlando-mobile-layout` e `orlando-nav-contraste` servem de canário para drift de layout
- `pnpm typecheck` e `npx eslint` — limpos
- Captura a 1440px: enquadramento correto, **alpha preservado em todos os logos**, zero imagens quebradas

## Fora de escopo

Não estendi `selectImagePreset` com presets menores — o conjunto fixo existe para maximizar cache hit da Cloudflare, e mexer nisso é decisão do site inteiro. Se 800 for grosseiro demais para logos de 200px, vale uma issue própria.

Também não sustento a alegação de CLS que estava na issue: as fotos e os logos já carregam `width`/`height` explícitos, então não são eles que crescem de 7206 para 7469px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)