### PR TITLE
feat(consultoria): dispara evento de funil e propaga atribuição no booking do Cal.com

### DIFF
--- a/lib/cal-embed.ts
+++ b/lib/cal-embed.ts
@@ -81,8 +81,13 @@ export function pushConsultoriaBookingCreatedDataLayerEvent(uid: string): void {
   });
 }
 
+// No fallback (embed bloqueado/lento/fora do ar), a navegação sai fora do
+// embed — o comando `modal` com o `metadata[...]` nunca chega a rodar. Sem
+// isto, a atribuição capturada se perderia justo nas reservas que passam
+// pelo caminho de fallback (achado de review, PR #1369).
 function navigateToBooking(): void {
-  window.location.href = CONSULTORIA_BOOKING_URL;
+  const attribution = new URLSearchParams(buildAttributionMetadataConfig()).toString();
+  window.location.href = attribution ? `${CONSULTORIA_BOOKING_URL}?${attribution}` : CONSULTORIA_BOOKING_URL;
 }
 
 // Loader oficial do Cal.com (o IIFE do snippet element-click), encapsulado para

--- a/lib/cal-embed.ts
+++ b/lib/cal-embed.ts
@@ -8,6 +8,8 @@
 //
 // Ver project-consultoria-modelo-pago (memória) e a PR do embed.
 
+import { getTrackingDataObject } from '../utils/whatsapp';
+
 const CAL_LINK = 'anhanga-viagens/consultoria';
 const CAL_NAMESPACE = 'consultoria';
 const CAL_ORIGIN = 'https://app.cal.com';
@@ -44,6 +46,40 @@ declare global {
 
 let initialized = false;
 let scriptState: 'idle' | 'loading' | 'loaded' | 'failed' = 'idle';
+
+// Shape do evento `bookingSuccessfulV2` do embed (https://cal.com/help/embedding/embed-events).
+// Só os campos que este módulo usa; o Cal.com envia mais (title, startTime etc.).
+interface CalBookingSuccessfulEvent {
+  detail?: {
+    data?: {
+      uid?: unknown;
+    };
+  };
+}
+
+// Marca "reserva criada" no dataLayer, não "pagamento concluído" — o embed não
+// emite um evento de pagamento (issue #1302). event_id é o uid do booking do
+// Cal.com sem transformação: mesma chave que o server-side verá quando #1297
+// ligar o webhook BOOKING_PAID ao purchase-dispatch, permitindo dedup por
+// event_id entre o evento de funil (aqui) e o Purchase real (server-side).
+export function pushConsultoriaBookingCreatedDataLayerEvent(uid: string): void {
+  if (typeof window === 'undefined' || !window.dataLayer) {
+    return;
+  }
+
+  window.dataLayer.push({
+    event: 'consultoria_booking_created',
+    event_id: uid,
+    page_location: window.location.href,
+  });
+
+  window.dataLayer.push({
+    event: 'form_submission',
+    form_type: 'consultoria_booking',
+    form_id: uid,
+    page_location: window.location.href,
+  });
+}
 
 function navigateToBooking(): void {
   window.location.href = CONSULTORIA_BOOKING_URL;
@@ -86,7 +122,10 @@ function ensureInitialized(): void {
   // Este primeiro Cal(...) é o que injeta o <script> do embed.js no head.
   Cal('init', CAL_NAMESPACE, { origin: CAL_ORIGIN });
 
-  // Encaminha query params da URL (ex.: UTMs no primeiro acesso) para o booking.
+  // Pré-preenche campos NOMEADOS do formulário (nome, e-mail etc.) a partir de
+  // query params com o mesmo identificador — NÃO é o mecanismo de atribuição.
+  // UTMs/click IDs vão por `metadata[chave]` (ver buildAttributionMetadataConfig),
+  // que o Cal.com grava na coluna metadata do booking e replica nos webhooks.
   Cal.config = Cal.config || {};
   Cal.config.forwardQueryParams = true;
 
@@ -97,6 +136,18 @@ function ensureInitialized(): void {
     },
     hideEventTypeDetails: false,
     layout: 'month_view',
+  });
+
+  // Dispara o evento de funil (issue #1302) assim que o embed confirma a
+  // reserva — no domínio do site, sessão do usuário, ligado ao sGTM.
+  Cal.ns?.[CAL_NAMESPACE]('on', {
+    action: 'bookingSuccessfulV2',
+    callback: (event: CalBookingSuccessfulEvent) => {
+      const uid = event?.detail?.data?.uid;
+      if (typeof uid === 'string' && uid) {
+        pushConsultoriaBookingCreatedDataLayerEvent(uid);
+      }
+    },
   });
 
   // Fallback de carregamento: o clique já deu preventDefault, então sem isto um
@@ -110,13 +161,35 @@ function ensureInitialized(): void {
   initialized = true;
 }
 
+// Converte o tracking já capturado por utils/whatsapp (UTMs, click IDs, GA4
+// cid/sid) em entradas `metadata[chave]` do embed. O Cal.com grava isso na
+// coluna metadata do booking e replica em payload.metadata nos webhooks
+// (BOOKING_CREATED e, na mesma reserva, BOOKING_PAID) — fecha a atribuição até
+// o purchase-dispatch (issue #1297). Ver cal.com/help/embedding/prefill-
+// booking-form-embed. Não usa forwardQueryParams: aquele mecanismo só
+// pré-preenche campos nomeados do formulário, não grava metadata arbitrário.
+export function buildAttributionMetadataConfig(): Record<string, string> {
+  const tracking = getTrackingDataObject();
+  if (!tracking) return {};
+
+  const metadataConfig: Record<string, string> = {};
+  for (const [key, value] of Object.entries(tracking)) {
+    if (value) metadataConfig[`metadata[${key}]`] = value;
+  }
+  return metadataConfig;
+}
+
 // Abre o modal de agendamento do Cal.com. Só deve ser chamado a partir de uma
 // interação do usuário no browser (onClick) — nunca em render/SSR.
 export function openConsultoriaBooking(): void {
   ensureInitialized();
   window.Cal?.ns?.[CAL_NAMESPACE]('modal', {
     calLink: CAL_LINK,
-    config: { layout: 'month_view', theme: 'auto' },
+    config: {
+      layout: 'month_view',
+      theme: 'auto',
+      ...buildAttributionMetadataConfig(),
+    },
   });
 
   // Backstop: se o embed.js não tiver carregado a tempo, navega para a página

--- a/tests/cal-embed.test.ts
+++ b/tests/cal-embed.test.ts
@@ -1,0 +1,135 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAttributionMetadataConfig, pushConsultoriaBookingCreatedDataLayerEvent } from '../lib/cal-embed.ts';
+
+type MockSessionStorage = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  clear: () => void;
+};
+
+function createSessionStorage(): MockSessionStorage {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => { store.set(key, value); },
+    removeItem: (key) => { store.delete(key); },
+    clear: () => { store.clear(); },
+  };
+}
+
+function withMockBrowserEnv(search: string, run: () => void): void {
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousSessionStorage = globalThis.sessionStorage;
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      location: {
+        search,
+        hash: '',
+        href: `https://www.anhanga.tur.br/consultoria-de-viagem/${search}`,
+      },
+      dataLayer: [] as Array<Record<string, unknown>>,
+    },
+  });
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: { cookie: '' },
+  });
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: createSessionStorage(),
+  });
+
+  try {
+    run();
+  } finally {
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: previousWindow });
+    Object.defineProperty(globalThis, 'document', { configurable: true, value: previousDocument });
+    Object.defineProperty(globalThis, 'sessionStorage', { configurable: true, value: previousSessionStorage });
+  }
+}
+
+function withMockWindow(href: string, run: (pushed: unknown[]) => void): void {
+  const pushed: unknown[] = [];
+  const previousWindow = globalThis.window;
+  Object.defineProperty(globalThis, 'window', {
+    value: {
+      location: { href },
+      dataLayer: { push: (event: unknown) => pushed.push(event) },
+    },
+    configurable: true,
+  });
+
+  try {
+    run(pushed);
+  } finally {
+    Object.defineProperty(globalThis, 'window', {
+      value: previousWindow,
+      configurable: true,
+    });
+  }
+}
+
+test('pushConsultoriaBookingCreatedDataLayerEvent pushes a funnel event and a unified form_submission with the booking uid as event_id', () => {
+  withMockWindow('https://www.anhanga.tur.br/consultoria-de-viagem/', (pushed) => {
+    pushConsultoriaBookingCreatedDataLayerEvent('cal_booking_abc123');
+
+    assert.equal(pushed.length, 2);
+    assert.deepEqual(pushed[0], {
+      event: 'consultoria_booking_created',
+      event_id: 'cal_booking_abc123',
+      page_location: 'https://www.anhanga.tur.br/consultoria-de-viagem/',
+    });
+    assert.deepEqual(pushed[1], {
+      event: 'form_submission',
+      form_type: 'consultoria_booking',
+      form_id: 'cal_booking_abc123',
+      page_location: 'https://www.anhanga.tur.br/consultoria-de-viagem/',
+    });
+  });
+});
+
+// Ordem importa: utils/whatsapp.ts guarda um cache em memória a nível de
+// módulo (cachedTrackingObject) que sobrevive entre testes deste arquivo (o
+// runner do node:test isola por arquivo, não por teste). Este caso "vazio"
+// roda ANTES do caso populado abaixo para não herdar o cache que ele preenche.
+test('buildAttributionMetadataConfig returns an empty object when there is no tracking data to propagate', () => {
+  withMockBrowserEnv('', () => {
+    assert.deepEqual(buildAttributionMetadataConfig(), {});
+  });
+});
+
+test('buildAttributionMetadataConfig maps captured UTMs/click IDs into Cal.com metadata[key] config entries', () => {
+  withMockBrowserEnv('?utm_source=google&utm_medium=cpc&utm_campaign=consultoria&gclid=test-gclid', () => {
+    const config = buildAttributionMetadataConfig();
+
+    assert.deepEqual(config, {
+      'metadata[utm_source]': 'google',
+      'metadata[utm_medium]': 'cpc',
+      'metadata[utm_campaign]': 'consultoria',
+      'metadata[gclid]': 'test-gclid',
+    });
+  });
+});
+
+test('pushConsultoriaBookingCreatedDataLayerEvent is a no-op without window.dataLayer', () => {
+  const previousWindow = globalThis.window;
+  Object.defineProperty(globalThis, 'window', {
+    value: { location: { href: 'https://www.anhanga.tur.br/' } },
+    configurable: true,
+  });
+
+  try {
+    assert.doesNotThrow(() => pushConsultoriaBookingCreatedDataLayerEvent('cal_booking_abc123'));
+  } finally {
+    Object.defineProperty(globalThis, 'window', {
+      value: previousWindow,
+      configurable: true,
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Parte client-side das issues #1297 e #1302, desbloqueadas pela aprovação da conta Stripe (calendário do Cal.com já aceita pagamentos reais).
- **#1302**: assina o evento `bookingSuccessfulV2` do embed (`lib/cal-embed.ts`) e empurra `consultoria_booking_created` + `form_submission` no `dataLayer` — marca "reserva criada", não pagamento (o embed não emite evento de pagamento; o `Purchase` com valor fica para o server-side via webhook `BOOKING_PAID`). `event_id` = `uid` do booking sem transformação, para casar com o dedup do lado server quando a #1297 ligar o webhook ao `purchase-dispatch`.
- **#1297**: pesquisei a documentação oficial do Cal.com para resolver o bloqueio registrado na issue. Descoberta: `forwardQueryParams` (já ligado no projeto) **não** propaga UTM/click IDs — ele só pré-preenche campos nomeados do formulário (nome, e-mail). O mecanismo correto é `"metadata[chave]": "valor"` no `config` do embed, que o Cal.com grava na coluna `metadata` do booking e replica em `payload.metadata` nos webhooks. Implementado `buildAttributionMetadataConfig()`, que usa `getTrackingDataObject()` (`utils/whatsapp.ts`, já usado no resto do projeto) para injetar UTMs/gclid/fbclid/GA4 cid-sid no `openConsultoriaBooking()`.
- Corrigido um comentário existente em `ensureInitialized` que descrevia incorretamente o que o `forwardQueryParams` fazia.

## Fora de escopo (segue pendente)
- Confirmação empírica de que o `metadata` sobrevive até o webhook `BOOKING_PAID` real (a doc não tem exemplo explícito disso) — só verificável com uma reserva paga de teste.
- Mapear os novos campos no `purchase-dispatch` do lado server (#1297 continua aberta para isso).
- Tag no GTM mapeando o evento pro standard do Meta (config externa ao repo, fora do código).

## Test plan
- [x] `pnpm typecheck`
- [x] `tsx --test tests/cal-embed.test.ts` (4 testes novos)
- [x] `pnpm test:regression` (988/988)
- [x] `pnpm lint:changed` / eslint nos arquivos tocados

🤖 Generated with [Claude Code](https://claude.com/claude-code)