### PR TITLE
feat(links): mensagens de intenção no WhatsApp da página de links

### DIFF
--- a/components/links/LinkButton.tsx
+++ b/components/links/LinkButton.tsx
@@ -1,24 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { WhatsappLogo, Compass, Globe, ShieldCheck, SimCard, CalendarCheck, type Icon } from '@phosphor-icons/react';
 import { getWhatsAppLink } from '../../utils/whatsapp';
 import { withTrackingParams, pushLinksPageClick } from '../../utils/linksTracking';
 import type { LinkItem } from '../../data/linksPage';
-
-const ICON_MAP: Record<string, Icon> = {
-    WhatsappLogo,
-    Compass,
-    Globe,
-    ShieldCheck,
-    SimCard,
-    CalendarCheck,
-};
-
-// Um `icon` fora do mapa falha em silêncio: o botão perde o ícone e, com ele, o tier pesado que
-// `isPrimaryLink` concede. Exportado para que os dados sejam validados em teste, não em produção.
-export function isSupportedIcon(name: string): boolean {
-    return Object.hasOwn(ICON_MAP, name);
-}
+import { ICON_MAP } from './linkIcons';
 
 interface LinkButtonProps {
     item: LinkItem;

--- a/components/links/LinkButton.tsx
+++ b/components/links/LinkButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { WhatsappLogo, Compass, Globe, ShieldCheck, SimCard, type Icon } from '@phosphor-icons/react';
+import { WhatsappLogo, Compass, Globe, ShieldCheck, SimCard, CalendarCheck, type Icon } from '@phosphor-icons/react';
 import { getWhatsAppLink } from '../../utils/whatsapp';
 import { withTrackingParams, pushLinksPageClick } from '../../utils/linksTracking';
 import type { LinkItem } from '../../data/linksPage';
@@ -11,7 +11,14 @@ const ICON_MAP: Record<string, Icon> = {
     Globe,
     ShieldCheck,
     SimCard,
+    CalendarCheck,
 };
+
+// Um `icon` fora do mapa falha em silêncio: o botão perde o ícone e, com ele, o tier pesado que
+// `isPrimaryLink` concede. Exportado para que os dados sejam validados em teste, não em produção.
+export function isSupportedIcon(name: string): boolean {
+    return Object.hasOwn(ICON_MAP, name);
+}
 
 interface LinkButtonProps {
     item: LinkItem;

--- a/components/links/linkIcons.ts
+++ b/components/links/linkIcons.ts
@@ -1,0 +1,18 @@
+import { WhatsappLogo, Compass, Globe, ShieldCheck, SimCard, CalendarCheck, type Icon } from '@phosphor-icons/react';
+
+// Mora fora de LinkButton.tsx para manter aquele arquivo exportando só o componente — exports
+// não-componente quebram o Fast Refresh (react-doctor/only-export-components).
+export const ICON_MAP: Record<string, Icon> = {
+    WhatsappLogo,
+    Compass,
+    Globe,
+    ShieldCheck,
+    SimCard,
+    CalendarCheck,
+};
+
+// Um `icon` fora do mapa falha em silêncio: o botão perde o ícone e, com ele, o tier pesado que
+// `isPrimaryLink` concede. Validado em teste sobre os dados, não em produção.
+export function isSupportedIcon(name: string): boolean {
+    return Object.hasOwn(ICON_MAP, name);
+}

--- a/data/linksPage.ts
+++ b/data/linksPage.ts
@@ -33,6 +33,11 @@ export interface LinksPageConfig {
 }
 
 // ⚙️ EDITÁVEL: troque banner e links aqui sem mexer em componente.
+//
+// Sobre `whatsappMessage`: as mensagens terminam num rótulo com dois-pontos para que a pessoa
+// complete o que falta ainda no campo de digitação — é o que chega ao atendimento já qualificado,
+// em vez de um "oi" seco. Não termine com espaço à direita: `buildWhatsAppLink` aplica `.trim()`
+// na mensagem, então o espaço não sobrevive até o WhatsApp.
 export const linksPageConfig: LinksPageConfig = {
     banner: {
         // Desligado: o quiz já aparece como link "Planejar minha viagem" abaixo, então o banner
@@ -45,7 +50,11 @@ export const linksPageConfig: LinksPageConfig = {
         href: '/quiz',
     },
     links: [
-        { id: 'whatsapp', label: 'Falar no WhatsApp', sublabel: 'Atendimento humano e rápido', type: 'whatsapp', whatsappMessage: 'Olá! Vim pelo Instagram e gostaria de falar com a Anhangá Viagens.', icon: 'WhatsappLogo', visible: true, highlight: true },
+        { id: 'whatsapp', label: 'Falar no WhatsApp', sublabel: 'Atendimento humano e rápido', type: 'whatsapp', whatsappMessage: 'Olá! Vim pelo Instagram e quero planejar uma viagem. Meu destino:', icon: 'WhatsappLogo', visible: true, highlight: true },
+    // Par com o quiz logo abaixo: o quiz atende quem ainda está explorando (ToFu — vira só
+    // `res.partner`), este atende quem já decidiu. Por isso a mensagem é estruturada aqui e
+    // conversacional no botão amarelo: quem clica aqui se declarou pronto a passar os dados.
+    { id: 'orcamento', label: 'Quero um orçamento', sublabel: 'Já tenho destino e datas', type: 'whatsapp', whatsappMessage: 'Olá! Vim pelo Instagram e quero um orçamento.\n\nDestino:\nDatas:\nPessoas:', icon: 'CalendarCheck', visible: true },
         { id: 'quiz', label: 'Planejar minha viagem', sublabel: 'Quiz de perfil de viagem', type: 'internal', href: '/quiz', icon: 'Compass', visible: true },
         { id: 'site', label: 'Site oficial', type: 'internal', href: '/', icon: 'Globe', visible: true },
         { id: 'seguro-viagem', label: 'Seguro viagem', sublabel: 'Cotação com nosso parceiro', type: 'external', href: 'https://go.nuvembr.com/anhanga_seguroviagem', icon: 'ShieldCheck', visible: true },

--- a/data/linksPage.ts
+++ b/data/linksPage.ts
@@ -51,10 +51,10 @@ export const linksPageConfig: LinksPageConfig = {
     },
     links: [
         { id: 'whatsapp', label: 'Falar no WhatsApp', sublabel: 'Atendimento humano e rápido', type: 'whatsapp', whatsappMessage: 'Olá! Vim pelo Instagram e quero planejar uma viagem. Meu destino:', icon: 'WhatsappLogo', visible: true, highlight: true },
-    // Par com o quiz logo abaixo: o quiz atende quem ainda está explorando (ToFu — vira só
-    // `res.partner`), este atende quem já decidiu. Por isso a mensagem é estruturada aqui e
-    // conversacional no botão amarelo: quem clica aqui se declarou pronto a passar os dados.
-    { id: 'orcamento', label: 'Quero um orçamento', sublabel: 'Já tenho destino e datas', type: 'whatsapp', whatsappMessage: 'Olá! Vim pelo Instagram e quero um orçamento.\n\nDestino:\nDatas:\nPessoas:', icon: 'CalendarCheck', visible: true },
+        // Par com o quiz logo abaixo: o quiz atende quem ainda está explorando (ToFu — vira só
+        // `res.partner`), este atende quem já decidiu. Por isso a mensagem é estruturada aqui e
+        // conversacional no botão amarelo: quem clica aqui se declarou pronto a passar os dados.
+        { id: 'orcamento', label: 'Quero um orçamento', sublabel: 'Já tenho destino e datas', type: 'whatsapp', whatsappMessage: 'Olá! Vim pelo Instagram e quero um orçamento.\n\nDestino:\nDatas:\nPessoas:', icon: 'CalendarCheck', visible: true },
         { id: 'quiz', label: 'Planejar minha viagem', sublabel: 'Quiz de perfil de viagem', type: 'internal', href: '/quiz', icon: 'Compass', visible: true },
         { id: 'site', label: 'Site oficial', type: 'internal', href: '/', icon: 'Globe', visible: true },
         { id: 'seguro-viagem', label: 'Seguro viagem', sublabel: 'Cotação com nosso parceiro', type: 'external', href: 'https://go.nuvembr.com/anhanga_seguroviagem', icon: 'ShieldCheck', visible: true },

--- a/tests/links-page-data.test.ts
+++ b/tests/links-page-data.test.ts
@@ -1,7 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { linksPageConfig, type LinkItem } from '../data/linksPage.ts';
-import { isSupportedIcon } from '../components/links/LinkButton.tsx';
+import { isSupportedIcon } from '../components/links/linkIcons.ts';
+import { getWhatsAppLink, getTrackingDataObject } from '../utils/whatsapp.ts';
 
 test('ids dos links são únicos', () => {
     const ids = linksPageConfig.links.map((l) => l.id);
@@ -54,5 +55,50 @@ test('mensagens de whatsapp não terminam em espaço', () => {
 test('todo icon declarado existe no ICON_MAP do LinkButton', () => {
     for (const link of linksPageConfig.links.filter((l) => l.icon)) {
         assert.ok(isSupportedIcon(link.icon as string), `${link.id} usa icon inexistente: ${link.icon}`);
+    }
+});
+
+// Regressão (codex, PR #1488): o prompt editável tem que ser a última coisa da mensagem, senão
+// o cursor do WhatsApp cai depois do que vier anexado e a pessoa digita no lugar errado —
+// "Meu destino: || Dados: utm_source=instagramNoronha".
+test('a mensagem termina no prompt editável mesmo com tracking na sessão', () => {
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    const originalSessionStorage = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: {
+            dataLayer: [],
+            location: {
+                search: '?utm_source=instagram&gclid=Cj0KTEST',
+                hash: '',
+                href: 'https://example.com/links?utm_source=instagram&gclid=Cj0KTEST',
+            },
+        },
+    });
+    Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        value: { cookie: '_ga=GA1.1.1234567890.1699887766' },
+    });
+    Object.defineProperty(globalThis, 'sessionStorage', {
+        configurable: true,
+        value: { getItem: () => null, setItem: () => {} },
+    });
+
+    try {
+        assert.equal(getTrackingDataObject()?.gclid, 'Cj0KTEST', 'fixture precisa ter tracking real');
+
+        for (const link of linksPageConfig.links.filter((l) => l.type === 'whatsapp')) {
+            const decoded = decodeURIComponent(getWhatsAppLink(link.whatsappMessage ?? '').split('?text=')[1] ?? '');
+            assert.equal(decoded, link.whatsappMessage, `${link.id}: algo foi anexado depois do prompt`);
+        }
+    } finally {
+        if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+        else Reflect.deleteProperty(globalThis, 'window');
+        if (originalDocument) Object.defineProperty(globalThis, 'document', originalDocument);
+        else Reflect.deleteProperty(globalThis, 'document');
+        if (originalSessionStorage) Object.defineProperty(globalThis, 'sessionStorage', originalSessionStorage);
+        else Reflect.deleteProperty(globalThis, 'sessionStorage');
     }
 });

--- a/tests/links-page-data.test.ts
+++ b/tests/links-page-data.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { linksPageConfig, type LinkItem } from '../data/linksPage.ts';
+import { isSupportedIcon } from '../components/links/LinkButton.tsx';
 
 test('ids dos links são únicos', () => {
     const ids = linksPageConfig.links.map((l) => l.id);
@@ -38,5 +39,20 @@ test('todo link tem label e visible booleano', () => {
     for (const link of linksPageConfig.links as LinkItem[]) {
         assert.ok(link.label.trim().length > 0, `${link.id} sem label`);
         assert.equal(typeof link.visible, 'boolean');
+    }
+});
+
+test('mensagens de whatsapp não terminam em espaço', () => {
+    // `buildWhatsAppLink` aplica `.trim()`, então um espaço à direita some antes de chegar ao
+    // WhatsApp. Escrever a mensagem contando com ele daria "Meu destino:Noronha" na prática.
+    for (const link of linksPageConfig.links.filter((l) => l.type === 'whatsapp')) {
+        const message = link.whatsappMessage ?? '';
+        assert.equal(message, message.trimEnd(), `${link.id} tem espaço à direita`);
+    }
+});
+
+test('todo icon declarado existe no ICON_MAP do LinkButton', () => {
+    for (const link of linksPageConfig.links.filter((l) => l.icon)) {
+        assert.ok(isSupportedIcon(link.icon as string), `${link.id} usa icon inexistente: ${link.icon}`);
     }
 });


### PR DESCRIPTION
## Problema

O botão amarelo da `/links` abria o WhatsApp com:

```
Olá! Vim pelo Instagram e gostaria de falar com a Anhangá Viagens.
```

Zero informação — o atendente ainda precisava fazer as 4 perguntas do BANT na mão.

## Mudanças

```
Falar no WhatsApp    → "...quero planejar uma viagem. Meu destino:"
Quero um orçamento   → "...quero um orçamento.\n\nDestino:\nDatas:\nPessoas:"
```

A mensagem terminando num rótulo com dois-pontos faz a pessoa completar o que falta **antes de enviar** — é o que chega ao atendimento já qualificado, em vez de um "oi" seco.

### Por que um segundo botão de WhatsApp

Ele faz par com o quiz logo abaixo, seguindo a segmentação que o próprio funil já assume: o quiz atende quem está **explorando** (ToFu — vira só `res.partner`, sem `crm.lead`), este atende quem **já decidiu**. Para quem está pronto, passar pelo quiz é um desvio.

Os dois botões de WhatsApp ficaram deliberadamente diferentes em registro — conversacional no amarelo, estruturado no orçamento. Dois CTAs quase sinônimos canibalizariam a ação de maior intenção da página. Quem clica em "já tenho destino e datas" se declarou pronto a passar os dados; o amarelo continua sendo a porta de conversa.

### Sistema de design

Mantém a **Regra do Âmbar** (o WhatsApp segue como único amarelo) e a fronteira de tiers: o novo item entra no bloco de ações, antes dos destinos, então a quebra de ritmo calculada por `isPrimaryLink` em `LinksPage.tsx` continua caindo no mesmo lugar.

## Detalhe que mudou o desenho

A ideia original era terminar a frase em espaço aberto (`"...viagem para "`). **Não funciona**: `buildWhatsAppLink` aplica `.trim()`, então o espaço não sobrevive e a pessoa digitaria `"paraNoronha"`. Daí o formato com dois-pontos — e um teste que trava isso para a próxima edição não cair na mesma armadilha.

## Testes

- `mensagens de whatsapp não terminam em espaço` — documenta o `.trim()` acima.
- `todo icon declarado existe no ICON_MAP do LinkButton` — um `icon` fora do mapa hoje falha **em silêncio**: some o ícone e, com ele, o tier pesado que `isPrimaryLink` concede. Para isso, `isSupportedIcon` passou a ser exportado do `LinkButton`.

## Verificação

- `pnpm typecheck` — limpo
- `pnpm test:regression` — 1049/1049
- `pnpm lint:changed` — sem achados
- `pnpm exec playwright test tests/e2e/links-page.spec.ts --project=chromium` — 5/5
- Conferido no browser em 390px: um só amarelo, bloco de ações com seis botões pesados, quebra de ritmo antes dos destinos intacta.

⚠️ Os e2e rodaram localmente **só em chromium** (os demais browsers não estavam instalados no ambiente). O CI cobre o resto.

## Relação com #1487

Ambas tocam `components/links/LinkButton.tsx`, em hunks diferentes. Testei o merge entre as duas: resolve automático, sem conflito, em qualquer ordem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)