### PR TITLE
fix(analytics): gate Traks collector by host like GTM/Mautic

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,8 +76,22 @@
     window.traks = window.traks || function () {
       (window.traks.q = window.traks.q || []).push(arguments);
     };
+    // Não carregar o coletor do Traks em ambientes não-produtivos (dev local +
+    // Playwright/CI em 127.0.0.1) — mesmo gate de host do GTM/Mautic mais abaixo:
+    // sem isso, cliques/submits de teste poluem quote_request/whatsapp_click/
+    // page_not_found de produção. O stub acima continua definido para não
+    // quebrar trackTraks() — os eventos só ficam enfileirados em window.traks.q
+    // sem nunca serem enviados.
+    (function () {
+      var h = location.hostname;
+      if (h === 'localhost' || h === '127.0.0.1' || h === '[::1]' || h === '::1' || h === '0.0.0.0' || h.endsWith('.local') || h.endsWith('.test')) return;
+      var script = document.createElement('script');
+      script.defer = true;
+      script.setAttribute('data-site', 'pb_live_y0tnugik6s7s2b0iy73w5aim');
+      script.src = 'https://analytics-collect.anhanga.tur.br/t.js';
+      document.head.appendChild(script);
+    })();
   </script>
-  <script defer data-site="pb_live_y0tnugik6s7s2b0iy73w5aim" src="https://analytics-collect.anhanga.tur.br/t.js"></script>
 
 </head>
 

--- a/index.html
+++ b/index.html
@@ -86,7 +86,12 @@
       var h = location.hostname;
       if (h === 'localhost' || h === '127.0.0.1' || h === '[::1]' || h === '::1' || h === '0.0.0.0' || h.endsWith('.local') || h.endsWith('.test')) return;
       var script = document.createElement('script');
-      script.defer = true;
+      // .defer não tem efeito em scripts inseridos via createElement (só o parser
+      // HTML respeita defer/async em tags estáticas) — dinamicamente, o default é
+      // comportamento async, que pode interromper o parser do documento. async =
+      // false restaura a execução não-bloqueante e em ordem que a tag estática
+      // original (<script defer>) tinha.
+      script.async = false;
       script.setAttribute('data-site', 'pb_live_y0tnugik6s7s2b0iy73w5aim');
       script.src = 'https://analytics-collect.anhanga.tur.br/t.js';
       document.head.appendChild(script);

--- a/index.html
+++ b/index.html
@@ -85,16 +85,28 @@
     (function () {
       var h = location.hostname;
       if (h === 'localhost' || h === '127.0.0.1' || h === '[::1]' || h === '::1' || h === '0.0.0.0' || h.endsWith('.local') || h.endsWith('.test')) return;
-      var script = document.createElement('script');
-      // .defer não tem efeito em scripts inseridos via createElement (só o parser
-      // HTML respeita defer/async em tags estáticas) — dinamicamente, o default é
-      // comportamento async, que pode interromper o parser do documento. async =
-      // false restaura a execução não-bloqueante e em ordem que a tag estática
-      // original (<script defer>) tinha.
-      script.async = false;
-      script.setAttribute('data-site', 'pb_live_y0tnugik6s7s2b0iy73w5aim');
-      script.src = 'https://analytics-collect.anhanga.tur.br/t.js';
-      document.head.appendChild(script);
+      var injectTraks = function () {
+        var script = document.createElement('script');
+        // async = false (não .defer, que scripts criados via createElement ignoram)
+        // dá execução em ordem, mas sozinho não replica a garantia de defer de
+        // esperar o parse do documento terminar — por isso o gate de
+        // DOMContentLoaded abaixo, que é o que efetivamente restaura o
+        // comportamento da tag estática original (<script defer>).
+        script.async = false;
+        script.setAttribute('data-site', 'pb_live_y0tnugik6s7s2b0iy73w5aim');
+        script.src = 'https://analytics-collect.anhanga.tur.br/t.js';
+        document.head.appendChild(script);
+      };
+      // Este bloco roda no topo do <head>, durante o parse — document.readyState
+      // ainda é 'loading' aqui. Esperar DOMContentLoaded (que só dispara depois do
+      // parse completo) garante que o coletor não injete no meio do parsing, igual
+      // a <script defer> fazia. Se por algum motivo já estiver 'interactive'/
+      // 'complete' quando este código rodar, o parse já terminou — injeta direto.
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', injectTraks, { once: true });
+      } else {
+        injectTraks();
+      }
     })();
   </script>
 

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -149,6 +149,39 @@ test('loadGtm tem gate de host para não poluir o GA4 de produção em dev/CI', 
   assert.ok(gateIndex < injectIndex, 'o gate de host deve preceder a injeção do GTM');
 });
 
+test('Traks tem gate de host para não poluir os goals de conversão em dev/CI', () => {
+  const headHtml = getHeadHtml(indexHtml);
+
+  // O stub de fila (window.traks = window.traks || function...) precisa continuar
+  // definido incondicionalmente — trackTraks() em toda a app depende dele existir
+  // mesmo quando o coletor não carrega (eventos só ficam enfileirados, sem envio).
+  assert.match(headHtml, /window\.traks\s*=\s*window\.traks\s*\|\|\s*function/, 'stub de fila do Traks deve continuar definido');
+
+  // O <script src="...t.js"> não pode ser um tag estático incondicional — precisa
+  // ser injetado programaticamente, atrás do mesmo gate de host do GTM/Mautic.
+  assert.doesNotMatch(
+    headHtml,
+    /<script[^>]*src="https:\/\/analytics-collect\.anhanga\.tur\.br\/t\.js"/i,
+    'o coletor do Traks não deve ser um <script> estático incondicional',
+  );
+  assert.match(headHtml, /analytics-collect\.anhanga\.tur\.br\/t\.js/, 'a URL do coletor deve continuar presente (injeção condicional)');
+
+  const gateIndex = headHtml.indexOf('location.hostname');
+  const trakerScriptIndex = headHtml.indexOf('analytics-collect.anhanga.tur.br/t.js');
+  assert.ok(gateIndex > -1 && trakerScriptIndex > -1, 'gate de host e injeção do coletor devem existir');
+  assert.ok(gateIndex < trakerScriptIndex, 'o gate de host deve preceder a injeção do coletor do Traks');
+
+  // Mesma cobertura de hosts do gate do GTM (localhost/127.0.0.1/loopback IPv6/Docker/.local/.test).
+  const gateToScriptSlice = headHtml.slice(gateIndex, trakerScriptIndex);
+  assert.match(gateToScriptSlice, /'localhost'/, 'gate deve cobrir localhost');
+  assert.match(gateToScriptSlice, /'127\.0\.0\.1'/, 'gate deve cobrir 127.0.0.1');
+  assert.match(gateToScriptSlice, /'\[::1\]'/, 'gate deve cobrir o loopback IPv6 [::1]');
+  assert.match(gateToScriptSlice, /'::1'/, 'gate deve cobrir o loopback IPv6 ::1');
+  assert.match(gateToScriptSlice, /'0\.0\.0\.0'/, 'gate deve cobrir 0.0.0.0 (Docker/CI)');
+  assert.match(gateToScriptSlice, /\.endsWith\('\.local'\)/, 'gate deve cobrir hosts .local');
+  assert.match(gateToScriptSlice, /\.endsWith\('\.test'\)/, 'gate deve cobrir hosts .test');
+});
+
 test('loadMautic tem gate de consentimento LGPD', () => {
   const loadMauticMatch = indexHtml.match(/var loadMautic\s*=\s*function\s*\(\)\s*\{([\s\S]*?)};/);
   assert.ok(loadMauticMatch, 'loadMautic deve estar definida');

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -171,15 +171,28 @@ test('Traks tem gate de host para não poluir os goals de conversão em dev/CI',
   assert.ok(gateIndex > -1 && trakerScriptIndex > -1, 'gate de host e injeção do coletor devem existir');
   assert.ok(gateIndex < trakerScriptIndex, 'o gate de host deve preceder a injeção do coletor do Traks');
 
-  // Mesma cobertura de hosts do gate do GTM (localhost/127.0.0.1/loopback IPv6/Docker/.local/.test).
-  const gateToScriptSlice = headHtml.slice(gateIndex, trakerScriptIndex);
+  // Slice até o fim da IIFE (não só até a URL) — o gate de DOMContentLoaded vem
+  // depois da definição de injectTraks, que é onde a URL do coletor aparece.
+  const iifeEndIndex = headHtml.indexOf('})();', trakerScriptIndex) + '})();'.length;
+  assert.ok(iifeEndIndex > trakerScriptIndex, 'a IIFE do gate do Traks deve se fechar depois da URL do coletor');
+  const gateToScriptSlice = headHtml.slice(gateIndex, iifeEndIndex);
 
   // .defer não tem efeito em scripts inseridos via createElement — só async = false
-  // restaura a execução não-bloqueante/em-ordem que a tag estática <script defer>
-  // original tinha. Sem isso o script vira async de fato e pode interromper o
-  // parser do documento (regressão de TBT, mesma classe do issue #1259).
+  // restaura a execução em ordem que a tag estática <script defer> original tinha.
   assert.doesNotMatch(gateToScriptSlice, /\.defer\s*=\s*true/, 'não deve usar .defer em script criado via createElement');
   assert.match(gateToScriptSlice, /\.async\s*=\s*false/, 'deve usar script.async = false para execução em ordem');
+
+  // async = false sozinho não replica a garantia de defer de esperar o parse do
+  // documento terminar (só ordena execução relativa a outros scripts em-ordem) —
+  // por isso a injeção precisa ficar atrás de um gate de DOMContentLoaded, que só
+  // dispara depois do parse completo (regressão de TBT/LCP apontada em review,
+  // mesma classe do issue #1259).
+  assert.match(gateToScriptSlice, /document\.readyState\s*===\s*'loading'/, 'deve checar document.readyState antes de injetar');
+  assert.match(gateToScriptSlice, /addEventListener\(\s*'DOMContentLoaded'/, 'deve esperar DOMContentLoaded quando o parse ainda está em andamento');
+  const domContentLoadedIndex = gateToScriptSlice.search(/addEventListener\(\s*'DOMContentLoaded'/);
+  const injectFnIndex = gateToScriptSlice.indexOf('var injectTraks');
+  assert.ok(injectFnIndex > -1 && domContentLoadedIndex > -1, 'função de injeção e gate de DOMContentLoaded devem existir');
+  assert.ok(injectFnIndex < domContentLoadedIndex, 'a função de injeção deve ser definida antes de ser agendada no gate');
 
   assert.match(gateToScriptSlice, /'localhost'/, 'gate deve cobrir localhost');
   assert.match(gateToScriptSlice, /'127\.0\.0\.1'/, 'gate deve cobrir 127.0.0.1');

--- a/tests/index-third-party-scripts.test.ts
+++ b/tests/index-third-party-scripts.test.ts
@@ -173,6 +173,14 @@ test('Traks tem gate de host para não poluir os goals de conversão em dev/CI',
 
   // Mesma cobertura de hosts do gate do GTM (localhost/127.0.0.1/loopback IPv6/Docker/.local/.test).
   const gateToScriptSlice = headHtml.slice(gateIndex, trakerScriptIndex);
+
+  // .defer não tem efeito em scripts inseridos via createElement — só async = false
+  // restaura a execução não-bloqueante/em-ordem que a tag estática <script defer>
+  // original tinha. Sem isso o script vira async de fato e pode interromper o
+  // parser do documento (regressão de TBT, mesma classe do issue #1259).
+  assert.doesNotMatch(gateToScriptSlice, /\.defer\s*=\s*true/, 'não deve usar .defer em script criado via createElement');
+  assert.match(gateToScriptSlice, /\.async\s*=\s*false/, 'deve usar script.async = false para execução em ordem');
+
   assert.match(gateToScriptSlice, /'localhost'/, 'gate deve cobrir localhost');
   assert.match(gateToScriptSlice, /'127\.0\.0\.1'/, 'gate deve cobrir 127.0.0.1');
   assert.match(gateToScriptSlice, /'\[::1\]'/, 'gate deve cobrir o loopback IPv6 [::1]');


### PR DESCRIPTION
## Resumo

- **O que muda:** o script coletor do Traks (`analytics-collect.anhanga.tur.br/t.js`) agora só é injetado em hosts de produção — mesmo gate de hostname (`localhost`, `127.0.0.1`, `[::1]`, `::1`, `0.0.0.0`, `.local`, `.test`) que `loadGtm`/`loadMautic` já usam em `index.html`. O stub de fila (`window.traks = window.traks || function...`) continua definido incondicionalmente, então `trackTraks()` (mergeado na PR #1493) segue funcionando em dev/CI sem erro — os eventos só ficam enfileirados em `window.traks.q`, nunca são enviados.
- **Por quê:** ao contrário do GTM/Mautic, o `<script>` do Traks era um tag estático incondicional — carregava em qualquer hostname, inclusive `localhost` (dev), `127.0.0.1` (Playwright/CI) e previews. Isso significa que testes locais e execuções de CI estavam mandando `quote_request`/`whatsapp_click`/`page_not_found` reais para o Traks de produção, poluindo os goals/funnels recém-criados.
- **Impacto para o usuário:** nenhum em produção (comportamento idêntico). Em dev/CI/preview, o coletor simplesmente não carrega mais.
- **Nível de risco:** baixo

## Issue relacionada

Follow-up direto da PR #1493 (feat(analytics): track conversions in Traks) — identificado ao comparar o loader do Traks com o gate de host que `loadGtm`/`loadMautic` já tinham.

## Tipo de mudança

- [x] 🐛 Bug fix

## Testes

- [x] Testes automatizados adicionados/atualizados
- [x] Menor camada de teste correta foi usada (node:test, string-matching sobre `index.html` — mesmo padrão do teste existente `loadGtm tem gate de host...`)

Comandos executados:

```text
pnpm exec tsx --test tests/index-third-party-scripts.test.ts
pnpm test:regression
pnpm exec tsc --noEmit -p .
pnpm exec eslint tests/index-third-party-scripts.test.ts
```

## API & Segurança

- [x] Não se aplica

## Checklist final

- [x] Segue os padrões em `docs/standards/`
- [x] Conventional commit no título (`fix:`)
- [x] Desvios intencionais de regra registrados abaixo

## Exceções / observações para o revisor

Nenhum desvio. Único ponto de atenção: `index.html` não é lintado/typechecked (é HTML puro), então a validação é só via `tests/index-third-party-scripts.test.ts` (string-matching), seguindo o padrão já usado para o gate do GTM.


---
_Generated by [Claude Code](https://claude.ai/code/session_018A3brah4zbjAkNGVexQaMt)_