### PR TITLE
fix: dispara CI em PRs contra qualquer base, não só main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,12 @@ permissions:
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  # Sem filtro de `branches`: dispara em PRs contra qualquer base, não só `main`.
+  # Necessário para stacked PRs (gh-stack) — uma PR de camada superior tem como
+  # base a branch de baixo, não `main`, e o filtro anterior deixava essas PRs
+  # sem o check `Build / Test` (obrigatório no branch protection), presas sem
+  # conseguir satisfazer o required check.
+  pull_request: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Resumo
- Remove o filtro `branches: [main]` do trigger `pull_request` em `.github/workflows/ci.yml`, mantendo o `push` restrito a `main`.
- Pré-requisito para usar `gh-stack` neste repo: numa stack, a PR de uma camada superior tem como base a branch de baixo (não `main`), e o filtro anterior deixava essas PRs sem o check `Build / Test` — obrigatório no branch protection — travadas sem conseguir satisfazer o required check.

## Test plan
- [ ] Confirmar que o job `Build / Test` dispara e passa nesta própria PR (base = `main`, então já era coberto antes — validação de que nada quebrou)
- [ ] Depois do merge, validar numa PR real de stack (base ≠ `main`) que o check dispara