### PR TITLE
fix: remove identificadores de tracking do prefill do WhatsApp

### DIFF
--- a/components/landings/corporativo/CorpContactSection.tsx
+++ b/components/landings/corporativo/CorpContactSection.tsx
@@ -4,7 +4,7 @@ import { CorpContactInfo } from './CorpContactInfo';
 import { CorpContactForm } from './CorpContactForm';
 
 export function CorpContactSection() {
-    const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE, { appendTrackingRef: true });
+    const whatsappUrl = useWhatsAppLink(WHATSAPP_MESSAGE);
 
     return (
         <section id="contato" className="py-24 bg-brand-surface relative overflow-hidden">

--- a/components/landings/quiz/WhatsAppUpgrade.tsx
+++ b/components/landings/quiz/WhatsAppUpgrade.tsx
@@ -57,7 +57,6 @@ export function WhatsAppUpgrade({ profileName, mainDestName, firstName, baseWaUr
     const waUrl = isValid && submitted
         ? getWhatsAppLink(
             `Oi! Sou ${firstName}. Descobri no Quiz da Anhangá que meu perfil é ${profileName} e meu próximo destino pode ser ${mainDestName}. Bora planejar essa viagem?`,
-            { appendTrackingRef: true },
           )
         : baseWaUrl;
 

--- a/components/links/LinkButton.tsx
+++ b/components/links/LinkButton.tsx
@@ -67,7 +67,7 @@ export const LinkButton: React.FC<LinkButtonProps> = ({ item, className: extraCl
     );
 
     if (item.type === 'whatsapp') {
-        const href = getWhatsAppLink(item.whatsappMessage ?? '', { appendTrackingRef: true });
+        const href = getWhatsAppLink(item.whatsappMessage ?? '');
         return (
             <a href={href} target="_blank" rel="noopener noreferrer" className={className}
                data-testid={`link-${item.id}`} onClick={() => pushLinksPageClick(item, href)}>

--- a/docs/compliance/ripd-legitimo-interesse.md
+++ b/docs/compliance/ripd-legitimo-interesse.md
@@ -9,9 +9,9 @@
 | **Endereço** | Av. Dom Pedro I, 773, Vila Monumento, São Paulo-SP, CEP 01552-001 |
 | **Encarregado (DPO)** | Felipe William Rodrigues Silva |
 | **E-mail DPO** | privacidade@anhanga.tur.br |
-| **Versão** | 1.6 |
+| **Versão** | 1.7 |
 | **Data de elaboração** | 02/06/2026 |
-| **Última revisão** | 23/07/2026 |
+| **Última revisão** | 20/08/2026 |
 | **Próxima revisão** | 03/06/2027 |
 | **Status** | Rascunho — pendente de revisão jurídica e aprovação do DPO |
 
@@ -116,6 +116,7 @@ Sem essa análise, decisões de investimento em tráfego pago seriam baseadas em
 | **Operadores** | Anhangá Turismo (armazenamento first-party); Stape OÜ/sGTM (repasse de conversões ao Google Ads, Meta CAPI e TikTok Events API; destinos de marketing somente após consentimento) |
 | **Retenção** | 30 dias (cookie `tracking_data`); duração da sessão (`sessionStorage`) |
 | **Transferência internacional** | Click IDs permanecem first-party antes do consentimento. Após opt-in de marketing, sinais necessários podem ser enviados ao Google, Meta e TikTok pelo sGTM e pelos pixels consentidos, conforme a finalidade de atribuição/conversão. |
+| **Limite de propagação** | Os identificadores **não** são incluídos no corpo das mensagens de WhatsApp pré-preenchidas (`wa.me?text=`). Chegam ao CRM apenas pelos handlers `/api/submit-*`, que os gravam no Odoo junto ao restante do formulário. |
 
 > **Arquitetura híbrida (issue #1261):** UTMs e click IDs são armazenados first-party para atribuição. GA4 continua via sGTM sob a premissa de legítimo interesse do projeto. Meta e TikTok permanecem bloqueados antes do consentimento e após recusa; depois do opt-in, os pixels podem medir PageView/Lead no navegador e as conversões server-side seguem por Meta CAPI e TikTok Events API.
 
@@ -343,6 +344,7 @@ O balancing test favorece o legítimo interesse nas Atividades 1, 2 e 3. A Ativi
 | 1.4 | 04/06/2026 | Pendência #10 concluída: e-mail de notificação LGPD enviado à base via Mautic (ID 24, 04/06/2026 10h00); janela de 15 dias iniciada; primeiro upload de customer match liberado a partir de 19/06/2026 |
 | 1.5 | 07/07/2026 | Auditoria do banner de cookies: nota sobre registro client-side do consentimento (risco aceito, §1); `<noscript>` do GTM removido do site (furava o Consent Mode para usuários sem JS) |
 | 1.6 | 23/07/2026 | Atividade 2 alinhada à arquitetura híbrida consent-gated: Meta/TikTok bloqueados antes do opt-in; destinos server-side e salvaguardas de matching atualizados; base legal e conclusão preservadas |
+| 1.7 | 20/08/2026 | Atividade 2: identificadores deixam de ser anexados ao corpo das mensagens de WhatsApp (`\|\| Dados:` removido de `utils/whatsapp.ts`), que os colocava sob retenção da Meta em vez da janela de 30 dias declarada; linha "Limite de propagação" adicionada |
 
 ---
 

--- a/hooks/useContactForm.ts
+++ b/hooks/useContactForm.ts
@@ -156,7 +156,7 @@ export function useContactForm(options: ContactModalOptions = {}) {
             const whatsappMessage =
                 options.message
                 ?? `Olá! Meu nome é ${validation.normalized.firstName}. Gostaria de saber mais sobre viagens.`;
-            const whatsappUrl = getWhatsAppLink(whatsappMessage, { appendTrackingRef: true });
+            const whatsappUrl = getWhatsAppLink(whatsappMessage);
 
             if (action === 'whatsapp') {
                 pushFormAnalyticsEvent({

--- a/hooks/useLeadCapture.ts
+++ b/hooks/useLeadCapture.ts
@@ -126,7 +126,7 @@ export function buildLeadWhatsAppMessage(lead: LeadDraft): string {
 }
 
 export function buildLeadWhatsAppUrl(lead: LeadDraft): string {
-    return getWhatsAppLink(buildLeadWhatsAppMessage(lead), { appendTrackingRef: true });
+    return getWhatsAppLink(buildLeadWhatsAppMessage(lead));
 }
 
 function resolveSubmitLeadEndpoint(): string {

--- a/pages/landings/QuizAnhangaLanding.tsx
+++ b/pages/landings/QuizAnhangaLanding.tsx
@@ -260,7 +260,7 @@ export default function QuizAnhangaLanding() {
 
         const firstName = form.nome.trim().split(/\s+/)[0] || 'Viajante';
         const waMsg = `Oi! Sou ${firstName}. Descobri no Quiz da Anhangá que meu perfil é ${profile.name} e meu próximo destino pode ser ${mainDest.name}. Bora planejar essa viagem?`;
-        const waUrl = getWhatsAppLink(waMsg, { appendTrackingRef: true });
+        const waUrl = getWhatsAppLink(waMsg);
 
         dispatch({ type: 'SUBMIT_RESULT', leadForm: form, profileKey: pKey, baseWaUrl: waUrl });
         go({ kind: 'result' });

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -120,7 +120,7 @@ function buildBudgetLink(handoff: GenerateHandoff): ChatResponse['budgetLink'] {
     destination: handoff.destination,
     dates: handoff.dates,
     baggagePreference: handoff.baggagePreference,
-    url: getWhatsAppLink(buildBudgetMessage(handoff), { appendTrackingRef: false }),
+    url: getWhatsAppLink(buildBudgetMessage(handoff)),
     bantSummary: handoff.bantSummary,
     iataCode: handoff.iataCode,
   };

--- a/tests/e2e/chatbot-lead-submit.spec.ts
+++ b/tests/e2e/chatbot-lead-submit.spec.ts
@@ -100,9 +100,12 @@ test.describe('Chatbot lead handoff', () => {
     const openedUrl = await page.evaluate(() => window.__openedUrls?.[0] ?? '');
     expect(decodeURIComponent(openedUrl)).toContain('wa.me/5511955021519');
     expect(decodeURIComponent(openedUrl)).toContain('Origem: São Paulo, SP');
-    expect(decodeURIComponent(openedUrl)).toContain('Dados: utm_source=google');
-    expect(decodeURIComponent(openedUrl)).toContain('gclid=test-gclid');
     expect(decodeURIComponent(openedUrl)).not.toContain('+5511988314487');
+    // O tracking desta sessão vai para o Odoo no payload de /api/submit-lead (asserções de
+    // `payload.utms` / `payload.tracking` abaixo) e não pode viajar como conteúdo da mensagem
+    // — ver docs/compliance/ripd-legitimo-interesse.md §3.1 "Limite de propagação".
+    expect(decodeURIComponent(openedUrl)).not.toContain('Dados:');
+    expect(decodeURIComponent(openedUrl)).not.toContain('gclid=test-gclid');
 
     const payload = submitPayload as unknown as Record<string, unknown>;
     expect(payload.firstName).toBe('Felipe');

--- a/tests/lead-whatsapp.test.ts
+++ b/tests/lead-whatsapp.test.ts
@@ -75,7 +75,7 @@ function createSessionStorage(): MockSessionStorage {
     };
 }
 
-test('buildLeadWhatsAppUrl should include origin, destination, dates, baggage and tracking ref', () => {
+test('buildLeadWhatsAppUrl should include lead details but never the tracking identifiers', () => {
     const mockWindow: MockWindow = {
         location: {
             search: '?utm_source=google&utm_medium=cpc&gclid=test-gclid',
@@ -121,9 +121,12 @@ test('buildLeadWhatsAppUrl should include origin, destination, dates, baggage an
     assert.match(message, /Destino: Orlando, Flórida/);
     assert.match(message, /Datas: Julho de 2026/);
     assert.match(message, /Bagagem: 1 mala despachada/);
-    assert.match(message, /Dados: .*utm_source=google/);
-    assert.match(message, /Dados: .*utm_medium=cpc/);
-    assert.match(message, /Dados: .*gclid=test-gclid/);
+
+    // O tracking capturado nesta fixture (utm_source=google, gclid=test-gclid) segue para o
+    // Odoo via /api/submit-lead; ele não pode aparecer na mensagem, que a pessoa envia pelo
+    // WhatsApp. Ver docs/compliance/ripd-legitimo-interesse.md §3.1 "Limite de propagação".
+    assert.doesNotMatch(message, /Dados:/);
+    assert.doesNotMatch(message, /utm_source|utm_medium|gclid/);
 
     restoreBrowserGlobals();
 });

--- a/tests/react-hooks-purity-fixes.test.ts
+++ b/tests/react-hooks-purity-fixes.test.ts
@@ -108,7 +108,7 @@ test('useWhatsAppLink does not capture tracking during render', () => {
         dataLayer.length = 0;
 
         const Harness: React.FC = () => {
-            useWhatsAppLink('Mensagem', { appendTrackingRef: true });
+            useWhatsAppLink('Mensagem');
             return null;
         };
 

--- a/tests/whatsapp-tracking.test.ts
+++ b/tests/whatsapp-tracking.test.ts
@@ -44,17 +44,10 @@ test('getWhatsAppLink trims trailing whitespace after stripping suffix', () => {
     assert.equal(decoded, 'Mensagem');
 });
 
-test('getWhatsAppLink with appendTrackingRef=false (default) does not append tracking data', () => {
+test('getWhatsAppLink never appends tracking data to the message', () => {
     const url = getWhatsAppLink('Mensagem simples');
     const decoded = decodeMessageFrom(url);
-    assert.ok(!decoded.includes('|| Dados:'));
-});
-
-test('getWhatsAppLink with appendTrackingRef=true but no tracking available omits Dados suffix', () => {
-    // In Node.js, window is undefined — no tracking data can be captured
-    const url = getWhatsAppLink('Mensagem', { appendTrackingRef: true });
-    const decoded = decodeMessageFrom(url);
-    assert.equal(decoded, 'Mensagem');
+    assert.equal(decoded, 'Mensagem simples');
     assert.ok(!decoded.includes('|| Dados:'));
 });
 
@@ -73,4 +66,53 @@ test('getWhatsAppLink handles message with special characters', () => {
 test('getTrackingDataObject returns null in Node.js environment (no window)', () => {
     const result = getTrackingDataObject();
     assert.equal(result, null);
+});
+
+// Regression: identifiers (cid/sid/gclid/fbclid) used to be appended to the message body, which
+// meant the user sent them as WhatsApp content — outside the retention declared in the RIPD.
+// They reach Odoo through /api/submit-* instead. This asserts the message stays clean even when
+// tracking data is available to capture.
+test('getWhatsAppLink omits identifiers even when tracking data is available', () => {
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    const originalSessionStorage = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: {
+            dataLayer: [],
+            location: {
+                search: '?utm_source=instagram&gclid=Cj0KTEST',
+                hash: '',
+                href: 'https://example.com/?utm_source=instagram&gclid=Cj0KTEST',
+            },
+        },
+    });
+    Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        value: { cookie: '_ga=GA1.1.1234567890.1699887766' },
+    });
+    Object.defineProperty(globalThis, 'sessionStorage', {
+        configurable: true,
+        value: { getItem: () => null, setItem: () => {} },
+    });
+
+    try {
+        // Proves the fixture is real: this data is captured and does reach the Odoo payloads.
+        const tracking = getTrackingDataObject();
+        assert.equal(tracking?.gclid, 'Cj0KTEST');
+
+        const decoded = decodeMessageFrom(getWhatsAppLink('Quero planejar uma viagem'));
+        assert.equal(decoded, 'Quero planejar uma viagem');
+        for (const identifier of ['gclid', 'Cj0KTEST', 'cid', '1234567890', '|| Dados:', '[ref:']) {
+            assert.ok(!decoded.includes(identifier), `mensagem não deve conter "${identifier}"`);
+        }
+    } finally {
+        if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+        else Reflect.deleteProperty(globalThis, 'window');
+        if (originalDocument) Object.defineProperty(globalThis, 'document', originalDocument);
+        else Reflect.deleteProperty(globalThis, 'document');
+        if (originalSessionStorage) Object.defineProperty(globalThis, 'sessionStorage', originalSessionStorage);
+        else Reflect.deleteProperty(globalThis, 'sessionStorage');
+    }
 });

--- a/utils/whatsapp.ts
+++ b/utils/whatsapp.ts
@@ -7,7 +7,7 @@
  * in memory + sessionStorage + cookie to ensure data is available after URL changes.
  */
 
-import { useState, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 const TRACKING_PARAMS = [
     'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term',
@@ -21,10 +21,6 @@ const STORAGE_KEY = 'anhanga_tracking_data';
 const WHATSAPP_NUMBER = '5511955021519';
 // Cookie name for GA4 session (dynamic based on measurement ID suffix)
 const GA4_SESSION_COOKIE = '_ga_QDBT5PM4KP';
-
-export interface WhatsAppLinkOptions {
-    appendTrackingRef?: boolean;
-}
 
 export type TrackingData = Record<string, string>;
 
@@ -270,63 +266,30 @@ export const getTrackingDataObject = (): TrackingData | null => {
     return null;
 };
 
-const getTrackingRef = (): string | null => {
-    const tracking = getTrackingDataObject();
-    if (!tracking) return null;
-
-    const serialized = serializeTrackingData(tracking);
-    return serialized.length > 0 ? serialized : null;
-};
-
-const getCachedTrackingRef = (): string | null => {
-    if (!cachedTrackingObject) return null;
-
-    const serialized = serializeTrackingData(cachedTrackingObject);
-    return serialized.length > 0 ? serialized : null;
-};
-
-const buildWhatsAppLink = (message: string, ref: string | null): string => {
-    let finalMessage = message;
-    finalMessage = finalMessage.split(' || Dados:')[0].split(' [ref:')[0].trim();
-
-    if (ref) {
-        finalMessage += ` || Dados: ${ref}`;
-    }
+// Identifiers (cid/sid/gclid/fbclid) must never ride in the message body: the user would
+// send them as WhatsApp content, putting them under Meta's retention instead of the 30-day
+// window declared in docs/compliance/ripd-legitimo-interesse.md. The form handlers already
+// deliver the same tracking to Odoo via /api/submit-*. The suffix stripping stays as a guard
+// for messages persisted before this change.
+const buildWhatsAppLink = (message: string): string => {
+    const finalMessage = message.split(' || Dados:')[0].split(' [ref:')[0].trim();
 
     return `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(finalMessage)}`;
 };
 
-export const getWhatsAppLink = (message: string, options: WhatsAppLinkOptions = {}): string => {
-    const { appendTrackingRef = false } = options;
-    const ref = appendTrackingRef ? getTrackingRef() : null;
-    return buildWhatsAppLink(message, ref);
-};
+export const getWhatsAppLink = (message: string): string => buildWhatsAppLink(message);
 
-export const useWhatsAppLink = (message: string, options: WhatsAppLinkOptions = {}): string => {
-    const { appendTrackingRef } = options;
-    // GA4 client/session cookies are often set slightly after mount, so we re-capture
-    // tracking ~1s later and bump this version to force a recompute of the link. The
-    // URL itself is derived (not effect-synced state), so it also stays current when
-    // `message`/`appendTrackingRef` change across renders.
-    const [trackingVersion, setTrackingVersion] = useState(0);
-
+export const useWhatsAppLink = (message: string): string => {
+    // GA4 sets its client/session cookies slightly after gtag boots, so re-capture ~1s after
+    // mount. The link no longer depends on tracking, but this keeps the cookie/sessionStorage
+    // snapshot fresh for the form submissions that carry it to Odoo.
     useEffect(() => {
-        // Fire exactly once ~1s after mount: the timer only re-captures GA cookies and
-        // bumps the version — it reads neither `message` nor `appendTrackingRef`, so an
-        // empty dep array is correct and avoids restarting the timer on prop changes.
         const timer = setTimeout(() => {
             captureTrackingDataObject();
-            setTrackingVersion((v) => v + 1);
         }, 1000);
 
         return () => clearTimeout(timer);
     }, []);
 
-    return useMemo(
-        // Render only formats the latest cached snapshot. Tracking capture and its
-        // cookie/sessionStorage/dataLayer side effects stay outside render.
-        () => buildWhatsAppLink(message, appendTrackingRef ? getCachedTrackingRef() : null),
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- trackingVersion is a deliberate recompute trigger, not read inside the callback
-        [message, appendTrackingRef, trackingVersion],
-    );
+    return useMemo(() => buildWhatsAppLink(message), [message]);
 };


### PR DESCRIPTION
## Problema

Os links `wa.me` anexavam os identificadores de atribuição ao **corpo da mensagem**:

```ts
if (ref) {
    finalMessage += ` || Dados: ${ref}`;
}
```

Na prática, a pessoa abria o WhatsApp e via no campo de digitação:

```
Olá! Vim pelo Instagram... || Dados: utm_source=instagram, utm_medium=bio,
gclid=Cj0KCQ..., fbclid=IwAR..., cid=1234567890.1699..., sid=1699887766
```

E **enviava**. Consequências:

- Os identificadores passam a trafegar como conteúdo de mensagem pela Meta e ficam no histórico da conversa indefinidamente — fora da janela de 30 dias declarada em `docs/compliance/ripd-legitimo-interesse.md` §3.1, e fora da finalidade de atribuição que sustenta o legítimo interesse.
- É duplicação sem finalidade adicional (art. 6º, III — necessidade): `useContactForm`, `useLeadCapture` e o quiz **já** postam `tracking` e `utms` para `/api/submit-*` antes de abrir o WhatsApp. O dado já chega ao Odoo pelo caminho correto.
- Efeito colateral de conversão: um bloco opaco de parâmetros no campo de digitação parece spam e derruba a taxa de envio.

## Solução

Em vez de só desligar a flag nos 6 call sites, a opção `appendTrackingRef` e os helpers de serialização (`getTrackingRef`, `getCachedTrackingRef`) saem junto — o objetivo é que esse dado não possa voltar ao corpo da mensagem por um booleano.

O strip dos sufixos (`|| Dados:`, `[ref:`) **permanece**, como guarda para mensagens gravadas antes desta mudança.

`useWhatsAppLink` mantém a recaptura ~1s após o mount: a URL não depende mais dela, mas o snapshot em cookie/`sessionStorage` alimenta os formulários que postam no Odoo. Removê-la mexeria no timing do `tracking_data_captured` sem necessidade.

## Call sites

| Arquivo | Endpoint que já leva o tracking |
|---|---|
| `hooks/useContactForm.ts` | `/api/submit-contact` |
| `hooks/useLeadCapture.ts` | `/api/submit-lead` |
| `pages/landings/QuizAnhangaLanding.tsx` | `/api/submit-quiz` |
| `components/landings/quiz/WhatsAppUpgrade.tsx` | `/api/submit-quiz` |
| `components/links/LinkButton.tsx` | — (sem form; atribuição segue no GA4 via `pushLinksPageClick`) |
| `components/landings/corporativo/CorpContactSection.tsx` | — (sem form; a landing tem caminho próprio de lead) |

## Testes

Quatro testes afirmavam o comportamento antigo e foram invertidos para cobrir a garantia atual:

- `tests/whatsapp-tracking.test.ts` — novo teste com fixture real de tracking (`gclid`, `_ga`), que primeiro **prova que o dado é capturado** e depois exige que ele não apareça na mensagem.
- `tests/lead-whatsapp.test.ts`
- `tests/react-hooks-purity-fixes.test.ts`
- `tests/e2e/chatbot-lead-submit.spec.ts` — o mais completo: as asserções de `payload.utms`/`payload.tracking` logo abaixo já provam que o tracking chega ao Odoo, então o par fecha a garantia ponta a ponta (vai por um caminho, não pelo outro).

## Compliance

RIPD atualizado para **1.7**, com a linha **"Limite de propagação"** em §3.1. A linha de retenção de 30 dias volta a ser verdadeira sem precisar ser alterada.

## Verificação

- `pnpm typecheck` — limpo
- `pnpm test:regression` — 1047/1047
- `pnpm lint:changed` — sem achados
- `pnpm exec playwright test tests/e2e/chatbot-lead-submit.spec.ts --project=chromium` — 3/3

⚠️ Os e2e rodaram localmente **só em chromium** (os demais browsers não estavam instalados no ambiente). O CI cobre o resto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)