### PR TITLE
fix(security): harden tracking_data cookie attributes

### DIFF
--- a/tests/lead-whatsapp.test.ts
+++ b/tests/lead-whatsapp.test.ts
@@ -158,6 +158,92 @@ test('getTrackingDataObject should capture referral ref from URL params', () => 
     restoreBrowserGlobals();
 });
 
+test('getTrackingDataObject should mark tracking_data Secure on HTTPS and SameSite=Lax', () => {
+    const cookieWrites: string[] = [];
+    const mockWindow: MockWindow & { location: { protocol: string } } = {
+        location: {
+            protocol: 'https:',
+            search: '?utm_source=security-test',
+            hash: '',
+            href: 'https://www.anhanga.tur.br/?utm_source=security-test',
+        },
+        dataLayer: [],
+    };
+
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: mockWindow,
+    });
+    Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        value: {
+            readyState: 'complete',
+            get cookie() {
+                return '';
+            },
+            set cookie(value: string) {
+                cookieWrites.push(value);
+            },
+        },
+    });
+    Object.defineProperty(globalThis, 'sessionStorage', {
+        configurable: true,
+        value: createSessionStorage(),
+    });
+
+    getTrackingDataObject();
+
+    const trackingCookie = cookieWrites.find((value) => value.startsWith('tracking_data='));
+    assert.ok(trackingCookie, 'tracking_data should be persisted as a cookie');
+    assert.match(trackingCookie, /;SameSite=Lax(?:;|$)/);
+    assert.match(trackingCookie, /;Secure(?:;|$)/);
+
+    restoreBrowserGlobals();
+});
+
+test('getTrackingDataObject should omit Secure for local HTTP while retaining SameSite=Lax', () => {
+    const cookieWrites: string[] = [];
+    const mockWindow: MockWindow & { location: { protocol: string } } = {
+        location: {
+            protocol: 'http:',
+            search: '?utm_source=local-test',
+            hash: '',
+            href: 'http://localhost:4175/?utm_source=local-test',
+        },
+        dataLayer: [],
+    };
+
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: mockWindow,
+    });
+    Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        value: {
+            readyState: 'complete',
+            get cookie() {
+                return '';
+            },
+            set cookie(value: string) {
+                cookieWrites.push(value);
+            },
+        },
+    });
+    Object.defineProperty(globalThis, 'sessionStorage', {
+        configurable: true,
+        value: createSessionStorage(),
+    });
+
+    getTrackingDataObject();
+
+    const trackingCookie = cookieWrites.find((value) => value.startsWith('tracking_data='));
+    assert.ok(trackingCookie, 'tracking_data should be persisted as a cookie');
+    assert.match(trackingCookie, /;SameSite=Lax(?:;|$)/);
+    assert.doesNotMatch(trackingCookie, /;Secure(?:;|$)/);
+
+    restoreBrowserGlobals();
+});
+
 test('pushGenerateLeadDataLayerEvent should use provided formType for form_submission event', () => {
     const mockWindow: MockWindow = {
         location: {

--- a/utils/whatsapp.ts
+++ b/utils/whatsapp.ts
@@ -36,7 +36,8 @@ const setCookie = (name: string, value: string, days: number) => {
     const date = new Date();
     date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
     const expires = `expires=${date.toUTCString()}`;
-    document.cookie = `${name}=${encodeURIComponent(value)};${expires};path=/`;
+    const secure = typeof window !== 'undefined' && window.location.protocol === 'https:' ? ';Secure' : '';
+    document.cookie = `${name}=${encodeURIComponent(value)};${expires};Path=/;SameSite=Lax${secure}`;
 };
 
 const getCookie = (name: string): string | null => {


### PR DESCRIPTION
## O que mudou

- adiciona `SameSite=Lax` ao cookie próprio `tracking_data`;
- adiciona `Secure` somente quando o site está em HTTPS;
- mantém o comportamento compatível com o ambiente local HTTP;
- adiciona testes cobrindo HTTPS e HTTP local.

## Por que

O relatório Behavior do Cloudflare Radar mostrou que `tracking_data` era criado sem `Secure` e sem `SameSite`. Como o frontend precisa ler esse cookie para atribuição de leads, `HttpOnly` não é aplicável nesta implementação.

## Validação

- `pnpm exec tsx --test tests/lead-whatsapp.test.ts` — 10 passaram;
- `pnpm test:regression` — 1004 passaram, 0 falharam;
- `pnpm exec tsc --noEmit`;
- ESLint focado;
- `git diff --check`.

A CSP permanece fora deste PR porque exige inventário completo das origens e uma etapa de validação separada.