### PR TITLE
fix: 🛡️ [HIGH] Add rate limiting to HubSpot webhook handler

### DIFF
--- a/api/hubspot-webhook.ts
+++ b/api/hubspot-webhook.ts
@@ -9,9 +9,14 @@ import { validateHubSpotSignature } from '../lib/hubspot-validation.js';
 import { getDeal, getAssociatedContactId, getContact } from '../services/hubspot.js';
 import { logger } from '../lib/logger.js';
 import { HubSpotWebhookPayloadSchema, type HubSpotWebhookEvent } from '../lib/schemas/hubspot-webhook.js';
+import { checkRateLimit } from '../lib/rate-limit.js';
+import { getClientIP } from '../lib/network.js';
 
-function buildJsonResponse(body: Record<string, unknown>, status: number): Response {
-  return new Response(JSON.stringify(body), { status });
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS = 30;
+
+function buildJsonResponse(body: Record<string, unknown>, status: number, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), { status, headers });
 }
 
 function getWebhookConfig(): { webhookSecret: string; hubspotToken: string } | null {
@@ -155,6 +160,25 @@ export default async function handler(request: Request): Promise<Response> {
 
   if (!isValid) {
     return buildJsonResponse({ error: 'Invalid signature' }, 401);
+  }
+
+  // Rate limit after signature verification (not before) so an unauthenticated
+  // caller can't exhaust the shared rate-limit quota with forged requests; this
+  // still bounds the per-event downstream calls to HubSpot/Google/Meta below.
+  const clientIP = getClientIP(request);
+  const rateLimit = await checkRateLimit(clientIP, {
+    limit: RATE_LIMIT_MAX_REQUESTS,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+    prefix: 'ratelimit:hubspot-webhook',
+  });
+
+  if (!rateLimit.allowed) {
+    logger.warn('HUBSPOT_WEBHOOK: rate limit exceeded', { clientIP });
+    return buildJsonResponse(
+      { error: 'Too many requests' },
+      429,
+      { 'Retry-After': String(Math.ceil(rateLimit.resetIn / 1000)) },
+    );
   }
 
   const events = await parseWebhookEvents(body);

--- a/tests/hubspot-webhook.test.ts
+++ b/tests/hubspot-webhook.test.ts
@@ -294,3 +294,47 @@ test('hubspot-webhook should send purchase conversion to Meta and derive fbc fro
   );
   assert.ok(!warns.some(message => message.includes('Conversion tracking incomplete')));
 });
+
+test('hubspot-webhook should rate limit repeated requests from the same client', async (t) => {
+  const clientIp = `203.0.113.${Math.floor(Math.random() * 200) + 1}`;
+
+  t.after(() => {
+    global.fetch = originalFetch;
+    console.warn = originalConsoleWarn;
+    restoreEnv();
+  });
+
+  const secret = 'test-secret';
+  process.env.HUBSPOT_WEBHOOK_SECRET = secret;
+  process.env.HUBSPOT_TOKEN = 'test-token';
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  console.warn = (() => {}) as typeof console.warn;
+  global.fetch = (async () => new Response(JSON.stringify({}), { status: 200 })) as typeof fetch;
+
+  const body = JSON.stringify([]);
+
+  let response: Response | undefined;
+  for (let index = 0; index < 31; index += 1) {
+    const timestamp = Date.now().toString();
+    const signature = await signRequest(body, timestamp, secret);
+    response = await handler(new Request('http://localhost/api/hubspot-webhook', {
+      method: 'POST',
+      headers: {
+        'X-HubSpot-Signature-v3': signature,
+        'X-HubSpot-Request-Timestamp': timestamp,
+        'Content-Type': 'application/json',
+        'x-real-ip': clientIp,
+      },
+      body,
+    }));
+  }
+
+  assert.ok(response);
+  assert.equal(response!.status, 429);
+
+  const data = await response!.json() as Record<string, unknown>;
+  assert.equal(data.error, 'Too many requests');
+  assert.ok(response!.headers.get('Retry-After'));
+});


### PR DESCRIPTION
## Resumo

- **O que muda:** Adiciona `checkRateLimit` (60s / 30 req por IP, mesmo padrão de `purchase-dispatch.ts`) ao handler `api/hubspot-webhook.ts`, após a verificação de assinatura HMAC e antes do processamento de eventos.
- **Por quê:** `api/hubspot-webhook.ts` era o único handler de webhook inbound sem rate limiting — `auth.ts`, `generate.ts`, `markdown.ts` e `purchase-dispatch.ts` já usam `checkRateLimit`. Cada evento `closedwon` válido dispara múltiplas chamadas downstream (HubSpot CRM `getDeal`/`getAssociatedContactId`/`getContact` + Google Ads/Meta conversion APIs). Sem limite, um segredo vazado, uma retentativa em loop, ou replay de payload assinado poderia esgotar as cotas desses provedores ou gerar custo de CPU desnecessário no Worker, sem nenhuma camada de contenção.
- **Impacto para o usuário:** Nenhum em uso normal — o HubSpot envia poucos eventos por minuto. Requisições excedentes do mesmo IP recebem `429` com `Retry-After`, sem afetar o fluxo legítimo de conversões.
- **Nível de risco:** baixo

## Issue relacionada

Não há issue associada — encontrado durante varredura de segurança de rotina (agente Sentinel) comparando os handlers de `api/` que já usam `lib/rate-limit.ts` contra os que não usam.

## Tipo de mudança

- [x] 🐛 Bug fix

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only)
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível)

Comandos executados:

```text
pnpm exec tsx --test tests/hubspot-webhook.test.ts
pnpm test:regression
pnpm typecheck
pnpm exec eslint api/hubspot-webhook.ts tests/hubspot-webhook.test.ts
```

## API & Segurança

- [x] Inputs validados/sanitizados na borda, antes de side effects ou chamadas a providers
- [x] Respostas e códigos de erro permanecem estruturados; helpers compartilhados (`lib/network`, `lib/rate-limit`, `lib/schemas`) reutilizados
- [x] Sem secrets ou PII bruta em logs
- [x] `dangerouslySetInnerHTML` não foi introduzido sem fonte controlada e justificativa

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`feat:`, `fix:`, `chore:`, `docs:`, `perf:`, `test:`, `refactor:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

O rate limit é aplicado **depois** da verificação de assinatura HMAC (não antes), seguindo o mesmo padrão já estabelecido em `purchase-dispatch.ts`: isso evita que um chamador não autenticado consuma a cota compartilhada de rate limit com requisições forjadas, mantendo a proteção onde ela importa — antes das chamadas caras a HubSpot/Google/Meta que seguem no fluxo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtTS9x6NzAxJyPZPddPpK9)_