### PR TITLE
feat: instrumentar cliques da AIResearchBar com ai_research_click

### DIFF
--- a/components/AIResearchBar.tsx
+++ b/components/AIResearchBar.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import { pushAiResearchClick, type AIResearchAssistantId } from '../utils/aiResearchTracking';
 
 type AIAssistant = {
-  id: 'chatgpt' | 'gemini' | 'claude' | 'perplexity' | 'grok';
+  id: AIResearchAssistantId;
   name: string;
   logoUrl: string;
   baseUrl: string;
   queryParameter?: string;
 };
+
+const PLACEMENT = 'hero';
 
 const RESEARCH_PROMPT =
   'O que você sabe sobre a Anhangá Viagens? Consulte o site oficial https://www.anhanga.tur.br/ e explique por que ela pode ser uma boa opção para planejar uma viagem personalizada.';
@@ -76,6 +79,7 @@ const AIResearchBar: React.FC = () => {
             rel="noopener noreferrer"
             title={assistant.name}
             aria-label={`Perguntar no ${assistant.name} sobre a Anhangá`}
+            onClick={() => pushAiResearchClick(assistant.id, PLACEMENT)}
             className="inline-flex size-12 items-center justify-center rounded-full border border-white/30 bg-white/95 p-2.5 shadow-lg shadow-black/10 transition hover:scale-110 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-anhanga-yellow"
           >
             <img

--- a/tests/ai-research-bar-tracking.test.ts
+++ b/tests/ai-research-bar-tracking.test.ts
@@ -15,6 +15,11 @@ import AIResearchBar from '../components/AIResearchBar.tsx';
   ver docs/standards/dom-testing-tier-decision.md) e disparam `click` em
   cada link, que é o mesmo evento que o navegador despacha tanto para clique
   de mouse quanto para ativação por teclado (Enter) num <a>.
+
+  O último teste cobre a reutilização de `currentPageLocation()`
+  (utils/formAnalytics.ts) para redigir e-mail/telefone/nome que estejam na
+  própria query string da home — a home é acessível com esses parâmetros,
+  e `page_location` não pode vazar PII para o GA4.
 */
 
 type DataLayerEvent = Record<string, unknown>;
@@ -65,4 +70,22 @@ test('o payload identifica placement=hero e page_location, sem prompt nem query 
   assert.doesNotMatch(serialized, /Anhang[aá] Viagens\?/);
   assert.doesNotMatch(serialized, /planejar uma viagem/i);
   assert.doesNotMatch(serialized, /[?&]q=/);
+});
+
+test('redige e-mail/telefone/nome presentes na query da página atual em page_location', () => {
+  const originalHref = window.location.href;
+  window.location.href = 'https://www.anhanga.tur.br/?email=ana@example.com&utm_source=ig';
+
+  try {
+    const { getByRole } = render(React.createElement(AIResearchBar));
+    fireEvent.click(getByRole('link', { name: /gemini/i }));
+
+    const [event] = (window.dataLayer as DataLayerEvent[]).filter(
+      (e) => e.event === 'ai_research_click',
+    );
+
+    assert.equal(event.page_location, 'https://www.anhanga.tur.br/?email=redacted&utm_source=ig');
+  } finally {
+    window.location.href = originalHref;
+  }
 });

--- a/tests/ai-research-bar-tracking.test.ts
+++ b/tests/ai-research-bar-tracking.test.ts
@@ -1,0 +1,68 @@
+import './helpers/dom-setup.ts';
+
+import React from 'react';
+import test, { afterEach, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+
+import AIResearchBar from '../components/AIResearchBar.tsx';
+
+/*
+  Issue #1405 — a barra AIResearchBar não disparava evento próprio no
+  dataLayer. Estes testes provam o contrato do evento `ai_research_click`
+  sem depender do GTM carregar (ele não carrega em ambiente de teste local
+  nem em CI): montam o componente de verdade (happy-dom + testing-library,
+  ver docs/standards/dom-testing-tier-decision.md) e disparam `click` em
+  cada link, que é o mesmo evento que o navegador despacha tanto para clique
+  de mouse quanto para ativação por teclado (Enter) num <a>.
+*/
+
+type DataLayerEvent = Record<string, unknown>;
+
+beforeEach(() => {
+  window.dataLayer = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+test('cada um dos cinco links dispara exatamente um ai_research_click com o assistant correto', () => {
+  const { getByRole } = render(React.createElement(AIResearchBar));
+
+  const expected = ['chatgpt', 'gemini', 'claude', 'perplexity', 'grok'];
+
+  for (const assistant of expected) {
+    const link = getByRole('link', { name: new RegExp(assistant, 'i') });
+    fireEvent.click(link);
+  }
+
+  const events = (window.dataLayer as DataLayerEvent[]).filter(
+    (e) => e.event === 'ai_research_click',
+  );
+
+  assert.equal(events.length, expected.length);
+  assert.deepEqual(
+    events.map((e) => e.assistant).sort(),
+    [...expected].sort(),
+  );
+});
+
+test('o payload identifica placement=hero e page_location, sem prompt nem query final', () => {
+  const { getByRole } = render(React.createElement(AIResearchBar));
+
+  fireEvent.click(getByRole('link', { name: /claude/i }));
+
+  const [event] = (window.dataLayer as DataLayerEvent[]).filter(
+    (e) => e.event === 'ai_research_click',
+  );
+
+  assert.equal(event.assistant, 'claude');
+  assert.equal(event.placement, 'hero');
+  assert.equal(typeof event.page_location, 'string');
+
+  const serialized = JSON.stringify(event);
+  assert.doesNotMatch(serialized, /Anhang[aá] Viagens\?/);
+  assert.doesNotMatch(serialized, /planejar uma viagem/i);
+  assert.doesNotMatch(serialized, /[?&]q=/);
+});

--- a/tests/helpers/dom-setup.ts
+++ b/tests/helpers/dom-setup.ts
@@ -19,5 +19,14 @@ declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean;
 }
 
-GlobalRegistrator.register({ url: 'https://www.anhanga.tur.br/' });
+GlobalRegistrator.register({
+  url: 'https://www.anhanga.tur.br/',
+  // Sem isso, clicar num <a href> real (ex.: target="_blank" para um provedor
+  // externo) faz o happy-dom navegar de verdade e disparar fetch de rede —
+  // lento, não-determinístico e proibido pelo padrão de testes do repo
+  // (docs/standards/testing.md: não bater em endpoints externos de verdade).
+  settings: {
+    navigation: { disableMainFrameNavigation: true, disableChildPageNavigation: true },
+  },
+});
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;

--- a/utils/aiResearchTracking.ts
+++ b/utils/aiResearchTracking.ts
@@ -1,17 +1,28 @@
+import { currentPageLocation } from './formAnalytics';
+
 export type AIResearchAssistantId = 'chatgpt' | 'gemini' | 'claude' | 'perplexity' | 'grok';
 
 /**
  * Evento GA4 disparado ao clicar (mouse ou teclado) num link da AIResearchBar,
  * antes da navegação externa ao provedor. Payload contém só metadados seguros:
  * nunca o prompt completo nem a URL final de busca (que carrega o prompt).
+ * `page_location` reusa a mesma redação de e-mail/telefone/nome de `formAnalytics.ts`,
+ * já que a home pode ser acessada com esses dados na própria query string.
  */
 export function pushAiResearchClick(assistant: AIResearchAssistantId, placement: string): void {
     if (typeof window === 'undefined') return;
     window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({
+
+    const event: Record<string, string> = {
         event: 'ai_research_click',
         assistant,
         placement,
-        page_location: window.location.href,
-    });
+    };
+
+    const pageLocation = currentPageLocation();
+    if (pageLocation) {
+        event.page_location = pageLocation;
+    }
+
+    window.dataLayer.push(event);
 }

--- a/utils/aiResearchTracking.ts
+++ b/utils/aiResearchTracking.ts
@@ -1,0 +1,17 @@
+export type AIResearchAssistantId = 'chatgpt' | 'gemini' | 'claude' | 'perplexity' | 'grok';
+
+/**
+ * Evento GA4 disparado ao clicar (mouse ou teclado) num link da AIResearchBar,
+ * antes da navegação externa ao provedor. Payload contém só metadados seguros:
+ * nunca o prompt completo nem a URL final de busca (que carrega o prompt).
+ */
+export function pushAiResearchClick(assistant: AIResearchAssistantId, placement: string): void {
+    if (typeof window === 'undefined') return;
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+        event: 'ai_research_click',
+        assistant,
+        placement,
+        page_location: window.location.href,
+    });
+}

--- a/utils/formAnalytics.ts
+++ b/utils/formAnalytics.ts
@@ -42,7 +42,8 @@ const SENSITIVE_QUERY_KEYS = /(?:email|mail|phone|telefone|whatsapp|name|nome|so
 const EMAIL_PATTERN = /[^\s@]+@[^\s@]+\.[^\s@]+/;
 const PHONE_PATTERN = /\+?\d[\d\s().-]{7,}\d/;
 
-function currentPageLocation(): string | undefined {
+/** Página atual com chaves de query sensíveis (e-mail/telefone/nome) redigidas antes de ir pro dataLayer. */
+export function currentPageLocation(): string | undefined {
   if (typeof window === 'undefined') return undefined;
 
   try {


### PR DESCRIPTION
## Resumo

- **O que muda:** cada um dos cinco links da `AIResearchBar` (ChatGPT, Gemini, Claude, Perplexity, Grok) agora dispara um evento `ai_research_click` no `window.dataLayer` (`assistant`, `placement: 'hero'`, `page_location`) no `onClick`, antes da navegação externa. `onClick` num `<a>` cobre tanto clique de mouse quanto ativação por teclado (Enter), então não há handlers duplicados. Nova função em `utils/aiResearchTracking.ts` (mesmo padrão de `utils/linksTracking.ts`, já usado em `/links`).
- **Por quê:** a barra não tinha evento próprio; não dava para medir quais provedores de IA geram interesse antes da conversa (issue #1405).
- **Impacto para o usuário:** nenhum visualmente — o comportamento de navegação é o mesmo. Só passa a existir um evento de analytics.
- **Nível de risco:** baixo

## Issue relacionada

Closes #1405

## Tipo de mudança

- [x] ✨ Feature

## Testes

- [x] Testes automatizados adicionados/atualizados (ou mudança é docs-only)
- [x] Menor camada de teste correta foi usada (node:test antes de E2E quando possível)

Novo `tests/ai-research-bar-tracking.test.ts` (terceiro tier: happy-dom + `@testing-library/react`, ver `docs/standards/dom-testing-tier-decision.md`) renderiza o componente de verdade e dispara `click` em cada um dos 5 links, provando: exatamente um `ai_research_click` por link, `assistant` correto, `placement: 'hero'`, `page_location` presente, e que o payload não carrega o prompt nem a query final (`?q=`). Isso evita depender do GTM carregar localmente (ele não carrega em dev/CI).

Também ajustei `tests/helpers/dom-setup.ts` (settings `navigation.disableMainFrameNavigation`/`disableChildPageNavigation`) porque clicar num `<a target="_blank" href="https://...">` de verdade no happy-dom estava disparando navegação/fetch real contra os domínios externos (chatgpt.com, grok.com etc.) — proibido pelo padrão de testes do repo. Afeta só esse tier de teste compartilhado; os demais testes que já usam esse helper continuam passando.

Comandos executados:

```text
pnpm test:regression
pnpm typecheck
pnpm lint:changed
```

## API & Segurança

- [x] Não se aplica (não toca `api/`, sem input externo processado — o payload só contém um enum fixo de 5 valores, uma string fixa `hero` e a URL da página atual)

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`feat:`, `fix:`, `chore:`, `docs:`, `perf:`, `test:`, `refactor:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

Este PR cobre a parte de código dos critérios de aceite da issue. Os seguintes itens são configuração externa ao repositório e ficam como próximo passo operacional (mesmo padrão já usado para `links_page_click`/`links_page_view`, ver `docs/superpowers/specs/2026-06-27-pagina-links-bio-design.md`):

- Mapear `ai_research_click` como evento GA4 no container GTM (nomenclatura: `event: ai_research_click`, params `assistant`, `placement`, `page_location`).
- Validar no GTM Preview/GA4 DebugView em produção/staging, incluindo consentimento e abertura da nova aba.
- Conferir no container se algum trigger genérico de outbound click já cobre esses mesmos links, para não duplicar contagem — não há como verificar isso a partir do repositório (config do GTM é externa).

---
_Generated by [Claude Code](https://claude.ai/code/session_0152xkfcoDf8qgi9Dzv1hpWe)_