### PR TITLE
chore(ci): allowlist react-router RSC CSRF advisory in dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,3 +24,8 @@ jobs:
           # quiser um gate mais rígido).
           fail-on-severity: high
           comment-summary-in-pr: on-failure
+          # GHSA-qwww-vcr4-c8h2: CSRF em modo RSC do react-router (>= 7.12.0, < 8.3.0).
+          # Só afeta apps usando as APIs instáveis de React Server Components — este
+          # projeto é Vite/React 19 client-side puro, sem RSC. O patch real exige
+          # bump major (7.x -> 8.x, breaking). Reavaliar ao migrar para react-router 8.
+          allow-ghsas: GHSA-qwww-vcr4-c8h2


### PR DESCRIPTION
## Summary
- The Dependency Review gate blocks #1398 (Dependabot bump react-router-dom 7.18.1 → 7.18.2) because 7.18.2 falls in the vulnerable range of [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) (CSRF bypass in react-router's unstable RSC mode).
- The advisory explicitly only affects apps using react-router's unstable RSC APIs. This repo is a client-side Vite + React 19 SPA — no RSC usage anywhere.
- The vulnerable range is `>= 7.12.0, < 8.3.0`; the fix only lands in 8.3.0 (a major version, out of scope for a patch bump). The currently deployed 7.18.1 is already in the same vulnerable range, so this PR does not introduce new exposure — it just lets the (theoretical, N/A-to-us) advisory stop blocking routine patch updates.
- Adds `allow-ghsas: GHSA-qwww-vcr4-c8h2` with an inline comment explaining the reasoning, so it's easy to revisit when the project eventually migrates to react-router 8.

## Test plan
- [x] `.github/workflows/dependency-review.yml` change only — no app code touched
- [ ] CI green on this PR
- [ ] Confirms #1398's Dependency Review check passes after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)