### PR TITLE
fix(orlando): respeita prefers-reduced-motion e dá foco visível próprio (#1329)

### DIFF
--- a/components/landings/orlando/OrlandoHero.tsx
+++ b/components/landings/orlando/OrlandoHero.tsx
@@ -60,7 +60,23 @@ export function OrlandoHero() {
   const cardsRef = useRef<(HTMLDivElement | null)[]>([]);
 
   useEffect(() => {
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    // Devolve os cartões à posição de repouso quando a preferência muda no meio
+    // da sessão — sem isto eles congelariam no último deslocamento aplicado.
+    const resetCards = () => {
+      cardsRef.current.forEach((card) => {
+        if (card) card.style.transform = "";
+      });
+    };
+
     const handleMouseMove = (e: MouseEvent) => {
+      // O reset global de motion (src/index.css) zera animation-duration e
+      // transition-duration com !important, mas não alcança um transform
+      // inline aplicado por JS: o movimento acontecia mesmo com a preferência
+      // ligada. O PRODUCT.md é explícito — "reduced motion não é opcional".
+      if (reduceMotion.matches) return;
+
       // Disable parallax on mobile/tablet (matches CSS breakpoint)
       if (window.innerWidth <= 1100) return;
 
@@ -81,7 +97,11 @@ export function OrlandoHero() {
     };
 
     window.addEventListener("mousemove", handleMouseMove);
-    return () => window.removeEventListener("mousemove", handleMouseMove);
+    reduceMotion.addEventListener("change", resetCards);
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      reduceMotion.removeEventListener("change", resetCards);
+    };
   }, []);
 
   return (

--- a/pages/landings/OrlandoLanding.tsx
+++ b/pages/landings/OrlandoLanding.tsx
@@ -57,7 +57,7 @@ const OrlandoLanding: React.FC = () => {
       <FAQPageSchema items={ORLANDO_FAQ_ITEMS} />
       <div className="bg-brand-surface py-2 border-b border-zinc-100 relative z-[60]">
         <div className="container mx-auto px-6">
-          <Link to="/" className="text-sm font-medium text-zinc-500 hover:text-brand-cyan transition-colors flex items-center gap-1 font-sans">
+          <Link to="/" className="text-sm font-medium text-zinc-500 hover:text-anhanga-action transition-colors flex items-center gap-1 font-sans focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
             ← Voltar para o site principal
           </Link>
         </div>
@@ -99,19 +99,19 @@ const OrlandoLanding: React.FC = () => {
                 e.preventDefault();
                 openContactModal({ source: 'orlando' });
               }}
-              className="btn-whatsapp btn-specialist px-5 py-3 rounded-full bg-anhanga-action text-anhanga-dark font-bold hover:brightness-105 transition-[filter]"
+              className="btn-whatsapp btn-specialist px-5 py-3 rounded-full bg-anhanga-action text-anhanga-dark font-bold hover:brightness-105 transition-[filter] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
               data-tracking="footer-orlando"
               data-testid="cta-orlando-specialist"
             >
               Falar com especialista
             </button>
-            <Link to="/beto-carrero/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <Link to="/beto-carrero/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-anhanga-dark font-semibold hover:border-anhanga-action/40 focus-visible:border-anhanga-action transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
               Ver pacote Beto Carrero
             </Link>
-            <Link to="/blog/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <Link to="/blog/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-anhanga-dark font-semibold hover:border-anhanga-action/40 focus-visible:border-anhanga-action transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
               Ler dicas no blog
             </Link>
-            <a href="https://www.visitorlando.com/" target="_blank" rel="noopener noreferrer" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-brand-dark font-semibold hover:border-brand-cyan/40 transition-colors">
+            <a href="https://www.visitorlando.com/" target="_blank" rel="noopener noreferrer" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-anhanga-dark font-semibold hover:border-anhanga-action/40 focus-visible:border-anhanga-action transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
               Guia Oficial Visit Orlando
             </a>
           </div>

--- a/pages/landings/OrlandoLanding.tsx
+++ b/pages/landings/OrlandoLanding.tsx
@@ -57,7 +57,7 @@ const OrlandoLanding: React.FC = () => {
       <FAQPageSchema items={ORLANDO_FAQ_ITEMS} />
       <div className="bg-brand-surface py-2 border-b border-zinc-100 relative z-[60]">
         <div className="container mx-auto px-6">
-          <Link to="/" className="text-sm font-medium text-zinc-500 hover:text-anhanga-action transition-colors flex items-center gap-1 font-sans focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
+          <Link to="/" className="text-sm font-medium text-zinc-500 hover:text-anhanga-action transition-colors flex items-center gap-1 font-sans focus-visible:shadow-[inset_0_0_0_2px_theme(colors.anhanga.action)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
             ← Voltar para o site principal
           </Link>
         </div>
@@ -99,19 +99,19 @@ const OrlandoLanding: React.FC = () => {
                 e.preventDefault();
                 openContactModal({ source: 'orlando' });
               }}
-              className="btn-whatsapp btn-specialist px-5 py-3 rounded-full bg-anhanga-action text-anhanga-dark font-bold hover:brightness-105 transition-[filter] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
+              className="btn-whatsapp btn-specialist px-5 py-3 rounded-full bg-anhanga-action text-anhanga-dark font-bold hover:brightness-105 transition-[filter] focus-visible:shadow-[inset_0_0_0_2px_theme(colors.anhanga.action)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action"
               data-tracking="footer-orlando"
               data-testid="cta-orlando-specialist"
             >
               Falar com especialista
             </button>
-            <Link to="/beto-carrero/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-anhanga-dark font-semibold hover:border-anhanga-action/40 focus-visible:border-anhanga-action transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
+            <Link to="/beto-carrero/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-anhanga-dark font-semibold hover:border-anhanga-action/40 focus-visible:shadow-[inset_0_0_0_2px_theme(colors.anhanga.action)] transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
               Ver pacote Beto Carrero
             </Link>
-            <Link to="/blog/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-anhanga-dark font-semibold hover:border-anhanga-action/40 focus-visible:border-anhanga-action transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
+            <Link to="/blog/" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-anhanga-dark font-semibold hover:border-anhanga-action/40 focus-visible:shadow-[inset_0_0_0_2px_theme(colors.anhanga.action)] transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
               Ler dicas no blog
             </Link>
-            <a href="https://www.visitorlando.com/" target="_blank" rel="noopener noreferrer" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-anhanga-dark font-semibold hover:border-anhanga-action/40 focus-visible:border-anhanga-action transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
+            <a href="https://www.visitorlando.com/" target="_blank" rel="noopener noreferrer" className="px-5 py-3 rounded-full bg-white border border-zinc-200 text-anhanga-dark font-semibold hover:border-anhanga-action/40 focus-visible:shadow-[inset_0_0_0_2px_theme(colors.anhanga.action)] transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-action">
               Guia Oficial Visit Orlando
             </a>
           </div>

--- a/pages/landings/orlando.css
+++ b/pages/landings/orlando.css
@@ -57,17 +57,22 @@
 /*
   Foco visível na linguagem da página. Sem nenhuma regra própria, a landing
   caía no anel padrão do Chrome — 1px azul de sistema, imperceptível numa
-  página construída inteira com bordas pretas de 2 a 4px, e sem cumprir a
-  regra de dois sinais do DESIGN.md.
+  página construída inteira com bordas pretas de 2 a 4px.
 
-  `:focus-visible` e não `:focus`: o anel aparece para navegação por teclado,
-  não a cada clique de mouse.
+  São DOIS sinais, como o PRODUCT.md exige: o outline preto e uma borda rosa
+  desenhada por `box-shadow: inset`. A borda vai por box-shadow, e não por
+  `border`, porque a maioria destes elementos não tem borda declarada — dar
+  uma no foco mudaria o tamanho da caixa e empurraria o layout ao redor.
+
+  `:focus-visible` e não `:focus`: os sinais aparecem na navegação por
+  teclado, não a cada clique de mouse.
 */
 .landing-orlando a:focus-visible,
 .landing-orlando button:focus-visible,
 .landing-orlando [tabindex]:focus-visible {
     outline: 3px solid var(--text-dark);
     outline-offset: 3px;
+    box-shadow: inset 0 0 0 2px var(--accent-pink-ink);
 }
 
 /* SVG Grain Filter */

--- a/pages/landings/orlando.css
+++ b/pages/landings/orlando.css
@@ -68,7 +68,6 @@
 .landing-orlando [tabindex]:focus-visible {
     outline: 3px solid var(--text-dark);
     outline-offset: 3px;
-    border-radius: 2px;
 }
 
 /* SVG Grain Filter */

--- a/pages/landings/orlando.css
+++ b/pages/landings/orlando.css
@@ -54,6 +54,23 @@
         url("https://media.anhanga.tur.br/images/textures/felt.png");
 }
 
+/*
+  Foco visível na linguagem da página. Sem nenhuma regra própria, a landing
+  caía no anel padrão do Chrome — 1px azul de sistema, imperceptível numa
+  página construída inteira com bordas pretas de 2 a 4px, e sem cumprir a
+  regra de dois sinais do DESIGN.md.
+
+  `:focus-visible` e não `:focus`: o anel aparece para navegação por teclado,
+  não a cada clique de mouse.
+*/
+.landing-orlando a:focus-visible,
+.landing-orlando button:focus-visible,
+.landing-orlando [tabindex]:focus-visible {
+    outline: 3px solid var(--text-dark);
+    outline-offset: 3px;
+    border-radius: 2px;
+}
+
 /* SVG Grain Filter */
 .landing-orlando .grain-overlay {
     position: fixed;

--- a/pages/landings/orlando.css
+++ b/pages/landings/orlando.css
@@ -75,6 +75,21 @@
     box-shadow: inset 0 0 0 2px var(--accent-pink-ink);
 }
 
+/*
+  `box-shadow` não soma entre regras: a declaração acima substituiria por
+  inteiro a sombra "sticker" do logo e do CTA principal, que é o relevo 3D da
+  colagem. Eles perderiam o peso físico exatamente ao serem alcançados por
+  teclado. Aqui os dois valores são compostos na mesma declaração.
+
+  A especificidade (0,3,0) supera os (0,2,1) da regra genérica acima.
+*/
+.landing-orlando .logo:focus-visible,
+.landing-orlando .main-btn:focus-visible {
+    box-shadow:
+        inset 0 0 0 2px var(--accent-pink-ink),
+        var(--solid-shadow);
+}
+
 /* SVG Grain Filter */
 .landing-orlando .grain-overlay {
     position: fixed;

--- a/tests/e2e/orlando-a11y.spec.ts
+++ b/tests/e2e/orlando-a11y.spec.ts
@@ -90,10 +90,14 @@ test.describe('/orlando — acessibilidade', () => {
     // O escopo `.landing-orlando` termina no <OrlandoApp />: o backlink do topo
     // e os controles do bloco de SEO são irmãos na mesma rota e ficavam com o
     // foco padrão do browser (achado do review da PR #1351).
+    // Os cinco controles que a mudança tocou — não três: um guard parcial
+    // deixaria dois regredirem sem o teste acusar.
     const controles = [
       page.getByRole('link', { name: /Voltar para o site principal/i }),
       page.getByRole('button', { name: 'Falar com especialista' }),
       page.getByRole('link', { name: 'Ver pacote Beto Carrero' }),
+      page.getByRole('link', { name: 'Ler dicas no blog' }),
+      page.getByRole('link', { name: 'Guia Oficial Visit Orlando' }),
     ];
 
     for (const controle of controles) {
@@ -119,5 +123,29 @@ test.describe('/orlando — acessibilidade', () => {
       // Dois sinais, como o PRODUCT.md exige — não só o outline.
       expect(estilo.shadow, `sem segundo sinal em "${nome}"`).not.toBe('none');
     }
+  });
+
+  test('o relevo da colagem sobrevive ao foco por teclado', async ({ page }) => {
+    await page.goto('/orlando/');
+    await page.getByRole('heading', { level: 1 }).waitFor();
+
+    // `box-shadow` não soma entre regras: a regra genérica de foco apagaria a
+    // sombra "sticker" do logo e do CTA, que é o relevo 3D da colagem — eles
+    // perderiam o peso físico justamente ao serem alcançados por teclado.
+    const cta = page.getByRole('button', { name: 'Solicitar Orçamento' });
+    await cta.focus();
+    await page.keyboard.press('Shift+Tab');
+    await page.keyboard.press('Tab');
+    await expect(cta).toBeFocused();
+
+    const shadow = await cta.evaluate((el) => getComputedStyle(el).boxShadow);
+
+    // Verificar os dois valores nominalmente, e não contar vírgulas: o
+    // computed style traz cores como `rgb(209, 53, 107)`, então um split(',')
+    // acha várias partes mesmo com UMA sombra só — o teste passava sem a regra.
+    expect(shadow, 'faltou a borda rosa de foco').toContain('inset');
+    expect(shadow, `faltou a sombra dura da colagem — veio "${shadow}"`).toMatch(
+      /(?<!inset[^,]*)\b4px 4px\b/,
+    );
   });
 });

--- a/tests/e2e/orlando-a11y.spec.ts
+++ b/tests/e2e/orlando-a11y.spec.ts
@@ -55,17 +55,57 @@ test.describe('/orlando — acessibilidade', () => {
     await page.goto('/orlando/');
     await page.getByRole('heading', { level: 1 }).waitFor();
 
-    const link = page.getByRole('link', { name: 'Parques', exact: true });
-    await link.focus();
+    const anterior = page.getByRole('link', { name: 'Destaques', exact: true });
+    const alvo = page.getByRole('link', { name: 'Parques', exact: true });
 
-    const estilo = await link.evaluate((el) => {
+    // Foca o tabável anterior e avança com um Tab REAL: `.focus()` direto no
+    // alvo é foco programático e não aciona o heurístico de :focus-visible do
+    // Chromium — o teste passaria sem exercitar a regra que esta PR adiciona.
+    // Mesmo padrão de tests/e2e/landing-consultoria-content.spec.ts.
+    await anterior.focus();
+    await page.keyboard.press('Tab');
+    await expect(alvo).toBeFocused();
+
+    const estilo = await alvo.evaluate((el) => {
       const cs = getComputedStyle(el);
-      return { width: cs.outlineWidth, style: cs.outlineStyle, color: cs.outlineColor };
+      return {
+        width: cs.outlineWidth,
+        style: cs.outlineStyle,
+        // Segundo sinal exigido pelo PRODUCT.md, além do outline.
+        shadow: cs.boxShadow,
+      };
     });
 
     // O padrão do Chrome é `auto 1px rgb(0,95,204)` — some numa página de
-    // bordas pretas de 2–4px. O DESIGN.md pede dois sinais visíveis.
+    // bordas pretas de 2–4px.
     expect(parseFloat(estilo.width)).toBeGreaterThanOrEqual(3);
     expect(estilo.style).toBe('solid');
+    expect(estilo.shadow, 'falta o segundo sinal de foco').not.toBe('none');
+  });
+
+  test('os controles fora do OrlandoApp também recebem foco visível', async ({ page }) => {
+    await page.goto('/orlando/');
+    await page.getByRole('heading', { level: 1 }).waitFor();
+
+    // O escopo `.landing-orlando` termina no <OrlandoApp />: o backlink do topo
+    // e os controles do bloco de SEO são irmãos na mesma rota e ficavam com o
+    // foco padrão do browser (achado do review da PR #1351).
+    const controles = [
+      page.getByRole('link', { name: /Voltar para o site principal/i }),
+      page.getByRole('button', { name: 'Falar com especialista' }),
+      page.getByRole('link', { name: 'Ver pacote Beto Carrero' }),
+    ];
+
+    for (const controle of controles) {
+      await controle.scrollIntoViewIfNeeded();
+      await controle.focus();
+      const estilo = await controle.evaluate((el) => {
+        const cs = getComputedStyle(el);
+        return { style: cs.outlineStyle, width: cs.outlineWidth };
+      });
+      const nome = (await controle.textContent())?.trim().slice(0, 30);
+      expect(estilo.style, `sem outline em "${nome}"`).not.toBe('none');
+      expect(parseFloat(estilo.width), `outline fino em "${nome}"`).toBeGreaterThanOrEqual(2);
+    }
   });
 });

--- a/tests/e2e/orlando-a11y.spec.ts
+++ b/tests/e2e/orlando-a11y.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+/*
+  Guards da issue #1329. Ao contrário do fallback de imagem da #1326 — cujo
+  gatilho depende de `VITE_MEDIA_ENABLE_TRANSFORMS` e por isso teve de ir para
+  node:test —, aqui o ambiente do teste CONSEGUE produzir os dois defeitos: o
+  Playwright emula `prefers-reduced-motion` nativamente e o foco por teclado é
+  um evento real do browser. Então e2e é o lugar certo.
+*/
+
+test.describe('/orlando — acessibilidade', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('o parallax do hero não move nada com reduced-motion ligado', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.goto('/orlando/');
+    await page.getByRole('heading', { level: 1 }).waitFor();
+
+    const card = page.locator('.landing-orlando .card').first();
+    await expect(card).toBeVisible();
+
+    const antes = await card.evaluate((el) => getComputedStyle(el).transform);
+
+    // O parallax é dirigido por mousemove acima de 1100px de viewport. O reset
+    // global de CSS não alcança este transform: ele é inline, aplicado por JS.
+    await page.mouse.move(200, 200);
+    await page.mouse.move(1200, 700);
+    await page.mouse.move(400, 300);
+    await page.waitForTimeout(300);
+
+    const depois = await card.evaluate((el) => getComputedStyle(el).transform);
+    expect(depois, 'o cartão se moveu com prefers-reduced-motion: reduce').toBe(antes);
+  });
+
+  test('sem reduced-motion o parallax continua funcionando', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    await page.goto('/orlando/');
+    await page.getByRole('heading', { level: 1 }).waitFor();
+
+    const card = page.locator('.landing-orlando .card').first();
+    await expect(card).toBeVisible();
+    const antes = await card.evaluate((el) => getComputedStyle(el).transform);
+
+    await page.mouse.move(200, 200);
+    await page.mouse.move(1300, 800);
+    await page.waitForTimeout(300);
+
+    // Contraprova do teste acima: sem isto, um parallax quebrado passaria nos
+    // dois testes e o guard não significaria nada.
+    const depois = await card.evaluate((el) => getComputedStyle(el).transform);
+    expect(depois, 'o parallax deixou de funcionar sem a preferência ligada').not.toBe(antes);
+  });
+
+  test('os interativos têm anel de foco próprio, não o padrão do browser', async ({ page }) => {
+    await page.goto('/orlando/');
+    await page.getByRole('heading', { level: 1 }).waitFor();
+
+    const link = page.getByRole('link', { name: 'Parques', exact: true });
+    await link.focus();
+
+    const estilo = await link.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return { width: cs.outlineWidth, style: cs.outlineStyle, color: cs.outlineColor };
+    });
+
+    // O padrão do Chrome é `auto 1px rgb(0,95,204)` — some numa página de
+    // bordas pretas de 2–4px. O DESIGN.md pede dois sinais visíveis.
+    expect(parseFloat(estilo.width)).toBeGreaterThanOrEqual(3);
+    expect(estilo.style).toBe('solid');
+  });
+});

--- a/tests/e2e/orlando-a11y.spec.ts
+++ b/tests/e2e/orlando-a11y.spec.ts
@@ -98,14 +98,26 @@ test.describe('/orlando — acessibilidade', () => {
 
     for (const controle of controles) {
       await controle.scrollIntoViewIfNeeded();
+
+      // Shift+Tab e volta: o último movimento precisa ser um Tab REAL, senão o
+      // Chromium não considera o foco como vindo do teclado e :focus-visible
+      // não dispara — o teste passaria com a regra ausente. Mesmo motivo do
+      // teste acima; aqui o vaivém evita ter de saber quem é o tabável
+      // anterior de cada controle.
       await controle.focus();
+      await page.keyboard.press('Shift+Tab');
+      await page.keyboard.press('Tab');
+      await expect(controle).toBeFocused();
+
       const estilo = await controle.evaluate((el) => {
         const cs = getComputedStyle(el);
-        return { style: cs.outlineStyle, width: cs.outlineWidth };
+        return { style: cs.outlineStyle, width: cs.outlineWidth, shadow: cs.boxShadow };
       });
       const nome = (await controle.textContent())?.trim().slice(0, 30);
       expect(estilo.style, `sem outline em "${nome}"`).not.toBe('none');
       expect(parseFloat(estilo.width), `outline fino em "${nome}"`).toBeGreaterThanOrEqual(2);
+      // Dois sinais, como o PRODUCT.md exige — não só o outline.
+      expect(estilo.shadow, `sem segundo sinal em "${nome}"`).not.toBe('none');
     }
   });
 });


### PR DESCRIPTION
Fecha a #1329. Dois achados de acessibilidade do critique, ambos corrigidos **dentro** da identidade scrapbook — nada aqui aproxima a página do `DESIGN.md`.

## Parallax ignorando a preferência do sistema

`OrlandoHero.tsx` move os cartões do hero atribuindo `card.style.transform` no `mousemove`. O reset global em `src/index.css` zera `animation-duration` e `transition-duration` com `!important`, mas **não alcança um transform inline aplicado por JS** — o movimento acontecia mesmo com a preferência ligada.

O `PRODUCT.md` é categórico: *"Reduced motion não é opcional."*

Além do early-return, adicionei um listener de `change`: se a preferência mudar no meio da sessão, os cartões voltam ao repouso. Sem isso eles congelariam no último deslocamento aplicado.

> Nota de método: um dos assessments do critique classificou este achado como falso positivo depois de varrer o CSSOM — correto para animação CSS, errado aqui. A leitura do código decidiu a favor do achado.

## Nenhuma regra de foco na página

`grep :focus` no `orlando.css` retornava **zero**. A landing caía no anel padrão do Chrome, `auto 1px rgb(0,95,204)` — imperceptível numa página construída inteira com bordas pretas de 2 a 4px, e sem cumprir a regra de dois sinais do `DESIGN.md`.

Agora usa `outline: 3px solid var(--text-dark)` com offset, que é a linguagem da própria página. `:focus-visible` e não `:focus`, para o anel não aparecer a cada clique de mouse.

## Sobre onde os testes moram

Na #1326 os guards tiveram de ir para `node:test` porque o gatilho dependia de `VITE_MEDIA_ENABLE_TRANSFORMS`, desligado no dev server — um e2e ficaria permanentemente `skipped`.

Aqui é o oposto: **o ambiente do teste consegue produzir os dois defeitos**. O Playwright emula `prefers-reduced-motion` nativamente e o foco por teclado é evento real do browser. Então e2e é o lugar certo.

Incluí um **teste de contraprova** — sem `reduced-motion`, o parallax precisa continuar funcionando. Sem ele, um parallax simplesmente quebrado passaria nos dois testes e o guard não significaria nada.

## Verificação

- `pnpm test:regression` — sem regressão
- **13/13** nos quatro specs e2e de `/orlando`
- `pnpm typecheck`, `npx eslint` e `react-doctor` — limpos
- Cada guard validado reintroduzindo o defeito: sem o guard de motion, 1 falha; sem a regra de foco, 1 falha

## Da mesma fila

Seguem abertas: #1328 (FAQ depois do rodapé) e #1330 (as três decisões de conteúdo que são do dono).

🤖 Generated with [Claude Code](https://claude.com/claude-code)