### PR TITLE
feat(schema): extract reusable ItemListSchema

### DIFF
--- a/components/schemas/ItemListSchema.tsx
+++ b/components/schemas/ItemListSchema.tsx
@@ -13,7 +13,7 @@ export interface ItemListSchemaItem {
 
 interface ItemListSchemaProps {
   items: ItemListSchemaItem[];
-  id?: string;
+  id: string;
   name?: string;
 }
 
@@ -28,7 +28,7 @@ const toAbsoluteUrl = (href: string): string => {
 
 export const ItemListSchema: React.FC<ItemListSchemaProps> = ({
   items,
-  id = 'item-list',
+  id,
   name = 'Destinos atendidos pela Anhangá Viagens',
 }) => {
   const schemaData: Record<string, unknown> = {

--- a/components/schemas/ItemListSchema.tsx
+++ b/components/schemas/ItemListSchema.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { StructuredData } from './StructuredData';
+
+const SITE_URL = 'https://www.anhanga.tur.br';
+
+export interface ItemListSchemaItem {
+  name: string;
+  description: string;
+  city: string;
+  state: string;
+  href?: string;
+}
+
+interface ItemListSchemaProps {
+  items: ItemListSchemaItem[];
+  id?: string;
+  name?: string;
+}
+
+const toAbsoluteUrl = (href: string): string => {
+  if (/^https?:\/\//.test(href)) {
+    return href;
+  }
+
+  const path = href.startsWith('/') ? href : `/${href}`;
+  return `${SITE_URL}${path.endsWith('/') ? path : `${path}/`}`;
+};
+
+export const ItemListSchema: React.FC<ItemListSchemaProps> = ({
+  items,
+  id = 'item-list',
+  name = 'Destinos atendidos pela Anhangá Viagens',
+}) => {
+  const schemaData: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name,
+    itemListOrder: 'https://schema.org/ItemListUnordered',
+    numberOfItems: items.length,
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      item: {
+        '@type': 'TouristAttraction',
+        name: item.name,
+        description: item.description,
+        address: {
+          '@type': 'PostalAddress',
+          addressLocality: item.city,
+          addressRegion: item.state,
+          addressCountry: 'BR',
+        },
+        ...(item.href ? { url: toAbsoluteUrl(item.href) } : {}),
+      },
+    })),
+  };
+
+  return <StructuredData id={id} data={schemaData} />;
+};

--- a/pages/ParquesBrasil.tsx
+++ b/pages/ParquesBrasil.tsx
@@ -3,7 +3,7 @@ import { Seo } from '../components/Seo';
 import { LandingFAQ } from '../components/LandingFAQ';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { FAQPageSchema } from '../components/schemas/FAQPageSchema';
-import { StructuredData } from '../components/schemas/StructuredData';
+import { ItemListSchema } from '../components/schemas/ItemListSchema';
 import {
   ComparisonSection,
   CredentialedSection,
@@ -20,35 +20,6 @@ const PAGE_URL = 'https://www.anhanga.tur.br/parques-brasil/';
 
 const WHATSAPP_MESSAGE =
   'Olá! Estou escolhendo um parque no Brasil para viajar com a família e queria ajuda para decidir.';
-
-/*
-  ItemList em vez de Service: a página não vende um serviço só — ela lista
-  cinco destinos comparáveis. `TouristAttraction` por item é o tipo que
-  motores de resposta usam para montar comparação de destino.
-*/
-const parksItemList = {
-  '@context': 'https://schema.org',
-  '@type': 'ItemList',
-  name: 'Parques do Brasil atendidos pela Anhangá Viagens',
-  itemListOrder: 'https://schema.org/ItemListUnordered',
-  numberOfItems: BOOKABLE_PARKS.length,
-  itemListElement: BOOKABLE_PARKS.map((park, index) => ({
-    '@type': 'ListItem',
-    position: index + 1,
-    item: {
-      '@type': 'TouristAttraction',
-      name: park.name,
-      description: park.claim,
-      address: {
-        '@type': 'PostalAddress',
-        addressLocality: park.city,
-        addressRegion: park.state,
-        addressCountry: 'BR',
-      },
-      ...(park.href ? { url: `https://www.anhanga.tur.br${park.href}/` } : {}),
-    },
-  })),
-};
 
 const ParquesBrasil: React.FC = () => {
   const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE);
@@ -71,7 +42,17 @@ const ParquesBrasil: React.FC = () => {
         ]}
       />
       <FAQPageSchema items={PARQUES_FAQ_ITEMS} />
-      <StructuredData id="parques-itemlist" data={parksItemList} />
+      <ItemListSchema
+        id="parques-itemlist"
+        name="Parques do Brasil atendidos pela Anhangá Viagens"
+        items={BOOKABLE_PARKS.map(({ name, claim: description, city, state, href }) => ({
+          name,
+          description,
+          city,
+          state,
+          href,
+        }))}
+      />
 
       <ParquesHero />
       <CredentialedSection />

--- a/tests/parques-brasil-hub.test.ts
+++ b/tests/parques-brasil-hub.test.ts
@@ -23,6 +23,26 @@ interface BreadcrumbListItem {
   item: string;
 }
 
+interface ItemListSchemaData {
+  '@type': string;
+  name: string;
+  numberOfItems: number;
+  itemListElement: Array<{
+    position: number;
+    item: {
+      '@type': string;
+      name: string;
+      description: string;
+      address: {
+        addressLocality: string;
+        addressRegion: string;
+        addressCountry: string;
+      };
+      url?: string;
+    };
+  }>;
+}
+
 // `render()` (ssr.tsx) compõe a árvore real da rota — Head tags incluem o JSON-LD
 // emitido por StructuredData, marcado com `data-av-head="script:ld-json:<id>"`
 // (lib/head.tsx). Extrair daqui prova o que a página realmente produz, em vez de
@@ -34,6 +54,14 @@ function extractBreadcrumbList(headHtml: string): BreadcrumbListItem[] {
   assert.ok(match, 'headHtml deve conter o script JSON-LD do breadcrumb');
   const data = JSON.parse(match[1]) as { itemListElement: Array<{ name: string; item: string }> };
   return data.itemListElement.map(({ name, item }) => ({ name, item }));
+}
+
+function extractItemList(headHtml: string): ItemListSchemaData {
+  const match = headHtml.match(
+    /<script[^>]*data-av-head="script:ld-json:parques-itemlist"[^>]*>(.*?)<\/script>/s,
+  );
+  assert.ok(match, 'headHtml deve conter o script JSON-LD do ItemList');
+  return JSON.parse(match[1]) as ItemListSchemaData;
 }
 
 test('o hub está registrado como rota estática e é prerenderizado', () => {
@@ -112,6 +140,33 @@ test('parque em obras fica fora da comparação e do que se vende', () => {
       `${park.name} ainda não abriu e não pode entrar na tabela comparativa`,
     );
   }
+});
+
+test('o hub emite um ItemList com os destinos comparáveis', async () => {
+  const { headHtml } = await render(HUB_ROUTE);
+  const itemList = extractItemList(headHtml);
+
+  assert.equal(itemList['@type'], 'ItemList');
+  assert.equal(itemList.name, 'Parques do Brasil atendidos pela Anhangá Viagens');
+  assert.equal(itemList.numberOfItems, BOOKABLE_PARKS.length);
+  assert.deepEqual(
+    itemList.itemListElement.map(({ position, item }) => ({
+      position,
+      name: item.name,
+      description: item.description,
+      city: item.address.addressLocality,
+      state: item.address.addressRegion,
+      url: item.url,
+    })),
+    BOOKABLE_PARKS.map((park, index) => ({
+      position: index + 1,
+      name: park.name,
+      description: park.claim,
+      city: park.city,
+      state: park.state,
+      url: park.href ? `https://www.anhanga.tur.br${park.href}/` : undefined,
+    })),
+  );
 });
 
 test('a filha declara o hub como pai no breadcrumb', async () => {


### PR DESCRIPTION
## O que mudou

- Cria o componente reutilizável `ItemListSchema` para emitir `ItemList` com `TouristAttraction`, endereço e URL opcional.
- Refatora `ParquesBrasil` para usar o componente em vez de montar o JSON-LD manualmente.
- Adiciona teste de regressão sobre o JSON-LD renderizado do hub.

## Por quê

Centraliza o padrão de schemas JSON-LD em `components/schemas` e mantém a lista de parques comparáveis consistente, incluindo apenas destinos vendáveis.

## Validação

- 119 testes de regressão aprovados.
- Typecheck aprovado.
- ESLint dos arquivos alterados aprovado.
- Build Vite de produção aprovada.

Closes #1361