### PR TITLE
chore(deps): bump undici override to 7.29.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   protobufjs: '>=7.6.3 <8'
   esbuild: ^0.28.1
   ws: ^8.21.0
-  undici: ^7.28.0
+  undici: ^7.29.0
   js-yaml@3: ^3.15.0
   '@ungap/structured-clone@1': ^1.3.2
   sharp: ^0.35.3
@@ -5506,10 +5506,6 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
@@ -7118,7 +7114,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.8(@typescript/typescript6@6.0.2)
       tinyglobby: 0.2.17
-      undici: 7.28.0
+      undici: 7.29.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - kerberos
@@ -11632,8 +11628,6 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@8.3.0: {}
-
-  undici@7.28.0: {}
 
   undici@7.29.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,8 +25,11 @@ overrides:
   # GHSA-35p6-xmwp-9g52, GHSA-g8m3-5g58-fq7m — undici 7.x < 7.28.0
   # (bypass de validação TLS, DoS WebSocket, vazamento entre origens,
   # injeção de header/cookie). Transitivo via wrangler > miniflare.
-  # 7.28.0 corrige; pinado em ^7.28.0 (mesma major).
-  undici: "^7.28.0"
+  # Dependabot #53-57 (high/moderate): mesma árvore, novos GHSAs em cache
+  # HTTP (desync de resposta, injeção de header/cookie via Cache-Control e
+  # setCookie, CRLF via body 'type'). undici@7.29.0 (publicado 2026-07-24,
+  # cooldown vencido em 2026-07-31) corrige; pinado em ^7.29.0.
+  undici: "^7.29.0"
   # Dependabot #45 (moderate): GHSA-h67p-54hq-rp68 — DoS quadrático em merge
   # keys do js-yaml via aliases repetidos. Transitivo build/dev-time via
   # gray-matter (scripts/blog-manifest) e bundlesize2 > cosmiconfig@5 — ambos


### PR DESCRIPTION
## Summary
- Dependabot flagged 5 new advisories (#53–57) on the `undici` 7.x tree already pinned in `pnpm-workspace.yaml`: response desync via retry interceptor, header/cookie injection via `Cache-Control`/`setCookie`, and CRLF via a blob body's `type` property.
- `undici` here is transitive dev-only (`wrangler` → `miniflare`, local dev runtime — never ships to production).
- 7.29.0 clears the repo's `minimumReleaseAge` cooldown (published 2026-07-24, cutoff 2026-07-31); bumped the pin from `^7.28.0` to `^7.29.0`.
- Left 3 other open dev-only alerts (`js-yaml@3.15.1`, `js-yaml@4.3.1`, `fast-uri@3.1.5`) out of this PR — their patched versions were published 2026-07-31 and are still inside the 7-day cooldown as of this PR. Follow-up once they clear it (later today/tomorrow).

## Test plan
- [x] `pnpm test:regression` — 1002/1002 passing
- [x] `pnpm why undici` confirms a single deduped `undici@7.29.0` in the tree
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)