### PR TITLE
Landing /cruzeiros: atualiza copy para temporada 2026/2027

### DIFF
--- a/components/landings/cruzeiros/CruzeirosLandingSections.tsx
+++ b/components/landings/cruzeiros/CruzeirosLandingSections.tsx
@@ -100,7 +100,7 @@ export function CruiseHero(): React.ReactElement {
           custom={0}
           className="text-sm font-semibold text-anhanga-blue mb-4 tracking-wide uppercase"
         >
-          Cruzeiros · Brasil e internacionais
+          Cruzeiros · Temporada 2026/2027
         </m.p>
         <m.h1
           variants={fadeUp}
@@ -163,7 +163,7 @@ export function CruiseOffersSection({
           className="mb-10"
         >
           <h2 id="ofertas-titulo" className="text-3xl md:text-4xl font-black text-anhanga-dark mb-3">
-            Seleção da temporada
+            Seleção da temporada 2026/2027
           </h2>
           <p className="text-zinc-600 text-lg max-w-2xl">
             Poucas saídas, escolhidas a dedo. Cada uma vem com o porquê de estar aqui — e um especialista para fechar a sua.

--- a/pages/landings/CruzeirosLanding.tsx
+++ b/pages/landings/CruzeirosLanding.tsx
@@ -49,7 +49,7 @@ const FAQ_ITEMS = [
   },
   {
     question: 'Quando começa a temporada de cruzeiros 2026/2027 no Brasil?',
-    answer: 'A temporada brasileira 2026/2027 vai de dezembro de 2026 a abril de 2027, com os navios baseados em Santos e no Rio de Janeiro antes de voltar para o Hemisfério Norte. Reservar cedo garante mais opções de cabine nessas saídas.'
+    answer: 'As saídas da temporada brasileira 2026/2027 vão de janeiro a março de 2027, embarcando em Santos. As datas mudam conforme os armadores confirmam a programação. Veja a seleção acima ou fale com um especialista para as saídas mais recentes.'
   }
 ];
 

--- a/pages/landings/CruzeirosLanding.tsx
+++ b/pages/landings/CruzeirosLanding.tsx
@@ -33,7 +33,7 @@ const FAQ_ITEMS = [
   },
   {
     question: 'Vocês trabalham só com saídas do Brasil?',
-    answer: 'Não. Temos cruzeiros saindo de Santos e do Rio de Janeiro na temporada brasileira, e também roteiros internacionais — Mediterrâneo, Caribe e outros. A seleção acima muda conforme a temporada e a disponibilidade dos armadores.'
+    answer: 'Não. Temos cruzeiros saindo de Santos e do Rio de Janeiro na temporada brasileira 2026/2027, e também roteiros internacionais — Mediterrâneo, Caribe e outros. A seleção acima muda conforme a temporada e a disponibilidade dos armadores.'
   },
   {
     question: 'Cabine interna ou com varanda?',
@@ -46,6 +46,10 @@ const FAQ_ITEMS = [
   {
     question: 'As ofertas do site têm preço fechado?',
     answer: 'As ofertas mostram navio, roteiro, porto de saída e período — o valor depende de cabine, número de passageiros e extras, e a gente fecha isso na conversa, sem taxa de curadoria.'
+  },
+  {
+    question: 'Quando começa a temporada de cruzeiros 2026/2027 no Brasil?',
+    answer: 'A temporada brasileira 2026/2027 vai de dezembro de 2026 a abril de 2027, com os navios baseados em Santos e no Rio de Janeiro antes de voltar para o Hemisfério Norte. Reservar cedo garante mais opções de cabine nessas saídas.'
   }
 ];
 
@@ -65,14 +69,14 @@ const CruzeirosLanding: React.FC = () => {
       <MotionConfig reducedMotion="user">
         <div data-cruzeiros-landing className="bg-anhanga-light min-h-screen font-sans">
           <Seo
-            title="Cruzeiros — Ofertas e Curadoria | Anhangá Viagens"
-            description="Ofertas selecionadas de cruzeiros no Brasil e internacionais, com curadoria consultiva para escolher navio, cabine e roteiro certos antes de fechar."
+            title="Cruzeiros Temporada 2026/2027 | Anhangá Viagens"
+            description="Ofertas de cruzeiros da temporada 2026/2027, saídas do Brasil e roteiros internacionais, com curadoria para acertar navio, cabine e data antes de fechar."
             canonical="https://www.anhanga.tur.br/cruzeiros/"
             noHreflang
           />
           <ServiceSchema
             name="Cruzeiros — Ofertas e Curadoria"
-            description="Seleção de cruzeiros no Brasil e internacionais com atendimento consultivo para escolher navio, cabine, roteiro e datas ideais. Para casais, famílias e primeira viagem."
+            description="Seleção de cruzeiros da temporada 2026/2027 no Brasil e internacionais, com atendimento consultivo para escolher navio, cabine, roteiro e datas ideais. Para casais, famílias e primeira viagem."
             serviceUrl="https://www.anhanga.tur.br/cruzeiros/"
             serviceType="Cruzeiros"
             areaServed="Brasil"


### PR DESCRIPTION
## Resumo
Pendência do Odoo (project.task, venceu 31/07): "Atualizar post Cruzeiros existente — adicionar temporada 2026/2027". Investigação mostrou que não é um post de blog — é a landing `/cruzeiros`. As ofertas em `data/cruiseOffers.ts` já são saídas Jan–Mai/2027, mas nenhum texto visível ou meta mencionava a temporada, o que reduz a chance de citação em buscadores de IA para buscas sazonais.

- Eyebrow do hero e H2 da seção de ofertas (`#ofertas-titulo`) passam a citar "Temporada 2026/2027"
- SEO title (47c) e description (153c) atualizados, dentro do limite de truncamento do SERP usado no resto do site (~60c/~160c, ver `tests/seo-title-length.test.ts`)
- `ServiceSchema` description alinhada ao mesmo texto
- FAQ #2 especifica "temporada brasileira 2026/2027" — não generaliza pra internacional, já que as ofertas incluem Mediterrâneo (mai/2027) e Caribe (abr/2027), que não seguem o calendário brasileiro
- Novo item de FAQ ("Quando começa a temporada de cruzeiros 2026/2027 no Brasil?") — formato Q&A com maior chance de citação em ChatGPT/Perplexity

Revisado e ajustado com o Redator SEO/GEO no canal `conteudo-social`, aprovado por Felipe.

## Test plan
- [x] `pnpm test:regression` — 989/989 passando
- [x] `pnpm typecheck` — sem erros
- [x] `eslint` nos dois arquivos alterados — limpo
- [x] Conferido manualmente: título 47c, descrição 153c (dentro do limite de truncamento do SERP)