### PR TITLE
feat(hero): add AI research assistant links

### DIFF
--- a/components/AIResearchBar.tsx
+++ b/components/AIResearchBar.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+
+type AIAssistant = {
+  id: 'chatgpt' | 'gemini' | 'claude' | 'perplexity' | 'grok';
+  name: string;
+  logoUrl: string;
+  baseUrl: string;
+  queryParameter?: string;
+};
+
+const RESEARCH_PROMPT =
+  'O que você sabe sobre a Anhangá Viagens? Consulte o site oficial https://www.anhanga.tur.br/ e explique por que ela pode ser uma boa opção para planejar uma viagem personalizada.';
+
+const AI_ASSISTANTS: readonly AIAssistant[] = [
+  {
+    id: 'chatgpt',
+    name: 'ChatGPT',
+    logoUrl: 'https://api.iconify.design/logos:openai-icon.svg',
+    baseUrl: 'https://chatgpt.com/',
+    queryParameter: 'q',
+  },
+  {
+    id: 'gemini',
+    name: 'Gemini',
+    logoUrl: 'https://api.iconify.design/simple-icons:googlegemini.svg',
+    baseUrl: 'https://www.google.com/search?udm=50&source=searchlabs',
+    queryParameter: 'q',
+  },
+  {
+    id: 'claude',
+    name: 'Claude',
+    logoUrl: 'https://api.iconify.design/simple-icons:claude.svg',
+    baseUrl: 'https://claude.ai/new',
+    queryParameter: 'q',
+  },
+  {
+    id: 'perplexity',
+    name: 'Perplexity',
+    logoUrl: 'https://api.iconify.design/simple-icons:perplexity.svg',
+    baseUrl: 'https://www.perplexity.ai/search/new',
+    queryParameter: 'q',
+  },
+  {
+    id: 'grok',
+    name: 'Grok',
+    logoUrl: 'https://api.iconify.design/logos:grok-icon.svg',
+    baseUrl: 'https://grok.com/',
+    queryParameter: 'q',
+  },
+];
+
+const getResearchUrl = ({ baseUrl, queryParameter }: AIAssistant) => {
+  if (!queryParameter) return baseUrl;
+
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}${queryParameter}=${encodeURIComponent(RESEARCH_PROMPT)}`;
+};
+
+const AIResearchBar: React.FC = () => {
+  return (
+    <div
+      role="group"
+      aria-label="Pesquisar sobre a Anhangá com uma IA"
+      className="mt-8 w-full max-w-3xl"
+    >
+      <p className="mb-3 text-sm font-medium text-white/75">
+        Quer pesquisar antes de conversar? Pergunte sobre a Anhangá:
+      </p>
+
+      <div className="flex flex-wrap justify-center gap-3">
+        {AI_ASSISTANTS.map((assistant) => (
+          <a
+            key={assistant.name}
+            href={getResearchUrl(assistant)}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={assistant.name}
+            aria-label={`Perguntar no ${assistant.name} sobre a Anhangá`}
+            className="inline-flex size-12 items-center justify-center rounded-full border border-white/30 bg-white/95 p-2.5 shadow-lg shadow-black/10 transition hover:scale-110 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-yellow"
+          >
+            <img
+              src={assistant.logoUrl}
+              alt={assistant.name}
+              width="24"
+              height="24"
+              loading="lazy"
+              decoding="async"
+              className="size-6 object-contain"
+            />
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AIResearchBar;

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useRef, useEffect, useMemo, memo } from 'react';
 import { m } from 'framer-motion';
 import { HERO_VIDEOS, optimizeRemoteImageUrl } from '../data/mediaConfig';
-import { QUICK_FEATURES } from '../data/destinations';
 import { NOISE_TEXTURE_URL } from '../lib/static-assets';
 import SearchForm from './SearchForm';
 import MobileHeroForm from './MobileHeroForm';
+import AIResearchBar from './AIResearchBar';
 
 const noiseTextureStyle = {
   backgroundImage: `url("${NOISE_TEXTURE_URL}")`,
@@ -197,28 +197,7 @@ const Hero: React.FC = memo(() => {
             Sem compromisso • Retorno humano em até 2h úteis
           </p>
 
-          {/* Quick Features - Staggered Spring */}
-          <m.div
-            className="mt-10 flex flex-wrap justify-center gap-6"
-            initial="hidden"
-            animate="visible"
-            variants={{ hidden: {}, visible: { transition: { staggerChildren: 0.1, delayChildren: 0.7 } } }}
-          >
-            {QUICK_FEATURES.map((feat) => (
-              <m.div
-                key={feat.text}
-                variants={{
-                  hidden: { opacity: 0, y: 16, scale: 0.9 },
-                  visible: { opacity: 1, y: 0, scale: 1, transition: { type: 'spring', stiffness: 400, damping: 20 } }
-                }}
-                className="flex items-center gap-2 text-white/90 font-bold text-sm bg-white/10 px-4 py-2 rounded-full backdrop-blur-md border border-white/10 hover:bg-white/20 transition duration-300 cursor-default"
-                whileHover={{ scale: 1.05, transition: { type: 'spring', stiffness: 400, damping: 15 } }}
-              >
-                <feat.icon className="size-4 text-yellow-300" />
-                {feat.text}
-              </m.div>
-            ))}
-          </m.div>
+          <AIResearchBar />
         </div>
       </div>
 

--- a/tests/e2e/hero_ux.spec.ts
+++ b/tests/e2e/hero_ux.spec.ts
@@ -85,4 +85,34 @@ test.describe('Hero UX and Accessibility', () => {
     await page.getByRole('button', { name: 'Férias / Lazer' }).click();
     await expect(tripTypeField).toContainText('Férias / Lazer');
   });
+
+  test('should offer five accessible AI research links below the hero form', async ({ page }) => {
+    const aiResearch = page.getByRole('group', { name: 'Pesquisar sobre a Anhangá com uma IA' });
+    await expect(aiResearch).toBeVisible();
+
+    for (const assistant of ['ChatGPT', 'Gemini', 'Claude', 'Perplexity', 'Grok']) {
+      const link = aiResearch.getByRole('link', { name: new RegExp(`Perguntar no ${assistant}`) });
+      await expect(link).toBeVisible();
+      await expect(link.locator('img')).toHaveAttribute('alt', assistant);
+      await expect(link.locator('img')).toHaveAttribute('src', /api\.iconify\.design/);
+      await expect(link).not.toContainText(assistant);
+      await expect(link).toHaveAttribute('target', '_blank');
+      await expect(link).toHaveAttribute('rel', /noopener/);
+      if (assistant === 'Gemini') {
+        const href = await link.getAttribute('href');
+        expect(href).toBeTruthy();
+
+        const geminiUrl = new URL(href!);
+        expect(geminiUrl.origin).toBe('https://www.google.com');
+        expect(geminiUrl.pathname).toBe('/search');
+        expect(geminiUrl.searchParams.get('udm')).toBe('50');
+        expect(geminiUrl.searchParams.get('source')).toBe('searchlabs');
+        expect(geminiUrl.searchParams.get('q')).toContain(
+          'O que você sabe sobre a Anhangá Viagens?',
+        );
+      } else {
+        await expect(link).toHaveAttribute('href', /%C3%81nhang%C3%A1|Anhang%C3%A1/);
+      }
+    }
+  });
 });

--- a/tests/hero-ai-research.test.ts
+++ b/tests/hero-ai-research.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const readHero = () => readFile(new URL('../components/Hero.tsx', import.meta.url), 'utf8');
+
+test('Hero replaces generic quick features with the AI research bar', async () => {
+  const source = await readHero();
+
+  assert.match(source, /import AIResearchBar from ['"]\.\/AIResearchBar['"]/);
+  assert.match(source, /<AIResearchBar\s*\/>/);
+  assert.doesNotMatch(source, /QUICK_FEATURES/);
+});


### PR DESCRIPTION
## O que mudou

- substitui os três badges genéricos do hero por uma barra de pesquisa em IAs;
- adiciona links para ChatGPT, Gemini, Claude, Perplexity e Grok;
- exibe apenas os logos, mantendo o nome no `alt`, `aria-label` e tooltip;
- abre cada provedor com um prompt sobre a Anhangá;
- usa o Google AI Mode para o Gemini com `udm=50`, `source=searchlabs` e o prompt em `q`;
- adiciona cobertura E2E e um teste de contrato para a integração no hero.

## Validação

- `pnpm exec playwright test tests/e2e/hero_ux.spec.ts -g "five accessible AI research links" --project=chromium`
- `pnpm typecheck`
- ESLint nos arquivos alterados
- `pnpm exec tsx --test tests/hero-ai-research.test.ts`
- `pnpm run build`
- `git diff --check`

O React Doctor não concluiu nesta rodada porque o processo ficou sem saída; a execução anterior da mesma alteração havia retornado 100/100.

## Observação

O rastreamento dos cliques será tratado separadamente na issue #1405, sem incluir o prompt completo no analytics.