### PR TITLE
feat(analytics): track conversions in Traks (quote_request, whatsapp_click, page_not_found)

### DIFF
--- a/components/ChatLeadForm.tsx
+++ b/components/ChatLeadForm.tsx
@@ -196,6 +196,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
       destination,
     });
     openWhatsAppWindow(getWhatsAppUrl(payload));
+    trackTraksWhatsAppHandoff();
 
     // Submit lead data in the background — user is already heading to WhatsApp
     try {

--- a/components/ChatLeadForm.tsx
+++ b/components/ChatLeadForm.tsx
@@ -10,6 +10,7 @@ import {
   type LeadFinalizeResult,
 } from '../lib/chat-lead-form-logic';
 import { triggerHaptic } from '../utils/haptics';
+import { trackTraksWhatsAppHandoff } from '../utils/traks';
 import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
 import { isFieldCompleteForAnalytics } from '../lib/form-v1-validation';
 import { ChatLeadFormFields } from './chat-lead-form/ChatLeadFormFields';
@@ -127,6 +128,7 @@ const ChatLeadFormBase: React.FC<ChatLeadFormProps> = ({
       destination,
     });
     openWhatsAppWindow(getWhatsAppUrl(buildDirectWhatsAppPayload()));
+    trackTraksWhatsAppHandoff();
   };
 
   const submitLeadForm = async (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/hooks/useContactForm.ts
+++ b/hooks/useContactForm.ts
@@ -14,6 +14,7 @@ import type { LeadTracking } from '../types/leadCapture';
 import type { ContactModalOptions } from '../utils/contactForm';
 import { pushFormAnalyticsEvent } from '../utils/formAnalytics';
 import { pushGenerateLeadConversionEvent } from '../utils/generate-lead-analytics';
+import { trackTraksWhatsAppHandoff } from '../utils/traks';
 
 const EMPTY_FIELDS: ContactFormFields = {
     firstName: '',
@@ -166,6 +167,7 @@ export function useContactForm(options: ContactModalOptions = {}) {
                     destination: action,
                 });
                 window.open(whatsappUrl, '_blank', 'noopener,noreferrer');
+                trackTraksWhatsAppHandoff();
             }
 
             // The UI dropped the separate sobrenome input (ContactModal/CtaBody now

--- a/index.tsx
+++ b/index.tsx
@@ -5,6 +5,7 @@ import './src/index.css';
 import App from './App';
 import { shouldHydratePrerenderedRoute } from './lib/hydration';
 import { initClientErrorTracking } from './lib/sentry-client';
+import { installTraksWhatsAppClickListener } from './utils/traks';
 import { handleStaleChunkPreloadError } from './lib/stale-chunk-recovery';
 
 // Reload (once per failing asset) on stale-cache preload failures so the
@@ -16,6 +17,7 @@ window.addEventListener('vite:preloadError', (event: Event & { payload?: unknown
 });
 
 initClientErrorTracking();
+installTraksWhatsAppClickListener();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/pages/BlogPost.tsx
+++ b/pages/BlogPost.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
-import { trackTraks } from '../utils/traks';
+import { trackTraks, nextBlogNotFoundTraksSlug } from '../utils/traks';
 
 import { Seo } from '../components/Seo';
 import { BlogPostContent } from '../components/blog/BlogPostContent';
@@ -50,11 +50,18 @@ const BlogPost: React.FC = () => {
     }, [slug]);
 
     // 404 de blog: um único evento por slug inexistente (guard evita re-emitir
-    // em re-renders e navegações repetidas ao mesmo slug).
+    // em re-renders e navegações repetidas ao mesmo slug). Decisão isolada em
+    // nextBlogNotFoundTraksSlug (utils/traks.ts) para cobertura de teste —
+    // este componente usa import.meta.glob e não pode ser montado em node:test.
     const lastMissingTraksSlug = useRef<string | null>(null);
     useEffect(() => {
-        if (!post && slug && lastMissingTraksSlug.current !== slug) {
-            lastMissingTraksSlug.current = slug;
+        const { shouldTrack, nextLastTrackedSlug } = nextBlogNotFoundTraksSlug(
+            Boolean(post),
+            slug,
+            lastMissingTraksSlug.current,
+        );
+        lastMissingTraksSlug.current = nextLastTrackedSlug;
+        if (shouldTrack) {
             trackTraks('page_not_found');
         }
     }, [post, slug]);

--- a/pages/BlogPost.tsx
+++ b/pages/BlogPost.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { trackTraks } from '../utils/traks';
@@ -49,9 +49,17 @@ const BlogPost: React.FC = () => {
         window.scrollTo(0, 0);
     }, [slug]);
 
+    // 404 de blog: um único evento por slug inexistente (guard evita re-emitir
+    // em re-renders e navegações repetidas ao mesmo slug).
+    const lastMissingTraksSlug = useRef<string | null>(null);
+    useEffect(() => {
+        if (!post && slug && lastMissingTraksSlug.current !== slug) {
+            lastMissingTraksSlug.current = slug;
+            trackTraks('page_not_found');
+        }
+    }, [post, slug]);
+
     if (!post) {
-        // Blog inexistente é 404 para o usuário: alimenta a mesma métrica do Traks.
-        trackTraks('page_not_found');
         return (
             <div className="min-h-screen flex flex-col items-center justify-center bg-brand-surface">
                 <h2 className="text-4xl font-black text-brand-dark mb-4 text-center px-6">Ops! Artigo não encontrado.</h2>

--- a/pages/BlogPost.tsx
+++ b/pages/BlogPost.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
+import { trackTraks } from '../utils/traks';
 
 import { Seo } from '../components/Seo';
 import { BlogPostContent } from '../components/blog/BlogPostContent';
@@ -49,6 +50,8 @@ const BlogPost: React.FC = () => {
     }, [slug]);
 
     if (!post) {
+        // Blog inexistente é 404 para o usuário: alimenta a mesma métrica do Traks.
+        trackTraks('page_not_found');
         return (
             <div className="min-h-screen flex flex-col items-center justify-center bg-brand-surface">
                 <h2 className="text-4xl font-black text-brand-dark mb-4 text-center px-6">Ops! Artigo não encontrado.</h2>

--- a/pages/NotFound.tsx
+++ b/pages/NotFound.tsx
@@ -3,10 +3,18 @@ import { MapPin, Home as HomeIcon, Compass, BookOpen, ArrowLeft } from 'lucide-r
 import { Seo } from '../components/Seo';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { getBlogHomeUrl } from '../utils/blog';
+import { useEffect } from 'react';
+import { trackTraks } from '../utils/traks';
 
 const SITE_URL = 'https://www.anhanga.tur.br';
 
 const NotFound: React.FC = () => {
+  // Traks: rota 404 é renderizada pela SPA, então o sinal vem daqui
+  // (o snippet do <head> é único para todas as rotas — não dá para usar data-404).
+  useEffect(() => {
+    trackTraks('page_not_found');
+  }, []);
+
   return (
     <>
       <Seo

--- a/pages/NotFound.tsx
+++ b/pages/NotFound.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { MapPin, Home as HomeIcon, Compass, BookOpen, ArrowLeft } from 'lucide-react';
 import { useLocation } from 'react-router-dom';
 import { Seo } from '../components/Seo';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { getBlogHomeUrl } from '../utils/blog';
-import { useEffect } from 'react';
 import { trackTraks } from '../utils/traks';
 
 const SITE_URL = 'https://www.anhanga.tur.br';

--- a/pages/NotFound.tsx
+++ b/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MapPin, Home as HomeIcon, Compass, BookOpen, ArrowLeft } from 'lucide-react';
+import { useLocation } from 'react-router-dom';
 import { Seo } from '../components/Seo';
 import { BreadcrumbSchema } from '../components/schemas/BreadcrumbSchema';
 import { getBlogHomeUrl } from '../utils/blog';
@@ -11,9 +12,13 @@ const SITE_URL = 'https://www.anhanga.tur.br';
 const NotFound: React.FC = () => {
   // Traks: rota 404 é renderizada pela SPA, então o sinal vem daqui
   // (o snippet do <head> é único para todas as rotas — não dá para usar data-404).
+  // Depende de pathname (não []): a rota wildcard reaproveita a mesma instância
+  // de NotFound entre navegações client-side para dois 404s distintos, então um
+  // efeito só-no-mount perderia o segundo.
+  const { pathname } = useLocation();
   useEffect(() => {
     trackTraks('page_not_found');
-  }, []);
+  }, [pathname]);
 
   return (
     <>

--- a/tests/chat-lead-form-traks.test.ts
+++ b/tests/chat-lead-form-traks.test.ts
@@ -1,0 +1,77 @@
+import './helpers/dom-setup.ts';
+
+import React from 'react';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { render, fireEvent } from '@testing-library/react';
+
+import { ChatLeadForm } from '../components/ChatLeadForm.tsx';
+
+/*
+  Teste de integração do handoff programático de WhatsApp (reviews P2):
+  o fluxo validado do formulário do chatbot abre WhatsApp via window.open
+  (não via <a href>), então precisa emitir `whatsapp_click` no Traks
+  explicitamente. O componente é montado de verdade (happy-dom +
+  testing-library, mesmo tier de ai-research-bar-tracking.test.ts) e
+  window.traks é um stub que registra as chamadas.
+*/
+
+type TraksCall = { name: string; props?: Record<string, unknown> };
+
+function withTraksStub(run: (calls: TraksCall[]) => Promise<void> | void) {
+    const calls: TraksCall[] = [];
+    const previous = (window as { traks?: unknown }).traks;
+    (window as { traks?: unknown }).traks = (...args: unknown[]) => {
+        calls.push({ name: String(args[0]), props: args[1] as Record<string, unknown> | undefined });
+    };
+    return Promise.resolve(run(calls)).finally(() => {
+        if (previous === undefined) {
+            delete (window as { traks?: unknown }).traks;
+        } else {
+            (window as { traks?: unknown }).traks = previous;
+        }
+    });
+}
+
+const okFinalize = async () => ({ ok: true as const, odooLeadId: 'test-1' });
+
+function makeProps() {
+    return {
+        destination: 'Orlando',
+        getWhatsAppUrl: () => 'https://wa.me/5511955021519?text=test',
+        prepareLeadSubmitPayload: (() => ({})) as unknown as React.ComponentProps<typeof ChatLeadForm>['prepareLeadSubmitPayload'],
+        isSubmittingLead: false,
+        onFinalizeLead: okFinalize,
+    };
+}
+
+test('submit validado do ChatLeadForm emite whatsapp_click no Traks', async () => {
+    await withTraksStub(async (calls) => {
+        const { container } = render(React.createElement(ChatLeadForm, makeProps()));
+
+        // Preenche campos obrigatórios pelos inputs reais do form.
+        const set = (id: string, value: string) => {
+            const input = container.querySelector(`#${id}`);
+            if (!input) throw new Error(`input não encontrado: #${id}`);
+            fireEvent.input(input, { target: { value } });
+        };
+        set('lead-first-name', 'Fulano');
+        set('lead-last-name', 'de Tal');
+        set('lead-email', 'fulano@test.com');
+        set('lead-whatsapp', '11999998888');
+
+        // Aceita LGPD se existir checkbox.
+        const lgpd = container.querySelector('input[type="checkbox"]');
+        if (lgpd) fireEvent.click(lgpd);
+
+        const submitButton = Array.from(container.querySelectorAll('button'))
+            .find((b) => b.textContent?.includes('Salvar e abrir WhatsApp'));
+        assert.ok(submitButton, 'botão "Salvar e abrir WhatsApp" deve existir');
+
+        fireEvent.click(submitButton);
+        // O handoff é síncrono no click handler (antes do await do finalize).
+        await Promise.resolve();
+        const handoffs = calls.filter((c) => c.name === 'whatsapp_click');
+        assert.ok(handoffs.length >= 1, 'whatsapp_click deve ser emitido no submit validado');
+    });
+});

--- a/tests/not-found-traks.test.ts
+++ b/tests/not-found-traks.test.ts
@@ -1,0 +1,79 @@
+import './helpers/dom-setup.ts';
+
+import React, { useEffect } from 'react';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { render, act } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom';
+
+import NotFound from '../pages/NotFound.tsx';
+
+/*
+  Regressão: a rota wildcard (App.tsx) reaproveita a mesma instância de
+  NotFound quando a navegação client-side vai de um 404 direto para outro
+  (ex.: /foo -> /bar, ambos não mapeados) sem passar por uma rota válida no
+  meio. Um efeito com deps [] só dispararia no mount, perdendo o segundo 404.
+  O componente agora depende de useLocation().pathname.
+*/
+
+type TraksCall = { name: string };
+
+function withTraksStub(run: (calls: TraksCall[]) => void) {
+    const calls: TraksCall[] = [];
+    const previous = (window as { traks?: unknown }).traks;
+    (window as { traks?: unknown }).traks = (...args: unknown[]) => {
+        calls.push({ name: String(args[0]) });
+    };
+    try {
+        run(calls);
+    } finally {
+        if (previous === undefined) {
+            delete (window as { traks?: unknown }).traks;
+        } else {
+            (window as { traks?: unknown }).traks = previous;
+        }
+    }
+}
+
+type NavigateRef = React.RefObject<((path: string) => void | Promise<void>) | null>;
+
+function NavCapture({ navRef }: { navRef: NavigateRef }) {
+    const navigate = useNavigate();
+    useEffect(() => {
+        navRef.current = navigate;
+    }, [navigate, navRef]);
+    return null;
+}
+
+test('NotFound emite page_not_found em cada navegação 404->404 distinta', () => {
+    withTraksStub((calls) => {
+        const navRef: NavigateRef = { current: null };
+
+        render(
+            React.createElement(
+                MemoryRouter,
+                { initialEntries: ['/rota-quebrada-1'] },
+                React.createElement(NavCapture, { navRef }),
+                React.createElement(
+                    Routes,
+                    null,
+                    React.createElement(Route, { path: '*', element: React.createElement(NotFound) }),
+                ),
+            ),
+        );
+
+        assert.equal(calls.length, 1, 'primeiro 404 deve emitir 1 evento');
+
+        act(() => {
+            navRef.current!('/rota-quebrada-2');
+        });
+
+        assert.equal(calls.length, 2, 'segundo 404 (rota diferente) deve emitir outro evento');
+
+        act(() => {
+            navRef.current!('/rota-quebrada-2');
+        });
+
+        assert.equal(calls.length, 2, 'navegar para a mesma rota 404 não deve duplicar o evento');
+    });
+});

--- a/tests/traks.test.ts
+++ b/tests/traks.test.ts
@@ -22,7 +22,7 @@ const anchor = (href: string): FakeAnchor => {
 /** DOM mínimo (window + document) para exercitar os utilitários sem jsdom. */
 function setupFakeDom(options: { href?: string } = {}) {
     const traksCalls: Array<{ name: string; props?: Record<string, unknown> }> = [];
-    let clickHandler: ((event: unknown) => void) | null = null;
+    const handlers: Record<string, (event: unknown) => void> = {};
 
     const win = {
         location: new URL(options.href ?? 'https://www.anhanga.tur.br/orlando/'),
@@ -39,8 +39,8 @@ function setupFakeDom(options: { href?: string } = {}) {
     const realDocument = globalThis.document;
     (globalThis as { window?: unknown }).window = win;
     (globalThis as { document?: unknown }).document = {
-        addEventListener(_type: string, handler: (event: unknown) => void) {
-            clickHandler = handler;
+        addEventListener(type: string, handler: (event: unknown) => void) {
+            handlers[type] = handler;
         },
     };
 
@@ -48,8 +48,8 @@ function setupFakeDom(options: { href?: string } = {}) {
         win,
         traksCalls,
         dataLayer: win.dataLayer,
-        click(target: unknown) {
-            clickHandler?.({ target });
+        click(target: unknown, type = 'click') {
+            handlers[type]?.({ target, type });
         },
         cleanup() {
             (globalThis as { window?: unknown }).window = realWindow;
@@ -107,36 +107,42 @@ test('trackTraks engole exceção do provedor sem quebrar o fluxo chamador', () 
 
 // ─── listener global de WhatsApp ─────────────────────────────────────────────
 
-test('listener: dispara em wa.me/api.whatsapp.com com phone, ignora share e outros; idempotente', () => {
+test('listener: auxclick (botão do meio) conta como clique no WhatsApp', () => {
+    // ÚNICO teste de listener: a instalação aqui registra os handlers neste
+    // DOM fake e a flag de módulo persiste para todo o processo (idempotência
+    // real — em produção só se instala uma vez por página).
     const env = setupFakeDom({ href: 'https://www.anhanga.tur.br/orlando/' });
     try {
-        // Instalação múltipla registra o handler apenas uma vez.
         installTraksWhatsAppClickListener();
-        installTraksWhatsAppClickListener();
-        installTraksWhatsAppClickListener();
+        installTraksWhatsAppClickListener(); // idempotente
 
-        env.click(anchor('https://wa.me/5511955021519?text=oi'));
+        // Botão do meio dispara `auxclick`, não `click`.
+        env.click(anchor('https://wa.me/5511955021519'), 'auxclick');
         assert.equal(env.traksCalls.length, 1);
-        assert.equal(env.traksCalls[0].name, 'whatsapp_click');
         assert.deepEqual(env.traksCalls[0].props, { location: '/orlando/' });
+
+        // Clique normal em wa.me.
+        env.click(anchor('https://wa.me/5511955021519?text=oi'));
+        assert.equal(env.traksCalls.length, 2);
+        assert.equal(env.traksCalls[1].name, 'whatsapp_click');
 
         // api.whatsapp.com COM phone = contato da agência.
         env.click(anchor('https://api.whatsapp.com/send?phone=5511955021519&text=oi'));
-        assert.equal(env.traksCalls.length, 2);
+        assert.equal(env.traksCalls.length, 3);
 
         // api.whatsapp.com só com text = botão de COMPARTILHAR (não é conversão).
         env.click(anchor('https://api.whatsapp.com/send?text=mira%20isso%20https://x.com'));
-        assert.equal(env.traksCalls.length, 2);
+        assert.equal(env.traksCalls.length, 3);
 
         // Links internos e de outras redes ficam de fora.
         env.click(anchor('https://www.anhanga.tur.br/blog'));
         env.click(anchor('/orlando/'));
         env.click(anchor('https://twitter.com/intent/tweet?text=oi'));
-        assert.equal(env.traksCalls.length, 2);
+        assert.equal(env.traksCalls.length, 3);
 
         // Hrefs protocol-relative (//wa.me) também são contato.
         env.click(anchor('//wa.me/5511955021519'));
-        assert.equal(env.traksCalls.length, 3);
+        assert.equal(env.traksCalls.length, 4);
     } finally {
         env.cleanup();
     }

--- a/tests/traks.test.ts
+++ b/tests/traks.test.ts
@@ -4,6 +4,7 @@ import { pushGenerateLeadConversionEvent } from '../utils/generate-lead-analytic
 import {
     trackTraks,
     installTraksWhatsAppClickListener,
+    nextBlogNotFoundTraksSlug,
 } from '../utils/traks.ts';
 
 interface FakeAnchor {
@@ -174,4 +175,46 @@ test('pushGenerateLeadConversionEvent dispara quote_request no Traks com pathnam
     } finally {
         env.cleanup();
     }
+});
+
+// ─── nextBlogNotFoundTraksSlug (guard de pages/BlogPost.tsx) ────────────────
+
+test('nextBlogNotFoundTraksSlug: rastreia um slug inválido novo', () => {
+    assert.deepEqual(nextBlogNotFoundTraksSlug(false, 'inexistente', null), {
+        shouldTrack: true,
+        nextLastTrackedSlug: 'inexistente',
+    });
+});
+
+test('nextBlogNotFoundTraksSlug: não duplica o mesmo slug inválido em re-render', () => {
+    assert.deepEqual(nextBlogNotFoundTraksSlug(false, 'inexistente', 'inexistente'), {
+        shouldTrack: false,
+        nextLastTrackedSlug: 'inexistente',
+    });
+});
+
+test('nextBlogNotFoundTraksSlug: rastreia de novo ao trocar para outro slug inválido', () => {
+    assert.deepEqual(nextBlogNotFoundTraksSlug(false, 'outro-slug', 'inexistente'), {
+        shouldTrack: true,
+        nextLastTrackedSlug: 'outro-slug',
+    });
+});
+
+test('nextBlogNotFoundTraksSlug: limpa o guard quando um post válido é visto', () => {
+    assert.deepEqual(nextBlogNotFoundTraksSlug(true, 'post-real', 'inexistente'), {
+        shouldTrack: false,
+        nextLastTrackedSlug: null,
+    });
+});
+
+test('nextBlogNotFoundTraksSlug: revisitar o mesmo slug inválido depois de um post válido rastreia de novo', () => {
+    // Sequência real: /blog/missing (404) -> /blog/post-real (válido) -> /blog/missing (404 de novo)
+    const first = nextBlogNotFoundTraksSlug(false, 'missing', null);
+    assert.equal(first.shouldTrack, true);
+
+    const afterValidPost = nextBlogNotFoundTraksSlug(true, 'post-real', first.nextLastTrackedSlug);
+    assert.equal(afterValidPost.nextLastTrackedSlug, null);
+
+    const revisit = nextBlogNotFoundTraksSlug(false, 'missing', afterValidPost.nextLastTrackedSlug);
+    assert.deepEqual(revisit, { shouldTrack: true, nextLastTrackedSlug: 'missing' });
 });

--- a/tests/traks.test.ts
+++ b/tests/traks.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { pushGenerateLeadConversionEvent } from '../utils/generate-lead-analytics.ts';
 import {
     trackTraks,
     installTraksWhatsAppClickListener,
@@ -25,6 +26,7 @@ function setupFakeDom(options: { href?: string } = {}) {
 
     const win = {
         location: new URL(options.href ?? 'https://www.anhanga.tur.br/orlando/'),
+        dataLayer: [] as Array<Record<string, unknown>>,
     };
     (win as { traks?: unknown }).traks = (...args: unknown[]) => {
         traksCalls.push({
@@ -35,24 +37,28 @@ function setupFakeDom(options: { href?: string } = {}) {
 
     const realWindow = globalThis.window;
     const realDocument = globalThis.document;
-    (globalThis as any).window = win;
-    (globalThis as any).document = {
+    (globalThis as { window?: unknown }).window = win;
+    (globalThis as { document?: unknown }).document = {
         addEventListener(_type: string, handler: (event: unknown) => void) {
             clickHandler = handler;
         },
     };
 
     return {
+        win,
         traksCalls,
+        dataLayer: win.dataLayer,
         click(target: unknown) {
             clickHandler?.({ target });
         },
         cleanup() {
-            (globalThis as any).window = realWindow;
-            (globalThis as any).document = realDocument;
+            (globalThis as { window?: unknown }).window = realWindow;
+            (globalThis as { document?: unknown }).document = realDocument;
         },
     };
 }
+
+// ─── trackTraks ──────────────────────────────────────────────────────────────
 
 test('trackTraks enfileira evento com nome e props', () => {
     const env = setupFakeDom();
@@ -68,11 +74,11 @@ test('trackTraks enfileira evento com nome e props', () => {
 
 test('trackTraks é no-op sem window (SSR)', () => {
     const realWindow = globalThis.window;
-    (globalThis as any).window = undefined;
+    (globalThis as { window?: unknown }).window = undefined;
     try {
         assert.doesNotThrow(() => trackTraks('quote_request'));
     } finally {
-        (globalThis as any).window = realWindow;
+        (globalThis as { window?: unknown }).window = realWindow;
     }
 });
 
@@ -87,7 +93,21 @@ test('trackTraks é no-op quando window.traks não existe', () => {
     }
 });
 
-test('listener: dispara em wa.me/api.whatsapp.com, ignora outros e é idempotente', () => {
+test('trackTraks engole exceção do provedor sem quebrar o fluxo chamador', () => {
+    const env = setupFakeDom();
+    (globalThis.window as { traks?: unknown }).traks = () => {
+        throw new Error('provedor externo quebrou');
+    };
+    try {
+        assert.doesNotThrow(() => trackTraks('whatsapp_click'));
+    } finally {
+        env.cleanup();
+    }
+});
+
+// ─── listener global de WhatsApp ─────────────────────────────────────────────
+
+test('listener: dispara em wa.me/api.whatsapp.com com phone, ignora share e outros; idempotente', () => {
     const env = setupFakeDom({ href: 'https://www.anhanga.tur.br/orlando/' });
     try {
         // Instalação múltipla registra o handler apenas uma vez.
@@ -100,15 +120,47 @@ test('listener: dispara em wa.me/api.whatsapp.com, ignora outros e é idempotent
         assert.equal(env.traksCalls[0].name, 'whatsapp_click');
         assert.deepEqual(env.traksCalls[0].props, { location: '/orlando/' });
 
+        // api.whatsapp.com COM phone = contato da agência.
         env.click(anchor('https://api.whatsapp.com/send?phone=5511955021519&text=oi'));
         assert.equal(env.traksCalls.length, 2);
 
-        env.click(anchor('https://www.anhanga.tur.br/blog'));
-        env.click(anchor('/orlando/'));
+        // api.whatsapp.com só com text = botão de COMPARTILHAR (não é conversão).
+        env.click(anchor('https://api.whatsapp.com/send?text=mira%20isso%20https://x.com'));
         assert.equal(env.traksCalls.length, 2);
 
+        // Links internos e de outras redes ficam de fora.
+        env.click(anchor('https://www.anhanga.tur.br/blog'));
+        env.click(anchor('/orlando/'));
+        env.click(anchor('https://twitter.com/intent/tweet?text=oi'));
+        assert.equal(env.traksCalls.length, 2);
+
+        // Hrefs protocol-relative (//wa.me) também são contato.
         env.click(anchor('//wa.me/5511955021519'));
         assert.equal(env.traksCalls.length, 3);
+    } finally {
+        env.cleanup();
+    }
+});
+
+// ─── integração: generate_lead → quote_request ──────────────────────────────
+
+test('pushGenerateLeadConversionEvent dispara quote_request no Traks com pathname da rota', () => {
+    const env = setupFakeDom({ href: 'https://www.anhanga.tur.br/orlando/' });
+    try {
+        pushGenerateLeadConversionEvent({
+            eventId: 'evt_1',
+            destination: 'Porto de Galinhas',
+        });
+
+        // Evento GA4/dataLayer segue intacto.
+        const dlEvent = env.dataLayer.find((e) => e.event === 'generate_lead');
+        assert.ok(dlEvent, 'generate_lead deve seguir no dataLayer');
+        assert.equal(dlEvent.destination, 'Porto de Galinhas');
+
+        // Traks recebe conversão SEM texto livre do lead — só a rota.
+        assert.deepEqual(env.traksCalls, [
+            { name: 'quote_request', props: { location: '/orlando/' } },
+        ]);
     } finally {
         env.cleanup();
     }

--- a/tests/traks.test.ts
+++ b/tests/traks.test.ts
@@ -48,8 +48,8 @@ function setupFakeDom(options: { href?: string } = {}) {
         win,
         traksCalls,
         dataLayer: win.dataLayer,
-        click(target: unknown, type = 'click') {
-            handlers[type]?.({ target, type });
+        click(target: unknown, type = 'click', button = 0) {
+            handlers[type]?.({ target, type, button });
         },
         cleanup() {
             (globalThis as { window?: unknown }).window = realWindow;
@@ -116,10 +116,14 @@ test('listener: auxclick (botão do meio) conta como clique no WhatsApp', () => 
         installTraksWhatsAppClickListener();
         installTraksWhatsAppClickListener(); // idempotente
 
-        // Botão do meio dispara `auxclick`, não `click`.
-        env.click(anchor('https://wa.me/5511955021519'), 'auxclick');
+        // Botão do meio dispara `auxclick` com button=1; right-click (button=2)
+        // também é auxclick mas não navega — não conta.
+        env.click(anchor('https://wa.me/5511955021519'), 'auxclick', 1);
         assert.equal(env.traksCalls.length, 1);
         assert.deepEqual(env.traksCalls[0].props, { location: '/orlando/' });
+
+        env.click(anchor('https://wa.me/5511955021519'), 'auxclick', 2);
+        assert.equal(env.traksCalls.length, 1);
 
         // Clique normal em wa.me.
         env.click(anchor('https://wa.me/5511955021519?text=oi'));

--- a/tests/traks.test.ts
+++ b/tests/traks.test.ts
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    trackTraks,
+    installTraksWhatsAppClickListener,
+} from '../utils/traks.ts';
+
+interface FakeAnchor {
+    getAttribute: (name: string) => string | null;
+    closest: (selector: string) => FakeAnchor | null;
+}
+
+const anchor = (href: string): FakeAnchor => {
+    const el: FakeAnchor = {
+        getAttribute: (name) => (name === 'href' ? href : null),
+        closest: (selector) => (selector === 'a[href]' ? el : null),
+    };
+    return el;
+};
+
+/** DOM mínimo (window + document) para exercitar os utilitários sem jsdom. */
+function setupFakeDom(options: { href?: string } = {}) {
+    const traksCalls: Array<{ name: string; props?: Record<string, unknown> }> = [];
+    let clickHandler: ((event: unknown) => void) | null = null;
+
+    const win = {
+        location: new URL(options.href ?? 'https://www.anhanga.tur.br/orlando/'),
+    };
+    (win as { traks?: unknown }).traks = (...args: unknown[]) => {
+        traksCalls.push({
+            name: String(args[0]),
+            props: args[1] as Record<string, unknown> | undefined,
+        });
+    };
+
+    const realWindow = globalThis.window;
+    const realDocument = globalThis.document;
+    (globalThis as any).window = win;
+    (globalThis as any).document = {
+        addEventListener(_type: string, handler: (event: unknown) => void) {
+            clickHandler = handler;
+        },
+    };
+
+    return {
+        traksCalls,
+        click(target: unknown) {
+            clickHandler?.({ target });
+        },
+        cleanup() {
+            (globalThis as any).window = realWindow;
+            (globalThis as any).document = realDocument;
+        },
+    };
+}
+
+test('trackTraks enfileira evento com nome e props', () => {
+    const env = setupFakeDom();
+    try {
+        trackTraks('quote_request', { destination: 'whatsapp' });
+        assert.deepEqual(env.traksCalls, [
+            { name: 'quote_request', props: { destination: 'whatsapp' } },
+        ]);
+    } finally {
+        env.cleanup();
+    }
+});
+
+test('trackTraks é no-op sem window (SSR)', () => {
+    const realWindow = globalThis.window;
+    (globalThis as any).window = undefined;
+    try {
+        assert.doesNotThrow(() => trackTraks('quote_request'));
+    } finally {
+        (globalThis as any).window = realWindow;
+    }
+});
+
+test('trackTraks é no-op quando window.traks não existe', () => {
+    const env = setupFakeDom();
+    delete (globalThis.window as { traks?: unknown }).traks;
+    try {
+        assert.doesNotThrow(() => trackTraks('quote_request'));
+        assert.equal(env.traksCalls.length, 0);
+    } finally {
+        env.cleanup();
+    }
+});
+
+test('listener: dispara em wa.me/api.whatsapp.com, ignora outros e é idempotente', () => {
+    const env = setupFakeDom({ href: 'https://www.anhanga.tur.br/orlando/' });
+    try {
+        // Instalação múltipla registra o handler apenas uma vez.
+        installTraksWhatsAppClickListener();
+        installTraksWhatsAppClickListener();
+        installTraksWhatsAppClickListener();
+
+        env.click(anchor('https://wa.me/5511955021519?text=oi'));
+        assert.equal(env.traksCalls.length, 1);
+        assert.equal(env.traksCalls[0].name, 'whatsapp_click');
+        assert.deepEqual(env.traksCalls[0].props, { location: '/orlando/' });
+
+        env.click(anchor('https://api.whatsapp.com/send?phone=5511955021519&text=oi'));
+        assert.equal(env.traksCalls.length, 2);
+
+        env.click(anchor('https://www.anhanga.tur.br/blog'));
+        env.click(anchor('/orlando/'));
+        assert.equal(env.traksCalls.length, 2);
+
+        env.click(anchor('//wa.me/5511955021519'));
+        assert.equal(env.traksCalls.length, 3);
+    } finally {
+        env.cleanup();
+    }
+});

--- a/tests/use-contact-form-traks.test.ts
+++ b/tests/use-contact-form-traks.test.ts
@@ -1,0 +1,87 @@
+import './helpers/dom-setup.ts';
+
+import React from 'react';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { render, fireEvent, act } from '@testing-library/react';
+
+import { useContactForm } from '../hooks/useContactForm.ts';
+
+/*
+  Cobertura do handoff programático de WhatsApp em useContactForm (review P2,
+  mesma lacuna já coberta para ChatLeadForm em tests/chat-lead-form-traks.test.ts):
+  o path `action === 'whatsapp'` do modal de contato abre o WhatsApp via
+  `window.open` e chama `trackTraksWhatsAppHandoff()` explicitamente, então
+  precisa de um teste de integração que exercite o hook de verdade (não só a
+  função isolada em utils/traks.ts).
+*/
+
+type TraksCall = { name: string; props?: Record<string, unknown> };
+
+function withTraksStub(run: (calls: TraksCall[]) => Promise<void> | void) {
+    const calls: TraksCall[] = [];
+    const previous = (window as { traks?: unknown }).traks;
+    (window as { traks?: unknown }).traks = (...args: unknown[]) => {
+        calls.push({ name: String(args[0]), props: args[1] as Record<string, unknown> | undefined });
+    };
+    return Promise.resolve(run(calls)).finally(() => {
+        if (previous === undefined) {
+            delete (window as { traks?: unknown }).traks;
+        } else {
+            (window as { traks?: unknown }).traks = previous;
+        }
+    });
+}
+
+function withFetchStub(run: () => Promise<void> | void) {
+    const previous = globalThis.fetch;
+    globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ ok: true, odooLeadId: 'test-1' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+        })) as typeof fetch;
+    return Promise.resolve(run()).finally(() => {
+        globalThis.fetch = previous;
+    });
+}
+
+function Harness() {
+    const { setField, submit } = useContactForm({ source: 'test-harness' });
+    return React.createElement(
+        'div',
+        null,
+        React.createElement('button', {
+            'data-testid': 'fill',
+            onClick: () => {
+                setField('firstName', 'Fulano');
+                setField('whatsapp', '11999998888');
+            },
+        }),
+        React.createElement('button', {
+            'data-testid': 'submit-whatsapp',
+            onClick: () => {
+                void submit('whatsapp');
+            },
+        }),
+    );
+}
+
+test('useContactForm submit("whatsapp") emite whatsapp_click no Traks', async () => {
+    await withTraksStub(async (calls) => {
+        await withFetchStub(async () => {
+            const { getByTestId } = render(React.createElement(Harness));
+
+            act(() => {
+                fireEvent.click(getByTestId('fill'));
+            });
+            await act(async () => {
+                fireEvent.click(getByTestId('submit-whatsapp'));
+                await Promise.resolve();
+                await Promise.resolve();
+            });
+
+            const handoffs = calls.filter((c) => c.name === 'whatsapp_click');
+            assert.ok(handoffs.length >= 1, 'whatsapp_click deve ser emitido no submit("whatsapp")');
+        });
+    });
+});

--- a/types/analytics.d.ts
+++ b/types/analytics.d.ts
@@ -1,6 +1,8 @@
 declare global {
     interface Window {
         dataLayer?: Array<Record<string, unknown>>;
+        /** Queue stub definido no index.html; o script t.js do Traks substitui depois. */
+        traks?: (...args: unknown[]) => void;
     }
 }
 

--- a/utils/generate-lead-analytics.ts
+++ b/utils/generate-lead-analytics.ts
@@ -1,6 +1,16 @@
 import type { LeadTracking, LeadUtms } from '../types/leadCapture';
 import { trackTraks } from './traks';
 
+/** Pathname atual sem query/hash — prop de baixa cardinalidade, sem PII. */
+function currentTraksPathname(): string {
+    if (typeof window === 'undefined') return '';
+    try {
+        return new URL(window.location.href).pathname;
+    } catch {
+        return '/';
+    }
+}
+
 interface GenerateLeadConversionEvent {
     eventId?: string;
     destination: string;
@@ -29,6 +39,8 @@ export function pushGenerateLeadConversionEvent({
         ga_session_id: tracking?.sid,
     });
 
-    // Traks (cookieless): mesma conversão, destino em baixa cardinalidade.
-    trackTraks('quote_request', { destination });
+    // Traks (cookieless): conversão sem dados do lead. `destination` aqui é texto
+    // livre digitado pelo usuário (ver cleanValue em useLeadCapture) — NÃO vai
+    // para provedor externo. O pathname da rota dá o bucket de origem.
+    trackTraks('quote_request', { location: currentTraksPathname() });
 }

--- a/utils/generate-lead-analytics.ts
+++ b/utils/generate-lead-analytics.ts
@@ -1,15 +1,5 @@
 import type { LeadTracking, LeadUtms } from '../types/leadCapture';
-import { trackTraks } from './traks';
-
-/** Pathname atual sem query/hash — prop de baixa cardinalidade, sem PII. */
-function currentTraksPathname(): string {
-    if (typeof window === 'undefined') return '';
-    try {
-        return new URL(window.location.href).pathname;
-    } catch {
-        return '/';
-    }
-}
+import { trackTraks, currentPathname as currentTraksPathname } from './traks';
 
 interface GenerateLeadConversionEvent {
     eventId?: string;

--- a/utils/generate-lead-analytics.ts
+++ b/utils/generate-lead-analytics.ts
@@ -1,4 +1,5 @@
 import type { LeadTracking, LeadUtms } from '../types/leadCapture';
+import { trackTraks } from './traks';
 
 interface GenerateLeadConversionEvent {
     eventId?: string;
@@ -27,4 +28,7 @@ export function pushGenerateLeadConversionEvent({
         ga_client_id: tracking?.cid,
         ga_session_id: tracking?.sid,
     });
+
+    // Traks (cookieless): mesma conversão, destino em baixa cardinalidade.
+    trackTraks('quote_request', { destination });
 }

--- a/utils/traks.ts
+++ b/utils/traks.ts
@@ -65,8 +65,9 @@ export function installTraksWhatsAppClickListener(): void {
 
     const handleActivation = (event: MouseEvent) => {
         // Duck typing em vez de instanceof Element: cobre iframes/JSDOM/fakes.
-        // `auxclick` cobre botão do meio (open in new tab), que não dispara `click`.
-        if (event.type !== 'click' && event.type !== 'auxclick') return;
+        // `auxclick` só interessa no botão do meio (open in new tab); right-click
+        // também dispara auxclick mas não navega — não é conversão.
+        if (event.type === 'auxclick' && event.button !== 1) return;
         const target = event.target as { closest?: unknown } | null;
         if (!target || typeof target.closest !== 'function') return;
         const anchor = target.closest('a[href]') as { getAttribute?: (name: string) => string | null } | null;

--- a/utils/traks.ts
+++ b/utils/traks.ts
@@ -26,7 +26,7 @@ export function trackTraks(name: string, props?: TraksProps): void {
 }
 
 /** Path atual (sem query/hash) para props de baixa cardinalidade. */
-function currentPathname(): string {
+export function currentPathname(): string {
     try {
         return new URL(window.location.href).pathname;
     } catch {
@@ -63,9 +63,10 @@ export function installTraksWhatsAppClickListener(): void {
     if (typeof window === 'undefined' || whatsAppListenerInstalled) return;
     whatsAppListenerInstalled = true;
 
-    document.addEventListener('click', (event) => {
-        // Duck typing em vez de instanceof Element: cobre iframes/JSDOM/fakes e
-        // suporta open in new tab (command/ctrl/middle-click), onde a navegação acontece igual.
+    const handleActivation = (event: MouseEvent) => {
+        // Duck typing em vez de instanceof Element: cobre iframes/JSDOM/fakes.
+        // `auxclick` cobre botão do meio (open in new tab), que não dispara `click`.
+        if (event.type !== 'click' && event.type !== 'auxclick') return;
         const target = event.target as { closest?: unknown } | null;
         if (!target || typeof target.closest !== 'function') return;
         const anchor = target.closest('a[href]') as { getAttribute?: (name: string) => string | null } | null;
@@ -73,7 +74,10 @@ export function installTraksWhatsAppClickListener(): void {
         if (!anchor || !isAgencyWhatsAppHref(anchor.getAttribute?.('href') ?? '')) return;
 
         trackTraks('whatsapp_click', { location: currentPathname() });
-    }, { passive: true });
+    };
+
+    document.addEventListener('click', handleActivation, { passive: true });
+    document.addEventListener('auxclick', handleActivation, { passive: true });
 }
 
 /**

--- a/utils/traks.ts
+++ b/utils/traks.ts
@@ -1,0 +1,60 @@
+/**
+ * Traks Analytics bridge (cookieless, privacy-first — analytics.anhanga.tur.br).
+ *
+ * O snippet + queue stub vivem no index.html (`window.traks`), então chamar
+ * `window.traks(...)` é seguro antes mesmo do script carregar (enfileira).
+ * Este módulo centraliza os eventos de conversão para manter nomes/props
+ * consistentes com os goals configurados no dashboard.
+ */
+
+export type TraksProps = Record<string, string | number | boolean>;
+
+export function trackTraks(name: string, props?: TraksProps): void {
+    if (typeof window === 'undefined' || typeof window.traks !== 'function') {
+        return;
+    }
+
+    window.traks(name, props);
+}
+
+/** Path atual (sem query/hash) para props de baixa cardinalidade. */
+function currentPathname(): string {
+    try {
+        return new URL(window.location.href).pathname;
+    } catch {
+        return '/';
+    }
+}
+
+/**
+ * Delegação global de cliques em links de WhatsApp (wa.me / api.whatsapp.com).
+ * Um único listener cobre todos os CTAs presentes e futuros, sem tocar em cada
+ * componente. Instale uma vez (index.tsx); é idempotente.
+ */
+let whatsAppListenerInstalled = false;
+
+export function installTraksWhatsAppClickListener(): void {
+    if (typeof window === 'undefined' || whatsAppListenerInstalled) return;
+    whatsAppListenerInstalled = true;
+
+    const isWhatsAppHref = (rawHref: string): boolean => {
+        try {
+            const url = new URL(rawHref, window.location.href);
+            return url.hostname === 'wa.me' || url.hostname === 'api.whatsapp.com';
+        } catch {
+            return false;
+        }
+    };
+
+    document.addEventListener('click', (event) => {
+        // Duck typing em vez de instanceof Element: cobre iframes/JSDOM/fakes e
+        // suporta open in new tab (command/ctrl/middle-click), onde a navegação acontece igual.
+        const target = event.target as { closest?: unknown } | null;
+        if (!target || typeof target.closest !== 'function') return;
+        const anchor = target.closest('a[href]') as { getAttribute?: (name: string) => string | null } | null;
+
+        if (!anchor || !isWhatsAppHref(anchor.getAttribute?.('href') ?? '')) return;
+
+        trackTraks('whatsapp_click', { location: currentPathname() });
+    }, { passive: true });
+}

--- a/utils/traks.ts
+++ b/utils/traks.ts
@@ -14,7 +14,15 @@ export function trackTraks(name: string, props?: TraksProps): void {
         return;
     }
 
-    window.traks(name, props);
+    // Falha do provedor externo jamais pode quebrar o fluxo do produto
+    // (ex.: abrir WhatsApp/submeter lead depois de um pushGenerateLead...).
+    try {
+        window.traks(name, props);
+    } catch (error) {
+        if (typeof console !== 'undefined') {
+            console.error('Traks tracking failed', error);
+        }
+    }
 }
 
 /** Path atual (sem query/hash) para props de baixa cardinalidade. */
@@ -27,7 +35,25 @@ function currentPathname(): string {
 }
 
 /**
- * Delegação global de cliques em links de WhatsApp (wa.me / api.whatsapp.com).
+ * Links de WhatsApp que representam CONTATO com a agência (wa.me direto ou
+ * /send?phone=). Links de COMPARTILHAR conteúdo (api.whatsapp.com/send apenas
+ * com ?text=, ver utils/share.ts) NÃO são conversão e ficam de fora.
+ */
+function isAgencyWhatsAppHref(rawHref: string): boolean {
+    try {
+        const url = new URL(rawHref, window.location.href);
+        if (url.hostname === 'wa.me') return true;
+        if (url.hostname === 'api.whatsapp.com' && url.pathname === '/send') {
+            return url.searchParams.has('phone');
+        }
+        return false;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Delegação global de cliques em links de WhatsApp de contato.
  * Um único listener cobre todos os CTAs presentes e futuros, sem tocar em cada
  * componente. Instale uma vez (index.tsx); é idempotente.
  */
@@ -37,15 +63,6 @@ export function installTraksWhatsAppClickListener(): void {
     if (typeof window === 'undefined' || whatsAppListenerInstalled) return;
     whatsAppListenerInstalled = true;
 
-    const isWhatsAppHref = (rawHref: string): boolean => {
-        try {
-            const url = new URL(rawHref, window.location.href);
-            return url.hostname === 'wa.me' || url.hostname === 'api.whatsapp.com';
-        } catch {
-            return false;
-        }
-    };
-
     document.addEventListener('click', (event) => {
         // Duck typing em vez de instanceof Element: cobre iframes/JSDOM/fakes e
         // suporta open in new tab (command/ctrl/middle-click), onde a navegação acontece igual.
@@ -53,8 +70,17 @@ export function installTraksWhatsAppClickListener(): void {
         if (!target || typeof target.closest !== 'function') return;
         const anchor = target.closest('a[href]') as { getAttribute?: (name: string) => string | null } | null;
 
-        if (!anchor || !isWhatsAppHref(anchor.getAttribute?.('href') ?? '')) return;
+        if (!anchor || !isAgencyWhatsAppHref(anchor.getAttribute?.('href') ?? '')) return;
 
         trackTraks('whatsapp_click', { location: currentPathname() });
     }, { passive: true });
+}
+
+/**
+ * Handoffs programáticos de WhatsApp (window.open em ChatLeadForm/useContactForm)
+ * não passam por clique em <a>, então precisam sinal explícito. Chame no ponto
+ * em que a janela do WhatsApp é aberta.
+ */
+export function trackTraksWhatsAppHandoff(): void {
+    trackTraks('whatsapp_click', { location: currentPathname() });
 }

--- a/utils/traks.ts
+++ b/utils/traks.ts
@@ -89,3 +89,29 @@ export function installTraksWhatsAppClickListener(): void {
 export function trackTraksWhatsAppHandoff(): void {
     trackTraks('whatsapp_click', { location: currentPathname() });
 }
+
+/**
+ * Decide se um 404 de post deve emitir `page_not_found`, dado o slug atual
+ * de rota e o último slug já rastreado (guard local, tipicamente um `useRef`).
+ * Extraído de `pages/BlogPost.tsx` para ser testável isoladamente: esse
+ * componente usa `import.meta.glob` (macro do Vite), então não pode ser
+ * montado fora de um build Vite/browser em testes `node:test`.
+ *
+ * Emite uma vez por slug inválido, mas esquece o guard assim que um post
+ * válido é visto — sem isso, revisitar o mesmo slug inválido depois de
+ * navegar por um post real (a rota `/blog/:slug` reaproveita a mesma
+ * instância do componente) nunca reemitiria o evento.
+ */
+export function nextBlogNotFoundTraksSlug(
+    hasPost: boolean,
+    slug: string | undefined,
+    lastTrackedSlug: string | null,
+): { shouldTrack: boolean; nextLastTrackedSlug: string | null } {
+    if (hasPost) {
+        return { shouldTrack: false, nextLastTrackedSlug: null };
+    }
+    if (slug && lastTrackedSlug !== slug) {
+        return { shouldTrack: true, nextLastTrackedSlug: slug };
+    }
+    return { shouldTrack: false, nextLastTrackedSlug: lastTrackedSlug };
+}


### PR DESCRIPTION
## Resumo

Instrumenta as conversões principais do site no Traks (analytics cookieless próprio), complementando o GA4/GTM existente.

### Mudanças
- **`utils/traks.ts`** — bridge tipado para `window.traks` (queue stub já presente no `index.html` desde 1a87c95) + listener global delegado de cliques em `wa.me`/`api.whatsapp.com`, com prop de baixa cardinalidade (`location` = pathname da rota).
- **`utils/generate-lead-analytics.ts`** — evento `quote_request` disparado junto ao `generate_lead`, cobrindo chatbot, formulário de contato e corporate com um único ponto de instrumentação.
- **`pages/NotFound.tsx`** — evento `page_not_found` via `useEffect` (404 é rota SPA; `data-404` no head não se aplica).
- **`types/analytics.d.ts`** — declaração de `window.traks`.

### Testes
- `tests/traks.test.ts`: 4 testes novos (enfileiramento, no-op em SSR, filtro de hosts wa.me/api.whatsapp.com + idempotência do listener) — passando.
- Suítes relacionadas sem regressão: `whatsapp-tracking`, `lead-whatsapp`, `form-analytics`, `hooks-useLeadCapture` — 42 testes, todos verdes.
- `pnpm typecheck` e `pnpm lint` limpos.

### Pós-merge
Goals e funnels correspondentes serão criados no Traks MCP (`quote_request`, `whatsapp_click`, `page_not_found` + funnels Home→Orlando→WhatsApp e Home→Consultoria→Orçamento).