### PR TITLE
fix: corrige menção ao Grand Tour Itália no post de terceira idade

### DIFF
--- a/content/blog/turismo-terceira-idade-guia-completo.mdx
+++ b/content/blog/turismo-terceira-idade-guia-completo.mdx
@@ -38,7 +38,7 @@ E tem documentação e seguro, que a gente detalha melhor na seção de seguran�
 
 Essa é a primeira bifurcação real do planejamento. Não existe resposta certa, existe a que combina com quem vai viajar.
 
-A Anhangá é parceira revendedora da Pastore Turismo, a maior empresa do Brasil especializada em viagens em grupo para o público 50+: mais de 33 anos de mercado, cerca de 40 mil viajantes atendidos, guias em português do início ao fim, hospedagem em hotéis de 4 e 5 estrelas. O modelo é roteiro e datas fixas, com todo mundo do grupo seguindo o mesmo programa. Um dos Grand Tours pela Itália que a Pastore já operou dá uma boa ideia do nível de curadoria envolvido, ainda que o catálogo de destinos mude por temporada.
+A Anhangá é parceira revendedora da Pastore Turismo, a maior empresa do Brasil especializada em viagens em grupo para o público 50+: mais de 33 anos de mercado, cerca de 40 mil viajantes atendidos, guias em português do início ao fim, hospedagem em hotéis de 4 e 5 estrelas. O modelo é roteiro e datas fixas, com todo mundo do grupo seguindo o mesmo programa. O Grand Tour Itália, um dos roteiros do catálogo atual, dá uma boa ideia do nível de curadoria envolvido, ainda que os destinos disponíveis mudem por temporada.
 
 Esse formato funciona bem para quem quer companhia garantida e zero decisão operacional durante a viagem. Costuma ser também a opção mais indicada para quem está retomando viagens depois de muito tempo parado, ou depois de perder o parceiro de viagem de sempre.
 


### PR DESCRIPTION
## Summary
- O catálogo 2026/2027 da Pastore (conferido em 03/08/2026) mostra o Grand Tour Itália como lançamento futuro (04/10–17/10/2026), não um roteiro já operado como o texto do post afirmava.
- Ajusta a frase em `turismo-terceira-idade-guia-completo.mdx` (agendado para publicar 2026-08-04) para referenciar o roteiro como parte do catálogo atual, sem a afirmação factualmente incorreta.
- Marca a pendência de frescor correspondente como resolvida em `docs/seo/melhor-idade-content-cluster.md` (não versionado — `docs/seo/` é gitignored).

## Test plan
- [x] Mudança apenas de conteúdo (.mdx), sem alteração de comportamento — sem testes automatizados necessários

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbasjcXjLRVc6coqtBjtm4