### PR TITLE
hopi hari hub

### DIFF
--- a/components/parques-brasil/constants.ts
+++ b/components/parques-brasil/constants.ts
@@ -62,6 +62,7 @@ export const PARKS: Park[] = [
       'Adolescente, adulto e criança grande que já encara brinquedo radical. Para quem tem filho pequeno, rende menos que os outros daqui.',
     days: '1 dia resolve',
     when: 'Dia de semana fora de férias escolares. A diferença de fila é grande.',
+    href: '/hopi-hari',
   },
   {
     slug: 'thermas-dos-laranjais',

--- a/lib/site-routes.js
+++ b/lib/site-routes.js
@@ -30,6 +30,12 @@ export const STATIC_SITEMAP_ENTRIES = [
     ]
   },
   {
+    route: '/hopi-hari',
+    lastmod: '2026-08-02',
+    changefreq: 'monthly',
+    priority: '0.9'
+  },
+  {
     route: '/lollapalooza',
     lastmod: '2026-05-24',
     changefreq: 'monthly',

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -26,6 +26,12 @@
     </image:image>
   </url>
   <url>
+    <loc>https://www.anhanga.tur.br/hopi-hari/</loc>
+    <lastmod>2026-08-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://www.anhanga.tur.br/lollapalooza/</loc>
     <lastmod>2026-05-24</lastmod>
     <changefreq>monthly</changefreq>

--- a/tests/parques-brasil-hub.test.ts
+++ b/tests/parques-brasil-hub.test.ts
@@ -91,6 +91,23 @@ test('a filha declara o hub como pai no breadcrumb', async () => {
   );
 });
 
+test('hopi-hari declara o hub como pai no breadcrumb', async () => {
+  const hopiHari = await readRepoFile('pages/landings/HopiHariLanding.tsx');
+
+  assert.match(
+    hopiHari,
+    /name: 'Parques no Brasil',\s*item: 'https:\/\/www\.anhanga\.tur\.br\/parques-brasil\/'/,
+    'HopiHariLanding deve listar o hub como item do BreadcrumbSchema',
+  );
+
+  const hubPosition = hopiHari.indexOf("name: 'Parques no Brasil'");
+  const childPosition = hopiHari.indexOf("name: 'Pacote Hopi Hari'");
+  assert.ok(
+    hubPosition > 0 && hubPosition < childPosition,
+    'o hub precisa vir antes da própria página na ordem do breadcrumb',
+  );
+});
+
 test('o FAQ não promete credenciamento nos parques aquáticos', () => {
   const waterParkNames = PARKS.filter((park) => park.kind === 'Parque aquático').map(
     (park) => park.name,


### PR DESCRIPTION
## Resumo
Camada 2/2 da stack para a issue #1332 (base: #1371). Liga a landing `/hopi-hari` ao hub:
- `href: '/hopi-hari'` em `components/parques-brasil/constants.ts` — o card do hub passa a linkar sozinho.
- Entrada em `STATIC_SITEMAP_ENTRIES` (`lib/site-routes.js`) — registra sitemap **e** prerender de uma vez. Sem `images:` (nenhum asset de Hopi Hari existe hoje, mesmo padrão de `/consultoria-de-viagem`, `/cruzeiros` e `/corporativo`).
- Estende o teste de paridade de breadcrumb (`tests/parques-brasil-hub.test.ts`) para a nova filha do hub.
- `public/sitemap.xml` regenerado.

Closes #1332

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint:changed`
- [x] `pnpm test:regression` (989 passando, +1 do teste de breadcrumb do Hopi Hari)
- [x] `pnpm test:size`
- [x] `pnpm build` + verificação manual do HTML prerenderizado: `grep` em `dist/hopi-hari/index.html` confirma "Pacote Hopi Hari", "Vinhedo", "Rodovia Bandeirantes", `BreadcrumbList` e `FAQPage` presentes no SSR (evita a regressão de conteúdo invisível das issues #1248–#1251)
- [x] `dist/parques-brasil/index.html` confirmado linkando `href="/hopi-hari"`