### PR TITLE
feat(agent-readiness): negotiate Markdown responses

### DIFF
--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -1,0 +1,47 @@
+import markdownHandler from '../api/markdown';
+import {
+  isUnsupportedDiscoveryPath,
+  normalizeAgentPath,
+  requestsMarkdown,
+} from '../lib/agent-readiness';
+
+interface PagesContext {
+  request: Request;
+  next: () => Promise<Response>;
+}
+
+function notFoundResponse(): Response {
+  return new Response('Not Found\n', {
+    status: 404,
+    headers: {
+      'Cache-Control': 'public, max-age=300',
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+}
+
+async function markdownResponseFor(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const markdownUrl = new URL('/api/markdown', url.origin);
+  markdownUrl.searchParams.set('path', normalizeAgentPath(url.pathname));
+
+  return markdownHandler(new Request(markdownUrl, {
+    method: 'GET',
+    headers: request.headers,
+  }));
+}
+
+export const onRequest = async ({ request, next }: PagesContext): Promise<Response> => {
+  const pathname = new URL(request.url).pathname;
+
+  if (isUnsupportedDiscoveryPath(pathname)) {
+    return notFoundResponse();
+  }
+
+  if (request.method !== 'GET' || !requestsMarkdown(request.headers.get('Accept'))) {
+    return next();
+  }
+
+  return markdownResponseFor(request);
+};

--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -8,6 +8,7 @@ import {
 interface PagesContext {
   request: Request;
   next: () => Promise<Response>;
+  env: Record<string, string>;
 }
 
 function notFoundResponse(): Response {
@@ -32,7 +33,8 @@ async function markdownResponseFor(request: Request): Promise<Response> {
   }));
 }
 
-export const onRequest = async ({ request, next }: PagesContext): Promise<Response> => {
+export const onRequest = async ({ request, next, env }: PagesContext): Promise<Response> => {
+  Object.assign(process.env, env);
   const pathname = new URL(request.url).pathname;
 
   if (isUnsupportedDiscoveryPath(pathname)) {

--- a/lib/agent-readiness.ts
+++ b/lib/agent-readiness.ts
@@ -1,0 +1,33 @@
+const SUPPORTED_DISCOVERY_PATHS = new Set([
+    '/.well-known/api-catalog',
+    '/.well-known/api-docs',
+    '/.well-known/http-message-signatures-directory',
+    '/.well-known/openapi.json',
+    '/.well-known/security.txt',
+]);
+
+export function normalizeAgentPath(pathname: string): string {
+    const withLeadingSlash = pathname.startsWith('/') ? pathname : `/${pathname}`;
+    return withLeadingSlash.replace(/\/+$/, '') || '/';
+}
+
+export function requestsMarkdown(accept: string | null): boolean {
+    if (!accept) return false;
+
+    return accept.split(',').some((entry) => {
+        const [mediaType, ...parameters] = entry.trim().toLowerCase().split(';');
+        if (mediaType !== 'text/markdown') return false;
+
+        const quality = parameters.find((parameter) => parameter.trim().startsWith('q='));
+        return !quality || Number(quality.trim().slice(2)) > 0;
+    });
+}
+
+export function isUnsupportedDiscoveryPath(pathname: string): boolean {
+    const path = normalizeAgentPath(pathname);
+
+    if (path === '/auth.md') return true;
+    if (!path.startsWith('/.well-known/')) return false;
+
+    return !SUPPORTED_DISCOVERY_PATHS.has(path);
+}

--- a/lib/agent-readiness.ts
+++ b/lib/agent-readiness.ts
@@ -26,6 +26,7 @@ export function requestsMarkdown(accept: string | null): boolean {
 export function isUnsupportedDiscoveryPath(pathname: string): boolean {
     const path = normalizeAgentPath(pathname);
 
+    // The Cloudflare Agent Readiness scan probes this unsupported discovery path.
     if (path === '/auth.md') return true;
     if (!path.startsWith('/.well-known/')) return false;
 

--- a/tests/agent-readiness.test.ts
+++ b/tests/agent-readiness.test.ts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    isUnsupportedDiscoveryPath,
+    normalizeAgentPath,
+    requestsMarkdown,
+} from '../lib/agent-readiness.ts';
+import { onRequest as agentReadinessMiddleware } from '../functions/[[path]].ts';
+
+test('requestsMarkdown recognizes explicit Markdown negotiation without hijacking normal browsers', () => {
+    assert.equal(requestsMarkdown('text/markdown'), true);
+    assert.equal(requestsMarkdown('text/html,application/xhtml+xml'), false);
+    assert.equal(requestsMarkdown('text/markdown;q=0'), false);
+    assert.equal(requestsMarkdown('*/*'), false);
+    assert.equal(requestsMarkdown(null), false);
+});
+
+test('normalizeAgentPath canonicalizes the route shape used by Markdown handlers', () => {
+    assert.equal(normalizeAgentPath('/'), '/');
+    assert.equal(normalizeAgentPath('/orlando/'), '/orlando');
+    assert.equal(normalizeAgentPath('blog/'), '/blog');
+    assert.equal(normalizeAgentPath(''), '/');
+});
+
+test('isUnsupportedDiscoveryPath keeps supported well-known resources available and rejects SPA fallbacks', () => {
+    assert.equal(isUnsupportedDiscoveryPath('/.well-known/api-catalog'), false);
+    assert.equal(isUnsupportedDiscoveryPath('/.well-known/security.txt'), false);
+    assert.equal(isUnsupportedDiscoveryPath('/.well-known/agent-card.json'), true);
+    assert.equal(isUnsupportedDiscoveryPath('/.well-known/mcp/server-card.json'), true);
+    assert.equal(isUnsupportedDiscoveryPath('/auth.md'), true);
+    assert.equal(isUnsupportedDiscoveryPath('/consultoria-de-viagem/'), false);
+});
+
+test('agent-readiness middleware serves the home page as Markdown when requested explicitly', async () => {
+    const response = await agentReadinessMiddleware({
+        request: new Request('https://www.anhanga.tur.br/', {
+            headers: { Accept: 'text/markdown' },
+        }),
+        next: async () => new Response('<html>fallback</html>', { status: 200 }),
+    });
+
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('Content-Type') ?? '', /^text\/markdown\b/);
+    assert.match(await response.text(), /^# Anhangá Viagens/);
+});
+
+test('agent-readiness middleware returns 404 for unsupported discovery documents instead of the SPA shell', async () => {
+    const response = await agentReadinessMiddleware({
+        request: new Request('https://www.anhanga.tur.br/.well-known/agent-card.json'),
+        next: async () => new Response('<html>fallback</html>', { status: 200 }),
+    });
+
+    assert.equal(response.status, 404);
+    assert.equal(response.headers.get('X-Robots-Tag'), 'noindex');
+    assert.equal(await response.text(), 'Not Found\n');
+});
+
+test('agent-readiness middleware preserves normal HTML requests', async () => {
+    const response = await agentReadinessMiddleware({
+        request: new Request('https://www.anhanga.tur.br/', {
+            headers: { Accept: 'text/html' },
+        }),
+        next: async () => new Response('<html>fallback</html>', { status: 200 }),
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), '<html>fallback</html>');
+});

--- a/tests/agent-readiness.test.ts
+++ b/tests/agent-readiness.test.ts
@@ -38,6 +38,7 @@ test('agent-readiness middleware serves the home page as Markdown when requested
             headers: { Accept: 'text/markdown' },
         }),
         next: async () => new Response('<html>fallback</html>', { status: 200 }),
+        env: {},
     });
 
     assert.equal(response.status, 200);
@@ -49,6 +50,7 @@ test('agent-readiness middleware returns 404 for unsupported discovery documents
     const response = await agentReadinessMiddleware({
         request: new Request('https://www.anhanga.tur.br/.well-known/agent-card.json'),
         next: async () => new Response('<html>fallback</html>', { status: 200 }),
+        env: {},
     });
 
     assert.equal(response.status, 404);
@@ -62,8 +64,34 @@ test('agent-readiness middleware preserves normal HTML requests', async () => {
             headers: { Accept: 'text/html' },
         }),
         next: async () => new Response('<html>fallback</html>', { status: 200 }),
+        env: {},
     });
 
     assert.equal(response.status, 200);
     assert.equal(await response.text(), '<html>fallback</html>');
+});
+
+test('agent-readiness middleware forwards Pages bindings before delegating to Markdown', async () => {
+    const previousValue = process.env.AGENT_READINESS_TEST_ENV;
+
+    try {
+        delete process.env.AGENT_READINESS_TEST_ENV;
+
+        const response = await agentReadinessMiddleware({
+            request: new Request('https://www.anhanga.tur.br/', {
+                headers: { Accept: 'text/markdown' },
+            }),
+            next: async () => new Response('<html>fallback</html>', { status: 200 }),
+            env: { AGENT_READINESS_TEST_ENV: 'forwarded' },
+        });
+
+        assert.equal(response.status, 200);
+        assert.equal(process.env.AGENT_READINESS_TEST_ENV, 'forwarded');
+    } finally {
+        if (previousValue === undefined) {
+            delete process.env.AGENT_READINESS_TEST_ENV;
+        } else {
+            process.env.AGENT_READINESS_TEST_ENV = previousValue;
+        }
+    }
 });


### PR DESCRIPTION
## O que mudou

- adiciona negociação explícita de conteúdo Markdown via `Accept: text/markdown`;
- reutiliza o handler Markdown existente na URL canônica, preservando `Vary: Accept`;
- mantém o comportamento HTML para navegadores comuns;
- retorna `404` com `X-Robots-Tag: noindex` para endpoints de descoberta não suportados, evitando fallback SPA com `200`;
- adiciona testes unitários e de middleware para esses cenários.

## Por que

O relatório do Cloudflare Agent Readiness classificou o site como **Bot-Aware**. O único requisito necessário para o próximo nível, **Agent-Readable**, era suportar Markdown para agentes.

A causa do falso positivo nos endpoints de descoberta era o fallback SPA responder HTML `200` para caminhos inexistentes. A correção deixa explícita a fronteira do que o site suporta sem implementar protocolos não necessários para este projeto.

## Validação

- `pnpm exec tsx --test tests/agent-readiness.test.ts`
- `pnpm test:regression` — 1.010 testes, 0 falhas
- `pnpm typecheck`
- `pnpm run build`
- `pnpm lint`
- verificação HTTP local com `Accept: text/markdown`, `Accept: text/html`, `/.well-known/security.txt` e endpoint de descoberta inexistente

Após o merge e deploy, o scan do Cloudflare deve ser executado novamente para confirmar a evolução do nível de agent-readiness.