### PR TITLE
🎨 Palette: associate corporate lead form errors with their inputs

### DIFF
--- a/components/landings/corporativo/CorpFormFields.tsx
+++ b/components/landings/corporativo/CorpFormFields.tsx
@@ -15,9 +15,9 @@ function fieldClass(hasError: boolean): string {
     return `${INPUT_CLASS} ${hasError ? 'border-red-400' : 'border-zinc-200'}`;
 }
 
-function FieldError({ show, message }: { show: boolean; message?: string }) {
+function FieldError({ id, show, message }: { id: string; show: boolean; message?: string }) {
     if (!show || !message) return null;
-    return <span className="mt-1 block text-xs font-semibold text-red-500" role="alert">{message}</span>;
+    return <span id={id} className="mt-1 block text-xs font-semibold text-red-500" role="alert">{message}</span>;
 }
 
 export function CorpFormFields({ form, onField, errorField, errorMessage }: CorpFormFieldsProps) {
@@ -39,9 +39,10 @@ export function CorpFormFields({ form, onField, errorField, errorMessage }: Corp
                         onChange={onField('firstName')}
                         required
                         aria-invalid={isError('firstName') || undefined}
+                        aria-describedby={isError('firstName') ? 'firstName-error' : undefined}
                         className={fieldClass(isError('firstName'))}
                     />
-                    <FieldError show={isError('firstName')} message={errorMessage} />
+                    <FieldError id="firstName-error" show={isError('firstName')} message={errorMessage} />
                 </div>
                 <div>
                     <label htmlFor="lastName" className="block text-xs font-bold text-zinc-500 uppercase tracking-wider mb-2">
@@ -56,9 +57,10 @@ export function CorpFormFields({ form, onField, errorField, errorMessage }: Corp
                         onChange={onField('lastName')}
                         required
                         aria-invalid={isError('lastName') || undefined}
+                        aria-describedby={isError('lastName') ? 'lastName-error' : undefined}
                         className={fieldClass(isError('lastName'))}
                     />
-                    <FieldError show={isError('lastName')} message={errorMessage} />
+                    <FieldError id="lastName-error" show={isError('lastName')} message={errorMessage} />
                 </div>
             </div>
 
@@ -75,9 +77,10 @@ export function CorpFormFields({ form, onField, errorField, errorMessage }: Corp
                     onChange={onField('email')}
                     required
                     aria-invalid={isError('email') || undefined}
+                    aria-describedby={isError('email') ? 'email-error' : undefined}
                     className={fieldClass(isError('email'))}
                 />
-                <FieldError show={isError('email')} message={errorMessage} />
+                <FieldError id="email-error" show={isError('email')} message={errorMessage} />
             </div>
 
             <div>
@@ -93,9 +96,10 @@ export function CorpFormFields({ form, onField, errorField, errorMessage }: Corp
                     onChange={onField('whatsapp')}
                     required
                     aria-invalid={isError('whatsapp') || undefined}
+                    aria-describedby={isError('whatsapp') ? 'whatsapp-error' : undefined}
                     className={fieldClass(isError('whatsapp'))}
                 />
-                <FieldError show={isError('whatsapp')} message={errorMessage} />
+                <FieldError id="whatsapp-error" show={isError('whatsapp')} message={errorMessage} />
             </div>
 
             <div className="grid grid-cols-2 gap-4">

--- a/tests/e2e/corporativo.spec.ts
+++ b/tests/e2e/corporativo.spec.ts
@@ -69,6 +69,10 @@ test.describe('Corporativo Landing Page', () => {
 
     await landing.expectError('Informe seu nome.');
     await expect(page.getByText('Aceite obrigatório')).toHaveCount(0);
+
+    // O erro precisa estar associado ao input via aria-describedby para leitores de tela.
+    await expect(landing.firstNameInput).toHaveAttribute('aria-describedby', 'firstName-error');
+    await expect(page.locator('#firstName-error')).toHaveText('Informe seu nome.');
   });
 
   test('should block submit when LGPD consent is not accepted', async ({ page }) => {


### PR DESCRIPTION
## 💡 What
`CorpFormFields` (the `/corporativo` B2B lead form) set `aria-invalid` on each input when validation failed, but never wired `aria-describedby` to the visible error message — the `FieldError` span had no `id` at all. Added an `id` per field (`firstName-error`, `lastName-error`, `email-error`, `whatsapp-error`) and pointed each input's `aria-describedby` at it, matching the existing pattern already used in `components/forms/FormField.tsx` and `components/chat-lead-form/TextField.tsx`.

## 🎯 Why
Screen reader users on the `/corporativo` landing page (a real lead-gen page) heard "invalid" with no explanation of *why* — the red error text was visible but not programmatically associated with the field. This is a genuine regression against the codebase's own established form-error pattern (WCAG 3.3.1 / 4.1.2).

## ♿ Accessibility
- Each required field's error message is now announced to screen readers via `aria-describedby` when validation fails.
- No visual change — same markup, same styling, same `role="alert"` behavior.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `eslint` on changed files passes clean
- [x] Extended `tests/e2e/corporativo.spec.ts`'s existing required-field validation test to assert `aria-describedby="firstName-error"` on the input and that `#firstName-error` renders the error text

---
_Generated by [Claude Code](https://claude.ai/code/session_015ncQWiSm5JhSFq8XUqbgUX)_